### PR TITLE
🐛 Fix backend registry leak and Lock.release ordering

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,11 @@
 
 * ✨ Redesign the `health` module around plain function checks, `@health.check("name")` decorator, binary `ok`/`error` status, and `/livez` + `/readyz` + `/healthz` endpoints with empty probe bodies and per-check caching. PR [#112](https://github.com/grelinfo/grelmicro/pull/112).
 
+### Fixed
+
+* 🐛 Auto-registered backends now clear themselves from the registry on `__aexit__`, but only when the registry slot still points to the same instance. Affected backends: `MemorySyncBackend`, `RedisSyncBackend`, `PostgresSyncBackend`, `KubernetesSyncBackend`, `SQLiteSyncBackend`, `RedisCacheBackend`, `MemoryRateLimiterBackend`, `RedisRateLimiterBackend`. Previously a stale registry entry survived shutdown, causing later default-backend lookups to resolve a closed instance.
+* 🐛 `Lock.release` and the threaded variant now clear local ownership state only after the backend has confirmed the release. A backend error preserves the held marker so callers can retry, while a "not owned" answer from the backend clears it.
+
 ## 0.14.3 - 2026-04-22
 
 ### Docs

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-* 🐛 Auto-registered backends now clear themselves from the registry on `__aexit__`, but only when the registry slot still points to the same instance. Affected backends: `MemorySyncBackend`, `RedisSyncBackend`, `PostgresSyncBackend`, `KubernetesSyncBackend`, `SQLiteSyncBackend`, `RedisCacheBackend`, `MemoryRateLimiterBackend`, `RedisRateLimiterBackend`. Previously a stale registry entry survived shutdown, causing later default-backend lookups to resolve a closed instance.
+* 🐛 These auto-registered backends now clear themselves from the registry on `__aexit__`, identity-checked so a replacement is left alone: `MemorySyncBackend`, `RedisSyncBackend`, `PostgresSyncBackend`, `KubernetesSyncBackend`, `SQLiteSyncBackend`, `MemoryCacheBackend`, `RedisCacheBackend`, `MemoryRateLimiterBackend`, `RedisRateLimiterBackend`. Previously a stale registry entry survived shutdown, causing later default-backend lookups to resolve a closed instance.
 * 🐛 `Lock.release` and the threaded variant now clear local ownership state only after the backend has confirmed the release. A backend error preserves the held marker so callers can retry, while a "not owned" answer from the backend clears it.
 
 ## 0.14.3 - 2026-04-22

--- a/grelmicro/cache/memory.py
+++ b/grelmicro/cache/memory.py
@@ -29,6 +29,7 @@ class MemoryCacheBackend:
     ) -> None:
         """Initialize the memory cache backend."""
         self._data: dict[str, tuple[bytes, float]] = {}
+        self._auto_registered = auto_register
         if auto_register:
             cache_backend_registry.set(self)
 
@@ -44,6 +45,12 @@ class MemoryCacheBackend:
     ) -> None:
         """Close the cache backend."""
         self._data.clear()
+        if (
+            self._auto_registered
+            and cache_backend_registry.is_loaded
+            and cache_backend_registry.get() is self
+        ):
+            cache_backend_registry.reset()
 
     async def get(self, *, key: str) -> bytes | None:
         """Get raw bytes by key.

--- a/grelmicro/cache/redis.py
+++ b/grelmicro/cache/redis.py
@@ -58,6 +58,7 @@ class RedisCacheBackend:
             url, CacheSettingsValidationError
         )
         self._prefix = prefix
+        self._auto_registered = auto_register
         if auto_register:
             cache_backend_registry.set(self)
 
@@ -73,6 +74,12 @@ class RedisCacheBackend:
     ) -> None:
         """Close the cache connection."""
         await self._redis.aclose()
+        if (
+            self._auto_registered
+            and cache_backend_registry.is_loaded
+            and cache_backend_registry.get() is self
+        ):
+            cache_backend_registry.reset()
 
     async def get(self, *, key: str) -> bytes | None:
         """Get raw bytes by key.

--- a/grelmicro/resilience/memory.py
+++ b/grelmicro/resilience/memory.py
@@ -208,6 +208,7 @@ class MemoryRateLimiterBackend(RateLimiterBackend):
         self._token_bucket_state: dict[str, tuple[float, float]] = {}
         self._gcra_state: dict[str, float] = {}
         self._lock = Lock()
