### PR TITLE
feat(health): log every unhealthy check path

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* ✨ `HealthRegistry` now logs every unhealthy path via the `grelmicro.health` logger, so operators can distinguish a slow query from a timeout from a permission error without external instrumentation.
+* ✨ `HealthError` and timeouts log at `WARNING` with `exc_info`; unexpected exceptions keep logging at `ERROR` with traceback.
+
 ## 0.13.0 - 2026-04-08
 
 ### Features

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,8 +4,8 @@
 
 ### Features
 
-* ✨ `HealthRegistry` now logs every unhealthy path via the `grelmicro.health` logger, so operators can distinguish a slow query from a timeout from a permission error without external instrumentation.
-* ✨ `HealthError` and timeouts log at `WARNING` with `exc_info`; unexpected exceptions keep logging at `ERROR` with traceback.
+* ✨ `HealthRegistry` now logs every unhealthy path via the `grelmicro.health` logger, so operators can distinguish between a slow query, a timeout, and a permission error without external instrumentation.
+* ✨ `HealthError` logs at `WARNING` with `exc_info`. Timeouts log at `WARNING` without `exc_info`. Unexpected exceptions keep logging at `ERROR` with traceback.
 
 ## 0.13.0 - 2026-04-08
 

--- a/grelmicro/health/_registry.py
+++ b/grelmicro/health/_registry.py
@@ -126,6 +126,11 @@ class HealthRegistry:
                 with anyio.move_on_after(timeout) as cancel_scope:
                     result: dict[str, Any] | None = await checker.check()
                 if cancel_scope.cancelled_caught:
+                    logger.warning(
+                        "Health check '%s' timed out after %gs",
+                        checker.name,
+                        timeout,
+                    )
                     error = HealthCheckTimeoutError(
                         name=checker.name, timeout=timeout
                     )
@@ -145,6 +150,11 @@ class HealthRegistry:
                         details=result,
                     )
             except HealthError as exc:
+                logger.warning(
+                    "Health check '%s' reported unhealthy",
+                    checker.name,
+                    exc_info=exc,
+                )
                 results[index] = ComponentHealth(
                     name=checker.name,
                     status=HealthStatus.UNHEALTHY,

--- a/tests/health/test_registry.py
+++ b/tests/health/test_registry.py
@@ -365,8 +365,8 @@ async def test_timeout_logs_warning(
     assert len(records) == 1
     record = records[0]
     assert record.levelno == logging.WARNING
-    assert "slow" in record.getMessage()
-    assert "0.05" in record.getMessage()
+    assert record.args == ("slow", 0.05)
+    assert record.exc_info is None
 
 
 def test_timeout_zero_raises() -> None:

--- a/tests/health/test_registry.py
+++ b/tests/health/test_registry.py
@@ -1,5 +1,6 @@
 """Tests for Health Check Registry."""
 
+import logging
 import time
 from collections.abc import Generator
 
@@ -311,6 +312,61 @@ async def test_generic_exception_hides_message() -> None:
     report = await registry.check()
 
     assert report["components"][0]["error"] == "Health check failed"
+
+
+async def test_health_error_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """HealthError failures are logged at WARNING with exc_info."""
+    registry = HealthRegistry(auto_register=False)
+    registry.add(UnhealthyCheckerWithHealthError("db"))
+
+    with caplog.at_level(logging.WARNING, logger="grelmicro.health"):
+        await registry.check()
+
+    records = [r for r in caplog.records if r.name == "grelmicro.health"]
+    assert len(records) == 1
+    record = records[0]
+    assert record.levelno == logging.WARNING
+    assert "db" in record.getMessage()
+    assert record.exc_info is not None
+    assert "Database connection pool exhausted" in str(record.exc_info[1])
+
+
+async def test_generic_exception_logs_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unexpected exceptions are logged at ERROR with a traceback."""
+    registry = HealthRegistry(auto_register=False)
+    registry.add(UnhealthyChecker("redis"))
+
+    with caplog.at_level(logging.WARNING, logger="grelmicro.health"):
+        await registry.check()
+
+    records = [r for r in caplog.records if r.name == "grelmicro.health"]
+    assert len(records) == 1
+    record = records[0]
+    assert record.levelno == logging.ERROR
+    assert "redis" in record.getMessage()
+    assert record.exc_info is not None
+
+
+async def test_timeout_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Timed-out checks are logged at WARNING with the configured timeout."""
+    registry = HealthRegistry(timeout=0.05, auto_register=False)
+    registry.add(SlowChecker("slow", delay=1.0))
+
+    with caplog.at_level(logging.WARNING, logger="grelmicro.health"):
+        await registry.check()
+
+    records = [r for r in caplog.records if r.name == "grelmicro.health"]
+    assert len(records) == 1
+    record = records[0]
+    assert record.levelno == logging.WARNING
+    assert "slow" in record.getMessage()
+    assert "0.05" in record.getMessage()
 
 
 def test_timeout_zero_raises() -> None:


### PR DESCRIPTION
## Summary
- `HealthRegistry` now emits a log record for every non-healthy outcome on the `grelmicro.health` logger, so operators can distinguish a slow query, a timeout, and a permission error without external instrumentation.
- `HealthError` and timeouts log at `WARNING`; unexpected exceptions keep logging at `ERROR` with traceback. Timeout records intentionally carry no `exc_info` (the cancel scope swallowed the cancellation).
- Tests assert on `record.args` for the timeout case instead of rendered strings, so format tweaks cannot silently mislead the check.

## Test plan
- [x] `uv run pytest tests/health/test_registry.py` — 29 passed
- [x] Pre-commit hooks (ruff, ty-check, pytest unit + integration, coverage) pass
- [ ] Manual probe under a real failing checker to eyeball log output

## Notes
A dedup helper for the repeated `caplog` → filter pattern in these tests was intentionally deferred — it belongs in a future `grelmicro.logging` helper usable beyond the health module.