### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
     name: Coverage report
     runs-on: ubuntu-latest
     needs: [test]
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/grelinfo/grelmicro/security/code-scanning/5](https://github.com/grelinfo/grelmicro/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the `Coverage report` job to explicitly define the least privileges required. Based on the actions used in the job, the minimal permissions required are likely `contents: read` and possibly `actions: read` for downloading artifacts. This ensures that the job operates securely without unnecessary write permissions.

The `permissions` block should be added under the `coverage-report` job definition, specifying the required permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