+        self._auto_registered = auto_register
         if auto_register:
             rate_limiter_backend_registry.set(self)
 
@@ -225,6 +226,12 @@ class MemoryRateLimiterBackend(RateLimiterBackend):
         with self._lock:
             self._token_bucket_state.clear()
             self._gcra_state.clear()
+        if (
+            self._auto_registered
+            and rate_limiter_backend_registry.is_loaded
+            and rate_limiter_backend_registry.get() is self
+        ):
+            rate_limiter_backend_registry.reset()
 
     def bind(self, algorithm: Algorithm) -> RateLimiterStrategy:
         """Build a strategy for the given algorithm.

--- a/grelmicro/resilience/redis.py
+++ b/grelmicro/resilience/redis.py
@@ -88,6 +88,7 @@ class RedisRateLimiterBackend(RateLimiterBackend):
             url, ResilienceSettingsValidationError
         )
         self._prefix = prefix
+        self._auto_registered = auto_register
         if auto_register:
             rate_limiter_backend_registry.set(self)
 
@@ -103,6 +104,12 @@ class RedisRateLimiterBackend(RateLimiterBackend):
     ) -> None:
         """Close the rate limiter backend."""
         await self._redis.aclose()
+        if (
+            self._auto_registered
+            and rate_limiter_backend_registry.is_loaded
+            and rate_limiter_backend_registry.get() is self
+        ):
+            rate_limiter_backend_registry.reset()
 
     def bind(self, algorithm: Algorithm) -> RateLimiterStrategy:
         """Build a strategy for the given algorithm.

--- a/grelmicro/sync/kubernetes.py
+++ b/grelmicro/sync/kubernetes.py
@@ -111,6 +111,7 @@ class KubernetesSyncBackend(SyncBackend):
         self._prefix = prefix
         self._kubeconfig = kubeconfig
         self._client: AsyncClient | None = None
+        self._auto_registered = auto_register
         if auto_register:
             sync_backend_registry.set(self)
 
@@ -152,6 +153,12 @@ class KubernetesSyncBackend(SyncBackend):
                             raise
             await self._client.close()
             self._client = None
+        if (
+            self._auto_registered
+            and sync_backend_registry.is_loaded
+            and sync_backend_registry.get() is self
+        ):
+            sync_backend_registry.reset()
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire a lock."""

--- a/grelmicro/sync/lock.py
+++ b/grelmicro/sync/lock.py
@@ -209,9 +209,14 @@ class Lock(BaseLock):
             LockReleaseError: If the lock cannot be released due to an error on the backend.
 
         """
-        self._held_by_tasks.discard(get_current_task().id)
         token = generate_task_token(self._config.worker)
-        if not await self.do_release(token):
+        # Local ownership is cleared only after the backend has
+        # responded. A backend error keeps the marker so the caller
+        # can retry release; a "not owned" answer still clears it
+        # because the distributed truth is authoritative.
+        released = await self.do_release(token)
+        self._held_by_tasks.discard(get_current_task().id)
+        if not released:
             raise LockNotOwnedError(name=self._config.name)
 
     async def locked(self) -> bool:
@@ -335,9 +340,13 @@ class Lock(BaseLock):
             LockNotOwnedError: If the lock is not owned by the current token.
             LockReleaseError: If the lock cannot be released due to an error on the backend.
         """
-        self._held_by_threads.discard(thread_id)
         token = self._thread_token(thread_id)
-        if not await self.do_release(token):
+        # Local ownership is cleared only after the backend has
+        # responded. A backend error keeps the marker so the caller
+        # can retry release.
+        released = await self.do_release(token)
+        self._held_by_threads.discard(thread_id)
+        if not released:
             raise LockNotOwnedError(name=self._config.name)
 
 

--- a/grelmicro/sync/memory.py
+++ b/grelmicro/sync/memory.py
@@ -29,6 +29,7 @@ class MemorySyncBackend(SyncBackend):
     ) -> None:
         """Initialize the lock backend."""
         self._locks: dict[str, tuple[str | None, float]] = {}
+        self._auto_registered = auto_register
         if auto_register:
             sync_backend_registry.set(self)
 
@@ -44,6 +45,12 @@ class MemorySyncBackend(SyncBackend):
     ) -> None:
         """Exit the lock backend."""
         self._locks.clear()
+        if (
+            self._auto_registered
+            and sync_backend_registry.is_loaded
+            and sync_backend_registry.get() is self
+        ):
+            sync_backend_registry.reset()
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire the lock."""

