### PR TITLE
✅ Patch the registry source, not the import alias

### DIFF
--- a/tests/sync/test_leaderelection_config.py
+++ b/tests/sync/test_leaderelection_config.py
@@ -3,6 +3,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
+from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.leaderelection import LeaderElection, LeaderElectionConfig
 from grelmicro.sync.memory import MemorySyncBackend
@@ -30,7 +31,7 @@ async def test_release_is_noop_when_backend_was_never_resolved() -> None:
 
 def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
     """`LeaderElection("svc")` performs zero registry calls at construction."""
-    spy = mocker.patch("grelmicro.sync.leaderelection.get_sync_backend")
+    spy = mocker.patch.object(sync_backend_registry, "get")
     LeaderElection("svc")
     assert spy.call_count == 0
 

--- a/tests/sync/test_lock_config.py
+++ b/tests/sync/test_lock_config.py
@@ -3,6 +3,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
+from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.lock import Lock, LockConfig
 from grelmicro.sync.memory import MemorySyncBackend
@@ -22,7 +23,7 @@ def backend() -> SyncBackend:
 
 def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
     """`Lock("cart")` performs zero registry calls at construction."""
-    spy = mocker.patch("grelmicro.sync.lock.get_sync_backend")
+    spy = mocker.patch.object(sync_backend_registry, "get")
     Lock("cart")
     assert spy.call_count == 0
 

--- a/tests/sync/test_tasklock_config.py
+++ b/tests/sync/test_tasklock_config.py
@@ -3,6 +3,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
+from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.memory import MemorySyncBackend
 from grelmicro.sync.tasklock import TaskLock, TaskLockConfig
@@ -23,7 +24,7 @@ def backend() -> SyncBackend:
 
 def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
     """`TaskLock("cart")` performs zero registry calls at construction."""
-    spy = mocker.patch("grelmicro.sync.tasklock.get_sync_backend")
+    spy = mocker.patch.object(sync_backend_registry, "get")
     TaskLock("cart")
     assert spy.call_count == 0
 


### PR DESCRIPTION
Addresses Copilot's three review comments on PR #129. The "no registry call at construction" tests now patch the registry source (`sync_backend_registry.get`) instead of the per-module `get_sync_backend` alias. A future refactor that calls the registry through a different import path can no longer silently bypass the check.

## Test plan

- [x] `tests/sync/test_lock_config.py`, `test_tasklock_config.py`, `test_leaderelection_config.py` still pass.
- [x] 100% coverage held.

Targets `0.16.1` (PATCH, test-only change, no API impact).