### PR TITLE
ci: Harden supply chain for Dependabot and workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,30 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "⬆️ "
       prefix-development: "⬆️ "
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "⬆️ ci: "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Load-bearing deps: require human review for major bumps.
+      - dependency-name: "fastapi"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pydantic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pydantic-settings"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "uvicorn"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "anyio"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "⬆️ "
       prefix-development: "⬆️ "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
       - name: Run Ty
         run: uv run ty check
 
+  workflow-lint:
+    name: Workflow Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+
   test:
     name: Test Python ${{ matrix.python }}
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.1.0
         with:
           enable-cache: true
           activate-environment: true
@@ -41,9 +41,9 @@ jobs:
         python: ${{ fromJSON(github.event_name == 'pull_request' && '["3.11"]' || '["3.11","3.12","3.13","3.14"]') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.1.0
         with:
           enable-cache: true
           activate-environment: true
@@ -53,12 +53,12 @@ jobs:
       - name: Run Unit Tests
         run: pytest -x -m "not integration" --cov --junitxml=junit.xml -o junit_family=legacy
       - name: Upload Unit Test Coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.6.0
         with:
           flags: "unit,python${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Unit Test Results to Codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.0
         with:
           flags: "unit,python${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -66,12 +66,12 @@ jobs:
         id: integration_tests
         run: pytest -x -m integration --cov --junitxml=junit.xml -o junit_family=legacy
       - name: Upload Integration Test Coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.6.0
         with:
           flags: "integration,python${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Integration Test Results to Codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.0
         with:
           flags: "integration,python${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto-Merge
+on: pull_request
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch/minor Python updates
+        if: >
+          steps.meta.outputs.package-ecosystem == 'uv' &&
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor')
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,7 +5,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,24 +24,25 @@ jobs:
     environment: pypi
     env:
       UV_FROZEN: 1
+      RELEASE_VERSION: ${{ github.event.release.tag_name || github.event.inputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
-          ref: ${{ github.event.release.tag_name || github.event.inputs.version }}
+          ref: ${{ env.RELEASE_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.1.0
         with:
           enable-cache: true
       - name: Set Package Version
-        run: uv version ${{ github.event.release.tag_name || github.event.inputs.version }}
+        run: uv version -- "$RELEASE_VERSION"
       - name: Build Package
         run: uv build
       - name: Verify Wheel Installs
         run: uv run --no-project -- pip install dist/*.whl
       - name: Publish Package to PyPI
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true
   publish-docs:
@@ -53,18 +54,21 @@ jobs:
       id-token: write
     env:
       UV_FROZEN: 1
+      RELEASE_VERSION: ${{ github.event.release.tag_name || github.event.inputs.version }}
+      GH_ACTOR: ${{ github.actor }}
+      GH_ACTOR_ID: ${{ github.actor_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
-          ref: ${{ github.event.release.tag_name || github.event.inputs.version }}
+          ref: ${{ env.RELEASE_VERSION }}
           fetch-depth: 0
       - name: Configure Git User
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$GH_ACTOR"
+          git config user.email "${GH_ACTOR_ID}+${GH_ACTOR}@users.noreply.github.com"
       - name: Install uv and Activate Environment
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.1.0
         with:
           enable-cache: true
           activate-environment: true


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full commit SHAs (mitigates tag-hijack attacks like tj-actions/changed-files, March 2025).
- Replace `pypa/gh-action-pypi-publish@release/v1` (mutable branch ref on the PyPI publish path) with a pinned SHA.
- Close workflow command-injection vectors: move `workflow_dispatch` inputs and \`github.actor\` into \`env:\` vars referenced as shell variables.
- Add \`github-actions\` ecosystem to Dependabot so pinned SHAs keep receiving updates.
- Add \`cooldown\` (7d default, 14d major), grouping, and open-PR limits to reduce rubber-stamping and shrink the window for malicious freshly-published versions.
- Add auto-merge workflow restricted to \`uv\` ecosystem + patch/minor only (majors and github-actions updates stay hand-reviewed).

## Test plan
- [ ] CI passes on this PR.
- [ ] After merge, confirm Dependabot opens a \`github-actions\` group PR next cycle.
- [ ] Confirm a subsequent \`uv\` patch/minor PR auto-merges once CI is green.
- [ ] Next release (or \`workflow_dispatch\` dry-run) still publishes successfully with pinned \`pypa/gh-action-pypi-publish\` SHA.