### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
   test:
     name: Test Python ${{ matrix.python }}
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/grelinfo/grelmicro/security/code-scanning/3](https://github.com/grelinfo/grelmicro/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `test` job in the workflow file. The permissions should be set to the least privilege required for the job to function correctly. Based on the steps in the `test` job, it only needs to read the repository contents to check out the code and run tests. Therefore, the permissions should be set to `contents: read`.

The changes will be made in the `.github/workflows/ci.yml` file, specifically within the `test` job definition. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
