### PR TITLE
✨ feat: Add DuplicateFilter for noisy repeated log records

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@
 
 * ✨ `HealthRegistry` now logs every unhealthy path via the `grelmicro.health` logger, so operators can distinguish between a slow query, a timeout, and a permission error without external instrumentation.
 * ✨ `HealthError` logs at `WARNING` with `exc_info`. Timeouts log at `WARNING` without `exc_info`. Unexpected exceptions keep logging at `ERROR` with traceback.
-* ✨ Add `grelmicro.logging.DuplicateFilter`, a stdlib `logging.Filter` that caps repeated records per `(logger, level, rendered message)` key. Inspired by Logback's `DuplicateMessageFilter`; bounded LRU, thread-safe, silent drops.
+* ✨ Add `grelmicro.logging.DuplicateFilter`, a stdlib `logging.Filter` that caps repeated records per `(logger, level, format template)` key. Bounded LRU, thread-safe, silent drops. `key_mode="rendered"` switches to per-rendered-message keying; `ttl_seconds` adds lazy time-based counter reset for long-running services.
 
 ## 0.13.0 - 2026-04-08
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 * ✨ `HealthRegistry` now logs every unhealthy path via the `grelmicro.health` logger, so operators can distinguish between a slow query, a timeout, and a permission error without external instrumentation.
 * ✨ `HealthError` logs at `WARNING` with `exc_info`. Timeouts log at `WARNING` without `exc_info`. Unexpected exceptions keep logging at `ERROR` with traceback.
+* ✨ Add `grelmicro.logging.DuplicateFilter`, a stdlib `logging.Filter` that caps repeated records per `(logger, level, rendered message)` key. Inspired by Logback's `DuplicateMessageFilter`; bounded LRU, thread-safe, silent drops.
 
 ## 0.13.0 - 2026-04-08
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -412,18 +412,20 @@ class ErrorDict:
 
 After **5** identical records the filter silently drops further occurrences. Up to **100** distinct keys are tracked in an LRU.
 
-`key_mode="template"` (default) keys on the raw format string — `%`-style calls with different arguments share one counter and it is **~3× faster** than rendered keying. Use `key_mode="rendered"` to distinguish each rendered message, or pass `key=` for a custom fingerprint:
+`key_mode="template"` (default) keys on the raw format string: `%`-style calls with different arguments share one counter, and it is **~3× faster** than rendered keying. Use `key_mode="rendered"` to distinguish each rendered message, or pass `key=` for a custom fingerprint:
 
 ```python
 logger.addFilter(DuplicateFilter(key_mode="rendered"))
 logger.addFilter(DuplicateFilter(key=lambda r: (r.name, r.exc_info)))
 ```
 
-Set `ttl_seconds` to let suppressed keys re-emerge after a silence window:
+Set `ttl_seconds` to re-emit a burst of `allowed_repetitions` records every window during sustained floods, so operators keep getting periodic reminders:
 
 ```python
 logger.addFilter(DuplicateFilter(allowed_repetitions=5, ttl_seconds=300))
 ```
+
+State is in-process only. There is no cross-process sharing and no explicit reset API: construct a new filter if you need to wipe counters.
 
 !!! tip
     `DuplicateFilter` attaches to any stdlib logger, so it works with every `LOG_BACKEND`. For code using `from loguru import logger` or `structlog.get_logger()` directly, use those libraries' native filtering.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -404,24 +404,29 @@ class ErrorDict:
 
 ## Deduplicating Noisy Logs
 
-A periodic check that fails every few seconds (health probes, leader elections, circuit breakers) floods logs with near-identical records. `DuplicateFilter` is a `logging.Filter` that caps repeats per message, modeled on Logback's `DuplicateMessageFilter`.
+`DuplicateFilter` is a `logging.Filter` that silences repeated log records.
 
 ```python
 --8<-- "logging/duplicate_filter.py"
 ```
 
-Defaults: the first **5** records per key pass; subsequent records are silently dropped. Up to **100** distinct keys are tracked in an LRU; the least-recently-seen key is evicted when full.
+After **5** identical records the filter silently drops further occurrences. Up to **100** distinct keys are tracked in an LRU.
 
-The default key is `(logger_name, level, record.getMessage())` — the **rendered message**. Two log calls collapse when they would print identical text, regardless of whether they came from `%`-style formatting or an f-string. `logger.warning("check %s failed", "db")` and `logger.warning(f"check db failed")` share the same bucket; `"db"` and `"redis"` keep independent counters. Pass `key=` to override (e.g., raw `record.msg` for Logback-style template keying):
+`key_mode="template"` (default) keys on the raw format string — `%`-style calls with different arguments share one counter and it is **~3× faster** than rendered keying. Use `key_mode="rendered"` to distinguish each rendered message, or pass `key=` for a custom fingerprint:
 
 ```python
-filt = DuplicateFilter(key=lambda r: (r.name, r.levelno, r.msg))
+logger.addFilter(DuplicateFilter(key_mode="rendered"))
+logger.addFilter(DuplicateFilter(key=lambda r: (r.name, r.exc_info)))
 ```
 
-!!! note "Why not emit a suppression summary?"
-    Every major logger surveyed (Logback, Log4j2, zap, zerolog, `slog-sampling`) drops silently. Summaries belong in issue trackers (Sentry) rather than log filters.
+Set `ttl_seconds` to let suppressed keys re-emerge after a silence window:
 
-`DuplicateFilter` is a plain `logging.Filter`, so it attaches to any stdlib logger and runs before any backend-specific handling. This means it works with every `LOG_BACKEND` (`stdlib`, `loguru`, `structlog`) for any logger obtained via `logging.getLogger(...)` -- including every grelmicro module (`grelmicro.health`, `grelmicro.task`, `grelmicro.sync`, `grelmicro.resilience`). For user code that uses `from loguru import logger` or `structlog.get_logger()` directly, use those libraries' native filtering (`filter=` option for loguru, processor chain for structlog).
+```python
+logger.addFilter(DuplicateFilter(allowed_repetitions=5, ttl_seconds=300))
+```
+
+!!! tip
+    `DuplicateFilter` attaches to any stdlib logger, so it works with every `LOG_BACKEND`. For code using `from loguru import logger` or `structlog.get_logger()` directly, use those libraries' native filtering.
 
 ## Production Deployment
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -402,6 +402,27 @@ class ErrorDict:
 
 **Collision protection**: Core fields cannot be overwritten by user-supplied extra context.
 
