### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/grelinfo/grelmicro/security/code-scanning/2](https://github.com/grelinfo/grelmicro/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `lint` job in the workflow file. Based on the steps in the `lint` job, it only requires `contents: read` permissions to access the repository's code. This change ensures that the job does not inadvertently inherit broader permissions from the repository or organization.

The fix involves:
1. Adding a `permissions` block under the `lint` job.
2. Setting the permissions to `contents: read`, which is the least privilege required for the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
