### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,16 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   bump-version:
     name: Bump version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
 
       - name: Generate GitHub App Token
@@ -69,6 +75,8 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     needs: [bump-version]
+    permissions:
+      pages: write
     env:
       UV_FROZEN: 1
     steps:
@@ -96,6 +104,8 @@ jobs:
   publish-pypi:
     needs: [bump-version]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     env:
       UV_FROZEN: 1
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/grelinfo/grelmicro/security/code-scanning/6](https://github.com/grelinfo/grelmicro/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow to explicitly define the least privileges required for each job. This ensures that the `GITHUB_TOKEN` has only the necessary access levels for the operations performed in the workflow.

1. Add a `permissions` block at the root level of the workflow to set default permissions for all jobs. Use `contents: read` as a minimal starting point.
2. For jobs that require additional permissions (e.g., `bump-version`, `publish-docs`, `publish-pypi`), override the default permissions by adding job-specific `permissions` blocks.
3. Ensure that write permissions are granted only where necessary, such as for committing changes, pushing tags, and publishing packages.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
