### PR TITLE
📝 Release 0.16.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.16.1 - 2026-04-29
+
+### Internal
+
+* ✅ "No registry call at construction" tests now patch the registry source instead of the per-module import alias, so a future refactor that bypasses the local alias can no longer silently pass the check. PR [#130](https://github.com/grelinfo/grelmicro/pull/130).
+
 ## 0.16.0 - 2026-04-29
 
 ### Breaking

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@
 ### Internal
 
 * ✅ "No registry call at construction" tests now patch the registry source instead of the per-module import alias, so a future refactor that bypasses the local alias can no longer silently pass the check. PR [#130](https://github.com/grelinfo/grelmicro/pull/130).
+* ⬆️ Bump `ty` from 0.0.29 to 0.0.30. PR [#111](https://github.com/grelinfo/grelmicro/pull/111).
+* ⬆️ Pre-commit autoupdate. PR [#114](https://github.com/grelinfo/grelmicro/pull/114).
 
 ## 0.16.0 - 2026-04-29
 


### PR DESCRIPTION
## Summary

Patch release bundling three internal items.

* ✅ "No registry call at construction" tests now patch the registry source (`sync_backend_registry.get`) instead of the per-module `get_sync_backend` alias. PR #130.
* ⬆️ Bump `ty` from 0.0.29 to 0.0.30. PR #111.
* ⬆️ Pre-commit autoupdate. PR #114.

No API change, no behavior change. PATCH-safe per the versioning policy.

After merge, tag `0.16.1` to publish.