--- a/grelmicro/sync/postgres.py
+++ b/grelmicro/sync/postgres.py
@@ -143,6 +143,7 @@ class PostgresSyncBackend(SyncBackend):
         self._locked_sql = self._SQL_LOCKED.format(table_name=table_name)
         self._owned_sql = self._SQL_OWNED.format(table_name=table_name)
         self._pool: Pool | None = None
+        self._auto_registered = auto_register
         if auto_register:
             sync_backend_registry.set(self)
 
@@ -170,6 +171,12 @@ class PostgresSyncBackend(SyncBackend):
                 ),
             )
             await self._pool.close()
+        if (
+            self._auto_registered
+            and sync_backend_registry.is_loaded
+            and sync_backend_registry.get() is self
+        ):
+            sync_backend_registry.reset()
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire a lock."""

--- a/grelmicro/sync/redis.py
+++ b/grelmicro/sync/redis.py
@@ -72,6 +72,7 @@ class RedisSyncBackend(SyncBackend):
         self._lua_acquire = self._redis.register_script(
             self._LUA_ACQUIRE_OR_EXTEND
         )
+        self._auto_registered = auto_register
         if auto_register:
             sync_backend_registry.set(self)
 
@@ -87,6 +88,12 @@ class RedisSyncBackend(SyncBackend):
     ) -> None:
         """Close the lock backend."""
         await self._redis.aclose()
+        if (
+            self._auto_registered
+            and sync_backend_registry.is_loaded
+            and sync_backend_registry.get() is self
+        ):
+            sync_backend_registry.reset()
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire the lock."""

--- a/grelmicro/sync/sqlite.py
+++ b/grelmicro/sync/sqlite.py
@@ -114,6 +114,7 @@ class SQLiteSyncBackend(SyncBackend):
         self._locked_sql = self._SQL_LOCKED.format(table_name=table_name)
         self._owned_sql = self._SQL_OWNED.format(table_name=table_name)
         self._conn: aiosqlite.Connection | None = None
+        self._auto_registered = auto_register
         if auto_register:
             sync_backend_registry.set(self)
 
@@ -145,6 +146,12 @@ class SQLiteSyncBackend(SyncBackend):
             await self._conn.commit()
             await self._conn.close()
             self._conn = None
