### PR TITLE
📝 Release 0.16.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.16.0 - 2026-04-29
+
 ### Breaking
 
 * 💥 `LockConfig`, `TaskLockConfig`, `LeaderElectionConfig`, and `RateLimiterConfig` no longer carry a `name` field. Pass the name positionally: `Lock("cart", LockConfig(lease_duration=30))`. PR [#123](https://github.com/grelinfo/grelmicro/pull/123).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,7 +21,12 @@
 
 ### Changed
 
-* ♻️ `Lock`, `TaskLock`, `LeaderElection`, and `RateLimiter` now resolve the backend lazily on first use instead of at construction. `BackendNotLoadedError` surfaces on the first `acquire`/`peek`/`reset` call rather than in `__init__`. Each component exposes a public `backend` property. PR #115.
+* ♻️ `Lock`, `TaskLock`, `LeaderElection`, and `RateLimiter` now resolve the backend lazily on first use instead of at construction. `BackendNotLoadedError` surfaces on the first `acquire`/`peek`/`reset` call rather than in `__init__`. Each component exposes a public `backend` property. PR [#128](https://github.com/grelinfo/grelmicro/pull/128).
+
+### Fixed
+
+* 🐛 Auto-registered backends now identity-check before clearing the registry on `__aexit__`, so a replacement instance is left alone. PR [#122](https://github.com/grelinfo/grelmicro/pull/122).
+* 🐛 `Lock.release` clears local ownership only after the backend confirms the release. PR [#122](https://github.com/grelinfo/grelmicro/pull/122).
 
 ## 0.15.0 - 2026-04-29
 
@@ -33,11 +38,6 @@
 * 💥 `HealthChecker` Protocol removed. Use plain `def` or `async def` functions. PR [#112](https://github.com/grelinfo/grelmicro/pull/112).
 * 💥 `HealthReport.components: list` becomes `HealthReport.checks: dict[name, ...]`. PR [#112](https://github.com/grelinfo/grelmicro/pull/112).
 * 💥 `HealthCheckTimeoutError` and the three-state `HealthStatus` removed. PR [#112](https://github.com/grelinfo/grelmicro/pull/112).
-
-### Fixed
-
-* 🐛 Auto-registered backends now identity-check before clearing the registry on `__aexit__`, so a replacement instance is left alone. PR [#122](https://github.com/grelinfo/grelmicro/pull/122).
-* 🐛 `Lock.release` clears local ownership only after the backend confirms the release. PR [#122](https://github.com/grelinfo/grelmicro/pull/122).
 
 ### Docs
 

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -485,7 +485,10 @@ class LeaderElection(SyncPrimitive, Task):
         return _LeaderGuard(self)
 
     async def _release(self) -> None:
-        backend = self._backend or self._resolve_backend()
+        backend = self._backend
+        if backend is None:
+            # Nothing was acquired, nothing to release.
+            return
         try:
             with fail_after(self._config.backend_timeout):
                 if not (

--- a/tests/sync/test_leaderelection_config.py
+++ b/tests/sync/test_leaderelection_config.py
@@ -23,7 +23,7 @@ def backend() -> SyncBackend:
 
 def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
     """`LeaderElection("svc")` performs zero registry calls at construction."""
-    spy = mocker.spy(LeaderElection, "_resolve_backend")
+    spy = mocker.patch("grelmicro.sync.leaderelection.get_sync_backend")
     LeaderElection("svc")
     assert spy.call_count == 0
 

--- a/tests/sync/test_leaderelection_config.py
+++ b/tests/sync/test_leaderelection_config.py
@@ -21,6 +21,13 @@ def backend() -> SyncBackend:
     return MemorySyncBackend()
 
 
+@pytest.mark.anyio
+async def test_release_is_noop_when_backend_was_never_resolved() -> None:
+    """`_release` returns silently when no backend was ever bound."""
+    le = LeaderElection("svc")
+    await le._release()
+
+
 def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
     """`LeaderElection("svc")` performs zero registry calls at construction."""
     spy = mocker.patch("grelmicro.sync.leaderelection.get_sync_backend")

--- a/tests/sync/test_lock_config.py
+++ b/tests/sync/test_lock_config.py
@@ -22,7 +22,7 @@ def backend() -> SyncBackend:
 
 def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
     """`Lock("cart")` performs zero registry calls at construction."""
-    spy = mocker.spy(Lock, "_resolve_backend")
+    spy = mocker.patch("grelmicro.sync.lock.get_sync_backend")
     Lock("cart")
     assert spy.call_count == 0
 

--- a/tests/sync/test_tasklock_config.py
+++ b/tests/sync/test_tasklock_config.py
@@ -23,7 +23,7 @@ def backend() -> SyncBackend:
 
 def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
     """`TaskLock("cart")` performs zero registry calls at construction."""
-    spy = mocker.spy(TaskLock, "_resolve_backend")
+    spy = mocker.patch("grelmicro.sync.tasklock.get_sync_backend")
     TaskLock("cart")
     assert spy.call_count == 0
 


### PR DESCRIPTION
## Summary

Cuts 0.16.0 from what is on main, plus a small set of follow-up fixes from Copilot's post-merge review of #128.

**Headline content:**
- Three-paths configuration contract (#123)
- Lazy backend resolution + public `backend` property (#128)
- Backend `__aexit__` identity-check + Lock.release ordering (#122, originally listed under Unreleased before 0.15.0)

**Follow-up fixes on this branch:**
- Strengthen "no registry call at construction" tests to patch the global directly instead of spying the private resolver. Catches future refactors that bypass `_resolve_backend`.
- `LeaderElection._release` now short-circuits when no backend was ever resolved. Avoids masking the original exception when `_release` runs from a `finally` clause during shutdown.
- Changelog entry for the lazy-backend change now links to PR #128 instead of plain text `PR #115`.

## Test plan

- [x] All tests green at 100% coverage.
- [x] `mkdocs build --strict` passes.
- [x] Changelog entries follow the FastAPI-terse style.

After merge, tag `0.16.0` to publish.