### PR TITLE
feat: Add peek(), reset(), and fail_open to RateLimiter

### DIFF
--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -96,5 +96,32 @@ Use the `cost` parameter to consume multiple tokens per request:
 result = await api_limiter.acquire(key=user_id, cost=10)
 ```
 
+### Peek (Check Without Consuming)
+
+Use `peek()` to check the current rate limit state without consuming tokens:
+
+```python
+--8<-- "resilience/ratelimiter_peek.py"
+```
+
+### Reset
+
+Use `reset()` to delete the rate limit state for a key, restoring its full quota:
+
+```python
+--8<-- "resilience/ratelimiter_reset.py"
+```
+
+### Fail-Open Mode
+
+Use `fail_open=True` when availability is more important than strictness. On backend errors (e.g. Redis down), the rate limiter returns an allowed result instead of propagating the exception:
+
+```python
+--8<-- "resilience/ratelimiter_fail_open.py"
+```
+
+!!! warning
+    Fail-open mode only catches backend infrastructure errors. Legitimate rate limit rejections still work normally.
+
 !!! tip
     The rate limiter uses the same backend registry pattern as the synchronization primitives. See [Backend Architecture](architecture/backends.md) for details.

--- a/docs/snippets/resilience/ratelimiter_fail_open.py
+++ b/docs/snippets/resilience/ratelimiter_fail_open.py
@@ -1,0 +1,14 @@
+from grelmicro.resilience.ratelimiter import RateLimiter
+
+# Non-critical limiter: prefer availability over strictness
+limiter = RateLimiter("analytics", limit=100, window=60, fail_open=True)
+
+
+def record_event(user_id: str) -> None: ...
+
+
+async def track_event(user_id: str) -> None:
+    # If Redis is down, the event is still tracked
+    result = await limiter.acquire(key=user_id)
+    if result.allowed:
+        record_event(user_id)

--- a/docs/snippets/resilience/ratelimiter_peek.py
+++ b/docs/snippets/resilience/ratelimiter_peek.py
@@ -1,0 +1,8 @@
+from grelmicro.resilience.ratelimiter import RateLimiter
+
+invite_limiter = RateLimiter("invite", limit=5, window=3600)
+
+
+async def is_locked(code: str) -> bool:
+    result = await invite_limiter.peek(key=code)
+    return not result.allowed

--- a/docs/snippets/resilience/ratelimiter_reset.py
+++ b/docs/snippets/resilience/ratelimiter_reset.py
@@ -1,0 +1,15 @@
+from grelmicro.resilience.ratelimiter import RateLimiter
+
+auth_limiter = RateLimiter("auth", limit=5, window=60)
+
+
+def verify_password(password: str) -> bool:
+    return True
+
+
+async def login(ip: str, password: str) -> None:
+    await auth_limiter.acquire_or_raise(key=ip)
+
+    if verify_password(password):
+        # Successful login: clear the failure counter
+        await auth_limiter.reset(key=ip)

--- a/grelmicro/resilience/_protocol.py
+++ b/grelmicro/resilience/_protocol.py
@@ -35,7 +35,7 @@ class RateLimiterBackend(Protocol):
     """Protocol for rate limiter storage backends.
 
     Implementations must be async context managers and provide
-    a single ``acquire`` method for atomic rate limit checks.
+    ``acquire``, ``peek``, and ``reset`` methods.
     """
 
     async def __aenter__(self) -> Self:
@@ -70,5 +70,36 @@ class RateLimiterBackend(Protocol):
         Returns:
             RateLimitResult with allowed, limit, remaining,
             retry_after, and reset_after fields.
+        """
+        ...
+
+    async def peek(
+        self,
+        *,
+        key: str,
+        limit: int,
+        window: float,
+    ) -> RateLimitResult:
+        """Check rate limit state without consuming tokens.
+
+        Args:
+            key: The rate limit key (e.g. IP, user ID, session).
+            limit: Maximum number of requests allowed in the window.
+            window: Window duration in seconds.
+
+        Returns:
+            RateLimitResult reflecting the current state.
+        """
+        ...
+
+    async def reset(
+        self,
+        *,
+        key: str,
+    ) -> None:
+        """Delete rate limit state for a key, restoring full quota.
+
+        Args:
+            key: The rate limit key to reset.
         """
         ...

--- a/grelmicro/resilience/memory.py
+++ b/grelmicro/resilience/memory.py
@@ -133,13 +133,12 @@ class MemoryRateLimiterBackend(RateLimiterBackend):
         now = monotonic()
 
         emission_interval = window / limit
-        burst_offset = emission_interval * limit
 
         tat = self._tats.get(key, now)
 
         # Compute current state without consuming (cost=0)
         new_tat = max(tat, now)
-        allow_at = new_tat - burst_offset
+        allow_at = new_tat - window
         diff = now - allow_at
         remaining = math.floor(diff / emission_interval + 0.5)
 
@@ -150,11 +149,11 @@ class MemoryRateLimiterBackend(RateLimiterBackend):
                 allowed=False,
                 limit=limit,
                 remaining=0,
-                retry_after=retry_after,
+                retry_after=max(0.0, retry_after),
                 reset_after=max(0.0, reset_after),
             )
 
-        reset_after = max(tat, now) - now
+        reset_after = new_tat - now
         return RateLimitResult(
             allowed=True,
             limit=limit,

--- a/grelmicro/resilience/memory.py
+++ b/grelmicro/resilience/memory.py
@@ -142,6 +142,8 @@ class MemoryRateLimiterBackend(RateLimiterBackend):
         diff = now - allow_at
         remaining = math.floor(diff / emission_interval + 0.5)
 
+        # Use <= 0 (not < 0 like acquire): remaining=0 means the next
+        # acquire(cost=1) would be rejected, so peek reports allowed=False.
         if remaining <= 0:
             reset_after = tat - now
             retry_after = -diff if remaining < 0 else emission_interval - diff

--- a/grelmicro/resilience/memory.py
+++ b/grelmicro/resilience/memory.py
@@ -111,3 +111,67 @@ class MemoryRateLimiterBackend(RateLimiterBackend):
             retry_after=0.0,
             reset_after=reset_after,
         )
+
+    async def peek(
+        self,
+        *,
+        key: str,
+        limit: int,
+        window: float,
+    ) -> RateLimitResult:
+        """Check rate limit state without consuming tokens.
+
+        Args:
+            key: The rate limit key.
+            limit: Maximum requests allowed in the window.
+            window: Window duration in seconds.
+
+        Returns:
+            RateLimitResult reflecting the current state.
+
+        """
+        now = monotonic()
+
+        emission_interval = window / limit
+        burst_offset = emission_interval * limit
+
+        tat = self._tats.get(key, now)
+
+        # Compute current state without consuming (cost=0)
+        new_tat = max(tat, now)
+        allow_at = new_tat - burst_offset
+        diff = now - allow_at
+        remaining = math.floor(diff / emission_interval + 0.5)
+
+        if remaining <= 0:
+            reset_after = tat - now
+            retry_after = -diff if remaining < 0 else emission_interval - diff
+            return RateLimitResult(
+                allowed=False,
+                limit=limit,
+                remaining=0,
+                retry_after=retry_after,
+                reset_after=max(0.0, reset_after),
+            )
+
+        reset_after = max(tat, now) - now
+        return RateLimitResult(
+            allowed=True,
+            limit=limit,
+            remaining=remaining,
+            retry_after=0.0,
+            reset_after=max(0.0, reset_after),
+        )
+
+    async def reset(
+        self,
+        *,
+        key: str,
+    ) -> None:
+        """Delete rate limit state for a key, restoring full quota.
+
+        Args:
+            key: The rate limit key to reset.
+
+        """
+        self._tats.pop(key, None)

--- a/grelmicro/resilience/ratelimiter.py
+++ b/grelmicro/resilience/ratelimiter.py
@@ -1,7 +1,8 @@
 """Rate Limiter."""
 
 import logging
-from typing import Annotated
+from collections.abc import Awaitable
+from typing import Annotated, TypeVar
 
 from pydantic import BaseModel, PositiveFloat, PositiveInt
 from typing_extensions import Doc
@@ -11,6 +12,8 @@ from grelmicro.resilience._protocol import RateLimitResult
 from grelmicro.resilience.errors import RateLimitExceededError
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
 
 
 class RateLimiterConfig(BaseModel, frozen=True, extra="forbid"):
@@ -87,6 +90,27 @@ class RateLimiter:
             reset_after=0.0,
         )
 
+    async def _call_backend(
+        self,
+        coro: Awaitable[_T],
+        *,
+        key: str,
+        fallback: _T,
+    ) -> _T:
+        """Call a backend method, returning fallback on error if fail_open."""
+        try:
+            return await coro
+        except Exception:
+            if self._fail_open:
+                logger.warning(
+                    "Rate limiter '%s' backend error, failing open for key '%s'",
+                    self._config.name,
+                    key,
+                    exc_info=True,
+                )
+                return fallback
+            raise
+
     async def acquire(
         self,
         *,
@@ -116,23 +140,16 @@ class RateLimiter:
             raise ValueError(msg)
         backend = get_rate_limiter_backend()
         full_key = f"{self._config.name}:{key}"
-        try:
-            return await backend.acquire(
+        return await self._call_backend(
+            backend.acquire(
                 key=full_key,
                 limit=self._config.limit,
                 window=self._config.window,
                 cost=cost,
-            )
-        except Exception:
-            if self._fail_open:
-                logger.warning(
-                    "Rate limiter '%s' backend error, failing open for key '%s'",
-                    self._config.name,
-                    key,
-                    exc_info=True,
-                )
-                return self._allowed_result()
-            raise
+            ),
+            key=key,
+            fallback=self._allowed_result(),
+        )
 
     async def acquire_or_raise(
         self,
@@ -184,22 +201,15 @@ class RateLimiter:
         """
         backend = get_rate_limiter_backend()
         full_key = f"{self._config.name}:{key}"
-        try:
-            return await backend.peek(
+        return await self._call_backend(
+            backend.peek(
                 key=full_key,
                 limit=self._config.limit,
                 window=self._config.window,
-            )
-        except Exception:
-            if self._fail_open:
-                logger.warning(
-                    "Rate limiter '%s' backend error, failing open for key '%s'",
-                    self._config.name,
-                    key,
-                    exc_info=True,
-                )
-                return self._allowed_result()
-            raise
+            ),
+            key=key,
+            fallback=self._allowed_result(),
+        )
 
     async def reset(
         self,
@@ -218,15 +228,8 @@ class RateLimiter:
         """
         backend = get_rate_limiter_backend()
         full_key = f"{self._config.name}:{key}"
-        try:
-            await backend.reset(key=full_key)
-        except Exception:
-            if self._fail_open:
-                logger.warning(
-                    "Rate limiter '%s' backend error, failing open for key '%s'",
-                    self._config.name,
-                    key,
-                    exc_info=True,
-                )
-                return
-            raise
+        await self._call_backend(
+            backend.reset(key=full_key),
+            key=key,
+            fallback=None,
+        )

--- a/grelmicro/resilience/ratelimiter.py
+++ b/grelmicro/resilience/ratelimiter.py
@@ -1,5 +1,6 @@
 """Rate Limiter."""
 
+import logging
 from typing import Annotated
 
 from pydantic import BaseModel, PositiveFloat, PositiveInt
@@ -8,6 +9,8 @@ from typing_extensions import Doc
 from grelmicro.resilience._backends import get_rate_limiter_backend
 from grelmicro.resilience._protocol import RateLimitResult
 from grelmicro.resilience.errors import RateLimitExceededError
+
+logger = logging.getLogger(__name__)
 
 
 class RateLimiterConfig(BaseModel, frozen=True, extra="forbid"):
@@ -51,6 +54,15 @@ class RateLimiter:
             PositiveFloat,
             Doc("Window duration in seconds."),
         ],
+        fail_open: Annotated[
+            bool,
+            Doc(
+                "When True, backend errors return an allowed result"
+                " instead of propagating the exception."
+                " Useful for non-critical rate limiters where"
+                " availability is more important than strictness."
+            ),
+        ] = False,
     ) -> None:
         """Initialize the rate limiter."""
         self._config = RateLimiterConfig(
@@ -58,11 +70,22 @@ class RateLimiter:
             limit=limit,
             window=window,
         )
+        self._fail_open = fail_open
 
     @property
     def config(self) -> RateLimiterConfig:
         """Return the config."""
         return self._config
+
+    def _allowed_result(self) -> RateLimitResult:
+        """Return a fully-allowed result for fail-open fallback."""
+        return RateLimitResult(
+            allowed=True,
+            limit=self._config.limit,
+            remaining=self._config.limit,
+            retry_after=0.0,
+            reset_after=0.0,
+        )
 
     async def acquire(
         self,
@@ -93,12 +116,23 @@ class RateLimiter:
             raise ValueError(msg)
         backend = get_rate_limiter_backend()
         full_key = f"{self._config.name}:{key}"
-        return await backend.acquire(
-            key=full_key,
-            limit=self._config.limit,
-            window=self._config.window,
-            cost=cost,
-        )
+        try:
+            return await backend.acquire(
+                key=full_key,
+                limit=self._config.limit,
+                window=self._config.window,
+                cost=cost,
+            )
+        except Exception:
+            if self._fail_open:
+                logger.warning(
+                    "Rate limiter '%s' backend error, failing open for key '%s'",
+                    self._config.name,
+                    key,
+                    exc_info=True,
+                )
+                return self._allowed_result()
+            raise
 
     async def acquire_or_raise(
         self,
@@ -130,3 +164,69 @@ class RateLimiter:
                 retry_after=result.retry_after,
             )
         return result
+
+    async def peek(
+        self,
+        *,
+        key: Annotated[
+            str,
+            Doc(
+                "Identifier for rate limiting"
+                " (e.g. IP address, user ID, session)."
+            ),
+        ],
+    ) -> RateLimitResult:
+        """Check rate limit state without consuming tokens.
+
+        Returns:
+            RateLimitResult reflecting the current state.
+            ``allowed`` indicates whether the next acquire would succeed.
+        """
+        backend = get_rate_limiter_backend()
+        full_key = f"{self._config.name}:{key}"
+        try:
+            return await backend.peek(
+                key=full_key,
+                limit=self._config.limit,
+                window=self._config.window,
+            )
+        except Exception:
+            if self._fail_open:
+                logger.warning(
+                    "Rate limiter '%s' backend error, failing open for key '%s'",
+                    self._config.name,
+                    key,
+                    exc_info=True,
+                )
+                return self._allowed_result()
+            raise
+
+    async def reset(
+        self,
+        *,
+        key: Annotated[
+            str,
+            Doc(
+                "Identifier for rate limiting"
+                " (e.g. IP address, user ID, session)."
+            ),
+        ],
+    ) -> None:
+        """Delete rate limit state for a key, restoring full quota.
+
+        Idempotent: resetting a nonexistent key is a no-op.
+        """
+        backend = get_rate_limiter_backend()
+        full_key = f"{self._config.name}:{key}"
+        try:
+            await backend.reset(key=full_key)
+        except Exception:
+            if self._fail_open:
+                logger.warning(
+                    "Rate limiter '%s' backend error, failing open for key '%s'",
+                    self._config.name,
+                    key,
+                    exc_info=True,
+                )
+                return
+            raise

--- a/grelmicro/resilience/ratelimiter.py
+++ b/grelmicro/resilience/ratelimiter.py
@@ -1,8 +1,7 @@
 """Rate Limiter."""
 
 import logging
-from collections.abc import Awaitable
-from typing import Annotated, TypeVar
+from typing import Annotated
 
 from pydantic import BaseModel, PositiveFloat, PositiveInt
 from typing_extensions import Doc
@@ -12,8 +11,6 @@ from grelmicro.resilience._protocol import RateLimitResult
 from grelmicro.resilience.errors import RateLimitExceededError
 
 logger = logging.getLogger(__name__)
-
-_T = TypeVar("_T")
 
 
 class RateLimiterConfig(BaseModel, frozen=True, extra="forbid"):
@@ -80,6 +77,19 @@ class RateLimiter:
         """Return the config."""
         return self._config
 
+    def _log_fail_open(
+        self,
+        key: str,
+        exc: Exception,
+    ) -> None:
+        """Log a fail-open warning for a backend error."""
+        logger.warning(
+            "Rate limiter '%s' backend error, failing open for key '%s'",
+            self._config.name,
+            key,
+            exc_info=exc,
+        )
+
     def _allowed_result(self) -> RateLimitResult:
         """Return a fully-allowed result for fail-open fallback."""
         return RateLimitResult(
@@ -89,27 +99,6 @@ class RateLimiter:
             retry_after=0.0,
             reset_after=0.0,
         )
-
-    async def _call_backend(
-        self,
-        coro: Awaitable[_T],
-        *,
-        key: str,
-        fallback: _T,
-    ) -> _T:
-        """Call a backend method, returning fallback on error if fail_open."""
-        try:
-            return await coro
-        except Exception:
-            if self._fail_open:
-                logger.warning(
-                    "Rate limiter '%s' backend error, failing open for key '%s'",
-                    self._config.name,
-                    key,
-                    exc_info=True,
-                )
-                return fallback
-            raise
 
     async def acquire(
         self,
@@ -140,16 +129,18 @@ class RateLimiter:
             raise ValueError(msg)
         backend = get_rate_limiter_backend()
         full_key = f"{self._config.name}:{key}"
-        return await self._call_backend(
-            backend.acquire(
+        try:
+            return await backend.acquire(
                 key=full_key,
                 limit=self._config.limit,
                 window=self._config.window,
                 cost=cost,
-            ),
-            key=key,
-            fallback=self._allowed_result(),
-        )
+            )
+        except Exception as exc:
+            if self._fail_open:
+                self._log_fail_open(key, exc)
+                return self._allowed_result()
+            raise
 
     async def acquire_or_raise(
         self,
@@ -201,15 +192,17 @@ class RateLimiter:
         """
         backend = get_rate_limiter_backend()
         full_key = f"{self._config.name}:{key}"
-        return await self._call_backend(
-            backend.peek(
+        try:
+            return await backend.peek(
                 key=full_key,
                 limit=self._config.limit,
                 window=self._config.window,
-            ),
-            key=key,
-            fallback=self._allowed_result(),
-        )
+            )
+        except Exception as exc:
+            if self._fail_open:
+                self._log_fail_open(key, exc)
+                return self._allowed_result()
+            raise
 
     async def reset(
         self,
@@ -228,8 +221,10 @@ class RateLimiter:
         """
         backend = get_rate_limiter_backend()
         full_key = f"{self._config.name}:{key}"
-        await self._call_backend(
-            backend.reset(key=full_key),
-            key=key,
-            fallback=None,
-        )
+        try:
+            await backend.reset(key=full_key)
+        except Exception as exc:
+            if self._fail_open:
+                self._log_fail_open(key, exc)
+                return
+            raise

--- a/grelmicro/resilience/redis.py
+++ b/grelmicro/resilience/redis.py
@@ -86,8 +86,10 @@ class RedisRateLimiterBackend(RateLimiterBackend):
         local diff = now - allow_at
         local remaining = math.floor(diff / emission_interval + 0.5)
 
+        -- Use <= 0 (not < 0 like acquire): remaining=0 means the next
+        -- acquire(cost=1) would be rejected, so peek reports allowed=false.
         if remaining <= 0 then
-            local reset_after = tat - now
+            local reset_after = math.max(0, tat - now)
             local retry_after = emission_interval - diff
             if remaining < 0 then
                 retry_after = diff * -1

--- a/grelmicro/resilience/redis.py
+++ b/grelmicro/resilience/redis.py
@@ -60,6 +60,47 @@ class RedisRateLimiterBackend(RateLimiterBackend):
         return {1, remaining, "0", tostring(reset_after)}
     """
 
+    _LUA_GCRA_PEEK = """
+        local key = KEYS[1]
+        local burst = tonumber(ARGV[1])
+        local rate = tonumber(ARGV[2])
+        local period = tonumber(ARGV[3])
+
+        local emission_interval = period / rate
+        local burst_offset = emission_interval * burst
+
+        -- Use Redis server time for cross-process consistency
+        local now = redis.call("TIME")
+        -- Offset to Jan 1 2017 to avoid double-precision issues
+        local jan_1_2017 = 1483228800
+        now = (now[1] - jan_1_2017) + (now[2] / 1000000)
+
+        local tat = redis.call("GET", key)
+        if not tat then
+            tat = now
+        else
+            tat = tonumber(tat)
+        end
+
+        -- Compute current state without consuming (cost=0)
+        local new_tat = math.max(tat, now)
+        local allow_at = new_tat - burst_offset
+        local diff = now - allow_at
+        local remaining = math.floor(diff / emission_interval + 0.5)
+
+        if remaining <= 0 then
+            local reset_after = tat - now
+            local retry_after = emission_interval - diff
+            if remaining < 0 then
+                retry_after = diff * -1
+            end
+            return {0, 0, tostring(retry_after), tostring(reset_after)}
+        end
+
+        local reset_after = math.max(tat, now) - now
+        return {1, remaining, "0", tostring(reset_after)}
+    """
+
     def __init__(
         self,
         url: Annotated[
@@ -96,6 +137,7 @@ class RedisRateLimiterBackend(RateLimiterBackend):
         )
         self._prefix = prefix
         self._lua_gcra = self._redis.register_script(self._LUA_GCRA)
+        self._lua_gcra_peek = self._redis.register_script(self._LUA_GCRA_PEEK)
         if auto_register:
             rate_limiter_backend_registry.set(self)
 
@@ -153,3 +195,53 @@ class RedisRateLimiterBackend(RateLimiterBackend):
             retry_after=retry_after,
             reset_after=reset_after,
         )
+
+    async def peek(
+        self,
+        *,
+        key: str,
+        limit: int,
+        window: float,
+    ) -> RateLimitResult:
+        """Check rate limit state without consuming tokens.
+
+        Args:
+            key: The rate limit key.
+            limit: Maximum requests allowed in the window.
+            window: Window duration in seconds.
+
+        Returns:
+            RateLimitResult reflecting the current state.
+
+        """
+        result = await self._lua_gcra_peek(
+            keys=[f"{self._prefix}{key}"],
+            args=[limit, limit, window],
+            client=self._redis,
+        )
+
+        allowed = bool(result[0])
+        remaining = int(result[1])
+        retry_after = float(result[2])
+        reset_after = float(result[3])
+
+        return RateLimitResult(
+            allowed=allowed,
+            limit=limit,
+            remaining=remaining,
+            retry_after=retry_after,
+            reset_after=reset_after,
+        )
+
+    async def reset(
+        self,
+        *,
+        key: str,
+    ) -> None:
+        """Delete rate limit state for a key, restoring full quota.
+
+        Args:
+            key: The rate limit key to reset.
+
+        """
+        await self._redis.delete(f"{self._prefix}{key}")

--- a/grelmicro/resilience/redis.py
+++ b/grelmicro/resilience/redis.py
@@ -62,12 +62,10 @@ class RedisRateLimiterBackend(RateLimiterBackend):
 
     _LUA_GCRA_PEEK = """
         local key = KEYS[1]
-        local burst = tonumber(ARGV[1])
-        local rate = tonumber(ARGV[2])
-        local period = tonumber(ARGV[3])
+        local rate = tonumber(ARGV[1])
+        local period = tonumber(ARGV[2])
 
         local emission_interval = period / rate
-        local burst_offset = emission_interval * burst
 
         -- Use Redis server time for cross-process consistency
         local now = redis.call("TIME")
@@ -84,7 +82,7 @@ class RedisRateLimiterBackend(RateLimiterBackend):
 
         -- Compute current state without consuming (cost=0)
         local new_tat = math.max(tat, now)
-        local allow_at = new_tat - burst_offset
+        local allow_at = new_tat - period
         local diff = now - allow_at
         local remaining = math.floor(diff / emission_interval + 0.5)
 
@@ -94,10 +92,10 @@ class RedisRateLimiterBackend(RateLimiterBackend):
             if remaining < 0 then
                 retry_after = diff * -1
             end
-            return {0, 0, tostring(retry_after), tostring(reset_after)}
+            return {0, 0, tostring(math.max(0, retry_after)), tostring(reset_after)}
         end
 
-        local reset_after = math.max(tat, now) - now
+        local reset_after = new_tat - now
         return {1, remaining, "0", tostring(reset_after)}
     """
 
@@ -216,7 +214,7 @@ class RedisRateLimiterBackend(RateLimiterBackend):
         """
         result = await self._lua_gcra_peek(
             keys=[f"{self._prefix}{key}"],
-            args=[limit, limit, window],
+            args=[limit, window],
             client=self._redis,
         )
 

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -1,6 +1,7 @@
 """Test RateLimiter implementation."""
 
 from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock
 
 import pytest
 from pydantic import ValidationError
@@ -284,3 +285,257 @@ def test_rate_limit_exceeded_error() -> None:
     assert error.retry_after == retry_after
     assert "192.168.1.1" in str(error)
     assert "12.5" in str(error)
+
+
+# --- peek ---
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_peek_allowed(limiter: RateLimiter) -> None:
+    """Test peek returns allowed result for fresh key."""
+    # Act
+    result = await limiter.peek(key="user:peek1")
+
+    # Assert
+    assert result.allowed is True
+    assert result.limit == LIMIT
+    assert result.remaining == LIMIT
+    assert result.retry_after == 0.0
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_peek_does_not_consume(limiter: RateLimiter) -> None:
+    """Test peek does not consume tokens."""
+    # Act
+    await limiter.peek(key="user:peek2")
+    await limiter.peek(key="user:peek2")
+    result = await limiter.acquire(key="user:peek2")
+
+    # Assert
+    assert result.remaining == LIMIT - 1
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_peek_after_exhaustion(limiter: RateLimiter) -> None:
+    """Test peek returns not allowed when limit exhausted."""
+    # Arrange
+    for _ in range(LIMIT):
+        await limiter.acquire(key="user:peek3")
+
+    # Act
+    result = await limiter.peek(key="user:peek3")
+
+    # Assert
+    assert result.allowed is False
+    assert result.remaining == 0
+    assert result.retry_after > 0.0
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_peek_reflects_remaining(limiter: RateLimiter) -> None:
+    """Test peek remaining reflects consumed tokens."""
+    # Arrange
+    await limiter.acquire(key="user:peek4", cost=3)
+
+    # Act
+    result = await limiter.peek(key="user:peek4")
+
+    # Assert
+    assert result.allowed is True
+    assert result.remaining == LIMIT - 3
+
+
+async def test_peek_without_backend() -> None:
+    """Test peek raises BackendNotLoadedError without backend."""
+    # Arrange
+    limiter = RateLimiter("test", limit=LIMIT, window=WINDOW)
+
+    # Act & Assert
+    with pytest.raises(BackendNotLoadedError):
+        await limiter.peek(key="user:1")
+
+
+# --- reset ---
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_reset_restores_quota(limiter: RateLimiter) -> None:
+    """Test reset restores full quota for a key."""
+    # Arrange
+    for _ in range(LIMIT):
+        await limiter.acquire(key="user:reset1")
+
+    # Act
+    await limiter.reset(key="user:reset1")
+    result = await limiter.acquire(key="user:reset1")
+
+    # Assert
+    assert result.allowed is True
+    assert result.remaining == LIMIT - 1
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_reset_nonexistent_key(limiter: RateLimiter) -> None:
+    """Test reset on a nonexistent key is a no-op."""
+    # Act (should not raise)
+    await limiter.reset(key="user:nonexistent")
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_reset_independent_keys(limiter: RateLimiter) -> None:
+    """Test reset only affects the specified key."""
+    # Arrange
+    await limiter.acquire(key="user:reset_a")
+    await limiter.acquire(key="user:reset_b")
+
+    # Act
+    await limiter.reset(key="user:reset_a")
+
+    # Assert
+    result_a = await limiter.peek(key="user:reset_a")
+    result_b = await limiter.peek(key="user:reset_b")
+    assert result_a.remaining == LIMIT
+    assert result_b.remaining == LIMIT - 1
+
+
+async def test_reset_without_backend() -> None:
+    """Test reset raises BackendNotLoadedError without backend."""
+    # Arrange
+    limiter = RateLimiter("test", limit=LIMIT, window=WINDOW)
+
+    # Act & Assert
+    with pytest.raises(BackendNotLoadedError):
+        await limiter.reset(key="user:1")
+
+
+# --- fail_open ---
+
+
+@pytest.fixture
+def _failing_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> MemoryRateLimiterBackend:
+    """Create a backend where all methods raise RuntimeError."""
+    backend = MemoryRateLimiterBackend()
+    error = RuntimeError("connection lost")
+    monkeypatch.setattr(backend, "acquire", AsyncMock(side_effect=error))
+    monkeypatch.setattr(backend, "peek", AsyncMock(side_effect=error))
+    monkeypatch.setattr(backend, "reset", AsyncMock(side_effect=error))
+    return backend
+
+
+@pytest.mark.usefixtures("_failing_backend")
+async def test_fail_open_acquire() -> None:
+    """Test fail_open returns allowed result on backend error."""
+    # Arrange
+    limiter = RateLimiter("test", limit=LIMIT, window=WINDOW, fail_open=True)
+
+    # Act
+    result = await limiter.acquire(key="user:1")
+
+    # Assert
+    assert result.allowed is True
+    assert result.limit == LIMIT
+    assert result.remaining == LIMIT
+
+
+@pytest.mark.usefixtures("_failing_backend")
+async def test_fail_open_false_acquire_propagates_error() -> None:
+    """Test fail_open=False propagates backend error on acquire."""
+    # Arrange
+    limiter = RateLimiter("test", limit=LIMIT, window=WINDOW, fail_open=False)
+
+    # Act & Assert
+    with pytest.raises(RuntimeError, match="connection lost"):
+        await limiter.acquire(key="user:1")
+
+
+@pytest.mark.usefixtures("_failing_backend")
+async def test_fail_open_peek() -> None:
+    """Test fail_open returns allowed result on backend peek error."""
+    # Arrange
+    limiter = RateLimiter("test", limit=LIMIT, window=WINDOW, fail_open=True)
+
+    # Act
+    result = await limiter.peek(key="user:1")
+
+    # Assert
+    assert result.allowed is True
+    assert result.remaining == LIMIT
+
+
+@pytest.mark.usefixtures("_failing_backend")
+async def test_fail_open_false_peek_propagates_error() -> None:
+    """Test fail_open=False propagates backend error on peek."""
+    # Arrange
+    limiter = RateLimiter("test", limit=LIMIT, window=WINDOW, fail_open=False)
+
+    # Act & Assert
+    with pytest.raises(RuntimeError, match="connection lost"):
+        await limiter.peek(key="user:1")
+
+
+@pytest.mark.usefixtures("_failing_backend")
+async def test_fail_open_reset() -> None:
+    """Test fail_open silently ignores backend reset error."""
+    # Arrange
+    limiter = RateLimiter("test", limit=LIMIT, window=WINDOW, fail_open=True)
+
+    # Act (should not raise)
+    await limiter.reset(key="user:1")
+
+
+@pytest.mark.usefixtures("_failing_backend")
+async def test_fail_open_false_reset_propagates_error() -> None:
+    """Test fail_open=False propagates backend error on reset."""
+    # Arrange
+    limiter = RateLimiter("test", limit=LIMIT, window=WINDOW, fail_open=False)
+
+    # Act & Assert
+    with pytest.raises(RuntimeError, match="connection lost"):
+        await limiter.reset(key="user:1")
+
+
+@pytest.mark.usefixtures("_failing_backend")
+async def test_fail_open_acquire_or_raise() -> None:
+    """Test fail_open on acquire_or_raise returns allowed on backend error."""
+    # Arrange
+    limiter = RateLimiter("test", limit=LIMIT, window=WINDOW, fail_open=True)
+
+    # Act
+    result = await limiter.acquire_or_raise(key="user:1")
+
+    # Assert
+    assert result.allowed is True
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_fail_open_still_rejects_when_limit_exceeded() -> None:
+    """Test fail_open does not bypass legitimate rate limit rejections."""
+    # Arrange
+    limiter = RateLimiter(
+        "fo_reject", limit=LIMIT, window=WINDOW, fail_open=True
+    )
+    for _ in range(LIMIT):
+        await limiter.acquire(key="user:1")
+
+    # Act
+    result = await limiter.acquire(key="user:1")
+
+    # Assert
+    assert result.allowed is False
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_fail_open_acquire_or_raise_still_raises_on_exceeded() -> None:
+    """Test fail_open acquire_or_raise still raises on legitimate exceeded."""
+    # Arrange
+    limiter = RateLimiter(
+        "fo_raise", limit=LIMIT, window=WINDOW, fail_open=True
+    )
+    for _ in range(LIMIT):
+        await limiter.acquire(key="user:1")
+
+    # Act & Assert
+    with pytest.raises(RateLimitExceededError):
+        await limiter.acquire_or_raise(key="user:1")

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -414,14 +414,13 @@ async def test_reset_without_backend() -> None:
 @pytest.fixture
 def _failing_backend(
     monkeypatch: pytest.MonkeyPatch,
-) -> MemoryRateLimiterBackend:
-    """Create a backend where all methods raise RuntimeError."""
+) -> None:
+    """Register a backend where all methods raise RuntimeError."""
     backend = MemoryRateLimiterBackend()
     error = RuntimeError("connection lost")
     monkeypatch.setattr(backend, "acquire", AsyncMock(side_effect=error))
     monkeypatch.setattr(backend, "peek", AsyncMock(side_effect=error))
     monkeypatch.setattr(backend, "reset", AsyncMock(side_effect=error))
-    return backend
 
 
 @pytest.mark.usefixtures("_failing_backend")

--- a/tests/resilience/test_ratelimiter_backends.py
+++ b/tests/resilience/test_ratelimiter_backends.py
@@ -138,3 +138,121 @@ async def test_acquire_cost(
     # Assert
     assert result.allowed is True
     assert result.remaining == LIMIT - 3
+
+
+# --- peek ---
+
+
+async def test_peek_fresh_key(
+    backend: RateLimiterBackend,
+) -> None:
+    """Test peek on a fresh key shows full quota."""
+    # Act
+    result = await backend.peek(key="peek_fresh", limit=LIMIT, window=WINDOW)
+
+    # Assert
+    assert result.allowed is True
+    assert result.limit == LIMIT
+    assert result.remaining == LIMIT
+    assert result.retry_after == 0.0
+
+
+async def test_peek_does_not_consume(
+    backend: RateLimiterBackend,
+) -> None:
+    """Test peek does not consume tokens."""
+    # Arrange
+    await backend.acquire(
+        key="peek_no_consume", limit=LIMIT, window=WINDOW, cost=1
+    )
+
+    # Act
+    result1 = await backend.peek(
+        key="peek_no_consume", limit=LIMIT, window=WINDOW
+    )
+    result2 = await backend.peek(
+        key="peek_no_consume", limit=LIMIT, window=WINDOW
+    )
+
+    # Assert
+    assert result1.remaining == result2.remaining
+    assert result1.allowed is True
+
+
+async def test_peek_after_exhaustion(
+    backend: RateLimiterBackend,
+) -> None:
+    """Test peek returns not allowed when limit exhausted."""
+    # Arrange
+    for _ in range(LIMIT):
+        await backend.acquire(
+            key="peek_exhausted", limit=LIMIT, window=WINDOW, cost=1
+        )
+
+    # Act
+    result = await backend.peek(
+        key="peek_exhausted", limit=LIMIT, window=WINDOW
+    )
+
+    # Assert
+    assert result.allowed is False
+    assert result.remaining == 0
+    assert result.retry_after > 0.0
+
+
+# --- reset ---
+
+
+async def test_reset_restores_quota(
+    backend: RateLimiterBackend,
+) -> None:
+    """Test reset restores full quota for a key."""
+    # Arrange
+    for _ in range(LIMIT):
+        await backend.acquire(
+            key="reset_restore", limit=LIMIT, window=WINDOW, cost=1
+        )
+
+    # Act
+    await backend.reset(key="reset_restore")
+    result = await backend.acquire(
+        key="reset_restore", limit=LIMIT, window=WINDOW, cost=1
+    )
+
+    # Assert
+    assert result.allowed is True
+    assert result.remaining == LIMIT - 1
+
+
+async def test_reset_nonexistent_key(
+    backend: RateLimiterBackend,
+) -> None:
+    """Test reset on a nonexistent key is a no-op."""
+    # Act (should not raise)
+    await backend.reset(key="reset_nonexistent")
+
+
+async def test_reset_independent_keys(
+    backend: RateLimiterBackend,
+) -> None:
+    """Test reset only affects the specified key."""
+    # Arrange
+    await backend.acquire(
+        key="reset_indep_a", limit=LIMIT, window=WINDOW, cost=1
+    )
+    await backend.acquire(
+        key="reset_indep_b", limit=LIMIT, window=WINDOW, cost=1
+    )
+
+    # Act
+    await backend.reset(key="reset_indep_a")
+
+    # Assert: key A is reset, key B is unchanged
+    result_a = await backend.peek(
+        key="reset_indep_a", limit=LIMIT, window=WINDOW
+    )
+    result_b = await backend.peek(
+        key="reset_indep_b", limit=LIMIT, window=WINDOW
+    )
+    assert result_a.remaining == LIMIT
+    assert result_b.remaining == LIMIT - 1


### PR DESCRIPTION
## Summary

- **`peek(key)`**: Check rate limit state without consuming tokens. Returns `RateLimitResult` where `allowed` indicates whether the next `acquire()` would succeed.
- **`reset(key)`**: Delete rate limit state for a key, restoring full quota. Idempotent (no-op on nonexistent keys).
- **`fail_open=True`**: Constructor parameter that catches backend errors (e.g. Redis down) and returns an allowed result instead of propagating the exception. Legitimate rate limit rejections still work normally.

### Backend protocol changes

`RateLimiterBackend` protocol extended with `peek()` and `reset()` methods, implemented for both Memory and Redis backends.

### Peek semantics

Uses cost=0 GCRA computation (read TAT without writing). `allowed = remaining > 0` so it correctly answers "would the next acquire succeed?"

## Test plan

- [x] Unit tests for `peek()`, `reset()`, `fail_open` on `RateLimiter` (39 tests)
- [x] Backend-level tests for `peek()` and `reset()` parametrized across Memory/Redis
- [x] `fail_open` tests cover acquire, peek, reset, acquire_or_raise
- [x] Verifies `fail_open` does NOT bypass legitimate rate limit rejections
- [x] 100% coverage on `ratelimiter.py`
- [x] All pre-commit hooks pass (ruff, ty, pytest, coverage)