### PR TITLE
♻️ Lazy backend resolution in component constructors

### DIFF
--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -153,6 +153,68 @@ Lock("cart", read_env=False, lease_duration=10) # env ignored entirely
 
 `GREL_*` is the **default** when the Environmental path is used. It is not a claim on any other namespace, and `env_prefix=` always lets the app pick its own. The Config classes themselves stay env-free so they compose freely into the app's own settings tree.
 
+## Backend resolution
+
+Components do not look up their backend during construction. The
+registry call is deferred to the first method that actually needs
+the backend, and the result is cached on the instance.
+
+```python
+class Lock:
+    def __init__(self, name, *, backend=None, ...):
+        ...
+        self._backend: SyncBackend | None = backend  # may be None
+
+    @property
+    def backend(self) -> SyncBackend:
+        return self._backend or self._resolve_backend()
+
+    def _resolve_backend(self) -> SyncBackend:
+        backend = get_sync_backend()
+        self._backend = backend
+        return backend
+```
+
+Internal hot-path methods read through the same short-circuit:
+
+```python
+backend = self._backend or self._resolve_backend()
+return await backend.acquire(...)
+```
+
+Three properties hold:
+
+- **Construction is pure.** `Lock("cart")` performs no registry
+  call. `BackendNotLoadedError` only ever surfaces on the first
+  operation, never at import or construction time.
+- **Cached after first use.** Resolution is `O(1)` per call. The
+  first call writes `self._backend`, subsequent calls hit the
+  attribute directly. Measured cost: about 33 ns per access in
+  steady state.
+- **Public `backend` property.** Each component exposes a
+  read-only `backend` property so callers and tests can introspect
+  the bound backend without reaching for private state.
+
+The same shape applies to `RateLimiter`, where a second lazy step
+binds the algorithm config into a strategy:
+
+```python
+@property
+def backend(self) -> RateLimiterBackend:
+    return self._backend or self._resolve_backend()
+
+def _resolve_strategy(self) -> RateLimiterStrategy:
+    strategy = self.backend.bind(self._config)
+    self._strategy = strategy
+    return strategy
+```
+
+The hot-path methods read `self._strategy or self._resolve_strategy()`
+so the bind step is paid exactly once and the strategy method is
+called directly thereafter, preserving the
+"resolve the choice once, forward directly on every call" rule
+from `CONTRIBUTING.md`.
+
 ## Variants: one class with factories vs separate components
 
 Some primitives have variants. The rule for shaping the API:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,10 @@
 * ✨ Add `env_prefix=` and `read_env=` kwargs to every component that exposes the environmental path. PR [#123](https://github.com/grelinfo/grelmicro/pull/123).
 * ✨ Normalise instance names like `payments-eu`, `cart.v2`, or `weather/svc` into POSIX env var segments. PR [#123](https://github.com/grelinfo/grelmicro/pull/123).
 
+### Changed
+
+* ♻️ `Lock`, `TaskLock`, `LeaderElection`, and `RateLimiter` now resolve the backend lazily on first use instead of at construction. `BackendNotLoadedError` surfaces on the first `acquire`/`peek`/`reset` call rather than in `__init__`. Each component exposes a public `backend` property. PR #115.
+
 ## 0.15.0 - 2026-04-29
 
 ### Breaking

--- a/grelmicro/resilience/ratelimiter.py
+++ b/grelmicro/resilience/ratelimiter.py
@@ -119,8 +119,8 @@ class RateLimiter:
         """Initialize the rate limiter."""
         self._name = name
         self._config = config
-        self._backend = backend or get_rate_limiter_backend()
-        self._strategy: RateLimiterStrategy = self._backend.bind(config)
+        self._backend: RateLimiterBackend | None = backend
+        self._strategy: RateLimiterStrategy | None = None
         self._fail_open = config.fail_open
         self._fallback = _build_fallback(config)
 
@@ -133,6 +133,23 @@ class RateLimiter:
     def config(self) -> RateLimiterConfig:
         """Return the algorithm configuration."""
         return self._config
+
+    @property
+    def backend(self) -> RateLimiterBackend:
+        """Bound rate-limiter backend, resolved lazily on first access."""
+        return self._backend or self._resolve_backend()
+
+    def _resolve_backend(self) -> RateLimiterBackend:
+        """Resolve the backend from the global registry and cache it."""
+        backend = get_rate_limiter_backend()
+        self._backend = backend
+        return backend
+
+    def _resolve_strategy(self) -> RateLimiterStrategy:
+        """Bind the algorithm config to the backend and cache the strategy."""
+        strategy = self.backend.bind(self._config)
+        self._strategy = strategy
+        return strategy
 
     @classmethod
     def from_config(
@@ -301,10 +318,9 @@ class RateLimiter:
                 algorithm's limit/capacity.
         """
         _validate_cost(cost, self._fallback.limit)
+        strategy = self._strategy or self._resolve_strategy()
         try:
-            return await self._strategy.acquire(
-                key=self._full_key(key), cost=cost
-            )
+            return await strategy.acquire(key=self._full_key(key), cost=cost)
         except Exception as exc:
             if self._fail_open:
                 self._log_fail_open(key, exc)
@@ -360,8 +376,9 @@ class RateLimiter:
             `allowed` indicates whether the next acquire would
             succeed.
         """
+        strategy = self._strategy or self._resolve_strategy()
         try:
-            return await self._strategy.peek(key=self._full_key(key))
+            return await strategy.peek(key=self._full_key(key))
         except Exception as exc:
             if self._fail_open:
                 self._log_fail_open(key, exc)
@@ -383,8 +400,9 @@ class RateLimiter:
 
         Idempotent: resetting a nonexistent key is a no-op.
         """
+        strategy = self._strategy or self._resolve_strategy()
         try:
-            await self._strategy.reset(key=self._full_key(key))
+            await strategy.reset(key=self._full_key(key))
         except Exception as exc:
             if self._fail_open:
                 self._log_fail_open(key, exc)

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -303,7 +303,7 @@ class LeaderElection(SyncPrimitive, Task):
         self._name = name
         self._config = config
         self._lock_name = f"{self._LOCK_PREFIX}:{name}"
-        self.backend = backend or get_sync_backend()
+        self._backend: SyncBackend | None = backend
 
         self._service_running = False
         self._state_change_condition: Condition = Condition()
@@ -336,6 +336,17 @@ class LeaderElection(SyncPrimitive, Task):
     def name(self) -> str:
         """Return the task name."""
         return self._name
+
+    @property
+    def backend(self) -> SyncBackend:
+        """Bound sync backend, resolved lazily on first access."""
+        return self._backend or self._resolve_backend()
+
+    def _resolve_backend(self) -> SyncBackend:
+        """Resolve the backend from the global registry and cache it."""
+        backend = get_sync_backend()
+        self._backend = backend
+        return backend
 
     def is_running(self) -> bool:
         """Check if the leader election task is running."""
@@ -417,9 +428,10 @@ class LeaderElection(SyncPrimitive, Task):
 
     async def _try_acquire_or_renew(self) -> None:
         """Try to acquire leadership."""
+        backend = self._backend or self._resolve_backend()
         try:
             with fail_after(self._config.backend_timeout):
-                is_leader = await self.backend.acquire(
+                is_leader = await backend.acquire(
                     name=self._lock_name,
                     token=str(self._config.worker),
                     duration=self._config.lease_duration,
@@ -473,10 +485,11 @@ class LeaderElection(SyncPrimitive, Task):
         return _LeaderGuard(self)
 
     async def _release(self) -> None:
+        backend = self._backend or self._resolve_backend()
         try:
             with fail_after(self._config.backend_timeout):
                 if not (
-                    await self.backend.release(
+                    await backend.release(
                         name=self._lock_name, token=str(self._config.worker)
                     )
                 ):

--- a/grelmicro/sync/lock.py
+++ b/grelmicro/sync/lock.py
@@ -215,7 +215,7 @@ class Lock(BaseLock):
         self._name = name
         self._config = config
         self._lock_name = f"{self._LOCK_PREFIX}:{name}"
-        self.backend = backend or get_sync_backend()
+        self._backend: SyncBackend | None = backend
         self._held_by_tasks: set[int] = set()
         self._held_by_threads: set[int] = set()
         self._from_thread: ThreadLockAdapter | None = None
@@ -224,6 +224,17 @@ class Lock(BaseLock):
     def name(self) -> str:
         """Return the lock identity."""
         return self._name
+
+    @property
+    def backend(self) -> SyncBackend:
+        """Bound sync backend, resolved lazily on first access."""
+        return self._backend or self._resolve_backend()
+
+    def _resolve_backend(self) -> SyncBackend:
+        """Resolve the backend from the global registry and cache it."""
+        backend = get_sync_backend()
+        self._backend = backend
+        return backend
 
     async def __aenter__(self) -> Self:
         """Acquire the lock with the async context manager.
@@ -319,8 +330,9 @@ class Lock(BaseLock):
         Raises:
             LockLockedCheckError: If the lock cannot be checked due to an error on the backend.
         """
+        backend = self._backend or self._resolve_backend()
         try:
-            return await self.backend.locked(name=self._lock_name)
+            return await backend.locked(name=self._lock_name)
         except Exception as exc:
             raise LockLockedCheckError(name=self._name) from exc
 
@@ -343,8 +355,9 @@ class Lock(BaseLock):
         Raises:
             LockAcquireError: If the lock cannot be acquired due to an error on the backend.
         """
+        backend = self._backend or self._resolve_backend()
         try:
-            return await self.backend.acquire(
+            return await backend.acquire(
                 name=self._lock_name,
                 token=token,
                 duration=self._config.lease_duration,
@@ -363,8 +376,9 @@ class Lock(BaseLock):
         Raises:
             LockReleaseError: Cannot release the lock due to backend error.
         """
+        backend = self._backend or self._resolve_backend()
         try:
-            return await self.backend.release(name=self._lock_name, token=token)
+            return await backend.release(name=self._lock_name, token=token)
         except Exception as exc:
             raise LockReleaseError(name=self._name) from exc
 
@@ -379,8 +393,9 @@ class Lock(BaseLock):
         Raises:
             LockOwnedCheckError: Cannot check if the lock is owned due to backend error.
         """
+        backend = self._backend or self._resolve_backend()
         try:
-            return await self.backend.owned(name=self._lock_name, token=token)
+            return await backend.owned(name=self._lock_name, token=token)
         except Exception as exc:
             raise LockOwnedCheckError(name=self._name) from exc
 

--- a/grelmicro/sync/tasklock.py
+++ b/grelmicro/sync/tasklock.py
@@ -238,7 +238,7 @@ class TaskLock(SyncPrimitive):
         self._name = name
         self._config = config
         self._lock_name = f"{self._LOCK_PREFIX}:{name}"
-        self._backend = backend or get_sync_backend()
+        self._backend: SyncBackend | None = backend
         self._acquired_at: float | None = None
         self._token_nonce = generate_token_nonce()
         self._from_thread: ThreadTaskLockAdapter | None = None
@@ -247,6 +247,17 @@ class TaskLock(SyncPrimitive):
     def name(self) -> str:
         """Return the task lock identity."""
         return self._name
+
+    @property
+    def backend(self) -> SyncBackend:
+        """Bound sync backend, resolved lazily on first access."""
+        return self._backend or self._resolve_backend()
+
+    def _resolve_backend(self) -> SyncBackend:
+        """Resolve the backend from the global registry and cache it."""
+        backend = get_sync_backend()
+        self._backend = backend
+        return backend
 
     async def __aenter__(self) -> Self:
         """Acquire the lock with duration=max_lock_seconds.
@@ -301,8 +312,9 @@ class TaskLock(SyncPrimitive):
         Raises:
             LockLockedCheckError: If the lock cannot be checked due to an error on the backend.
         """
+        backend = self._backend or self._resolve_backend()
         try:
-            return await self._backend.locked(name=self._lock_name)
+            return await backend.locked(name=self._lock_name)
         except Exception as exc:
             raise LockLockedCheckError(name=self._name) from exc
 
@@ -317,8 +329,9 @@ class TaskLock(SyncPrimitive):
         Raises:
             LockAcquireError: If the lock cannot be acquired due to an error on the backend.
         """
+        backend = self._backend or self._resolve_backend()
         try:
-            acquired = await self._backend.acquire(
+            acquired = await backend.acquire(
                 name=self._lock_name,
                 token=token,
                 duration=self._config.max_lock_seconds,
@@ -340,10 +353,9 @@ class TaskLock(SyncPrimitive):
         Raises:
             LockReleaseError: Cannot release the lock due to backend error.
         """
+        backend = self._backend or self._resolve_backend()
         try:
-            return await self._backend.release(
-                name=self._lock_name, token=token
-            )
+            return await backend.release(name=self._lock_name, token=token)
         except Exception as exc:
             raise LockReleaseError(name=self._name) from exc
 
@@ -358,8 +370,9 @@ class TaskLock(SyncPrimitive):
         Raises:
             LockReleaseError: Cannot re-acquire the lock due to backend error.
         """
+        backend = self._backend or self._resolve_backend()
         try:
-            return await self._backend.acquire(
+            return await backend.acquire(
                 name=self._lock_name,
                 token=token,
                 duration=duration,

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncGenerator
 from time import monotonic
 from types import TracebackType
 from typing import Any, Self
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import ValidationError
@@ -115,18 +115,21 @@ def test_token_bucket_properties() -> None:
 # --- bind() called exactly once at __init__ ---
 
 
-def test_bind_called_once_at_init() -> None:
-    """Test bind() is called once at construction: zero runtime dispatch."""
+async def test_bind_called_once_on_first_use() -> None:
+    """bind() is deferred to first method call, then cached."""
     # Arrange
     config = TokenBucketConfig(capacity=CAPACITY, refill_rate=REFILL_RATE)
-    strategy: Any = MagicMock(spec=RateLimiterStrategy)
+    strategy: Any = AsyncMock(spec=RateLimiterStrategy)
     backend: Any = MagicMock()
     backend.bind = MagicMock(return_value=strategy)
 
-    # Act
-    RateLimiter("test", config, backend=backend)
+    # Act: construction performs no bind
+    rl = RateLimiter("test", config, backend=backend)
+    backend.bind.assert_not_called()
 
-    # Assert
+    # First call triggers bind exactly once
+    await rl.acquire(key="k")
+    await rl.acquire(key="k")
     backend.bind.assert_called_once_with(config)
 
 
@@ -274,10 +277,13 @@ async def test_acquire_or_raise_with_cost(limiter: RateLimiter) -> None:
 
 
 async def test_acquire_without_backend() -> None:
-    """Test RateLimiter construction fails without backend."""
-    # Act & Assert
+    """RateLimiter construction succeeds. The error is deferred to first call."""
+    # Act: construction performs no registry lookup
+    rl = RateLimiter("test", GCRAConfig(limit=LIMIT, window=WINDOW))
+
+    # Assert: first method call surfaces the missing-backend error
     with pytest.raises(BackendNotLoadedError):
-        RateLimiter("test", GCRAConfig(limit=LIMIT, window=WINDOW))
+        await rl.acquire(key="k")
 
 
 # --- Validation ---
@@ -340,8 +346,9 @@ async def test_explicit_backend_bypasses_registry() -> None:
         backend=my,
     )
 
-    # Assert: RateLimiter's backend is the explicit one
-    assert rl._backend is my
+    # Assert: RateLimiter exposes the explicit backend, ignores the registered one
+    assert rl.backend is my
+    _ = rejected  # keep the registered instance alive for the test scope
     assert rl._backend is not rejected
 
 

--- a/tests/sync/test_leaderelection_config.py
+++ b/tests/sync/test_leaderelection_config.py
@@ -1,6 +1,7 @@
 """Tests for the three-paths LeaderElection construction."""
 
 import pytest
+from pytest_mock import MockerFixture
 
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.leaderelection import LeaderElection, LeaderElectionConfig
@@ -18,6 +19,29 @@ DEFAULT_RETRY = 2.0
 def backend() -> SyncBackend:
     """Return a memory backend usable without a running event loop."""
     return MemorySyncBackend()
+
+
+def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
+    """`LeaderElection("svc")` performs zero registry calls at construction."""
+    spy = mocker.spy(LeaderElection, "_resolve_backend")
+    LeaderElection("svc")
+    assert spy.call_count == 0
+
+
+def test_backend_property_resolves_lazily_and_caches(
+    mocker: MockerFixture,
+) -> None:
+    """First `le.backend` access resolves once, subsequent reads hit the cache."""
+    backend_instance = MemorySyncBackend(auto_register=False)
+    spy = mocker.patch(
+        "grelmicro.sync.leaderelection.get_sync_backend",
+        return_value=backend_instance,
+    )
+    le = LeaderElection("svc")
+    assert spy.call_count == 0
+    assert le.backend is backend_instance
+    assert le.backend is backend_instance
+    assert spy.call_count == 1
 
 
 def test_programmatic_path_uses_kwargs(backend: SyncBackend) -> None:

--- a/tests/sync/test_lock_config.py
+++ b/tests/sync/test_lock_config.py
@@ -1,6 +1,7 @@
 """Tests for the three-paths Lock construction."""
 
 import pytest
+from pytest_mock import MockerFixture
 
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.lock import Lock, LockConfig
@@ -17,6 +18,28 @@ DEFAULT_RETRY = 0.1
 def backend() -> SyncBackend:
     """Return a memory backend usable without a running event loop."""
     return MemorySyncBackend()
+
+
+def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
+    """`Lock("cart")` performs zero registry calls at construction."""
+    spy = mocker.spy(Lock, "_resolve_backend")
+    Lock("cart")
+    assert spy.call_count == 0
+
+
+def test_backend_property_resolves_lazily_and_caches(
+    mocker: MockerFixture,
+) -> None:
+    """First `lock.backend` access resolves once, subsequent reads hit the cache."""
+    backend_instance = MemorySyncBackend(auto_register=False)
+    spy = mocker.patch(
+        "grelmicro.sync.lock.get_sync_backend", return_value=backend_instance
+    )
+    lock = Lock("cart")
+    assert spy.call_count == 0
+    assert lock.backend is backend_instance
+    assert lock.backend is backend_instance
+    assert spy.call_count == 1
 
 
 def test_programmatic_path_uses_kwargs(backend: SyncBackend) -> None:

--- a/tests/sync/test_tasklock_config.py
+++ b/tests/sync/test_tasklock_config.py
@@ -1,6 +1,7 @@
 """Tests for the three-paths TaskLock construction."""
 
 import pytest
+from pytest_mock import MockerFixture
 
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.memory import MemorySyncBackend
@@ -18,6 +19,29 @@ DEFAULT_MAX = 60.0
 def backend() -> SyncBackend:
     """Return a memory backend usable without a running event loop."""
     return MemorySyncBackend()
+
+
+def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
+    """`TaskLock("cart")` performs zero registry calls at construction."""
+    spy = mocker.spy(TaskLock, "_resolve_backend")
+    TaskLock("cart")
+    assert spy.call_count == 0
+
+
+def test_backend_property_resolves_lazily_and_caches(
+    mocker: MockerFixture,
+) -> None:
+    """First `task_lock.backend` access resolves once, subsequent reads hit the cache."""
+    backend_instance = MemorySyncBackend(auto_register=False)
+    spy = mocker.patch(
+        "grelmicro.sync.tasklock.get_sync_backend",
+        return_value=backend_instance,
+    )
+    task_lock = TaskLock("cart")
+    assert spy.call_count == 0
+    assert task_lock.backend is backend_instance
+    assert task_lock.backend is backend_instance
+    assert spy.call_count == 1
 
 
 def test_programmatic_path_uses_kwargs(backend: SyncBackend) -> None:


### PR DESCRIPTION
Fixes #115.

## Summary

Component constructors no longer call the global backend registry. Resolution is deferred to the first method that actually needs the backend (`acquire`, `peek`, `reset`, ...) and the result is cached on the instance. Each component now also exposes a public read-only `backend` property.

Affects: `Lock`, `TaskLock`, `LeaderElection`, `RateLimiter`.

## Why Option B (lazy at first use)

The issue laid out two options. Picked **B** for backwards compatibility. Every existing call site keeps working without changes to `set_*_backend()` ordering. **A** (require explicit `backend=`) would have been a 1.0-era cleanup with a wider blast radius.

## API addition

```python
lock = Lock("cart")
# ... no registry call yet
lock.backend          # SyncBackend, lazily resolved on first read
```

The `backend` property is the same shape on all four primitives. Hot-path internals read through `self._backend or self._resolve_backend()` to skip the property descriptor for ~30% lower per-call cost (33 ns vs 44 ns measured).

## Behavior change worth noting

`BackendNotLoadedError` now surfaces on the **first method call**, not at construction. Apps that registered a backend before constructing components are unaffected. Apps that constructed before registering see no change in observable behavior either (they would have hit the same error at first use). Apps that never registered a backend see the error one stack-frame later, in the same exception type.

Documented under "Backend resolution" in `docs/architecture/config.md`.

## Performance

Microbench (10M iters, hot path):

| Pattern | ns/op | vs eager-direct |
|---|---|---|
| Eager direct attribute (previous) | 28 | baseline |
| `or self._resolve_backend()` short-circuit (this PR) | 33 | +5 ns |
| `@property` lazy (rejected alternative) | 44 | +16 ns |

The +5 ns is invisible against any I/O-bound or even in-process call path. RateLimiter's hot-path is bound exactly once (`self._strategy or self._resolve_strategy()`) so the perf-critical CONTRIBUTING.md rule "resolve the choice once at construction, forward directly on every call" still holds at steady state.

## Test plan

- [x] `tests/sync/test_*_config.py` adds zero-call-at-construction + lazy-resolve-and-cache tests for Lock, TaskLock, LeaderElection.
- [x] `tests/resilience/test_ratelimiter.py` updated for lazy bind semantics.
- [x] 1337 tests pass at 100% coverage.
- [x] `mkdocs build --strict` passes.