### PR TITLE
♻️ Migrate CircuitBreaker to the three-paths configuration contract

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Breaking
+
+* 💥 `CircuitBreaker` config moves to a frozen `CircuitBreakerConfig`. Read it via `cb.config`. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+* 💥 The mutable attributes `cb.error_threshold`, `cb.success_threshold`, `cb.reset_timeout`, `cb.half_open_capacity`, `cb.ignore_exceptions`, `cb.log_level` are removed. Construct a new `CircuitBreaker` to change config. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+
+### Features
+
+* ✨ Add `CircuitBreakerConfig` and `CircuitBreaker.from_config(name, config)`. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+* ✨ `CircuitBreaker` reads `GREL_CIRCUIT_BREAKER_<NAME>_*` env vars and accepts `env_prefix=` / `read_env=`. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+* ✨ `ignore_exceptions` accepts fully-qualified import strings (`"builtins.ValueError"`) so YAML and env loaders can specify exception types. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+* ✨ Env vars for tuple/list fields accept comma-separated values in addition to JSON arrays. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+
+### Internal
+
+* ♻️ Add `grelmicro/_types.py` for shared lightweight type aliases (`LogLevel`). PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+* ♻️ Add `grelmicro/_config.py::parse_csv_or_json` shared utility for env var list parsing. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+
 ## 0.16.1 - 2026-04-29
 
 ### Internal

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,20 +4,20 @@
 
 ### Breaking
 