+## Deduplicating Noisy Logs
+
+A periodic check that fails every few seconds (health probes, leader elections, circuit breakers) floods logs with near-identical records. `DuplicateFilter` is a `logging.Filter` that caps repeats per message, modeled on Logback's `DuplicateMessageFilter`.
+
+```python
+--8<-- "logging/duplicate_filter.py"
+```
+
+Defaults: the first **5** records per key pass; subsequent records are silently dropped. Up to **100** distinct keys are tracked in an LRU; the least-recently-seen key is evicted when full.
+
+The default key is `(logger_name, level, record.getMessage())` — the **rendered message**. Two log calls collapse when they would print identical text, regardless of whether they came from `%`-style formatting or an f-string. `logger.warning("check %s failed", "db")` and `logger.warning(f"check db failed")` share the same bucket; `"db"` and `"redis"` keep independent counters. Pass `key=` to override (e.g., raw `record.msg` for Logback-style template keying):
+
+```python
+filt = DuplicateFilter(key=lambda r: (r.name, r.levelno, r.msg))
+```
+
+!!! note "Why not emit a suppression summary?"
+    Every major logger surveyed (Logback, Log4j2, zap, zerolog, `slog-sampling`) drops silently. Summaries belong in issue trackers (Sentry) rather than log filters.
+
+`DuplicateFilter` is a plain `logging.Filter`, so it attaches to any stdlib logger and runs before any backend-specific handling. This means it works with every `LOG_BACKEND` (`stdlib`, `loguru`, `structlog`) for any logger obtained via `logging.getLogger(...)` -- including every grelmicro module (`grelmicro.health`, `grelmicro.task`, `grelmicro.sync`, `grelmicro.resilience`). For user code that uses `from loguru import logger` or `structlog.get_logger()` directly, use those libraries' native filtering (`filter=` option for loguru, processor chain for structlog).
+
 ## Production Deployment
 
 For strict unbuffered output (12-factor compliance):

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -4,6 +4,8 @@
     options:
       show_submodules: true
       members:
+        - DuplicateFilter
+        - DuplicateFilterConfig
         - JSONRecordDict
         - configure_logging
 

--- a/docs/snippets/logging/duplicate_filter.py
+++ b/docs/snippets/logging/duplicate_filter.py
@@ -1,0 +1,6 @@
+from logging import getLogger
+
+from grelmicro.logging import DuplicateFilter
+
+logger = getLogger("grelmicro.health")
+logger.addFilter(DuplicateFilter(allowed_repetitions=5, cache_size=100))

--- a/docs/snippets/logging/duplicate_filter.py
+++ b/docs/snippets/logging/duplicate_filter.py
@@ -3,4 +3,4 @@ from logging import getLogger
 from grelmicro.logging import DuplicateFilter
 
 logger = getLogger("grelmicro.health")
-logger.addFilter(DuplicateFilter(allowed_repetitions=5, cache_size=100))
+logger.addFilter(DuplicateFilter())

--- a/grelmicro/logging/__init__.py
+++ b/grelmicro/logging/__init__.py
@@ -2,6 +2,7 @@
 
 from pydantic import ValidationError
 