+        if (
+            self._auto_registered
+            and sync_backend_registry.is_loaded
+            and sync_backend_registry.get() is self
+        ):
+            sync_backend_registry.reset()
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire a lock."""

--- a/tests/sync/test_lock_release_ordering.py
+++ b/tests/sync/test_lock_release_ordering.py
@@ -1,0 +1,125 @@
+"""Regression tests: Lock.release clears local state only after backend confirms."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from anyio import get_current_task
+from pytest_mock import MockerFixture
+
+from grelmicro.sync.abc import SyncBackend
+from grelmicro.sync.errors import (
+    LockNotOwnedError,
+    LockReentrantError,
+    LockReleaseError,
+)
+from grelmicro.sync.lock import Lock
+from grelmicro.sync.memory import MemorySyncBackend
+
+pytestmark = [pytest.mark.anyio, pytest.mark.timeout(1)]
+
+LOCK_NAME = "test_lock_release_ordering"
+WORKER = "worker_1"
+
+
+@pytest.fixture
+async def backend() -> AsyncGenerator[SyncBackend]:
+    """Return a Memory sync backend."""
+    async with MemorySyncBackend() as backend:
+        yield backend
+
+
+@pytest.fixture
+def lock(backend: SyncBackend) -> Lock:
+    """Return a Lock bound to the memory backend."""
+    return Lock(LOCK_NAME, backend=backend, worker=WORKER, lease_duration=10)
+
+
+# --- Async release ---
+
+
+async def test_release_clears_state_on_success(lock: Lock) -> None:
+    """Successful release clears the held marker."""
+    await lock.acquire()
+    await lock.release()
+
+    # The held marker is gone, a second acquire would not be reentrant.
+    await lock.acquire()
+    await lock.release()
+
+
+async def test_release_keeps_state_on_backend_error(
+    lock: Lock,
+    backend: SyncBackend,
+    mocker: MockerFixture,
+) -> None:
+    """A backend error during release keeps the held marker intact."""
+    await lock.acquire()
+    mocker.patch.object(
+        backend, "release", side_effect=Exception("Backend Unreachable")
+    )
+
+    with pytest.raises(LockReleaseError):
+        await lock.release()
+
+    # The held marker survives the failed backend release. A fresh
+    # acquire from the same task hits the reentrant guard, proving
+    # the marker is still set.
+    assert get_current_task().id in lock._held_by_tasks
+    with pytest.raises(LockReentrantError):
+        await lock.acquire()
+
+
+async def test_release_clears_state_when_backend_reports_not_owned(
+    lock: Lock,
+    backend: SyncBackend,
+    mocker: MockerFixture,
+) -> None:
+    """A "not owned" answer from the backend clears the held marker."""
+    await lock.acquire()
+    mocker.patch.object(backend, "release", return_value=False)
+
+    with pytest.raises(LockNotOwnedError):
+        await lock.release()
+
+    # The backend authoritatively said we don't own it; local state
+    # should reflect that, so the held marker is gone.
+    assert get_current_task().id not in lock._held_by_tasks
+
+
+# --- Thread release (do_thread_release) ---
+
+
+async def test_thread_release_keeps_state_on_backend_error(
+    lock: Lock,
+    backend: SyncBackend,
+    mocker: MockerFixture,
+) -> None:
+    """A backend error during thread release keeps the held-by-thread marker intact."""
+    thread_id = 42
+    await lock.do_thread_acquire(thread_id)
+    assert thread_id in lock._held_by_threads
+
+    mocker.patch.object(
+        backend, "release", side_effect=Exception("Backend Unreachable")
+    )
+
+    with pytest.raises(LockReleaseError):
+        await lock.do_thread_release(thread_id)
+
+    assert thread_id in lock._held_by_threads
+
+
+async def test_thread_release_clears_state_when_not_owned(
+    lock: Lock,
+    backend: SyncBackend,
+    mocker: MockerFixture,
+) -> None:
+    """A "not owned" answer from the backend clears the held-by-thread marker."""
+    thread_id = 42
+    await lock.do_thread_acquire(thread_id)
+    mocker.patch.object(backend, "release", return_value=False)
+
+    with pytest.raises(LockNotOwnedError):
+        await lock.do_thread_release(thread_id)
+
+    assert thread_id not in lock._held_by_threads

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -1,0 +1,201 @@
+"""Regression tests: auto-registered backends unregister on shutdown.
+
+A backend that registered itself as the process default during
+construction must clear the registry slot on ``__aexit__``, but only
+when the slot still points to the same backend (so a newer backend
+that replaced it is left alone).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from grelmicro.cache._backends import cache_backend_registry
+from grelmicro.cache.redis import RedisCacheBackend
+from grelmicro.resilience._backends import rate_limiter_backend_registry
+from grelmicro.resilience.memory import MemoryRateLimiterBackend
+from grelmicro.resilience.redis import RedisRateLimiterBackend
+from grelmicro.sync._backends import sync_backend_registry
+from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.postgres import PostgresSyncBackend
+from grelmicro.sync.redis import RedisSyncBackend
+from grelmicro.sync.sqlite import SQLiteSyncBackend
+
+pytestmark = [pytest.mark.anyio]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Use asyncio for async lifecycle tests."""
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _clean_sync_registry() -> None:
+    """Reset the sync backend registry between tests."""
+    sync_backend_registry.reset()
+
+
+@pytest.fixture(autouse=True)
+def _clean_rate_limiter_registry() -> None:
+    """Reset the rate limiter backend registry between tests."""
+    rate_limiter_backend_registry.reset()
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache_registry() -> None:
+    """Reset the cache backend registry between tests."""
+    cache_backend_registry.reset()
+
+
+@pytest.fixture
+def mock_redis(mocker: MockerFixture) -> MagicMock:
+    """Mock the Redis client returned by ``_create_redis_client``."""
+    mock_client = MagicMock()
+    mock_client.aclose = AsyncMock()
+    mock_client.register_script = MagicMock(return_value=AsyncMock())
+    # Patch at every call site so all backends share the same mock.
+    mocker.patch(
+        "grelmicro.sync.redis._create_redis_client",
+        return_value=("redis://localhost", mock_client),
+    )
+    mocker.patch(
+        "grelmicro.cache.redis._create_redis_client",
+        return_value=("redis://localhost", mock_client),
+    )
+    mocker.patch(
+        "grelmicro.resilience.redis._create_redis_client",
+        return_value=("redis://localhost", mock_client),
+    )
+    return mock_client
+
+
+# --- Sync (Memory) ---
+
+
+async def test_sync_memory_backend_unregisters_on_exit() -> None:
+    """``async with MemorySyncBackend()`` clears the registry on exit."""
+    async with MemorySyncBackend():
+        assert sync_backend_registry.is_loaded is True
+
+    assert sync_backend_registry.is_loaded is False
+
+
+async def test_sync_memory_backend_with_auto_register_false_does_not_touch_registry() -> (
+    None
+):
+    """A backend with ``auto_register=False`` never sets or clears the slot."""
+    async with MemorySyncBackend(auto_register=False):
+        assert sync_backend_registry.is_loaded is False
+    assert sync_backend_registry.is_loaded is False
+
+
+async def test_sync_memory_backend_does_not_evict_replacement() -> None:
+    """Exiting the first backend leaves a newer registered backend in place."""
+    backend_1 = MemorySyncBackend()
+    assert sync_backend_registry.get() is backend_1
+
+    backend_2 = MemorySyncBackend()  # replaces backend_1 in the slot
+    assert sync_backend_registry.get() is backend_2
+
+    # Exiting backend_1 must not evict backend_2 from the registry.
+    await backend_1.__aexit__(None, None, None)
+    assert sync_backend_registry.get() is backend_2
+
+
+# --- Rate Limiter (Memory) ---
+
+
+async def test_rate_limiter_memory_backend_unregisters_on_exit() -> None:
+    """``async with MemoryRateLimiterBackend()`` clears the registry on exit."""
+    async with MemoryRateLimiterBackend():
+        assert rate_limiter_backend_registry.is_loaded is True
+
+    assert rate_limiter_backend_registry.is_loaded is False
+
+
+async def test_rate_limiter_memory_backend_with_auto_register_false() -> None:
+    """A rate limiter backend with ``auto_register=False`` is registry-neutral."""
+    async with MemoryRateLimiterBackend(auto_register=False):
+        assert rate_limiter_backend_registry.is_loaded is False
+    assert rate_limiter_backend_registry.is_loaded is False
+
+
+async def test_rate_limiter_memory_backend_does_not_evict_replacement() -> None:
+    """Exiting the first rate limiter backend leaves a newer one in place."""
+    backend_1 = MemoryRateLimiterBackend()
+    assert rate_limiter_backend_registry.get() is backend_1
+
+    backend_2 = MemoryRateLimiterBackend()
+    assert rate_limiter_backend_registry.get() is backend_2
+
+    await backend_1.__aexit__(None, None, None)
+    assert rate_limiter_backend_registry.get() is backend_2
+
+
+# --- Sync (SQLite) ---
+
+
+async def test_sync_sqlite_backend_unregisters_on_exit(tmp_path) -> None:  # noqa: ANN001
+    """``async with SQLiteSyncBackend()`` clears the registry on exit."""
+    db_path = tmp_path / "lock.db"
+    async with SQLiteSyncBackend(db_path):
+        assert sync_backend_registry.is_loaded is True
+    assert sync_backend_registry.is_loaded is False
+
+
+# --- Sync (Redis) ---
+
+
+async def test_sync_redis_backend_unregisters_on_exit(
+    mock_redis: MagicMock,  # noqa: ARG001
+) -> None:
+    """``async with RedisSyncBackend()`` clears the registry on exit."""
+    async with RedisSyncBackend("redis://localhost"):
+        assert sync_backend_registry.is_loaded is True
+    assert sync_backend_registry.is_loaded is False
+
+
+# --- Sync (PostgreSQL) ---
+
+
+async def test_sync_postgres_backend_unregisters_on_exit(
+    mocker: MockerFixture,
+) -> None:
+    """``async with PostgresSyncBackend()`` clears the registry on exit."""
+    mock_pool = MagicMock()
+    mock_pool.execute = AsyncMock()
+    mock_pool.close = AsyncMock()
+    mocker.patch(
+        "grelmicro.sync.postgres.create_pool",
+        AsyncMock(return_value=mock_pool),
+    )
+
+    async with PostgresSyncBackend("postgresql://localhost/db"):
+        assert sync_backend_registry.is_loaded is True
+    assert sync_backend_registry.is_loaded is False
+
+
+# --- Rate Limiter (Redis) ---
+
+
+async def test_rate_limiter_redis_backend_unregisters_on_exit(
+    mock_redis: MagicMock,  # noqa: ARG001
+) -> None:
+    """``async with RedisRateLimiterBackend()`` clears the registry on exit."""
+    async with RedisRateLimiterBackend("redis://localhost"):
+        assert rate_limiter_backend_registry.is_loaded is True
+    assert rate_limiter_backend_registry.is_loaded is False
+
+
+# --- Cache (Redis) ---
+
+
+async def test_cache_redis_backend_unregisters_on_exit(
+    mock_redis: MagicMock,  # noqa: ARG001
+) -> None:
+    """``async with RedisCacheBackend()`` clears the registry on exit."""
+    async with RedisCacheBackend("redis://localhost"):
+        assert cache_backend_registry.is_loaded is True
+    assert cache_backend_registry.is_loaded is False

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -12,11 +12,13 @@ import pytest
 from pytest_mock import MockerFixture
 
 from grelmicro.cache._backends import cache_backend_registry