-* 💥 `CircuitBreaker` config moves to a frozen `CircuitBreakerConfig`. Read it via `cb.config`. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
-* 💥 The mutable attributes `cb.error_threshold`, `cb.success_threshold`, `cb.reset_timeout`, `cb.half_open_capacity`, `cb.ignore_exceptions`, `cb.log_level` are removed. Construct a new `CircuitBreaker` to change config. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+* 💥 `CircuitBreaker` config moves to a frozen `CircuitBreakerConfig`. Read it via `cb.config`. PR [#132](https://github.com/grelinfo/grelmicro/pull/132).
+* 💥 The mutable attributes `cb.error_threshold`, `cb.success_threshold`, `cb.reset_timeout`, `cb.half_open_capacity`, `cb.ignore_exceptions`, `cb.log_level` are removed. Construct a new `CircuitBreaker` to change config. PR [#132](https://github.com/grelinfo/grelmicro/pull/132).
 
 ### Features
 
-* ✨ Add `CircuitBreakerConfig` and `CircuitBreaker.from_config(name, config)`. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
-* ✨ `CircuitBreaker` reads `GREL_CIRCUIT_BREAKER_<NAME>_*` env vars and accepts `env_prefix=` / `read_env=`. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
-* ✨ `ignore_exceptions` accepts fully-qualified import strings (`"builtins.ValueError"`) so YAML and env loaders can specify exception types. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
-* ✨ Env vars for tuple/list fields accept comma-separated values in addition to JSON arrays. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+* ✨ Add `CircuitBreakerConfig` and `CircuitBreaker.from_config(name, config)`. PR [#132](https://github.com/grelinfo/grelmicro/pull/132).
+* ✨ `CircuitBreaker` reads `GREL_CIRCUIT_BREAKER_<NAME>_*` env vars and accepts `env_prefix=` / `read_env=`. PR [#132](https://github.com/grelinfo/grelmicro/pull/132).
+* ✨ `ignore_exceptions` accepts fully-qualified import strings (`"builtins.ValueError"`) so YAML and env loaders can specify exception types. PR [#132](https://github.com/grelinfo/grelmicro/pull/132).
+* ✨ Env vars for tuple/list fields accept comma-separated values in addition to JSON arrays. PR [#132](https://github.com/grelinfo/grelmicro/pull/132).
 
 ### Internal
 
-* ♻️ Add `grelmicro/_types.py` for shared lightweight type aliases (`LogLevel`). PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
-* ♻️ Add `grelmicro/_config.py::parse_csv_or_json` shared utility for env var list parsing. PR [#117](https://github.com/grelinfo/grelmicro/issues/117).
+* ♻️ Add `grelmicro/_types.py` for shared lightweight type aliases (`LogLevel`). PR [#132](https://github.com/grelinfo/grelmicro/pull/132).
+* ♻️ Add `grelmicro/_config.py::parse_csv_or_json` shared utility for env var list parsing. PR [#132](https://github.com/grelinfo/grelmicro/pull/132).
 
 ## 0.16.1 - 2026-04-29
 

--- a/docs/resilience/circuit-breaker.md
+++ b/docs/resilience/circuit-breaker.md
@@ -40,3 +40,43 @@ stateDiagram-v2
     The Circuit Breaker is not thread-safe. Decorated sync functions or `from_thread` methods ensure state changes run safely within the async event loop. Threaded usage is supported only in AnyIO worker threads and may be slower than pure async usage.
 
 See the [API reference](../reference/resilience.md#grelmicro.resilience.CircuitBreaker) for every option.
+
+## Configuration
+
+`CircuitBreaker` follows the three-paths configuration contract.
+
+### Programmatic
+
+```python
+--8<-- "resilience/circuitbreaker_programmatic.py"
+```
+
+### Declarative
+
+```python
+--8<-- "resilience/circuitbreaker_declarative.py"
+```
+
+### Environmental
+
+Prefix: `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_`
+
+| Env var                                                  | Config field         | Type                | Default      |
+|----------------------------------------------------------|----------------------|---------------------|--------------|
+| `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_ERROR_THRESHOLD`      | `error_threshold`    | `int` (> 0)         | `5`          |
+| `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_SUCCESS_THRESHOLD`    | `success_threshold`  | `int` (> 0)         | `2`          |
+| `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_RESET_TIMEOUT`        | `reset_timeout`      | `float` (> 0)       | `30.0`       |
+| `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_HALF_OPEN_CAPACITY`   | `half_open_capacity` | `int` (> 0)         | `1`          |
+| `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_LOG_LEVEL`            | `log_level`          | `str`               | `"WARNING"`  |
+| `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_IGNORE_EXCEPTIONS`    | `ignore_exceptions`  | JSON list of FQN strings (e.g. `'["builtins.ValueError"]'`) | `[]`         |
+
+Concrete example for `CircuitBreaker("payments")`:
+
+```bash
+GREL_CIRCUIT_BREAKER_PAYMENTS_ERROR_THRESHOLD=10
+GREL_CIRCUIT_BREAKER_PAYMENTS_RESET_TIMEOUT=60
+```
+
+```python
+--8<-- "resilience/circuitbreaker_environmental.py"
+```

--- a/docs/resilience/circuit-breaker.md
+++ b/docs/resilience/circuit-breaker.md
@@ -68,7 +68,7 @@ Prefix: `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_`
 | `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_RESET_TIMEOUT`        | `reset_timeout`      | `float` (> 0)       | `30.0`       |
 | `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_HALF_OPEN_CAPACITY`   | `half_open_capacity` | `int` (> 0)         | `1`          |
 | `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_LOG_LEVEL`            | `log_level`          | `str`               | `"WARNING"`  |
-| `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_IGNORE_EXCEPTIONS`    | `ignore_exceptions`  | JSON list of FQN strings (e.g. `'["builtins.ValueError"]'`) | `[]`         |
+| `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_IGNORE_EXCEPTIONS`    | `ignore_exceptions`  | CSV or JSON list of FQN strings (e.g. `builtins.ValueError,my_app.errors.PaymentError` or `'["builtins.ValueError"]'`) | `[]`         |
 
 Concrete example for `CircuitBreaker("payments")`:
 

--- a/docs/snippets/resilience/circuitbreaker_declarative.py
+++ b/docs/snippets/resilience/circuitbreaker_declarative.py
@@ -1,0 +1,8 @@
+from grelmicro.resilience import CircuitBreaker, CircuitBreakerConfig
+
+config = CircuitBreakerConfig(
+    error_threshold=10,
+    reset_timeout=60.0,
+    ignore_exceptions=(ValueError,),
+)
+cb = CircuitBreaker.from_config("payments", config)

--- a/docs/snippets/resilience/circuitbreaker_environmental.py
+++ b/docs/snippets/resilience/circuitbreaker_environmental.py
@@ -1,0 +1,5 @@
+from grelmicro.resilience import CircuitBreaker
+
+# GREL_CIRCUIT_BREAKER_PAYMENTS_ERROR_THRESHOLD=10
+# GREL_CIRCUIT_BREAKER_PAYMENTS_RESET_TIMEOUT=60
+cb = CircuitBreaker("payments")

--- a/docs/snippets/resilience/circuitbreaker_programmatic.py
+++ b/docs/snippets/resilience/circuitbreaker_programmatic.py
@@ -1,0 +1,8 @@
+from grelmicro.resilience import CircuitBreaker
+
+cb = CircuitBreaker(
+    "payments",
+    error_threshold=5,
+    success_threshold=2,
+    reset_timeout=30,
+)

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -1,8 +1,13 @@
-"""Configuration resolution for grelmicro components.
+"""Configuration helpers for grelmicro components.
 
-Exposes `resolve_config`, a helper that builds a validated Pydantic
-config from either a pre-built instance or kwargs merged with
-environment variables.
+Exposes:
+
+- `resolve_config`: build a validated Pydantic config from a pre-built
+  instance or from kwargs merged with environment variables.
+- `env_segment`: normalise an instance name into a POSIX env var
+  segment.
+- `parse_csv_or_json`: coerce an env var string into a list, accepting
+  comma-separated or JSON-array form.
 
 The full contract, including the precedence rules and the
 name-as-namespace convention, is documented in
@@ -12,10 +17,12 @@ name-as-namespace convention, is documented in
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from pydantic import BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from grelmicro._json import json_loads
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -24,6 +31,21 @@ C = TypeVar("C", bound=BaseModel)
 
 _NON_ENV_CHARS = re.compile(r"[^A-Z0-9_]+")
 _REPEATED_UNDERSCORES = re.compile(r"_+")
+
+
+def parse_csv_or_json(value: Any) -> Any:  # noqa: ANN401
+    """Coerce a string into a list, accepting CSV or JSON-array form.
+
+    Pass-through for any non-string value. Strings starting with `[`
+    are parsed as JSON arrays. Otherwise the string is split on commas
+    and each item is stripped. Empty items are dropped.
+    """
+    if isinstance(value, str):
+        s = value.strip()
+        if s.startswith("["):
+            return json_loads(s)
+        return [item.strip() for item in s.split(",") if item.strip()]
+    return value
 
 
 def env_segment(name: str) -> str:

--- a/grelmicro/_types.py
+++ b/grelmicro/_types.py
@@ -1,0 +1,11 @@
+"""Shared type aliases used across grelmicro modules.
+
+Lightweight by design. Modules that depend on a small primitive type
+(e.g. a `Literal` or a narrow `TypeAlias`) import from here instead
+of from a heavyweight module. Keeps the import graph clean.
+"""
+
+from typing import Literal
+
+LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+"""Standard logging level names, matching `logging.getLevelName` output."""

--- a/grelmicro/_types.py
+++ b/grelmicro/_types.py
@@ -5,7 +5,7 @@ Lightweight by design. Modules that depend on a small primitive type
 of from a heavyweight module. Keeps the import graph clean.
 """
 
-from typing import Literal
+from typing import Literal, TypeAlias
 
-LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+LogLevel: TypeAlias = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 """Standard logging level names, matching `logging.getLevelName` output."""

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -14,6 +14,7 @@ from grelmicro.resilience.algorithms import (
 )
 from grelmicro.resilience.circuitbreaker import (
     CircuitBreaker,
+    CircuitBreakerConfig,
     CircuitBreakerMetrics,
     CircuitBreakerState,
     ErrorDetails,
@@ -29,6 +30,7 @@ from grelmicro.resilience.ratelimiter import RateLimiter
 
 __all__ = [
     "CircuitBreaker",
+    "CircuitBreakerConfig",
     "CircuitBreakerError",
     "CircuitBreakerMetrics",
     "CircuitBreakerState",

--- a/grelmicro/resilience/circuitbreaker.py
+++ b/grelmicro/resilience/circuitbreaker.py
@@ -190,9 +190,9 @@ class CircuitBreaker:
                 Errors of these types do not count toward `error_threshold`.
                 Accepts a single exception class, a tuple, or fully-qualified
                 import strings such as `"builtins.ValueError"` or
-                `"my_app.errors.PaymentError"`.
-
-                Default: empty tuple.
+                `"my_app.errors.PaymentError"`. When unset, resolves from the
+                env path or falls back to the `CircuitBreakerConfig` default
+                (empty tuple).
                 """
             ),
         ] = None,

--- a/grelmicro/resilience/circuitbreaker.py
+++ b/grelmicro/resilience/circuitbreaker.py
@@ -12,18 +12,28 @@ from types import TracebackType
 from typing import (
     Annotated,
     Any,
-    Literal,
     Self,
 )
 
 from anyio import from_thread
-from pydantic import BaseModel
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ImportString,
+    PositiveFloat,
+    PositiveInt,
+    field_validator,
+)
+from pydantic_settings import NoDecode
 from typing_extensions import Doc
 
+from grelmicro._config import env_segment, parse_csv_or_json, resolve_config
+from grelmicro._types import LogLevel
 from grelmicro.resilience.errors import CircuitBreakerError
 
 __all__ = [
     "CircuitBreaker",
+    "CircuitBreakerConfig",
     "CircuitBreakerError",
     "CircuitBreakerMetrics",
     "CircuitBreakerState",
@@ -95,6 +105,60 @@ class CircuitBreakerMetrics(BaseModel, frozen=True, extra="forbid"):
     last_error: ErrorDetails | None
 
 
+class CircuitBreakerConfig(BaseModel, frozen=True, extra="forbid"):
+    """Circuit Breaker Config."""
+
+    ignore_exceptions: Annotated[
+        tuple[ImportString[type[Exception]], ...],
+        NoDecode,
+        BeforeValidator(parse_csv_or_json),
+        Doc(
+            """
+            Exceptions ignored by the breaker.
+
+            Errors of these types do not count toward `error_threshold`.
+            Accepts a single exception class, a tuple, or fully-qualified
+            import strings such as `"builtins.ValueError"` or
+            `"my_app.errors.PaymentError"` for YAML and env loading.
+
+            Env vars accept comma-separated values or JSON arrays.
+            """
+        ),
+    ] = ()
+    error_threshold: Annotated[
+        PositiveInt,
+        Doc("Consecutive errors before the breaker opens."),
+    ] = 5
+    success_threshold: Annotated[
+        PositiveInt,
+        Doc(
+            "Consecutive successes in `HALF_OPEN` state before the breaker closes."
+        ),
+    ] = 2
+    reset_timeout: Annotated[
+        PositiveFloat,
+        Doc(
+            "Seconds the breaker stays `OPEN` before transitioning to `HALF_OPEN`."
+        ),
+    ] = 30.0
+    half_open_capacity: Annotated[
+        PositiveInt,
+        Doc("Maximum concurrent calls allowed in the `HALF_OPEN` state."),
+    ] = 1
+    log_level: Annotated[
+        LogLevel,
+        Doc("Logging level for state-change messages."),
+    ] = "WARNING"
+
+    @field_validator("ignore_exceptions", mode="before")
+    @classmethod
+    def _wrap_single(cls, value: Any) -> Any:  # noqa: ANN401
+        """Wrap a single class into a one-tuple."""
+        if isinstance(value, type):
+            return (value,)
+        return value
+
+
 class CircuitBreaker:
     """Circuit Breaker.
 
@@ -110,67 +174,149 @@ class CircuitBreaker:
             Doc(
                 """
                 Name of the circuit breaker instance.
+
+                Acts as the instance identity. Used as the env var
+                prefix and exposed via the `name` property.
                 """
             ),
         ],
         *,
         ignore_exceptions: Annotated[
-            type[Exception] | tuple[type[Exception], ...],
+            type[Exception] | str | tuple[type[Exception] | str, ...] | None,
             Doc(
                 """
-                Exceptions that are ignored and do not count as errors.
+                Exceptions ignored by the breaker.
+
+                Errors of these types do not count toward `error_threshold`.
+                Accepts a single exception class, a tuple, or fully-qualified
+                import strings such as `"builtins.ValueError"` or
+                `"my_app.errors.PaymentError"`.
+
+                Default: empty tuple.
                 """
             ),
-        ] = (),
+        ] = None,
         error_threshold: Annotated[
-            int,
+            PositiveInt | None,
             Doc(
                 """
-                Number of consecutive errors before opening the circuit.
+                Consecutive errors before the breaker opens.
+
+                Default: 5. When unset, resolves from
+                `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_ERROR_THRESHOLD` if
+                present, otherwise falls back to the
+                `CircuitBreakerConfig` default.
                 """
             ),
-        ] = 5,
+        ] = None,
         success_threshold: Annotated[
-            int,
+            PositiveInt | None,
             Doc(
                 """
-                Number of consecutive successes in HALF_OPEN state before closing the circuit.
+                Consecutive successes in `HALF_OPEN` state before the breaker closes.
+
+                Default: 2.
                 """
             ),
-        ] = 2,
+        ] = None,
         reset_timeout: Annotated[
-            float,
+            PositiveFloat | None,
             Doc(
                 """
-                Seconds the circuit stays OPEN before transitioning to HALF_OPEN.
+                Seconds the breaker stays `OPEN` before transitioning to `HALF_OPEN`.
+
+                Default: 30.0.
                 """
             ),
-        ] = 30,
+        ] = None,
         half_open_capacity: Annotated[
-            int,
+            PositiveInt | None,
             Doc(
                 """
-                Maximum number of concurrent calls allowed in the HALF_OPEN state.
+                Maximum concurrent calls allowed in the `HALF_OPEN` state.
+
+                Default: 1.
                 """
             ),
-        ] = 1,
+        ] = None,
         log_level: Annotated[
-            Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+            LogLevel | None,
             Doc(
                 """
-                Logging level for the circuit breaker. Defaults to INFO.
+                Logging level for state-change messages.
+
+                Default: `WARNING`.
                 """
             ),
-        ] = "WARNING",
+        ] = None,
+        env_prefix: Annotated[
+            str | None,
+            Doc(
+                """
+                Override the auto-derived environment variable prefix.
+
+                Default: `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_`.
+                """
+            ),
+        ] = None,
+        read_env: Annotated[
+            bool,
+            Doc(
+                """
+                Whether to read environment variables.
+
+                Default: True.
+                """
+            ),
+        ] = True,
     ) -> None:
         """Initialize the circuit breaker."""
-        self.error_threshold = error_threshold
-        self.success_threshold = success_threshold
-        self.reset_timeout = reset_timeout
-        self.half_open_capacity = half_open_capacity
-        self.ignore_exceptions = ignore_exceptions
+        config = resolve_config(
+            CircuitBreakerConfig,
+            explicit=None,
+            kwargs={
+                "ignore_exceptions": ignore_exceptions,
+                "error_threshold": error_threshold,
+                "success_threshold": success_threshold,
+                "reset_timeout": reset_timeout,
+                "half_open_capacity": half_open_capacity,
+                "log_level": log_level,
+            },
+            env_prefix=env_prefix
+            or f"GREL_CIRCUIT_BREAKER_{env_segment(name)}_",
+            read_env=read_env,
+        )
+        self._setup(name, config)
 
+    @classmethod
+    def from_config(
+        cls,
+        name: Annotated[
+            str,
+            Doc("Name of the circuit breaker instance."),
+        ],
+        config: Annotated[
+            CircuitBreakerConfig,
+            Doc(
+                """
+                The pre-built circuit breaker configuration.
+
+                Use this path when the configuration is assembled at
+                startup from a settings tree. The environment path is
+                bypassed and the config is used as-is.
+                """
+            ),
+        ],
+    ) -> Self:
+        """Construct a `CircuitBreaker` from a name and a pre-built `CircuitBreakerConfig`."""
+        instance = cls.__new__(cls)
+        instance._setup(name, config)  # noqa: SLF001
+        return instance
+
+    def _setup(self, name: str, config: CircuitBreakerConfig) -> None:
+        """Wire the validated config and runtime deps onto the instance."""
         self._name = name
+        self._config = config
         self._state = CircuitBreakerState.CLOSED
         self._consecutive_error_count = 0
         self._consecutive_success_count = 0
@@ -181,7 +327,7 @@ class CircuitBreaker:
         self._open_until_time = 0.0
         self._active_call_count = 0
         self._logger = getLogger(f"grelmicro.circuitbreaker.{name}")
-        self._logger.setLevel(log_level)
+        self._logger.setLevel(config.log_level)
         self._from_thread: _ThreadAdapter | None = None
 
     def __call__(
@@ -226,7 +372,7 @@ class CircuitBreaker:
         """Exit the context manager."""
         await self._release_call()
 
-        if not exc_type or issubclass(exc_type, self.ignore_exceptions):
+        if not exc_type or issubclass(exc_type, self._config.ignore_exceptions):
             await self._on_success()
 
         elif isinstance(exc_value, Exception):
@@ -262,16 +408,9 @@ class CircuitBreaker:
         return self._last_error_time
 
     @property
-    def log_level(self) -> str:
-        """Return the logging level of the circuit breaker."""
-        return logging.getLevelName(self._logger.level)
-
-    @log_level.setter
-    def log_level(
-        self, level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
-    ) -> None:
-        """Set the logging level of the circuit breaker."""
-        self._logger.setLevel(level)
+    def config(self) -> CircuitBreakerConfig:
+        """Return the circuit breaker configuration."""
+        return self._config
 
     def metrics(self) -> CircuitBreakerMetrics:
         """Return current metrics for this circuit breaker."""
@@ -340,7 +479,7 @@ class CircuitBreaker:
 
         self._open_until_time = (
             monotonic()
-            + (self.reset_timeout if open_until is None else open_until)
+            + (self._config.reset_timeout if open_until is None else open_until)
             if state == CircuitBreakerState.OPEN
             else 0
         )
@@ -374,7 +513,7 @@ class CircuitBreaker:
 
         if (
             self._state == CircuitBreakerState.HALF_OPEN
-            and self._active_call_count < self.half_open_capacity
+            and self._active_call_count < self._config.half_open_capacity
         ):
             self._active_call_count += 1
             return True
@@ -395,7 +534,7 @@ class CircuitBreaker:
 
         if (
             self._state != CircuitBreakerState.OPEN
-            and self._consecutive_error_count >= self.error_threshold
+            and self._consecutive_error_count >= self._config.error_threshold
         ):
             self._do_transition_to_state(
                 CircuitBreakerState.OPEN, _TransitionCause.ERROR_THRESHOLD
@@ -409,7 +548,8 @@ class CircuitBreaker:
 
         if (
             self._state == CircuitBreakerState.HALF_OPEN
-            and self._consecutive_success_count >= self.success_threshold
+            and self._consecutive_success_count
+            >= self._config.success_threshold
         ):
             self._do_transition_to_state(
                 CircuitBreakerState.CLOSED, _TransitionCause.SUCCESS_THRESHOLD
@@ -453,7 +593,10 @@ class _ThreadAdapter:
         """Exit the context manager, releasing the circuit breaker lock."""
         from_thread.run(self._cb._release_call)  # noqa: SLF001
 
-        if not exc_type or issubclass(exc_type, self._cb.ignore_exceptions):
+        if not exc_type or issubclass(
+            exc_type,
+            self._cb._config.ignore_exceptions,  # noqa: SLF001
+        ):
             from_thread.run(self._cb._on_success)  # noqa: SLF001
 
         elif isinstance(exc_value, Exception):

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -64,10 +64,22 @@ async def transition(cb: CircuitBreaker, state: CircuitBreakerState) -> None:
 
 async def create_circuit(
     state: CircuitBreakerState,
+    *,
     ignore_exceptions: type[Exception] | tuple[type[Exception], ...] = (),
+    error_threshold: int | None = None,
+    success_threshold: int | None = None,
+    reset_timeout: float | None = None,
+    half_open_capacity: int | None = None,
 ) -> CircuitBreaker:
     """Create a circuit breaker in the specified state."""
-    cb = CircuitBreaker("test", ignore_exceptions=ignore_exceptions)
+    cb = CircuitBreaker(
+        "test",
+        ignore_exceptions=ignore_exceptions,
+        error_threshold=error_threshold,
+        success_threshold=success_threshold,
+        reset_timeout=reset_timeout,
+        half_open_capacity=half_open_capacity,
+    )
     await transition(cb, state)
     return cb
 
@@ -103,8 +115,11 @@ async def circuit_call_not_permitted(
     request: pytest.FixtureRequest,
 ) -> CircuitBreaker:
     """Fixture for circuit breakers that do not permit calls."""
-    cb = await create_circuit(request.param)
-    cb.half_open_capacity = 0  # Ensure no calls are permitted
+    # `half_open_capacity=1` is the minimum. For HALF_OPEN, we saturate
+    # the slot below so any further call is rejected.
+    cb = await create_circuit(request.param, half_open_capacity=1)
+    if request.param == CircuitBreakerState.HALF_OPEN:
+        await cb._try_acquire_call()
     return cb
 
 
@@ -119,10 +134,11 @@ async def circuit_call_permitted(
     request: pytest.FixtureRequest,
 ) -> CircuitBreaker:
     """Fixture for circuit breakers that permit calls."""
-    cb = await create_circuit(request.param)
-    cb.error_threshold = sys.maxsize
-    cb.success_threshold = sys.maxsize
-    return cb
+    return await create_circuit(
+        request.param,
+        error_threshold=sys.maxsize,
+        success_threshold=sys.maxsize,
+    )
 
 
 def test_circuit_init() -> None:
@@ -365,9 +381,10 @@ async def test_circuit_transition_to_half_open_after_timeout(
 ) -> None:
     """Test circuit breaker transitions to half-open after reset timeout."""
     # Arrange
-    cb = await create_circuit(CircuitBreakerState.OPEN)
-    cb.success_threshold = 2  # Ensure it doesn't close immediately
-    frozen_time.tick(timedelta(seconds=cb.reset_timeout))
+    cb = await create_circuit(
+        CircuitBreakerState.OPEN, success_threshold=2
+    )  # Ensure it doesn't close immediately
+    frozen_time.tick(timedelta(seconds=cb.config.reset_timeout))
 
     # Act
     await generate_success(cb)
@@ -382,10 +399,11 @@ async def test_circuit_not_transition_to_half_open_before_timeout(
 ) -> None:
     """Test circuit breaker does not transition to half-open before reset timeout."""
     # Arrange
-    cb = await create_circuit(CircuitBreakerState.OPEN)
-    cb.reset_timeout = reset_timeout
+    cb = await create_circuit(
+        CircuitBreakerState.OPEN, reset_timeout=reset_timeout
+    )
     frozen_time.tick(
-        timedelta(seconds=cb.reset_timeout) - timedelta(milliseconds=1)
+        timedelta(seconds=cb.config.reset_timeout) - timedelta(milliseconds=1)
     )  # Ensure not enough time has passed
 
     # Act & Assert
@@ -398,8 +416,11 @@ async def test_circuit_not_transition_to_half_open_before_timeout(
 async def test_circuit_transition_to_closed(success_count: int) -> None:
     """Test circuit breaker closes after success threshold in half-open."""
     # Arrange
-    cb = await create_circuit(CircuitBreakerState.HALF_OPEN)
-    cb.success_threshold = success_count
+    cb = await create_circuit(
+        CircuitBreakerState.HALF_OPEN,
+        success_threshold=success_count,
+        half_open_capacity=success_count,
+    )
 
     # Act & Assert
     for _ in range(success_count):
@@ -414,8 +435,11 @@ async def test_circuit_transition_from_half_open_to_open(
 ) -> None:
     """Test circuit breaker transitions to open after errors in half-open."""
     # Arrange
-    cb = await create_circuit(CircuitBreakerState.HALF_OPEN)
-    cb.error_threshold = error_count
+    cb = await create_circuit(
+        CircuitBreakerState.HALF_OPEN,
+        error_threshold=error_count,
+        half_open_capacity=error_count,
+    )
 
     # Act & Assert
     for _ in range(error_count):
@@ -447,8 +471,11 @@ async def test_circuit_with_ignore_exceptions(
 ) -> None:
     """Test circuit breaker transitions to closed state when ignoring errors."""
     # Arrange
-    cb = await create_circuit(state, ignore_exceptions=ignore_exceptions)
-    cb.success_threshold = 1  # Avoid immediate closure
+    cb = await create_circuit(
+        state,
+        ignore_exceptions=ignore_exceptions,
+        success_threshold=1,
+    )  # success_threshold=1 avoids immediate closure
 
     # Act & Assert
     with pytest.raises(error):
@@ -479,8 +506,11 @@ async def test_circuit_from_thread_with_ignore_exceptions(
 ) -> None:
     """Test from_thread protect ignores specified error in various states."""
     # Arrange
-    cb = await create_circuit(state, ignore_exceptions=ignore_exceptions)
-    cb.success_threshold = 1  # Avoid immediate closure
+    cb = await create_circuit(
+        state,
+        ignore_exceptions=ignore_exceptions,
+        success_threshold=1,
+    )  # success_threshold=1 avoids immediate closure
 
     def sync() -> None:
         with cb.from_thread:
@@ -597,8 +627,11 @@ async def test_circuit_metrics_counters_with_ignore_exceptions(
 ) -> None:
     """Test metrics when errors are ignored."""
     # Arrange
-    cb = await create_circuit(state, ignore_exceptions=SentinelError)
-    cb.success_threshold = success_count + 1  # Avoid immediate closure
+    cb = await create_circuit(
+        state,
+        ignore_exceptions=SentinelError,
+        success_threshold=success_count + 1,
+    )  # success_threshold=count+1 avoids immediate closure
     for _ in range(success_count):
         with suppress(SentinelError):
             async with cb:
@@ -624,18 +657,31 @@ async def test_circuit_metrics_counters_with_ignore_exceptions(
     "call_count",
     [0, 1, 3, 5],
 )
+@pytest.mark.parametrize(
+    "state",
+    [
+        CircuitBreakerState.CLOSED,
+        CircuitBreakerState.HALF_OPEN,
+        CircuitBreakerState.FORCED_CLOSED,
+    ],
+)
 async def test_circuit_metrics_active_calls(
-    circuit_call_permitted: CircuitBreaker, call_count: int
+    state: CircuitBreakerState, call_count: int
 ) -> None:
     """Active call count is correct for each state."""
     # Arrange
-    circuit_call_permitted.half_open_capacity = call_count + 1
+    cb = await create_circuit(
+        state,
+        error_threshold=sys.maxsize,
+        success_threshold=sys.maxsize,
+        half_open_capacity=call_count + 1,
+    )
 
     # Act
     async with AsyncExitStack() as stack:
         for _ in range(call_count):
-            await stack.enter_async_context(circuit_call_permitted)
-        metrics = circuit_call_permitted.metrics()
+            await stack.enter_async_context(cb)
+        metrics = cb.metrics()
 
     # Assert
     assert metrics.active_calls == call_count
@@ -653,10 +699,17 @@ async def test_circuit_metrics_with_call_not_permitted(
     metrics = circuit_call_not_permitted.metrics()
 
     # Assert
+    # HALF_OPEN's slot is saturated by the fixture to make the call
+    # not permitted, so active_calls reflects the saturating call.
+    expected_active = (
+        1
+        if circuit_call_not_permitted.state == CircuitBreakerState.HALF_OPEN
+        else 0
+    )
     assert metrics == CircuitBreakerMetrics(
         name=circuit_call_not_permitted.name,
         state=circuit_call_not_permitted.state,
-        active_calls=0,
+        active_calls=expected_active,
         total_error_count=0,
         total_success_count=0,
         consecutive_error_count=0,
@@ -763,12 +816,9 @@ async def test_circuit_from_thread_state_transition(
 def test_circuitbreaker_log_level(
     level: Literal["WARNING", "DEBUG", "INFO", "ERROR", "CRITICAL"],
 ) -> None:
-    """Test log_level property getter and setter."""
-    # Arrange
-    cb = CircuitBreaker("test")
-
+    """`log_level` is read from the frozen config."""
     # Act
-    cb.log_level = level
+    cb = CircuitBreaker("test", log_level=level)
 
     # Assert
-    assert cb.log_level == level
+    assert cb.config.log_level == level

--- a/tests/resilience/test_circuitbreaker_config.py
+++ b/tests/resilience/test_circuitbreaker_config.py
@@ -1,0 +1,186 @@
+"""Tests for the three-paths CircuitBreaker construction."""
+
+import pytest
+from pydantic import ValidationError
+
+from grelmicro.resilience.circuitbreaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+)
+
+ERROR_KWARG = 7
+ERROR_ENV = 12
+RESET_ENV = 99.0
+DEFAULT_ERROR = 5
+DEFAULT_SUCCESS = 2
+DEFAULT_RESET = 30.0
+DEFAULT_HALF_OPEN_CAPACITY = 1
+DEFAULT_LOG_LEVEL = "WARNING"
+
+
+def test_programmatic_path_uses_kwargs() -> None:
+    """Plain kwargs build a config, falling back to CircuitBreakerConfig defaults."""
+    cb = CircuitBreaker("payments", error_threshold=ERROR_KWARG)
+    assert cb.name == "payments"
+    assert cb.config.error_threshold == ERROR_KWARG
+    assert cb.config.success_threshold == DEFAULT_SUCCESS
+
+
+def test_declarative_path_uses_from_config() -> None:
+    """`CircuitBreaker.from_config()` constructs from a name and a `CircuitBreakerConfig`."""
+    cfg = CircuitBreakerConfig(error_threshold=ERROR_KWARG, reset_timeout=10.0)
+    cb = CircuitBreaker.from_config("payments", cfg)
+    assert cb.name == "payments"
+    assert cb.config is cfg
+
+
+def test_from_config_bypasses_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`CircuitBreaker.from_config()` ignores env even when set."""
+    monkeypatch.setenv(
+        "GREL_CIRCUIT_BREAKER_PAYMENTS_ERROR_THRESHOLD", str(ERROR_ENV)
+    )
+    cfg = CircuitBreakerConfig(error_threshold=ERROR_KWARG)
+    cb = CircuitBreaker.from_config("payments", cfg)
+    assert cb.config.error_threshold == ERROR_KWARG
+
+
+def test_environmental_path_reads_grel_prefixed_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env vars under ``GREL_CIRCUIT_BREAKER_{NAME}_*`` populate unset fields."""
+    monkeypatch.setenv(
+        "GREL_CIRCUIT_BREAKER_PAYMENTS_ERROR_THRESHOLD", str(ERROR_ENV)
+    )
+    monkeypatch.setenv(
+        "GREL_CIRCUIT_BREAKER_PAYMENTS_RESET_TIMEOUT", str(RESET_ENV)
+    )
+    cb = CircuitBreaker("payments")
+    assert cb.config.error_threshold == ERROR_ENV
+    assert cb.config.reset_timeout == RESET_ENV
+
+
+def test_kwargs_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Caller kwargs win over env vars."""
+    monkeypatch.setenv(
+        "GREL_CIRCUIT_BREAKER_PAYMENTS_ERROR_THRESHOLD", str(ERROR_ENV)
+    )
+    cb = CircuitBreaker("payments", error_threshold=ERROR_KWARG)
+    assert cb.config.error_threshold == ERROR_KWARG
+
+
+def test_env_prefix_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``env_prefix=`` replaces the auto-derived ``GREL_CIRCUIT_BREAKER_{NAME}_``."""
+    monkeypatch.setenv(
+        "APP_CIRCUIT_BREAKER_PAYMENTS_ERROR_THRESHOLD", str(ERROR_ENV)
+    )
+    cb = CircuitBreaker("payments", env_prefix="APP_CIRCUIT_BREAKER_PAYMENTS_")
+    assert cb.config.error_threshold == ERROR_ENV
+
+
+def test_read_env_false_ignores_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``read_env=False`` skips env reads entirely."""
+    monkeypatch.setenv(
+        "GREL_CIRCUIT_BREAKER_PAYMENTS_ERROR_THRESHOLD", str(ERROR_ENV)
+    )
+    cb = CircuitBreaker("payments", read_env=False)
+    assert cb.config.error_threshold == DEFAULT_ERROR
+
+
+def test_zero_config_uses_circuitbreakerconfig_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without env or kwargs, CircuitBreakerConfig defaults take over."""
+    monkeypatch.delenv(
+        "GREL_CIRCUIT_BREAKER_PAYMENTS_ERROR_THRESHOLD", raising=False
+    )
+    cb = CircuitBreaker("payments")
+    assert cb.config.error_threshold == DEFAULT_ERROR
+    assert cb.config.success_threshold == DEFAULT_SUCCESS
+    assert cb.config.reset_timeout == DEFAULT_RESET
+    assert cb.config.half_open_capacity == DEFAULT_HALF_OPEN_CAPACITY
+    assert cb.config.log_level == DEFAULT_LOG_LEVEL
+
+
+def test_ignore_exceptions_accepts_single_class() -> None:
+    """`ignore_exceptions=SomeError` is accepted as shorthand for `(SomeError,)`."""
+    cb = CircuitBreaker("payments", ignore_exceptions=ValueError)
+    assert cb.config.ignore_exceptions == (ValueError,)
+
+
+def test_ignore_exceptions_accepts_tuple() -> None:
+    """`ignore_exceptions=(A, B)` is preserved."""
+    cb = CircuitBreaker(
+        "payments", ignore_exceptions=(ValueError, RuntimeError)
+    )
+    assert cb.config.ignore_exceptions == (ValueError, RuntimeError)
+
+
+def test_ignore_exceptions_accepts_fqn_string() -> None:
+    """`ignore_exceptions="builtins.ValueError"` resolves via `ImportString`."""
+    cfg = CircuitBreakerConfig(ignore_exceptions="builtins.ValueError")  # ty: ignore[invalid-argument-type]
+    assert cfg.ignore_exceptions == (ValueError,)
+
+
+def test_constructor_accepts_fqn_string_for_ignore_exceptions() -> None:
+    """`CircuitBreaker("...", ignore_exceptions="...")` works end-to-end."""
+    cb = CircuitBreaker("payments", ignore_exceptions="builtins.ValueError")
+    assert cb.config.ignore_exceptions == (ValueError,)
+
+
+def test_constructor_accepts_mixed_class_and_fqn() -> None:
+    """A tuple mixing class refs and FQN strings resolves consistently."""
+    cb = CircuitBreaker(
+        "payments",
+        ignore_exceptions=(ValueError, "builtins.RuntimeError"),
+    )
+    assert cb.config.ignore_exceptions == (ValueError, RuntimeError)
+
+
+def test_ignore_exceptions_accepts_tuple_of_fqn_strings() -> None:
+    """A tuple of FQN strings resolves to a tuple of classes."""
+    cfg = CircuitBreakerConfig(
+        ignore_exceptions=("builtins.ValueError", "builtins.RuntimeError"),  # ty: ignore[invalid-argument-type]
+    )
+    assert cfg.ignore_exceptions == (ValueError, RuntimeError)
+
+
+def test_ignore_exceptions_from_env_accepts_csv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env var supports CSV format for operator-friendly shell input."""
+    monkeypatch.setenv(
+        "GREL_CIRCUIT_BREAKER_PAYMENTS_IGNORE_EXCEPTIONS",
+        "builtins.ValueError,builtins.RuntimeError",
+    )
+    cb = CircuitBreaker("payments")
+    assert cb.config.ignore_exceptions == (ValueError, RuntimeError)
+
+
+def test_ignore_exceptions_from_env_accepts_json_array(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env var also accepts a JSON array for back-compat."""
+    monkeypatch.setenv(
+        "GREL_CIRCUIT_BREAKER_PAYMENTS_IGNORE_EXCEPTIONS",
+        '["builtins.ValueError","builtins.RuntimeError"]',
+    )
+    cb = CircuitBreaker("payments")
+    assert cb.config.ignore_exceptions == (ValueError, RuntimeError)
+
+
+def test_invalid_threshold_raises() -> None:
+    """Non-positive threshold values raise `ValidationError`."""
+    with pytest.raises(ValidationError):
+        CircuitBreaker("payments", error_threshold=0)
+
+
+def test_name_with_punctuation_normalises_env_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A name with punctuation normalises into a valid env prefix."""
+    monkeypatch.setenv(
+        "GREL_CIRCUIT_BREAKER_PAYMENTS_EU_ERROR_THRESHOLD", str(ERROR_ENV)
+    )
+    cb = CircuitBreaker("payments-eu")
+    assert cb.config.error_threshold == ERROR_ENV
+    assert cb.name == "payments-eu"

--- a/tests/resilience/test_errors.py
+++ b/tests/resilience/test_errors.py
@@ -35,6 +35,7 @@ def test_resilience_module_exports() -> None:
     """Test resilience module __all__ contains expected symbols."""
     expected = {
         "CircuitBreaker",
+        "CircuitBreakerConfig",
         "CircuitBreakerError",
         "CircuitBreakerMetrics",
         "CircuitBreakerState",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import BaseModel, ConfigDict, PositiveFloat, ValidationError
 
-from grelmicro._config import env_segment, resolve_config
+from grelmicro._config import env_segment, parse_csv_or_json, resolve_config
 
 DEFAULT_TIMEOUT = 5.0
 DEFAULT_RETRIES = 3
@@ -246,3 +246,27 @@ def test_env_segment_rejects_leading_digit(bad: str) -> None:
     """A name producing an env segment starting with a digit raises."""
     with pytest.raises(ValueError, match="starts with a digit"):
         env_segment(bad)
+
+
+# --- parse_csv_or_json ---
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("a,b,c", ["a", "b", "c"]),
+        (" a , b , c ", ["a", "b", "c"]),
+        ("a", ["a"]),
+        (",a,,b,", ["a", "b"]),
+        ('["a","b"]', ["a", "b"]),
+        ("[1, 2]", [1, 2]),
+        ("", []),
+        (["a", "b"], ["a", "b"]),
+        (("a", "b"), ("a", "b")),
+        (None, None),
+        (42, 42),
+    ],
+)
+def test_parse_csv_or_json(value: object, expected: object) -> None:
+    """CSV strings split on commas, JSON arrays parse, others pass through."""
+    assert parse_csv_or_json(value) == expected


### PR DESCRIPTION
Closes #117.

## Summary

`CircuitBreaker` is the last primitive that wasn't on the three-paths configuration contract. This PR brings it in line with `Lock`, `TaskLock`, `LeaderElection`, `RateLimiter`, `HealthRegistry`, `RateLimitFilter`, `DuplicateFilter`.

## What changes

- Introduces `CircuitBreakerConfig` (frozen, `extra="forbid"`).
- `CircuitBreaker.__init__` resolves through `_config.resolve_config` with `env_prefix=f"GREL_CIRCUIT_BREAKER_{env_segment(name)}_"`.
- Adds `CircuitBreaker.from_config(name, config)`.
- Adds `cb.config` property; removes the previously mutable scalar attributes (`error_threshold`, `success_threshold`, `reset_timeout`, `half_open_capacity`, `ignore_exceptions`, `log_level`).
- `ignore_exceptions` accepts Python class refs **and** fully-qualified import strings via Pydantic's `ImportString[type[Exception]]`.
- Env vars accept comma-separated lists or JSON arrays via a shared `parse_csv_or_json` helper + `NoDecode`.

## Path A vs Path B

Picked **Path A** (break and rewrite tests) per the spec recommendation. Path B (block on `reconfigure()` from #120) would have doubled this PR. The 12 mutation sites in the test suite were rewritten to construct fresh `CircuitBreaker`s with the desired config — tests are now more honest.

## New shared utilities

Two small additions land here, useful across the codebase:

- `grelmicro/_types.py` — shared lightweight type aliases (`LogLevel`). Keeps cross-module imports cheap (avoids pulling logging-config heavyweight imports into resilience).
- `grelmicro/_config.py::parse_csv_or_json` — env var list parser. Reusable for any future tuple/list field in any component.

## Test plan

- [x] All 1373 tests green at 100% coverage.
- [x] `mkdocs build --strict` passes.
- [x] `tests/resilience/test_circuitbreaker.py` — 12 mutation sites rewritten, all 173 CB tests pass.
- [x] `tests/resilience/test_circuitbreaker_config.py` — 18 new tests covering all three paths plus FQN-string and CSV/JSON env forms.
- [x] `tests/test_config.py` — 11 new tests for `parse_csv_or_json`.

## Out of scope

- `reconfigure()` — see #120.
- Sliding-window failure-rate algorithm — explored, deemed YAGNI for now (no current user demand).