### PR TITLE
📝 docs: Release 0.14.1 (brand identity + flaky-test fix)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+## 0.14.1 - 2026-04-22
+
 ### Docs
 
+* 🎨 Ship the grelmicro brand identity: wordmark, favicon, and social-preview card. PR [#106](https://github.com/grelinfo/grelmicro/pull/106).
+* 🎨 Refresh the docs theme with the brand palette. PR [#106](https://github.com/grelinfo/grelmicro/pull/106).
+* 📝 Rewrite the "Why grelmicro" pillars. PR [#106](https://github.com/grelinfo/grelmicro/pull/106).
 * 📝 Split the resilience docs into per-pattern pages.
 * 📝 Add an Installation guide with `pip`, `uv`, and `poetry` tabs.
 * 📝 Render PEP 727 `Annotated[..., Doc(...)]` parameter docs via `griffe-typingdoc`.
@@ -14,6 +19,7 @@
 
 ### Internal
 
+* 🐛 De-flake `test_lock_reentrant_from_thread` on Python 3.12. Fixes [#105](https://github.com/grelinfo/grelmicro/issues/105).
 * 🔧 Add keywords to `pyproject.toml` for PyPI discovery.
 
 ## 0.14.0 - 2026-04-21

--- a/tests/sync/test_lock.py
+++ b/tests/sync/test_lock.py
@@ -43,20 +43,13 @@ async def backend() -> AsyncGenerator[SyncBackend]:
 
 @pytest.fixture
 def locks(backend: SyncBackend) -> list[Lock]:
-    """Locks of multiple workers.
-
-    ``lease_duration`` is set to 500 ms so that reentrant / context-manager
-    tests never race with lease expiry (a 10 ms lease is shorter than Python
-    3.12 thread-scheduling jitter under CI load, which caused
-    ``test_lock_reentrant_from_thread`` to flake). Expiry tests read
-    ``config.lease_duration`` and sleep through it, so they stay correct.
-    """
+    """Locks of multiple workers."""
     return [
         Lock(
             backend=backend,
             name=LOCK_NAME,
             worker=f"worker_{i}",
-            lease_duration=0.5,
+            lease_duration=0.01,
             retry_interval=0.001,
         )
         for i in range(WORKER_COUNT)
@@ -67,6 +60,26 @@ def locks(backend: SyncBackend) -> list[Lock]:
 def lock(locks: list[Lock]) -> Lock:
     """Lock."""
     return locks[WORKER_1]
+
+
+@pytest.fixture
+def reentrant_thread_lock(backend: SyncBackend) -> Lock:
+    """Lock with a lease long enough to outlive thread-scheduling jitter.
+
+    The reentrant-from-thread tests do *acquire → attempt-reacquire-raises →
+    release* in a single worker thread. On Python 3.12 under CI load that
+    sequence can exceed a 10 ms lease, which makes the outer release race
+    with lease expiry and spuriously raise ``LockNotOwnedError``. Use this
+    fixture only for tests that need the slow-path guarantee; the default
+    ``lock`` fixture keeps its 10 ms lease for expiry tests and the rest.
+    """
+    return Lock(
+        backend=backend,
+        name=LOCK_NAME,
+        worker=f"worker_{WORKER_1}",
+        lease_duration=0.5,
+        retry_interval=0.001,
+    )
 
 
 async def test_lock_key_prefix(backend: SyncBackend, lock: Lock) -> None:
@@ -587,8 +600,9 @@ async def test_lock_reacquire_after_context_manager(lock: Lock) -> None:
         assert await lock.locked() is True
 
 
-async def test_lock_reentrant_from_thread(lock: Lock) -> None:
+async def test_lock_reentrant_from_thread(reentrant_thread_lock: Lock) -> None:
     """Test Lock nested from_thread raises LockReentrantError."""
+    lock = reentrant_thread_lock
 
     def sync() -> None:
         with (
@@ -601,8 +615,11 @@ async def test_lock_reentrant_from_thread(lock: Lock) -> None:
     await to_thread.run_sync(sync)
 
 
-async def test_lock_reentrant_from_thread_acquire(lock: Lock) -> None:
+async def test_lock_reentrant_from_thread_acquire(
+    reentrant_thread_lock: Lock,
+) -> None:
     """Test Lock nested from_thread acquire raises LockReentrantError."""
+    lock = reentrant_thread_lock
 
     def sync() -> None:
         lock.from_thread.acquire()
@@ -612,8 +629,11 @@ async def test_lock_reentrant_from_thread_acquire(lock: Lock) -> None:
     await to_thread.run_sync(sync)
 
 
-async def test_lock_reentrant_from_thread_acquire_nowait(lock: Lock) -> None:
+async def test_lock_reentrant_from_thread_acquire_nowait(
+    reentrant_thread_lock: Lock,
+) -> None:
     """Test Lock nested from_thread acquire_nowait raises LockReentrantError."""
+    lock = reentrant_thread_lock
 
     def sync() -> None:
         lock.from_thread.acquire_nowait()
@@ -624,9 +644,10 @@ async def test_lock_reentrant_from_thread_acquire_nowait(lock: Lock) -> None:
 
 
 async def test_lock_reentrant_from_thread_acquire_then_acquire_nowait(
-    lock: Lock,
+    reentrant_thread_lock: Lock,
 ) -> None:
     """Test Lock from_thread acquire then acquire_nowait raises LockReentrantError."""
+    lock = reentrant_thread_lock
 
     def sync() -> None:
         lock.from_thread.acquire()
@@ -637,9 +658,10 @@ async def test_lock_reentrant_from_thread_acquire_then_acquire_nowait(
 
 
 async def test_lock_reentrant_from_thread_acquire_nowait_then_acquire(
-    lock: Lock,
+    reentrant_thread_lock: Lock,
 ) -> None:
     """Test Lock from_thread acquire_nowait then acquire raises LockReentrantError."""
+    lock = reentrant_thread_lock
 
     def sync() -> None:
         lock.from_thread.acquire_nowait()

--- a/tests/sync/test_lock.py
+++ b/tests/sync/test_lock.py
@@ -43,13 +43,20 @@ async def backend() -> AsyncGenerator[SyncBackend]:
 
 @pytest.fixture
 def locks(backend: SyncBackend) -> list[Lock]:
-    """Locks of multiple workers."""
+    """Locks of multiple workers.
+
+    ``lease_duration`` is set to 500 ms so that reentrant / context-manager
+    tests never race with lease expiry (a 10 ms lease is shorter than Python
+    3.12 thread-scheduling jitter under CI load, which caused
+    ``test_lock_reentrant_from_thread`` to flake). Expiry tests read
+    ``config.lease_duration`` and sleep through it, so they stay correct.
+    """
     return [
         Lock(
             backend=backend,
             name=LOCK_NAME,
             worker=f"worker_{i}",
-            lease_duration=0.01,
+            lease_duration=0.5,
             retry_interval=0.001,
         )
         for i in range(WORKER_COUNT)


### PR DESCRIPTION
## Summary

- De-flake `test_lock_reentrant_from_thread` on Python 3.12 by raising the test-fixture lease above thread-scheduling jitter. Fixes #105.
- Update `docs/changelog.md` for the 0.14.1 release.

## Test plan

- [x] `pytest tests/sync/test_lock.py` (53 passed in 2.85 s)
- [x] Stress-loop `test_lock_reentrant_from_thread` 20× green
- [x] `mkdocs build --strict` passes