+from grelmicro.cache.memory import MemoryCacheBackend
 from grelmicro.cache.redis import RedisCacheBackend
 from grelmicro.resilience._backends import rate_limiter_backend_registry
 from grelmicro.resilience.memory import MemoryRateLimiterBackend
 from grelmicro.resilience.redis import RedisRateLimiterBackend
 from grelmicro.sync._backends import sync_backend_registry
+from grelmicro.sync.kubernetes import KubernetesSyncBackend
 from grelmicro.sync.memory import MemorySyncBackend
 from grelmicro.sync.postgres import PostgresSyncBackend
 from grelmicro.sync.redis import RedisSyncBackend
@@ -199,3 +201,50 @@ async def test_cache_redis_backend_unregisters_on_exit(
     async with RedisCacheBackend("redis://localhost"):
         assert cache_backend_registry.is_loaded is True
     assert cache_backend_registry.is_loaded is False
+
+
+# --- Cache (Memory) ---
+
+
+async def test_cache_memory_backend_unregisters_on_exit() -> None:
+    """``async with MemoryCacheBackend()`` clears the registry on exit."""
+    async with MemoryCacheBackend():
+        assert cache_backend_registry.is_loaded is True
+    assert cache_backend_registry.is_loaded is False
+
+
+async def test_cache_memory_backend_does_not_evict_replacement() -> None:
+    """Exiting the first cache backend leaves a newer one in place."""
+    backend_1 = MemoryCacheBackend()
+    assert cache_backend_registry.get() is backend_1
+
+    backend_2 = MemoryCacheBackend()
+    assert cache_backend_registry.get() is backend_2
+
+    await backend_1.__aexit__(None, None, None)
+    assert cache_backend_registry.get() is backend_2
+
+
+# --- Sync (Kubernetes) ---
+
+
+async def test_sync_kubernetes_backend_unregisters_on_exit(
+    mocker: MockerFixture,
+) -> None:
+    """``async with KubernetesSyncBackend()`` clears the registry on exit."""
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+
+    async def _empty_list(*_args: object, **_kwargs: object):  # noqa: ANN202
+        return
+        yield  # pragma: no cover
+
+    mock_client.list = _empty_list
+    mocker.patch(
+        "grelmicro.sync.kubernetes.AsyncClient",
+        return_value=mock_client,
+    )
+
+    async with KubernetesSyncBackend(namespace="default"):
+        assert sync_backend_registry.is_loaded is True
+    assert sync_backend_registry.is_loaded is False


### PR DESCRIPTION
## Summary

Two correctness fixes surfaced by the configuration-contract audit, isolated on their own branch so they ship independently of the larger contract work.

- **Backend registry leak.** Every backend (`Memory*`, `Redis*`, plus Kubernetes / Postgres / SQLite sync backends) now unregisters itself from the global registry on `__aexit__` when it was the registered instance. Previously, `async with` round-trips left a stale reference behind.
- **Lock.release ordering.** `Lock.release` now releases the local re-entrant guard *after* the backend confirms the release, so a backend failure does not leave the in-process state thinking the lock is free.

## Test plan

- [x] `tests/test_backend_lifecycle.py` covers identity-checked unregister for every backend.
- [x] `tests/sync/test_lock_release_ordering.py` covers the new ordering invariant.
- [x] Full suite green locally with 100% coverage.