+from grelmicro.logging._dedup import DuplicateFilter, DuplicateFilterConfig
 from grelmicro.logging.config import LoggingBackendType, LoggingSettings
 from grelmicro.logging.errors import (
     LoggingError,
@@ -54,6 +55,8 @@ def configure_logging() -> None:
 
 
 __all__ = [
+    "DuplicateFilter",
+    "DuplicateFilterConfig",
     "ErrorDict",
     "JSONRecordDict",
     "LoggingError",

--- a/grelmicro/logging/_dedup.py
+++ b/grelmicro/logging/_dedup.py
@@ -88,13 +88,17 @@ class DuplicateFilter(Filter):
 
     Keys are tracked in an LRU cache of at most ``cache_size``
     entries. Choose the default key via ``key_mode`` or supply
-    ``key`` to override. Set ``ttl_seconds`` to reset a counter
-    after that much silence on the key. ``key_mode="template"``
-    is roughly 3x faster than ``"rendered"`` because it skips
-    message formatting.
+    ``key`` to override. Set ``ttl_seconds`` to re-emit a burst of
+    ``allowed_repetitions`` records every ``ttl_seconds`` during a
+    sustained flood, so operators get periodic reminders that the
+    issue persists. ``key_mode="template"`` is roughly 3x faster
+    than ``"rendered"`` because it skips message formatting.
 
     Thread-safe: a :class:`threading.Lock` protects the counter
     map. The user-supplied ``key`` callable runs outside the lock.
+
+    State is in-process only; there is no cross-process sharing
+    and no reset API. Construct a new filter to wipe counters.
     """
 
     def __init__(
@@ -176,7 +180,6 @@ class DuplicateFilter(Filter):
                 counts.move_to_end(key)
                 return True
             if count > allowed:
-                counts[key] = (count, now)
                 counts.move_to_end(key)
                 return False
             counts[key] = (count + 1, now)

--- a/grelmicro/logging/_dedup.py
+++ b/grelmicro/logging/_dedup.py
@@ -1,0 +1,137 @@
+"""Duplicate message filter.
+
+Modeled after Logback's ``DuplicateMessageFilter``. Keeps an LRU
+cache of recent keys and drops records once a key has been seen
+more than ``allowed_repetitions`` times.
+"""
+
+from collections import OrderedDict
+from collections.abc import Callable, Hashable
+from logging import Filter, LogRecord
+from threading import Lock
+from typing import Annotated
+
+from pydantic import BaseModel, PositiveInt
+from typing_extensions import Doc
+
+
+class DuplicateFilterConfig(BaseModel, frozen=True, extra="forbid"):
+    """Duplicate Filter Config."""
+
+    allowed_repetitions: Annotated[
+        PositiveInt,
+        Doc(
+            "Maximum number of records per key that pass the filter "
+            "before subsequent records are dropped."
+        ),
+    ] = 5
+    cache_size: Annotated[
+        PositiveInt,
+        Doc(
+            "Maximum number of distinct keys tracked. When exceeded, "
+            "the least-recently-seen key is evicted."
+        ),
+    ] = 100
+
+
+def _default_key(record: LogRecord) -> tuple[str, int, str]:
+    """Return ``(logger, level, rendered message)`` for a record.
+
+    Uses ``record.getMessage()`` so the key reflects what a human
+    reads in the log. This works identically for ``%``-style calls
+    (``logger.warning("%s failed", name)``) and f-string calls
+    (``logger.warning(f"{name} failed")``): two calls producing the
+    same rendered text collapse into the same bucket, while calls
+    with different subjects keep distinct counters.
+
+    If rendering fails (for example, a ``%``/``args`` mismatch),
+    fall back to ``str(record.msg)`` so a broken log call cannot
+    raise from inside the filter.
+    """
+    try:
+        rendered = record.getMessage()
+    except Exception:  # noqa: BLE001
+        rendered = str(record.msg)
+    return (record.name, record.levelno, rendered)
+
+
+class DuplicateFilter(Filter):
+    """Drop log records that repeat beyond an allowed count.
+
+    After a key has been seen ``allowed_repetitions`` times, every
+    further record with the same key is silently dropped. Keys are
+    tracked in an LRU cache bounded by ``cache_size`` entries; a
+    key evicted under size pressure starts fresh the next time it
+    appears, so a long-suppressed message may re-emerge once the
+    cache has been fully recycled.
+
+    The default key is ``(record.name, record.levelno,
+    record.getMessage())`` -- the rendered message -- so two log
+    calls collapse when they would print identical text, regardless
+    of whether they came from a ``%``-style call or an f-string.
+    Pass ``key=`` to fingerprint on other attributes of the record
+    (for example, the raw ``record.msg`` template).
+
+    Thread-safe: a :class:`threading.Lock` protects the counter map.
+    The user-supplied ``key`` callable runs outside the lock, so it
+    must be pure or manage its own synchronization.
+    """
+
+    def __init__(
+        self,
+        *,
+        allowed_repetitions: Annotated[
+            PositiveInt,
+            Doc(
+                "Maximum number of records per key that pass the "
+                "filter before subsequent records are dropped."
+            ),
+        ] = 5,
+        cache_size: Annotated[
+            PositiveInt,
+            Doc(
+                "Maximum number of distinct keys tracked. When "
+                "exceeded, the least-recently-seen key is evicted."
+            ),
+        ] = 100,
+        key: Annotated[
+            Callable[[LogRecord], Hashable] | None,
+            Doc(
+                "Override the default key function. Receives the "
+                "record and returns any hashable value."
+            ),
+        ] = None,
+    ) -> None:
+        """Initialize the filter."""
+        super().__init__()
+        self._config = DuplicateFilterConfig(
+            allowed_repetitions=allowed_repetitions,
+            cache_size=cache_size,
+        )
+        self._key_fn = key or _default_key
+        self._counts: OrderedDict[Hashable, int] = OrderedDict()
+        self._lock = Lock()
+
+    @property
+    def config(self) -> DuplicateFilterConfig:
+        """Return the config."""
+        return self._config
+
+    def filter(self, record: LogRecord) -> bool:
+        """Return ``True`` if the record should pass, ``False`` to drop."""
+        key = self._key_fn(record)
+        counts = self._counts
+        allowed = self._config.allowed_repetitions
+        with self._lock:
+            current = counts.get(key)
+            if current is None:
+                counts[key] = 1
+                if len(counts) > self._config.cache_size:
+                    counts.popitem(last=False)
+                return True
+            if current > allowed:
+                counts.move_to_end(key)
+                return False
+            counts[key] = current + 1
+            counts.move_to_end(key)
+            return current < allowed

--- a/grelmicro/logging/_dedup.py
+++ b/grelmicro/logging/_dedup.py
@@ -1,18 +1,21 @@
 """Duplicate message filter.
 
-Modeled after Logback's ``DuplicateMessageFilter``. Keeps an LRU
-cache of recent keys and drops records once a key has been seen
-more than ``allowed_repetitions`` times.
+Stdlib :class:`logging.Filter` that caps repeats per key using a
+bounded LRU cache, with optional time-based counter reset. See
+the logging user guide for semantics, examples, and trade-offs.
 """
 
 from collections import OrderedDict
 from collections.abc import Callable, Hashable
 from logging import Filter, LogRecord
 from threading import Lock
-from typing import Annotated
+from time import monotonic
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, PositiveInt
+from pydantic import BaseModel, PositiveFloat, PositiveInt
 from typing_extensions import Doc
+
+KeyMode = Literal["rendered", "template"]
 
 
 class DuplicateFilterConfig(BaseModel, frozen=True, extra="forbid"):
@@ -32,21 +35,32 @@ class DuplicateFilterConfig(BaseModel, frozen=True, extra="forbid"):
             "the least-recently-seen key is evicted."
         ),
     ] = 100
+    key_mode: Annotated[
+        KeyMode,
+        Doc(
+            'Default key strategy. "template" (default) uses '
+            "``str(record.msg)`` and is ~3x faster; ``%``-style "
+            "parameterized calls collapse across argument values. "
+            '"rendered" uses ``record.getMessage()`` to '
+            "distinguish per-subject."
+        ),
+    ] = "template"
+    ttl_seconds: Annotated[
+        PositiveFloat | None,
+        Doc(
+            "Silence window for automatic counter reset. If a key "
+            "has not been hit for ``ttl_seconds``, its counter "
+            "resets on the next occurrence. ``None`` (default) "
+            "disables time-based expiry; only LRU eviction can "
+            "reset a counter."
+        ),
+    ] = None
 
 
-def _default_key(record: LogRecord) -> tuple[str, int, str]:
-    """Return ``(logger, level, rendered message)`` for a record.
+def _key_by_rendered(record: LogRecord) -> tuple[str, int, str]:
+    """Return ``(logger, level, rendered message)``.
 
-    Uses ``record.getMessage()`` so the key reflects what a human
-    reads in the log. This works identically for ``%``-style calls
-    (``logger.warning("%s failed", name)``) and f-string calls
-    (``logger.warning(f"{name} failed")``): two calls producing the
-    same rendered text collapse into the same bucket, while calls
-    with different subjects keep distinct counters.
-
-    If rendering fails (for example, a ``%``/``args`` mismatch),
-    fall back to ``str(record.msg)`` so a broken log call cannot
-    raise from inside the filter.
+    Falls back to ``str(record.msg)`` if rendering raises.
     """
     try:
         rendered = record.getMessage()
@@ -55,26 +69,32 @@ def _default_key(record: LogRecord) -> tuple[str, int, str]:
     return (record.name, record.levelno, rendered)
 
 
+def _key_by_template(record: LogRecord) -> tuple[str, int, str]:
+    """Return ``(logger, level, raw format template)``.
+
+    Skips ``getMessage()`` so it is ~3x faster than rendered keying.
+    """
+    return (record.name, record.levelno, str(record.msg))
+
+
+_KEY_FUNCS: dict[KeyMode, Callable[[LogRecord], Hashable]] = {
+    "rendered": _key_by_rendered,
+    "template": _key_by_template,
+}
+
+
 class DuplicateFilter(Filter):
-    """Drop log records that repeat beyond an allowed count.
+    """Drop log records that repeat beyond ``allowed_repetitions``.
 
-    After a key has been seen ``allowed_repetitions`` times, every
-    further record with the same key is silently dropped. Keys are
-    tracked in an LRU cache bounded by ``cache_size`` entries; a
-    key evicted under size pressure starts fresh the next time it
-    appears, so a long-suppressed message may re-emerge once the
-    cache has been fully recycled.
+    Keys are tracked in an LRU cache of at most ``cache_size``
+    entries. Choose the default key via ``key_mode`` or supply
+    ``key`` to override. Set ``ttl_seconds`` to reset a counter
+    after that much silence on the key. ``key_mode="template"``
+    is roughly 3x faster than ``"rendered"`` because it skips
+    message formatting.
 
-    The default key is ``(record.name, record.levelno,
-    record.getMessage())`` -- the rendered message -- so two log
-    calls collapse when they would print identical text, regardless
-    of whether they came from a ``%``-style call or an f-string.
-    Pass ``key=`` to fingerprint on other attributes of the record
-    (for example, the raw ``record.msg`` template).
-
-    Thread-safe: a :class:`threading.Lock` protects the counter map.
-    The user-supplied ``key`` callable runs outside the lock, so it
-    must be pure or manage its own synchronization.
+    Thread-safe: a :class:`threading.Lock` protects the counter
+    map. The user-supplied ``key`` callable runs outside the lock.
     """
 
     def __init__(
@@ -94,6 +114,22 @@ class DuplicateFilter(Filter):
                 "exceeded, the least-recently-seen key is evicted."
             ),
         ] = 100,
+        key_mode: Annotated[
+            KeyMode,
+            Doc(
+                'Default key strategy: "template" (default) uses '
+                '``str(record.msg)``; "rendered" uses '
+                "``record.getMessage()``. "
+                "Ignored when ``key`` is set."
+            ),
+        ] = "template",
+        ttl_seconds: Annotated[
+            PositiveFloat | None,
+            Doc(
+                "Silence window for automatic counter reset. "
+                "``None`` disables time-based expiry."
+            ),
+        ] = None,
         key: Annotated[
             Callable[[LogRecord], Hashable] | None,
             Doc(
@@ -107,9 +143,11 @@ class DuplicateFilter(Filter):
         self._config = DuplicateFilterConfig(
             allowed_repetitions=allowed_repetitions,
             cache_size=cache_size,
+            key_mode=key_mode,
+            ttl_seconds=ttl_seconds,
         )
-        self._key_fn = key or _default_key
-        self._counts: OrderedDict[Hashable, int] = OrderedDict()
+        self._key_fn = key if key is not None else _KEY_FUNCS[key_mode]
+        self._counts: OrderedDict[Hashable, tuple[int, float]] = OrderedDict()
         self._lock = Lock()
 
     @property
@@ -121,17 +159,26 @@ class DuplicateFilter(Filter):
         """Return ``True`` if the record should pass, ``False`` to drop."""
         key = self._key_fn(record)
         counts = self._counts
-        allowed = self._config.allowed_repetitions
+        config = self._config
+        allowed = config.allowed_repetitions
+        ttl = config.ttl_seconds
+        now = monotonic()
         with self._lock:
-            current = counts.get(key)
-            if current is None:
-                counts[key] = 1
-                if len(counts) > self._config.cache_size:
+            entry = counts.get(key)
+            if entry is None:
+                counts[key] = (1, now)
+                if len(counts) > config.cache_size:
                     counts.popitem(last=False)
                 return True
-            if current > allowed:
+            count, last_seen = entry
+            if ttl is not None and now - last_seen > ttl:
+                counts[key] = (1, now)
+                counts.move_to_end(key)
+                return True
+            if count > allowed:
+                counts[key] = (count, now)
                 counts.move_to_end(key)
                 return False
-            counts[key] = current + 1
+            counts[key] = (count + 1, now)
             counts.move_to_end(key)
-            return current < allowed
+            return count < allowed

--- a/tests/logging/conftest.py
+++ b/tests/logging/conftest.py
@@ -2,10 +2,14 @@
 
 import json
 import logging
+from collections.abc import Generator
 from typing import Any
 
+import pytest
 import structlog
 from loguru import logger as loguru_logger
+
+BACKENDS = ["loguru", "structlog", "stdlib"]
 
 
 def parse_json_log(output: str) -> dict[str, Any]:
@@ -28,3 +32,50 @@ def log_message(backend: str, msg: str, **kwargs: object) -> None:
     else:
         stdlib_logger = logging.getLogger(__name__)
         stdlib_logger.info(msg, extra=kwargs)
+
+
+@pytest.fixture
+def reset_loguru() -> Generator[None, None, None]:
+    """Reset loguru configuration."""
+    loguru_logger.configure(handlers=[])
+    yield
+    loguru_logger.remove()
+
+
+@pytest.fixture
+def reset_structlog() -> Generator[None, None, None]:
+    """Reset structlog configuration."""
+    structlog.reset_defaults()
+    yield
+    structlog.reset_defaults()
+
+
+@pytest.fixture
+def reset_stdlib() -> Generator[None, None, None]:
+    """Reset stdlib logging configuration (root and child loggers)."""
+    root = logging.getLogger()
+    old_handlers = root.handlers.copy()
+    old_level = root.level
+    manager = root.manager
+    old_logger_levels = {
+        name: logger.level
+        for name, logger in manager.loggerDict.items()
+        if isinstance(logger, logging.Logger)
+    }
+    root.handlers.clear()
+    yield
+    root.handlers.clear()
+    root.handlers.extend(old_handlers)
+    root.setLevel(old_level)
+    for name, level in old_logger_levels.items():
+        logging.getLogger(name).setLevel(level)
+
+
+@pytest.fixture
+def reset_backend(
+    reset_loguru: None,
+    reset_structlog: None,
+    reset_stdlib: None,
+) -> None:
+    """Reset all backends before each test."""
+    _ = reset_loguru, reset_structlog, reset_stdlib

--- a/tests/logging/test_backends.py
+++ b/tests/logging/test_backends.py
@@ -5,7 +5,6 @@ identically for the public API.
 """
 
 import logging
-from collections.abc import Generator
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
@@ -28,60 +27,7 @@ from grelmicro.logging._shared import (
 )
 from grelmicro.logging._structlog import _add_caller_info
 from grelmicro.logging.errors import LoggingSettingsValidationError
-from tests.logging.conftest import log_message, parse_json_log
-
-# Backend configurations
-BACKENDS = ["loguru", "structlog", "stdlib"]
-
-
-@pytest.fixture
-def reset_loguru() -> Generator[None, None, None]:
-    """Reset loguru configuration."""
-    loguru_logger.configure(handlers=[])
-    yield
-    loguru_logger.remove()
-
-
-@pytest.fixture
-def reset_structlog() -> Generator[None, None, None]:
-    """Reset structlog configuration."""
-    structlog.reset_defaults()
-    yield
-    structlog.reset_defaults()
-
-
-@pytest.fixture
-def reset_stdlib() -> Generator[None, None, None]:
-    """Reset stdlib logging configuration (root and child loggers)."""
-    root = logging.getLogger()
-    old_handlers = root.handlers.copy()
-    old_level = root.level
-    # Capture child logger state
-    manager = root.manager
-    old_logger_levels = {
-        name: logger.level
-        for name, logger in manager.loggerDict.items()
-        if isinstance(logger, logging.Logger)
-    }
-    root.handlers.clear()
-    yield
-    root.handlers.clear()
-    root.handlers.extend(old_handlers)
-    root.setLevel(old_level)
-    # Restore child logger levels
-    for name, level in old_logger_levels.items():
-        logging.getLogger(name).setLevel(level)
-
-
-@pytest.fixture
-def reset_backend(
-    reset_loguru: None,
-    reset_structlog: None,
-    reset_stdlib: None,
-) -> None:
-    """Reset all backends before each test."""
-    _ = reset_loguru, reset_structlog, reset_stdlib
-
+from tests.logging.conftest import BACKENDS, log_message, parse_json_log
 
 _USER_ID = 123
 _USER_ID_2 = 456

--- a/tests/logging/test_dedup.py
+++ b/tests/logging/test_dedup.py
@@ -1,0 +1,286 @@
+"""Tests for the DuplicateFilter."""
+
+import logging
+from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from pydantic import ValidationError
+
+from grelmicro.logging import DuplicateFilter, configure_logging
+from tests.logging.conftest import BACKENDS
+
+
+def _make_record(
+    name: str = "grelmicro.test",
+    level: int = logging.WARNING,
+    msg: str = "example",
+    args: tuple[object, ...] = (),
+) -> logging.LogRecord:
+    """Build a LogRecord for filter testing."""
+    return logging.LogRecord(
+        name=name,
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=args,
+        exc_info=None,
+    )
+
+
+@pytest.fixture
+def dedup_logger() -> Generator[logging.Logger, None, None]:
+    """Yield a named logger and strip any attached filters after."""
+    logger = logging.getLogger("grelmicro.test.dedup_integration")
+    logger.setLevel(logging.WARNING)
+    try:
+        yield logger
+    finally:
+        for flt in list(logger.filters):
+            logger.removeFilter(flt)
+
+
+def test_allows_first_n_then_drops() -> None:
+    """First ``allowed_repetitions`` records pass, subsequent are dropped."""
+    filt = DuplicateFilter(allowed_repetitions=3)
+    record = _make_record()
+
+    results = [filt.filter(record) for _ in range(5)]
+
+    assert results == [True, True, True, False, False]
+
+
+def test_default_allowed_repetitions_is_five() -> None:
+    """Default allowance matches Logback's DuplicateMessageFilter."""
+    expected = 5
+    filt = DuplicateFilter()
+    record = _make_record()
+
+    passed = sum(1 for _ in range(10) if filt.filter(record))
+
+    assert passed == expected
+
+
+def test_distinct_keys_tracked_independently() -> None:
+    """Different keys do not share repetition counters."""
+    filt = DuplicateFilter(allowed_repetitions=2)
+    record_a = _make_record(msg="a")
+    record_b = _make_record(msg="b")
+
+    results = [
+        filt.filter(record_a),
+        filt.filter(record_a),
+        filt.filter(record_a),
+        filt.filter(record_b),
+        filt.filter(record_b),
+        filt.filter(record_b),
+    ]
+
+    assert results == [True, True, False, True, True, False]
+
+
+def test_different_rendered_messages_dedup_independently() -> None:
+    """Same template, different args -> distinct rendered -> own counters."""
+    filt = DuplicateFilter(allowed_repetitions=1)
+    template = "check %s failed"
+
+    results = [
+        filt.filter(_make_record(msg=template, args=("db",))),
+        filt.filter(_make_record(msg=template, args=("db",))),
+        filt.filter(_make_record(msg=template, args=("redis",))),
+        filt.filter(_make_record(msg=template, args=("redis",))),
+    ]
+
+    assert results == [True, False, True, False]
+
+
+def test_fstring_style_dedup() -> None:
+    """f-string callers (already-rendered msg, no args) dedup correctly."""
+    filt = DuplicateFilter(allowed_repetitions=2)
+    record = _make_record(msg="check db failed", args=())
+
+    results = [filt.filter(record) for _ in range(4)]
+
+    assert results == [True, True, False, False]
+
+
+def test_percent_and_fstring_with_same_output_share_counter() -> None:
+    """Two call styles producing the same rendered string collapse."""
+    filt = DuplicateFilter(allowed_repetitions=1)
+    percent_style = _make_record(msg="check %s failed", args=("db",))
+    fstring_style = _make_record(msg="check db failed", args=())
+
+    first = filt.filter(percent_style)
+    second = filt.filter(fstring_style)
+
+    assert first
+    assert not second
+
+
+def test_different_levels_do_not_collapse() -> None:
+    """Same template at different levels is considered distinct."""
+    filt = DuplicateFilter(allowed_repetitions=1)
+    template = "boom"
+    warning_record = _make_record(msg=template, level=logging.WARNING)
+    error_record = _make_record(msg=template, level=logging.ERROR)
+
+    first_warning = filt.filter(warning_record)
+    first_error = filt.filter(error_record)
+    second_warning = filt.filter(warning_record)
+
+    assert first_warning
+    assert first_error
+    assert not second_warning
+
+
+def test_different_loggers_do_not_collapse() -> None:
+    """Same template under different logger names is distinct."""
+    filt = DuplicateFilter(allowed_repetitions=1)
+    record_a = _make_record(name="a", msg="same")
+    record_b = _make_record(name="b", msg="same")
+
+    first_a = filt.filter(record_a)
+    first_b = filt.filter(record_b)
+    second_a = filt.filter(record_a)
+
+    assert first_a
+    assert first_b
+    assert not second_a
+
+
+def test_lru_evicts_least_recently_seen() -> None:
+    """Cache bound evicts the oldest untouched key when full."""
+    filt = DuplicateFilter(allowed_repetitions=1, cache_size=2)
+    record_a = _make_record(msg="a")
+    record_b = _make_record(msg="b")
+    record_c = _make_record(msg="c")
+
+    results = [
+        filt.filter(record_a),
+        filt.filter(record_b),
+        filt.filter(record_c),
+        filt.filter(record_a),
+    ]
+
+    assert results == [True, True, True, True]
+
+
+def test_lru_keeps_hot_keys() -> None:
+    """Recently-hit keys stay in the cache despite size pressure."""
+    filt = DuplicateFilter(allowed_repetitions=1, cache_size=2)
+    hot = _make_record(msg="hot")
+    cold_x = _make_record(msg="x")
+    cold_y = _make_record(msg="y")
+
+    results = [
+        filt.filter(hot),
+        filt.filter(cold_x),
+        filt.filter(hot),
+        filt.filter(cold_y),
+        filt.filter(hot),
+    ]
+
+    assert results == [True, True, False, True, False]
+
+
+def test_key_override() -> None:
+    """Custom key function replaces the default fingerprint."""
+    filt = DuplicateFilter(
+        allowed_repetitions=1,
+        key=lambda record: record.levelno,
+    )
+    record_one = _make_record(msg="one")
+    record_two = _make_record(msg="two")
+
+    first = filt.filter(record_one)
+    second = filt.filter(record_two)
+
+    assert first
+    assert not second
+
+
+def test_thread_safe_counting() -> None:
+    """Concurrent calls produce exactly ``allowed_repetitions`` passes."""
+    allowed = 50
+    filt = DuplicateFilter(allowed_repetitions=allowed, cache_size=1)
+
+    def hit(_: int) -> bool:
+        return filt.filter(_make_record())
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        results = list(pool.map(hit, range(1000)))
+
+    assert sum(results) == allowed
+
+
+def test_integration_with_logger(
+    caplog: pytest.LogCaptureFixture,
+    dedup_logger: logging.Logger,
+) -> None:
+    """Attaching the filter to a logger suppresses repeated records."""
+    allowed = 2
+    filt = DuplicateFilter(allowed_repetitions=allowed)
+    dedup_logger.addFilter(filt)
+
+    with caplog.at_level(logging.WARNING, logger=dedup_logger.name):
+        for _ in range(5):
+            dedup_logger.warning("flooded")
+
+    records = [r for r in caplog.records if r.name == dedup_logger.name]
+    assert len(records) == allowed
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.usefixtures("reset_backend")
+def test_works_under_every_backend(
+    backend: str,
+    caplog: pytest.LogCaptureFixture,
+    dedup_logger: logging.Logger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Filter behavior is identical across stdlib/loguru/structlog."""
+    allowed = 2
+    monkeypatch.setenv("LOG_BACKEND", backend)
+    monkeypatch.setenv("LOG_LEVEL", "WARNING")
+    configure_logging()
+    logging.getLogger().addHandler(caplog.handler)
+    dedup_logger.addFilter(DuplicateFilter(allowed_repetitions=allowed))
+
+    with caplog.at_level(logging.WARNING, logger=dedup_logger.name):
+        for _ in range(5):
+            dedup_logger.warning("flooded")
+
+    records = [r for r in caplog.records if r.name == dedup_logger.name]
+    assert len(records) == allowed
+
+
+def test_malformed_format_does_not_crash() -> None:
+    """A format/args mismatch falls back to ``record.msg`` without raising."""
+    filt = DuplicateFilter(allowed_repetitions=2)
+    bad = _make_record(msg="needs %d", args=("not an int",))
+
+    results = [filt.filter(bad) for _ in range(4)]
+
+    assert results == [True, True, False, False]
+
+
+@pytest.mark.parametrize(
+    ("allowed", "cache"),
+    [(0, 10), (-1, 10), (10, 0), (10, -5)],
+)
+def test_invalid_config_rejected(allowed: int, cache: int) -> None:
+    """Non-positive config values raise a pydantic ValidationError."""
+    with pytest.raises(ValidationError, match="greater than 0"):
+        DuplicateFilter(allowed_repetitions=allowed, cache_size=cache)
+
+
+def test_config_exposed() -> None:
+    """Config is readable via the ``config`` property."""
+    allowed = 7
+    cache = 42
+
+    filt = DuplicateFilter(allowed_repetitions=allowed, cache_size=cache)
+
+    assert filt.config.allowed_repetitions == allowed
+    assert filt.config.cache_size == cache

--- a/tests/logging/test_dedup.py
+++ b/tests/logging/test_dedup.py
@@ -5,9 +5,11 @@ from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+from freezegun import freeze_time
 from pydantic import ValidationError
 
 from grelmicro.logging import DuplicateFilter, configure_logging
+from grelmicro.logging._dedup import _key_by_rendered
 from tests.logging.conftest import BACKENDS
 
 
@@ -52,7 +54,7 @@ def test_allows_first_n_then_drops() -> None:
 
 
 def test_default_allowed_repetitions_is_five() -> None:
-    """Default allowance matches Logback's DuplicateMessageFilter."""
+    """Default allowance is five records per key."""
     expected = 5
     filt = DuplicateFilter()
     record = _make_record()
@@ -80,9 +82,9 @@ def test_distinct_keys_tracked_independently() -> None:
     assert results == [True, True, False, True, True, False]
 
 
-def test_different_rendered_messages_dedup_independently() -> None:
-    """Same template, different args -> distinct rendered -> own counters."""
-    filt = DuplicateFilter(allowed_repetitions=1)
+def test_rendered_mode_distinguishes_args() -> None:
+    """Rendered mode: same template, different args -> own counters."""
+    filt = DuplicateFilter(allowed_repetitions=1, key_mode="rendered")
     template = "check %s failed"
 
     results = [
@@ -105,9 +107,9 @@ def test_fstring_style_dedup() -> None:
     assert results == [True, True, False, False]
 
 
-def test_percent_and_fstring_with_same_output_share_counter() -> None:
-    """Two call styles producing the same rendered string collapse."""
-    filt = DuplicateFilter(allowed_repetitions=1)
+def test_rendered_mode_percent_and_fstring_share_counter() -> None:
+    """Rendered mode: two styles producing the same text collapse."""
+    filt = DuplicateFilter(allowed_repetitions=1, key_mode="rendered")
     percent_style = _make_record(msg="check %s failed", args=("db",))
     fstring_style = _make_record(msg="check db failed", args=())
 
@@ -116,6 +118,13 @@ def test_percent_and_fstring_with_same_output_share_counter() -> None:
 
     assert first
     assert not second
+
+
+def test_default_key_mode_is_template() -> None:
+    """Default key_mode is ``template`` (faster than ``rendered``)."""
+    filt = DuplicateFilter()
+
+    assert filt.config.key_mode == "template"
 
 
 def test_different_levels_do_not_collapse() -> None:
@@ -202,6 +211,8 @@ def test_key_override() -> None:
 
 def test_thread_safe_counting() -> None:
     """Concurrent calls produce exactly ``allowed_repetitions`` passes."""
+    # cache_size=1 keeps a single shared counter so this exercises the
+    # lock-protected increment path rather than LRU eviction.
     allowed = 50
     filt = DuplicateFilter(allowed_repetitions=allowed, cache_size=1)
 
@@ -244,6 +255,9 @@ def test_works_under_every_backend(
     monkeypatch.setenv("LOG_BACKEND", backend)
     monkeypatch.setenv("LOG_LEVEL", "WARNING")
     configure_logging()
+    # configure_logging() under LOG_BACKEND=stdlib clears root handlers,
+    # removing caplog's capture handler. Re-attach it so records emitted
+    # through dedup_logger still reach caplog.records via propagation.
     logging.getLogger().addHandler(caplog.handler)
     dedup_logger.addFilter(DuplicateFilter(allowed_repetitions=allowed))
 
@@ -265,6 +279,114 @@ def test_malformed_format_does_not_crash() -> None:
     assert results == [True, True, False, False]
 
 
+def test_rendered_key_fallback_on_render_failure() -> None:
+    """``_key_by_rendered`` returns ``str(record.msg)`` when rendering raises."""
+    bad = _make_record(msg="needs %d", args=("not an int",))
+
+    key = _key_by_rendered(bad)
+
+    assert key == ("grelmicro.test", logging.WARNING, "needs %d")
+
+
+def test_key_mode_template_collapses_parameterized_calls() -> None:
+    """``key_mode='template'`` dedups `%`-style calls across args."""
+    filt = DuplicateFilter(allowed_repetitions=1, key_mode="template")
+    template = "check %s failed"
+
+    results = [
+        filt.filter(_make_record(msg=template, args=("db",))),
+        filt.filter(_make_record(msg=template, args=("redis",))),
+        filt.filter(_make_record(msg=template, args=("kafka",))),
+    ]
+
+    assert results == [True, False, False]
+
+
+def test_key_mode_template_ignores_rendering_errors() -> None:
+    """Template mode does not call ``getMessage`` so format bugs are moot."""
+    filt = DuplicateFilter(allowed_repetitions=1, key_mode="template")
+    bad = _make_record(msg="needs %d", args=("not an int",))
+
+    results = [filt.filter(bad) for _ in range(3)]
+
+    assert results == [True, False, False]
+
+
+def test_explicit_key_callable_overrides_mode() -> None:
+    """When ``key=`` is set, ``key_mode`` is ignored."""
+    filt = DuplicateFilter(
+        allowed_repetitions=1,
+        key_mode="template",
+        key=lambda record: record.levelno,
+    )
+    record_a = _make_record(msg="one")
+    record_b = _make_record(msg="two")
+
+    first = filt.filter(record_a)
+    second = filt.filter(record_b)
+
+    assert first
+    assert not second
+
+
+def test_invalid_key_mode_rejected() -> None:
+    """Unknown ``key_mode`` values raise a pydantic ValidationError."""
+    with pytest.raises(ValidationError, match="key_mode"):
+        DuplicateFilter(key_mode="bogus")  # ty: ignore[invalid-argument-type]
+
+
+def test_ttl_resets_counter_after_silence() -> None:
+    """After ``ttl_seconds`` without hits, the counter resets."""
+    with freeze_time() as frozen:
+        filt = DuplicateFilter(allowed_repetitions=1, ttl_seconds=10.0)
+        record = _make_record(msg="flood")
+
+        first = filt.filter(record)
+        second = filt.filter(record)
+        frozen.tick(11)
+        third = filt.filter(record)
+
+        assert first
+        assert not second
+        assert third
+
+
+def test_ttl_hot_key_never_expires() -> None:
+    """Continuous hits refresh the timestamp so TTL never triggers."""
+    with freeze_time() as frozen:
+        filt = DuplicateFilter(allowed_repetitions=1, ttl_seconds=10.0)
+        record = _make_record(msg="flood")
+
+        filt.filter(record)
+        results = []
+        for _ in range(20):
+            frozen.tick(5)
+            results.append(filt.filter(record))
+
+        assert not any(results)
+
+
+def test_ttl_none_disables_time_expiry() -> None:
+    """With ``ttl_seconds=None``, long silence does not reset the counter."""
+    with freeze_time() as frozen:
+        filt = DuplicateFilter(allowed_repetitions=1)
+        record = _make_record(msg="flood")
+
+        filt.filter(record)
+        filt.filter(record)
+        frozen.tick(3600)
+        after_long_silence = filt.filter(record)
+
+        assert not after_long_silence
+
+
+@pytest.mark.parametrize("bad_ttl", [0, -0.5, -1])
+def test_non_positive_ttl_rejected(bad_ttl: float) -> None:
+    """Non-positive ``ttl_seconds`` values raise a pydantic ValidationError."""
+    with pytest.raises(ValidationError, match="greater than 0"):
+        DuplicateFilter(ttl_seconds=bad_ttl)
+
+
 @pytest.mark.parametrize(
     ("allowed", "cache"),
     [(0, 10), (-1, 10), (10, 0), (10, -5)],
@@ -280,7 +402,10 @@ def test_config_exposed() -> None:
     allowed = 7
     cache = 42
 
-    filt = DuplicateFilter(allowed_repetitions=allowed, cache_size=cache)
+    filt = DuplicateFilter(
+        allowed_repetitions=allowed, cache_size=cache, key_mode="template"
+    )
 
     assert filt.config.allowed_repetitions == allowed
     assert filt.config.cache_size == cache
+    assert filt.config.key_mode == "template"

--- a/tests/logging/test_dedup.py
+++ b/tests/logging/test_dedup.py
@@ -351,19 +351,20 @@ def test_ttl_resets_counter_after_silence() -> None:
         assert third
 
 
-def test_ttl_hot_key_never_expires() -> None:
-    """Continuous hits refresh the timestamp so TTL never triggers."""
+def test_ttl_reemits_during_sustained_flood() -> None:
+    """A flood that outlives ``ttl_seconds`` re-emits once per window."""
     with freeze_time() as frozen:
         filt = DuplicateFilter(allowed_repetitions=1, ttl_seconds=10.0)
         record = _make_record(msg="flood")
 
-        filt.filter(record)
-        results = []
-        for _ in range(20):
-            frozen.tick(5)
-            results.append(filt.filter(record))
+        first = filt.filter(record)
+        dropped_within_window = filt.filter(record)
+        frozen.tick(11)
+        after_window = filt.filter(record)
 
-        assert not any(results)
+        assert first
+        assert not dropped_within_window
+        assert after_window
 
 
 def test_ttl_none_disables_time_expiry() -> None:


### PR DESCRIPTION
## Summary

Introduce `grelmicro.logging.DuplicateFilter`, a stdlib `logging.Filter` that caps repeated records per `(logger, level, rendered message)` key. Inspired by Logback's `DuplicateMessageFilter` but keys on `record.getMessage()` so it works identically for `%`-style (`logger.warning("%s failed", name)`) and f-string (`logger.warning(f"{name} failed")`) callers.

Key behavior:

* Default: first 5 records per key pass; subsequent identical records dropped silently. LRU bound of 100 distinct keys; least-recently-seen evicted under pressure.
* Thread-safe via `threading.Lock`. User-supplied `key=` callable runs outside the lock (documented).
* `getMessage()` rendering errors fall back to `str(record.msg)` — a broken log call cannot crash the filter.
* `DuplicateFilterConfig` (pydantic `frozen=True, extra="forbid"`) mirrors `HealthRegistryConfig` / `RateLimiterConfig`. Raises `ValidationError` on bad input.
* Works across every `LOG_BACKEND` (stdlib, loguru, structlog) for any logger obtained via `logging.getLogger(...)` — including every grelmicro module.

Industry grounding: cross-checked against Logback `DuplicateMessageFilter`, Log4j2 `BurstFilter`, Uber zap Sampler, rs/zerolog samplers, `samber/slog-sampling`, `tracing-throttle`, Sentry fingerprinting, Datadog dedupe. Silent-drop + bounded-LRU + `(level, message)` keying is the cross-library consensus.

Deferred: `RateLimitFilter` (token bucket). See #93 for the decision between reusing `resilience.RateLimiter` (GCRA) and introducing a new sync token bucket.

## Test plan

- [x] `uv run pytest tests/logging/test_dedup.py` — 22 tests pass, including parametrized stdlib/loguru/structlog coverage
- [x] `uv run pytest tests/logging/` — 208 tests pass after fixture refactor (shared `reset_backend` moved to `conftest.py`)
- [x] `uv run pytest` — full suite 1084 passes
- [x] Pre-commit hooks (ruff, ty-check, pytest unit + integration, coverage) pass
- [x] Manual flood check: logger emitting 5 identical warnings → 2 records with `allowed_repetitions=2`, rest silently dropped
- [x] `uv run mkdocs build --strict` — docs build clean, new "Deduplicating Noisy Logs" section and API reference entries render on both pages