### PR TITLE
🔒 ci: Fix zizmor findings from workflow lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.1.0
         with:
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          persist-credentials: false
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
 
@@ -53,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           ref: ${{ env.RELEASE_VERSION }}
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.1.0
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Set Package Version
         run: uv version -- "$RELEASE_VERSION"
       - name: Build Package
@@ -63,6 +64,7 @@ jobs:
         with:
           ref: ${{ env.RELEASE_VERSION }}
           fetch-depth: 0
+          persist-credentials: true
       - name: Configure Git User
         run: |
           git config user.name "$GH_ACTOR"


### PR DESCRIPTION
## Summary
Follow-up to #95. The newly-introduced \`zizmor\` workflow-lint job flagged real issues on \`main\`:

- **artipacked** (5 warnings) — \`actions/checkout\` persists \`GITHUB_TOKEN\` into \`.git/config\` by default. If any step later uploads the working tree as an artifact, the token leaks. Set \`persist-credentials: false\` on all read-only checkouts. Keep \`true\` on \`publish-docs\` (needs the token for \`mkdocs gh-deploy\`).
- **cache-poisoning** (1 error) — \`setup-uv\` enables caching by default. On the \`publish-pypi\` job a poisoned cache could be baked into the wheel uploaded to PyPI. Explicitly disable cache on that job.

## Test plan
- [ ] CI passes (zizmor returns no findings).
- [ ] Release \`workflow_dispatch\` dry-run still succeeds with cache disabled.