### PR TITLE
♻️ Make backend registration explicit (#116)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,10 +300,13 @@ If you adapt code from another project, even a snippet:
   `_protocol.py`, with at least a Memory and a Redis
   implementation.
 - Backends are registered in a shared registry
-  (`grelmicro/_backends.py::BackendRegistry`). User code picks a
-  backend either by initialising a concrete backend class with
-  `auto_register=True` or by passing `backend=` explicitly to the
-  primitive's constructor.
+  (`grelmicro/_backends.py::BackendRegistry`). Construction is
+  pure: `__init__` performs no registry writes. User code picks a
+  backend either by entering it as an async context manager
+  (`async with` registers on enter, unregisters on exit), by
+  calling the module-level `use_backend` helper for process-
+  lifetime registration, or by passing `backend=` explicitly to
+  the primitive's constructor.
 - Primitives expose the `backend=` override even when they also
   fall back to the registry.
 

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -15,25 +15,44 @@ The `BackendRegistry[T]` is a generic, typed container that holds a single defau
 | `sync` | `sync_backend_registry` | `SyncBackend` | Redis, PostgreSQL, SQLite, Kubernetes, Memory |
 | `cache` | `cache_backend_registry` | `CacheBackend` | Redis, Memory |
 
-## Registration
+## Construction vs registration
 
-Backends register themselves on initialization via `auto_register=True` (the default):
+Construction and registration are two distinct steps. `__init__` is pure: it validates configuration and binds locals, but never touches the global registry. Registration is explicit and reversible.
+
+There are three ways to register a backend:
+
+**1. Scoped registration via `async with` (recommended).** `__aenter__` registers the backend, `__aexit__` unregisters it. The registry is empty after the context exits.
 
 ```python
 async with RedisSyncBackend() as backend:
-    # backend is now the default for Lock, TaskLock, LeaderElection
+    # backend is the default for Lock, TaskLock, LeaderElection here
     ...
+# unregistered on exit
 ```
 
-This calls `sync_backend_registry.set(self)` internally. Consumers that accept an optional `backend` parameter fall back to the registry when none is provided:
+**2. Process-lifetime registration via `use_backend`.** Each module exposes a small helper for `main()` or lifespan wiring:
 
 ```python
-# Explicit backend
-lock = Lock(name="my-lock", backend=my_backend)
+from grelmicro import sync
 
-# Uses the registered default
-lock = Lock(name="my-lock")
+backend = RedisSyncBackend()
+sync.use_backend(backend)  # idempotent on the same instance
 ```
+
+The helpers are: `grelmicro.sync.use_backend`, `grelmicro.cache.use_backend`, `grelmicro.resilience.use_backend`, `grelmicro.health.use_registry`.
+
+**3. Pure construction without registration.** Pass the backend explicitly to consumers and skip the registry entirely:
+
+```python
+backend = MemorySyncBackend()
+lock = Lock(name="my-lock", backend=backend)
+```
+
+Consumers that accept an optional `backend` parameter fall back to the registry when none is provided.
+
+### Identity-checked unregister
+
+`registry.unregister(backend)` only clears the slot when the registered instance is identical to the one passed in. Calling it on a non-current instance is a no-op. This means a stale backend's `__aexit__` cannot evict a newer backend that replaced it.
 
 ## Protocol-Based Polymorphism
 
@@ -42,19 +61,6 @@ Backends are defined by protocols (structural typing), not base classes. Any obj
 - Swapping backends without changing application code
 - Writing test backends (e.g. `MemorySyncBackend`) with no external dependencies
 - Adding new backends without modifying existing code
-
-## Auto-Registration Control
-
-Set `auto_register=False` to create a backend without registering it as the default. This is useful for:
-
-- Tests that need isolated backend instances
-- Applications using multiple backends for different purposes
-- Manual wiring in dependency injection setups
-
-```python
-# Not registered as default
-cache = RedisCache(url="redis://localhost/1", ttl=60, auto_register=False)
-```
 
 ## Connection Pool Isolation
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,13 +4,13 @@
 
 ### Breaking
 
-* 💥 Backend constructors are now pure: `__init__` performs no registry writes. The `auto_register` kwarg is removed from `MemorySyncBackend`, `RedisSyncBackend`, `PostgresSyncBackend`, `SQLiteSyncBackend`, `KubernetesSyncBackend`, `MemoryCacheBackend`, `RedisCacheBackend`, `MemoryRateLimiterBackend`, `RedisRateLimiterBackend`, and `HealthRegistry`. Register via `async with` (scoped) or the new `use_backend` / `use_registry` helpers (process lifetime). PR [#116](https://github.com/grelinfo/grelmicro/issues/116).
-* 💥 `BackendRegistry.set` is renamed `register` and `BackendRegistry.unregister` is added with an identity check. `reset` remains for test fixtures. PR [#116](https://github.com/grelinfo/grelmicro/issues/116).
+* 💥 Backend constructors are now pure: `__init__` performs no registry writes. The `auto_register` kwarg is removed from `MemorySyncBackend`, `RedisSyncBackend`, `PostgresSyncBackend`, `SQLiteSyncBackend`, `KubernetesSyncBackend`, `MemoryCacheBackend`, `RedisCacheBackend`, `MemoryRateLimiterBackend`, `RedisRateLimiterBackend`, and `HealthRegistry`. Register via `async with` (scoped) or the new `use_backend` / `use_registry` helpers (process lifetime). PR [#138](https://github.com/grelinfo/grelmicro/pull/138).
+* 💥 `BackendRegistry.set` is renamed `register` and `BackendRegistry.unregister` is added with an identity check. `reset` remains for test fixtures. PR [#138](https://github.com/grelinfo/grelmicro/pull/138).
 
 ### Features
 
-* ✨ Add `grelmicro.sync.use_backend`, `grelmicro.cache.use_backend`, `grelmicro.resilience.use_backend`, and `grelmicro.health.use_registry` for explicit, idempotent process-lifetime registration. PR [#116](https://github.com/grelinfo/grelmicro/issues/116).
-* ✨ Backends register on `__aenter__` and unregister on `__aexit__` with identity-checked unregister, so a stale backend cannot evict the one that replaced it. PR [#116](https://github.com/grelinfo/grelmicro/issues/116).
+* ✨ Add `grelmicro.sync.use_backend`, `grelmicro.cache.use_backend`, `grelmicro.resilience.use_backend`, and `grelmicro.health.use_registry` for explicit, idempotent process-lifetime registration. PR [#138](https://github.com/grelinfo/grelmicro/pull/138).
+* ✨ Backends register on `__aenter__` and unregister on `__aexit__` with identity-checked unregister, so a stale backend cannot evict the one that replaced it. PR [#138](https://github.com/grelinfo/grelmicro/pull/138).
 
 ## 0.17.0 - 2026-04-29
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Breaking
+
+* 💥 Backend constructors are now pure: `__init__` performs no registry writes. The `auto_register` kwarg is removed from `MemorySyncBackend`, `RedisSyncBackend`, `PostgresSyncBackend`, `SQLiteSyncBackend`, `KubernetesSyncBackend`, `MemoryCacheBackend`, `RedisCacheBackend`, `MemoryRateLimiterBackend`, `RedisRateLimiterBackend`, and `HealthRegistry`. Register via `async with` (scoped) or the new `use_backend` / `use_registry` helpers (process lifetime). PR [#116](https://github.com/grelinfo/grelmicro/issues/116).
+* 💥 `BackendRegistry.set` is renamed `register` and `BackendRegistry.unregister` is added with an identity check. `reset` remains for test fixtures. PR [#116](https://github.com/grelinfo/grelmicro/issues/116).
+
+### Features
+
+* ✨ Add `grelmicro.sync.use_backend`, `grelmicro.cache.use_backend`, `grelmicro.resilience.use_backend`, and `grelmicro.health.use_registry` for explicit, idempotent process-lifetime registration. PR [#116](https://github.com/grelinfo/grelmicro/issues/116).
+* ✨ Backends register on `__aenter__` and unregister on `__aexit__` with identity-checked unregister, so a stale backend cannot evict the one that replaced it. PR [#116](https://github.com/grelinfo/grelmicro/issues/116).
+
 ## 0.17.0 - 2026-04-29
 
 ### Breaking

--- a/grelmicro/_backends.py
+++ b/grelmicro/_backends.py
@@ -16,9 +16,10 @@ class BackendRegistry(Generic[T]):
     """Generic backend registry.
 
     Stores a single default backend instance per named slot.
-    Backends register themselves on initialization (via
-    ``auto_register=True``) and consumers look up the default
-    via ``get()``.
+    Registration is explicit: callers invoke
+    :meth:`register` (typically from a module-level
+    ``use_backend`` helper or a backend's ``__aenter__``).
+    Consumers look up the default via :meth:`get`.
     """
 
     def __init__(self, *, name: str) -> None:
@@ -31,14 +32,30 @@ class BackendRegistry(Generic[T]):
         self._name = name
         self._backend: T | None = None
 
-    def set(self, backend: T) -> None:
-        """Register a backend as the default."""
+    def register(self, backend: T) -> None:
+        """Register a backend as the default.
+
+        Warns if a different backend is already registered.
+        Re-registering the same instance is a no-op.
+        """
+        if self._backend is backend:
+            return
         if self._backend is not None:
             warnings.warn(
                 f"Overwriting already-registered {self._name} backend.",
                 stacklevel=2,
             )
         self._backend = backend
+
+    def unregister(self, backend: T) -> None:
+        """Unregister ``backend`` if it is the current default.
+
+        Identity check: clears the slot only when
+        ``self._backend is backend``. Calling on a non-current
+        instance is a no-op.
+        """
+        if self._backend is backend:
+            self._backend = None
 
     def get(self) -> T:
         """Return the registered backend.
@@ -61,7 +78,11 @@ class BackendRegistry(Generic[T]):
         return self._backend is not None
 
     def reset(self) -> None:
-        """Remove the registered backend."""
+        """Remove the registered backend unconditionally.
+
+        Intended for test fixtures. Production code should call
+        :meth:`unregister` with the instance to clear.
+        """
         self._backend = None
 
 

--- a/grelmicro/cache/__init__.py
+++ b/grelmicro/cache/__init__.py
@@ -1,5 +1,10 @@
 """Cache."""
 
+from typing import Annotated
+
+from typing_extensions import Doc
+
+from grelmicro.cache._backends import cache_backend_registry
 from grelmicro.cache._protocol import CacheBackend
 from grelmicro.cache.cached import cached
 from grelmicro.cache.errors import CacheError, CacheSettingsValidationError
@@ -10,6 +15,21 @@ from grelmicro.cache.serializers import (
     PydanticSerializer,
 )
 from grelmicro.cache.ttl import CacheInfo, TTLCache
+
+
+def use_backend(
+    backend: Annotated[
+        CacheBackend,
+        Doc("The cache backend to register as the default."),
+    ],
+) -> None:
+    """Register `backend` as the default cache backend.
+
+    Idempotent: re-registering the same instance is a no-op.
+    Registering a different instance warns and replaces.
+    """
+    cache_backend_registry.register(backend)
+
 
 __all__ = [
     "CacheBackend",
@@ -22,4 +42,5 @@ __all__ = [
     "PydanticSerializer",
     "TTLCache",
     "cached",
+    "use_backend",
 ]

--- a/grelmicro/cache/memory.py
+++ b/grelmicro/cache/memory.py
@@ -2,9 +2,7 @@
 
 from time import monotonic
 from types import TracebackType
-from typing import Annotated, Self
-
-from typing_extensions import Doc
+from typing import Self
 
 from grelmicro.cache._backends import cache_backend_registry
 
@@ -16,25 +14,13 @@ class MemoryCacheBackend:
     Suitable for testing and single-process applications.
     """
 
-    def __init__(
-        self,
-        *,
-        auto_register: Annotated[
-            bool,
-            Doc(
-                "Automatically register this cache backend in the "
-                "backend registry."
-            ),
-        ] = True,
-    ) -> None:
+    def __init__(self) -> None:
         """Initialize the memory cache backend."""
         self._data: dict[str, tuple[bytes, float]] = {}
-        self._auto_registered = auto_register
-        if auto_register:
-            cache_backend_registry.set(self)
 
     async def __aenter__(self) -> Self:
-        """Open the cache backend."""
+        """Open the cache backend and register it as the default."""
+        cache_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -43,14 +29,9 @@ class MemoryCacheBackend:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the cache backend."""
+        """Close the cache backend and unregister it."""
         self._data.clear()
-        if (
-            self._auto_registered
-            and cache_backend_registry.is_loaded
-            and cache_backend_registry.get() is self
-        ):
-            cache_backend_registry.reset()
+        cache_backend_registry.unregister(self)
 
     async def get(self, *, key: str) -> bytes | None:
         """Get raw bytes by key.

--- a/grelmicro/cache/redis.py
+++ b/grelmicro/cache/redis.py
@@ -45,25 +45,16 @@ class RedisCacheBackend:
                 By default no prefix is added.
                 """),
         ] = "",
-        auto_register: Annotated[
-            bool,
-            Doc(
-                "Automatically register this cache backend in the "
-                "backend registry."
-            ),
-        ] = True,
     ) -> None:
         """Initialize the Redis cache backend."""
         self._url, self._redis = _create_redis_client(
             url, CacheSettingsValidationError
         )
         self._prefix = prefix
-        self._auto_registered = auto_register
-        if auto_register:
-            cache_backend_registry.set(self)
 
     async def __aenter__(self) -> Self:
-        """Open the cache connection."""
+        """Open the cache connection and register the backend as default."""
+        cache_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -72,14 +63,9 @@ class RedisCacheBackend:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the cache connection."""
+        """Close the cache connection and unregister the backend."""
         await self._redis.aclose()
-        if (
-            self._auto_registered
-            and cache_backend_registry.is_loaded
-            and cache_backend_registry.get() is self
-        ):
-            cache_backend_registry.reset()
+        cache_backend_registry.unregister(self)
 
     async def get(self, *, key: str) -> bytes | None:
         """Get raw bytes by key.

--- a/grelmicro/health/__init__.py
+++ b/grelmicro/health/__init__.py
@@ -1,6 +1,10 @@
 """Health Check Registry."""
 
-from grelmicro.health._backends import get_health_registry
+from typing import Annotated
+
+from typing_extensions import Doc
+
+from grelmicro.health._backends import get_health_registry, health_registry
 from grelmicro.health._models import (
     CheckResult,
     HealthReport,
@@ -9,6 +13,21 @@ from grelmicro.health._models import (
 from grelmicro.health._registry import HealthRegistry, HealthRegistryConfig
 from grelmicro.health._types import HealthCheckFunc, HealthDetails
 from grelmicro.health.errors import HealthError
+
+
+def use_registry(
+    registry: Annotated[
+        HealthRegistry,
+        Doc("The health registry to install as the global default."),
+    ],
+) -> None:
+    """Register `registry` as the global default health registry.
+
+    Idempotent: re-registering the same instance is a no-op.
+    Registering a different instance warns and replaces.
+    """
+    health_registry.register(registry)
+
 
 __all__ = [
     "CheckResult",
@@ -20,4 +39,5 @@ __all__ = [
     "HealthReport",
     "HealthStatus",
     "get_health_registry",
+    "use_registry",
 ]

--- a/grelmicro/health/_registry.py
+++ b/grelmicro/health/_registry.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from logging import getLogger
+from types import TracebackType
 from typing import Annotated, Self
 
 import anyio
@@ -151,13 +152,6 @@ class HealthRegistry:
                 """
             ),
         ] = True,
-        auto_register: Annotated[
-            bool,
-            Doc(
-                "Automatically register this instance as the global "
-                "health registry singleton. Set to False for testing."
-            ),
-        ] = True,
     ) -> None:
         """Initialize the health registry."""
         config = resolve_config(
@@ -167,7 +161,7 @@ class HealthRegistry:
             env_prefix=env_prefix or "GREL_HEALTH_",
             read_env=read_env,
         )
-        self._setup(config, auto_register=auto_register)
+        self._setup(config)
 
     @classmethod
     def from_config(
@@ -186,31 +180,30 @@ class HealthRegistry:
                 """
             ),
         ],
-        *,
-        auto_register: Annotated[
-            bool,
-            Doc(
-                "Automatically register this instance as the global "
-                "health registry singleton. Set to False for testing."
-            ),
-        ] = True,
     ) -> Self:
         """Construct a `HealthRegistry` from a pre-built `HealthRegistryConfig`."""
         instance = cls.__new__(cls)
-        instance._setup(config, auto_register=auto_register)  # noqa: SLF001
+        instance._setup(config)  # noqa: SLF001
         return instance
 
-    def _setup(
-        self,
-        config: HealthRegistryConfig,
-        *,
-        auto_register: bool,
-    ) -> None:
+    def _setup(self, config: HealthRegistryConfig) -> None:
         """Wire the validated config and runtime deps onto the instance."""
         self._config = config
         self._entries: dict[str, _Entry] = {}
-        if auto_register:
-            health_registry.set(self)
+
+    async def __aenter__(self) -> Self:
+        """Register this registry as the global default."""
+        health_registry.register(self)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Unregister this registry."""
+        health_registry.unregister(self)
 
     def add(
         self,

--- a/grelmicro/health/fastapi.py
+++ b/grelmicro/health/fastapi.py
@@ -49,8 +49,8 @@ def health_router(
         Doc(
             "Health registry whose checks the router runs. When "
             "omitted, the router resolves the global registry "
-            "(the most recent ``HealthRegistry`` created with "
-            "``auto_register=True``)."
+            "(the registry installed via ``health.use_registry`` "
+            "or entered as an async context manager)."
         ),
     ] = None,
     *,

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -1,7 +1,11 @@
 """Resilience."""
 
 import warnings
+from typing import Annotated
 
+from typing_extensions import Doc
+
+from grelmicro.resilience._backends import rate_limiter_backend_registry
 from grelmicro.resilience._protocol import (
     RateLimiterBackend,
     RateLimiterStrategy,
@@ -28,6 +32,21 @@ from grelmicro.resilience.errors import (
 from grelmicro.resilience.memory import MemoryTokenBucket
 from grelmicro.resilience.ratelimiter import RateLimiter
 
+
+def use_backend(
+    backend: Annotated[
+        RateLimiterBackend,
+        Doc("The rate limiter backend to register as the default."),
+    ],
+) -> None:
+    """Register `backend` as the default rate limiter backend.
+
+    Idempotent: re-registering the same instance is a no-op.
+    Registering a different instance warns and replaces.
+    """
+    rate_limiter_backend_registry.register(backend)
+
+
 __all__ = [
     "CircuitBreaker",
     "CircuitBreakerConfig",
@@ -46,6 +65,7 @@ __all__ = [
     "ResilienceError",
     "ResilienceSettingsValidationError",
     "TokenBucketConfig",
+    "use_backend",
 ]
 
 

--- a/grelmicro/resilience/memory.py
+++ b/grelmicro/resilience/memory.py
@@ -177,45 +177,27 @@ class MemoryRateLimiterBackend(RateLimiterBackend):
 
     Example:
     ```python
-    from grelmicro.resilience import RateLimiter, TokenBucketConfig
+    from grelmicro.resilience import RateLimiter, TokenBucketConfig, use_backend
     from grelmicro.resilience.memory import MemoryRateLimiterBackend
 
-    MemoryRateLimiterBackend()  # auto-registers
+    use_backend(MemoryRateLimiterBackend())
     rl = RateLimiter("api", TokenBucketConfig(capacity=10, refill_rate=1))
     ```
 
     Read more in the [Rate Limiter](../resilience/rate-limiter.md) docs.
     """
 
-    def __init__(
-        self,
-        *,
-        auto_register: Annotated[
-            bool,
-            Doc(
-                """
-                Automatically register the backend as the default
-                for rate limiters.
-
-                Set to `False` to manage the backend manually, for
-                example when wiring multiple backends side-by-side
-                in tests.
-                """
-            ),
-        ] = True,
-    ) -> None:
+    def __init__(self) -> None:
         """Initialize the rate limiter backend."""
         # Separate per-algorithm state maps so keys never alias
         # across algorithms.
         self._token_bucket_state: dict[str, tuple[float, float]] = {}
         self._gcra_state: dict[str, float] = {}
         self._lock = Lock()
-        self._auto_registered = auto_register
-        if auto_register:
-            rate_limiter_backend_registry.set(self)
 
     async def __aenter__(self) -> Self:
-        """Open the rate limiter backend."""
+        """Open the rate limiter backend and register it as the default."""
+        rate_limiter_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -224,16 +206,11 @@ class MemoryRateLimiterBackend(RateLimiterBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the rate limiter backend."""
+        """Close the rate limiter backend and unregister it."""
         with self._lock:
             self._token_bucket_state.clear()
             self._gcra_state.clear()
-        if (
-            self._auto_registered
-            and rate_limiter_backend_registry.is_loaded
-            and rate_limiter_backend_registry.get() is self
-        ):
-            rate_limiter_backend_registry.reset()
+        rate_limiter_backend_registry.unregister(self)
 
     def bind(self, config: RateLimiterConfig) -> RateLimiterStrategy:
         """Build a strategy for the given algorithm config.

--- a/grelmicro/resilience/redis.py
+++ b/grelmicro/resilience/redis.py
@@ -76,29 +76,16 @@ class RedisRateLimiterBackend(RateLimiterBackend):
                 """
             ),
         ] = "",
-        auto_register: Annotated[
-            bool,
-            Doc(
-                """
-                Automatically register the backend as the default
-                for rate limiters.
-
-                Set to `False` to manage multiple backends manually.
-                """
-            ),
-        ] = True,
     ) -> None:
         """Initialize the rate limiter backend."""
         self._url, self._redis = _create_redis_client(
             url, ResilienceSettingsValidationError
         )
         self._prefix = prefix
-        self._auto_registered = auto_register
-        if auto_register:
-            rate_limiter_backend_registry.set(self)
 
     async def __aenter__(self) -> Self:
-        """Open the rate limiter backend."""
+        """Open the rate limiter backend and register it as the default."""
+        rate_limiter_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -107,14 +94,9 @@ class RedisRateLimiterBackend(RateLimiterBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the rate limiter backend."""
+        """Close the rate limiter backend and unregister it."""
         await self._redis.aclose()
-        if (
-            self._auto_registered
-            and rate_limiter_backend_registry.is_loaded
-            and rate_limiter_backend_registry.get() is self
-        ):
-            rate_limiter_backend_registry.reset()
+        rate_limiter_backend_registry.unregister(self)
 
     def bind(self, config: RateLimiterConfig) -> RateLimiterStrategy:
         """Build a strategy for the given algorithm config.

--- a/grelmicro/sync/__init__.py
+++ b/grelmicro/sync/__init__.py
@@ -1,12 +1,31 @@
 """Synchronization."""
 
 import warnings
+from typing import Annotated
 
-from grelmicro.sync.abc import SyncPrimitive
+from typing_extensions import Doc
+
+from grelmicro.sync._backends import sync_backend_registry
+from grelmicro.sync.abc import SyncBackend, SyncPrimitive
 from grelmicro.sync.errors import SyncError, SyncSettingsValidationError
 from grelmicro.sync.leaderelection import LeaderElection
 from grelmicro.sync.lock import Lock
 from grelmicro.sync.tasklock import TaskLock
+
+
+def use_backend(
+    backend: Annotated[
+        SyncBackend,
+        Doc("The synchronization backend to register as the default."),
+    ],
+) -> None:
+    """Register `backend` as the default synchronization backend.
+
+    Idempotent: re-registering the same instance is a no-op.
+    Registering a different instance warns and replaces.
+    """
+    sync_backend_registry.register(backend)
+
 
 __all__ = [
     "LeaderElection",
@@ -15,6 +34,7 @@ __all__ = [
     "SyncPrimitive",
     "SyncSettingsValidationError",
     "TaskLock",
+    "use_backend",
 ]
 
 

--- a/grelmicro/sync/kubernetes.py
+++ b/grelmicro/sync/kubernetes.py
@@ -94,13 +94,6 @@ class KubernetesSyncBackend(SyncBackend):
                 By default no prefix is added.
                 """),
         ] = "",
-        auto_register: Annotated[
-            bool,
-            Doc(
-                "Automatically register the lock backend in the backend"
-                " registry."
-            ),
-        ] = True,
         kubeconfig: Annotated[
             str | None,
             Doc("Path to the kubeconfig file."),
@@ -111,16 +104,14 @@ class KubernetesSyncBackend(SyncBackend):
         self._prefix = prefix
         self._kubeconfig = kubeconfig
         self._client: AsyncClient | None = None
-        self._auto_registered = auto_register
-        if auto_register:
-            sync_backend_registry.set(self)
 
     async def __aenter__(self) -> Self:
-        """Enter the lock backend."""
+        """Enter the lock backend and register it as the default."""
         config = (
             KubeConfig.from_file(self._kubeconfig) if self._kubeconfig else None
         )
         self._client = AsyncClient(config=config)
+        sync_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -129,7 +120,7 @@ class KubernetesSyncBackend(SyncBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Exit the lock backend."""
+        """Exit the lock backend and unregister it."""
         if self._client:
             # Clean up expired leases managed by grelmicro
             now = datetime.now(tz=UTC)
@@ -153,12 +144,7 @@ class KubernetesSyncBackend(SyncBackend):
                             raise
             await self._client.close()
             self._client = None
-        if (
-            self._auto_registered
-            and sync_backend_registry.is_loaded
-            and sync_backend_registry.get() is self
-        ):
-            sync_backend_registry.reset()
+        sync_backend_registry.unregister(self)
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire a lock."""

--- a/grelmicro/sync/memory.py
+++ b/grelmicro/sync/memory.py
@@ -2,9 +2,7 @@
 
 from time import monotonic
 from types import TracebackType
-from typing import Annotated, Self
-
-from typing_extensions import Doc
+from typing import Self
 
 from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
@@ -17,24 +15,13 @@ class MemorySyncBackend(SyncBackend):
     testing purposes or for locking operations that are executed in the same AnyIO event loop.
     """
 
-    def __init__(
-        self,
-        *,
-        auto_register: Annotated[
-            bool,
-            Doc(
-                "Automatically register the lock backend in the backend registry."
-            ),
-        ] = True,
-    ) -> None:
+    def __init__(self) -> None:
         """Initialize the lock backend."""
         self._locks: dict[str, tuple[str | None, float]] = {}
-        self._auto_registered = auto_register
-        if auto_register:
-            sync_backend_registry.set(self)
 
     async def __aenter__(self) -> Self:
-        """Enter the lock backend."""
+        """Enter the lock backend and register it as the default."""
+        sync_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -43,14 +30,9 @@ class MemorySyncBackend(SyncBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Exit the lock backend."""
+        """Exit the lock backend and unregister it."""
         self._locks.clear()
-        if (
-            self._auto_registered
-            and sync_backend_registry.is_loaded
-            and sync_backend_registry.get() is self
-        ):
-            sync_backend_registry.reset()
+        sync_backend_registry.unregister(self)
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire the lock."""

--- a/grelmicro/sync/postgres.py
+++ b/grelmicro/sync/postgres.py
@@ -119,12 +119,6 @@ class PostgresSyncBackend(SyncBackend):
                 """),
         ] = None,
         *,
-        auto_register: Annotated[
-            bool,
-            Doc(
-                "Automatically register the lock backend in the backend registry."
-            ),
-        ] = True,
         table_name: Annotated[
             str, Doc("The table name to store the locks.")
         ] = "locks",
@@ -143,18 +137,16 @@ class PostgresSyncBackend(SyncBackend):
         self._locked_sql = self._SQL_LOCKED.format(table_name=table_name)
         self._owned_sql = self._SQL_OWNED.format(table_name=table_name)
         self._pool: Pool | None = None
-        self._auto_registered = auto_register
-        if auto_register:
-            sync_backend_registry.set(self)
 
     async def __aenter__(self) -> Self:
-        """Enter the lock backend."""
+        """Enter the lock backend and register it as the default."""
         self._pool = await create_pool(str(self._url))
         await self._pool.execute(
             self._SQL_CREATE_TABLE_IF_NOT_EXISTS.format(
                 table_name=self._table_name
             ),
         )
+        sync_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -163,7 +155,7 @@ class PostgresSyncBackend(SyncBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Exit the lock backend."""
+        """Exit the lock backend and unregister it."""
         if self._pool:
             await self._pool.execute(
                 self._SQL_RELEASE_ALL_EXPIRED.format(
@@ -171,12 +163,7 @@ class PostgresSyncBackend(SyncBackend):
                 ),
             )
             await self._pool.close()
-        if (
-            self._auto_registered
-            and sync_backend_registry.is_loaded
-            and sync_backend_registry.get() is self
-        ):
-            sync_backend_registry.reset()
+        sync_backend_registry.unregister(self)
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire a lock."""

--- a/grelmicro/sync/redis.py
+++ b/grelmicro/sync/redis.py
@@ -56,12 +56,6 @@ class RedisSyncBackend(SyncBackend):
                 By default no prefix is added.
                 """),
         ] = "",
-        auto_register: Annotated[
-            bool,
-            Doc(
-                "Automatically register the lock backend in the backend registry."
-            ),
-        ] = True,
     ) -> None:
         """Initialize the lock backend."""
         self._url, self._redis = _create_redis_client(
@@ -72,12 +66,10 @@ class RedisSyncBackend(SyncBackend):
         self._lua_acquire = self._redis.register_script(
             self._LUA_ACQUIRE_OR_EXTEND
         )
-        self._auto_registered = auto_register
-        if auto_register:
-            sync_backend_registry.set(self)
 
     async def __aenter__(self) -> Self:
-        """Open the lock backend."""
+        """Open the lock backend and register it as the default."""
+        sync_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -86,14 +78,9 @@ class RedisSyncBackend(SyncBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the lock backend."""
+        """Close the lock backend and unregister it."""
         await self._redis.aclose()
-        if (
-            self._auto_registered
-            and sync_backend_registry.is_loaded
-            and sync_backend_registry.get() is self
-        ):
-            sync_backend_registry.reset()
+        sync_backend_registry.unregister(self)
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire the lock."""

--- a/grelmicro/sync/sqlite.py
+++ b/grelmicro/sync/sqlite.py
@@ -90,12 +90,6 @@ class SQLiteSyncBackend(SyncBackend):
                 """),
         ] = None,
         *,
-        auto_register: Annotated[
-            bool,
-            Doc(
-                "Automatically register the lock backend in the backend registry."
-            ),
-        ] = True,
         table_name: Annotated[
             str, Doc("The table name to store the locks.")
         ] = "locks",
@@ -114,12 +108,9 @@ class SQLiteSyncBackend(SyncBackend):
         self._locked_sql = self._SQL_LOCKED.format(table_name=table_name)
         self._owned_sql = self._SQL_OWNED.format(table_name=table_name)
         self._conn: aiosqlite.Connection | None = None
-        self._auto_registered = auto_register
-        if auto_register:
-            sync_backend_registry.set(self)
 
     async def __aenter__(self) -> Self:
-        """Enter the lock backend."""
+        """Enter the lock backend and register it as the default."""
         self._conn = await aiosqlite.connect(self._path)
         await self._conn.execute("PRAGMA journal_mode=WAL;")
         await self._conn.execute(
@@ -128,6 +119,7 @@ class SQLiteSyncBackend(SyncBackend):
             ),
         )
         await self._conn.commit()
+        sync_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -136,7 +128,7 @@ class SQLiteSyncBackend(SyncBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Exit the lock backend."""
+        """Exit the lock backend and unregister it."""
         if self._conn:
             await self._conn.execute(
                 self._SQL_RELEASE_ALL_EXPIRED.format(
@@ -146,12 +138,7 @@ class SQLiteSyncBackend(SyncBackend):
             await self._conn.commit()
             await self._conn.close()
             self._conn = None
-        if (
-            self._auto_registered
-            and sync_backend_registry.is_loaded
-            and sync_backend_registry.get() is self
-        ):
-            sync_backend_registry.reset()
+        sync_backend_registry.unregister(self)
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire a lock."""

--- a/tests/cache/test_cache_backends.py
+++ b/tests/cache/test_cache_backends.py
@@ -59,11 +59,10 @@ async def backend(
         async with RedisCacheBackend(
             f"redis://localhost:{port}/0",
             prefix="test:",
-            auto_register=False,
         ) as redis_backend:
             yield redis_backend
     elif backend_name == "memory":
-        async with MemoryCacheBackend(auto_register=False) as memory_backend:
+        async with MemoryCacheBackend() as memory_backend:
             yield memory_backend
 
 
@@ -143,10 +142,8 @@ async def test_redis_prefix_isolation() -> None:
         port = container.get_exposed_port(6379)
         url = f"redis://localhost:{port}/0"
         async with (
-            RedisCacheBackend(
-                url, prefix="alpha:", auto_register=False
-            ) as alpha,
-            RedisCacheBackend(url, prefix="beta:", auto_register=False) as beta,
+            RedisCacheBackend(url, prefix="alpha:") as alpha,
+            RedisCacheBackend(url, prefix="beta:") as beta,
         ):
             await alpha.set(key="k", value=b"alpha", ttl=60)
             await beta.set(key="k", value=b"beta", ttl=60)
@@ -166,9 +163,7 @@ async def test_cached_end_to_end_with_redis() -> None:
     with RedisContainer() as container:
         port = container.get_exposed_port(6379)
         url = f"redis://localhost:{port}/0"
-        async with RedisCacheBackend(
-            url, prefix="e2e:", auto_register=False
-        ) as redis_backend:
+        async with RedisCacheBackend(url, prefix="e2e:") as redis_backend:
             cache = TTLCache(
                 ttl=60,
                 backend=redis_backend,
@@ -192,7 +187,7 @@ async def test_cached_end_to_end_with_redis() -> None:
 
 async def test_cached_end_to_end_with_memory() -> None:
     """Test @cached with TTLCache backed by MemoryCacheBackend."""
-    async with MemoryCacheBackend(auto_register=False) as memory_backend:
+    async with MemoryCacheBackend() as memory_backend:
         cache = TTLCache(
             ttl=60,
             backend=memory_backend,

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -26,7 +26,7 @@ EXPECTED_CURRSIZE_2 = 2
 
 def _make_cache(maxsize: int = 10, ttl: float = 60) -> TTLCache:
     """Create a TTLCache with MemoryCacheBackend and pickle serialization."""
-    backend = MemoryCacheBackend(auto_register=False)
+    backend = MemoryCacheBackend()
     return TTLCache(
         maxsize=maxsize,
         ttl=ttl,

--- a/tests/cache/test_memory.py
+++ b/tests/cache/test_memory.py
@@ -4,6 +4,7 @@ import pytest
 from anyio import sleep
 
 from grelmicro._backends import BackendNotLoadedError
+from grelmicro.cache import use_backend
 from grelmicro.cache._backends import cache_backend_registry, get_cache_backend
 from grelmicro.cache.memory import MemoryCacheBackend
 
@@ -15,7 +16,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_returns_stored_bytes(self) -> None:
         """Test that get returns the bytes stored by set."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="k", value=b"hello", ttl=60)
 
         result = await backend.get(key="k")
@@ -24,7 +25,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_miss_returns_none(self) -> None:
         """Test that get returns None for a key that was never written."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
 
         result = await backend.get(key="nonexistent")
 
@@ -32,7 +33,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_expired_returns_none(self) -> None:
         """Test that get returns None after the entry's TTL has elapsed."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="exp", value=b"data", ttl=0.05)
 
         await sleep(0.1)
@@ -42,7 +43,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_removes_expired_entry_lazily(self) -> None:
         """Test that expired entries are removed from internal storage on access."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="lazy", value=b"val", ttl=0.05)
 
         await sleep(0.1)
@@ -53,7 +54,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_not_yet_expired_returns_value(self) -> None:
         """Test that get returns the value when the TTL has not yet elapsed."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="fresh", value=b"still here", ttl=60)
 
         result = await backend.get(key="fresh")
@@ -62,7 +63,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_empty_bytes_value(self) -> None:
         """Test that get correctly returns an empty bytes value."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="empty", value=b"", ttl=60)
 
         result = await backend.get(key="empty")
@@ -71,7 +72,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_large_value(self) -> None:
         """Test that get returns large byte payloads without truncation."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         large = b"x" * 100_000
         await backend.set(key="big", value=large, ttl=60)
 
@@ -81,7 +82,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_unicode_key(self) -> None:
         """Test that get works with Unicode (non-ASCII) key strings."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="unicode-key", value=b"unicode-value", ttl=60)
 
         result = await backend.get(key="unicode-key")
@@ -94,7 +95,7 @@ class TestMemoryCacheBackendSet:
 
     async def test_set_overwrites_existing_key(self) -> None:
         """Test that a second set replaces the previous value for the same key."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="k", value=b"first", ttl=60)
         await backend.set(key="k", value=b"second", ttl=60)
 
@@ -104,7 +105,7 @@ class TestMemoryCacheBackendSet:
 
     async def test_set_updates_ttl_on_overwrite(self) -> None:
         """Test that overwriting a key resets its expiry to the new TTL."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         # Write with a very short TTL.
         await backend.set(key="k", value=b"v", ttl=0.05)
         # Immediately overwrite with a long TTL.
@@ -119,7 +120,7 @@ class TestMemoryCacheBackendSet:
 
     async def test_set_multiple_keys_independently(self) -> None:
         """Test that multiple keys do not interfere with each other."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="a", value=b"aaa", ttl=60)
         await backend.set(key="b", value=b"bbb", ttl=60)
 
@@ -132,7 +133,7 @@ class TestMemoryCacheBackendDelete:
 
     async def test_delete_removes_key(self) -> None:
         """Test that delete makes the key unavailable."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="del", value=b"bye", ttl=60)
 
         await backend.delete(key="del")
@@ -141,14 +142,14 @@ class TestMemoryCacheBackendDelete:
 
     async def test_delete_missing_key_is_no_op(self) -> None:
         """Test that deleting a key that does not exist does not raise."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
 
         # Should not raise.
         await backend.delete(key="ghost")
 
     async def test_delete_does_not_affect_other_keys(self) -> None:
         """Test that deleting one key leaves other keys intact."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="keep", value=b"safe", ttl=60)
         await backend.set(key="remove", value=b"gone", ttl=60)
 
@@ -163,7 +164,7 @@ class TestMemoryCacheBackendClear:
 
     async def test_clear_removes_all_entries(self) -> None:
         """Test that clear empties the store completely."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="one", value=b"1", ttl=60)
         await backend.set(key="two", value=b"2", ttl=60)
 
@@ -174,7 +175,7 @@ class TestMemoryCacheBackendClear:
 
     async def test_clear_on_empty_store_is_no_op(self) -> None:
         """Test that clearing an already-empty store does not raise."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
 
         await backend.clear()
 
@@ -182,7 +183,7 @@ class TestMemoryCacheBackendClear:
 
     async def test_can_set_after_clear(self) -> None:
         """Test that the backend remains usable after a clear."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="before", value=b"old", ttl=60)
         await backend.clear()
 
@@ -197,14 +198,14 @@ class TestMemoryCacheBackendContextManager:
 
     async def test_context_manager_returns_self(self) -> None:
         """Test that __aenter__ returns the backend instance."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
 
         async with backend as entered:
             assert entered is backend
 
     async def test_context_manager_clears_data_on_exit(self) -> None:
         """Test that __aexit__ clears the internal store."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="k", value=b"v", ttl=60)
 
         async with backend:
@@ -215,7 +216,7 @@ class TestMemoryCacheBackendContextManager:
 
     async def test_context_manager_clears_even_on_exception(self) -> None:
         """Test that __aexit__ clears the store even when the body raises."""
-        backend = MemoryCacheBackend(auto_register=False)
+        backend = MemoryCacheBackend()
         await backend.set(key="k", value=b"v", ttl=60)
 
         with pytest.raises(RuntimeError, match="test error"):  # noqa: PT012
@@ -226,38 +227,26 @@ class TestMemoryCacheBackendContextManager:
         assert await backend.get(key="k") is None
 
 
-class TestMemoryCacheBackendAutoRegister:
-    """Tests for MemoryCacheBackend auto-registration in the backend registry."""
+class TestMemoryCacheBackendRegistration:
+    """Tests for explicit registration of MemoryCacheBackend."""
 
-    def test_auto_register_true(self) -> None:
-        """Test that MemoryCacheBackend registers itself by default."""
+    def test_constructor_does_not_register(self) -> None:
+        """Constructing the backend performs no registry writes."""
         cache_backend_registry.reset()
 
         MemoryCacheBackend()
 
-        assert cache_backend_registry.is_loaded
-
-        # Cleanup
-        cache_backend_registry.reset()
-
-    def test_auto_register_false(self) -> None:
-        """Test that auto_register=False skips registration."""
-        cache_backend_registry.reset()
-
-        MemoryCacheBackend(auto_register=False)
-
         assert not cache_backend_registry.is_loaded
 
-    def test_get_cache_backend_returns_registered_instance(self) -> None:
-        """Test that get_cache_backend returns the MemoryCacheBackend instance."""
+    def test_use_backend_registers(self) -> None:
+        """`cache.use_backend` registers the backend as default."""
         cache_backend_registry.reset()
         backend = MemoryCacheBackend()
 
-        result = get_cache_backend()
+        use_backend(backend)
 
-        assert result is backend
+        assert get_cache_backend() is backend
 
-        # Cleanup
         cache_backend_registry.reset()
 
     def test_get_cache_backend_not_loaded_raises(self) -> None:

--- a/tests/cache/test_redis.py
+++ b/tests/cache/test_redis.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from grelmicro._backends import BackendNotLoadedError
+from grelmicro.cache import use_backend
 from grelmicro.cache._backends import cache_backend_registry, get_cache_backend
 from grelmicro.cache.errors import CacheSettingsValidationError
 from grelmicro.cache.redis import RedisCacheBackend
@@ -52,7 +53,7 @@ class TestRedisCacheBackendEnvVarSettings:
             monkeypatch.setenv(key, value)
 
         # Act
-        backend = RedisCacheBackend(auto_register=False)
+        backend = RedisCacheBackend()
 
         # Assert
         assert backend._url == expected_url
@@ -99,7 +100,7 @@ class TestRedisCacheBackendConstructor:
         monkeypatch.delenv("REDIS_HOST", raising=False)
 
         # Act
-        backend = RedisCacheBackend(URL, auto_register=False)
+        backend = RedisCacheBackend(URL)
 
         # Assert
         assert backend._url == URL
@@ -111,20 +112,20 @@ class TestRedisCacheBackendConstructor:
         monkeypatch.delenv("REDIS_URL", raising=False)
         monkeypatch.delenv("REDIS_HOST", raising=False)
 
-        backend = RedisCacheBackend(url=URL, auto_register=False)
+        backend = RedisCacheBackend(url=URL)
 
         assert backend._url == URL
 
     def test_prefix_stored(self) -> None:
         """Test that the prefix argument is stored on the backend."""
-        backend = RedisCacheBackend(URL, prefix="myns:", auto_register=False)
+        backend = RedisCacheBackend(URL, prefix="myns:")
 
         assert backend._prefix == "myns:"
 
     def test_no_ttl_in_constructor(self) -> None:
         """Test that RedisCacheBackend has no ttl constructor parameter."""
         # TTL is now per-call; constructing without ttl must not raise.
-        backend = RedisCacheBackend(URL, auto_register=False)
+        backend = RedisCacheBackend(URL)
 
         # The backend protocol exposes no ttl attribute.
         assert not hasattr(backend, "ttl")
@@ -134,52 +135,29 @@ class TestRedisCacheBackendConstructor:
 class TestCacheBackendRegistry:
     """Tests for cache backend registry integration."""
 
-    def test_auto_register_true(self) -> None:
-        """Test that RedisCacheBackend registers itself by default."""
-        # Arrange
+    def test_constructor_does_not_register(self) -> None:
+        """Constructing RedisCacheBackend performs no registry writes."""
         cache_backend_registry.reset()
 
-        # Act
         RedisCacheBackend(URL)
 
-        # Assert
-        assert cache_backend_registry.is_loaded
-
-        # Cleanup
-        cache_backend_registry.reset()
-
-    def test_auto_register_false(self) -> None:
-        """Test that auto_register=False skips registration."""
-        # Arrange
-        cache_backend_registry.reset()
-
-        # Act
-        RedisCacheBackend(URL, auto_register=False)
-
-        # Assert
         assert not cache_backend_registry.is_loaded
 
-    def test_get_cache_backend_returns_registered_instance(self) -> None:
-        """Test that get_cache_backend returns the registered backend instance."""
-        # Arrange
+    def test_use_backend_registers(self) -> None:
+        """`cache.use_backend` registers the backend as default."""
         cache_backend_registry.reset()
         backend = RedisCacheBackend(URL)
 
-        # Act
-        result = get_cache_backend()
+        use_backend(backend)
 
-        # Assert
-        assert result is backend
+        assert get_cache_backend() is backend
 
-        # Cleanup
         cache_backend_registry.reset()
 
     def test_get_cache_backend_not_loaded_raises(self) -> None:
         """Test that get_cache_backend raises BackendNotLoadedError when empty."""
-        # Arrange
         cache_backend_registry.reset()
 
-        # Act / Assert
         with pytest.raises(BackendNotLoadedError):
             get_cache_backend()
 
@@ -189,7 +167,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_get_hit(self) -> None:
         """Test that get returns the stored bytes when the key exists."""
-        backend = RedisCacheBackend(URL, auto_register=False)
+        backend = RedisCacheBackend(URL)
         backend._redis = MagicMock()
         backend._redis.get = AsyncMock(return_value=b"value")
 
@@ -200,7 +178,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_get_miss_returns_none(self) -> None:
         """Test that get returns None when the key does not exist."""
-        backend = RedisCacheBackend(URL, auto_register=False)
+        backend = RedisCacheBackend(URL)
         backend._redis = MagicMock()
         backend._redis.get = AsyncMock(return_value=None)
 
@@ -210,7 +188,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_get_with_prefix(self) -> None:
         """Test that get prepends the configured prefix to the Redis key."""
-        backend = RedisCacheBackend(URL, prefix="ns:", auto_register=False)
+        backend = RedisCacheBackend(URL, prefix="ns:")
         backend._redis = MagicMock()
         backend._redis.get = AsyncMock(return_value=b"v")
 
@@ -220,7 +198,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_set_passes_key_value_ttl(self) -> None:
         """Test that set calls redis.set with the prefixed key, value, and TTL."""
-        backend = RedisCacheBackend(URL, prefix="p:", auto_register=False)
+        backend = RedisCacheBackend(URL, prefix="p:")
         backend._redis = MagicMock()
         backend._redis.set = AsyncMock()
 
@@ -230,7 +208,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_set_without_prefix(self) -> None:
         """Test that set uses the bare key when no prefix is configured."""
-        backend = RedisCacheBackend(URL, auto_register=False)
+        backend = RedisCacheBackend(URL)
         backend._redis = MagicMock()
         backend._redis.set = AsyncMock()
 
@@ -240,7 +218,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_set_float_ttl(self) -> None:
         """Test that set passes fractional TTL values through to Redis."""
-        backend = RedisCacheBackend(URL, auto_register=False)
+        backend = RedisCacheBackend(URL)
         backend._redis = MagicMock()
         backend._redis.set = AsyncMock()
 
@@ -250,7 +228,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_delete(self) -> None:
         """Test that delete calls redis.delete with the prefixed key."""
-        backend = RedisCacheBackend(URL, prefix="p:", auto_register=False)
+        backend = RedisCacheBackend(URL, prefix="p:")
         backend._redis = MagicMock()
         backend._redis.delete = AsyncMock()
 
@@ -260,7 +238,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_delete_missing_key_is_no_op(self) -> None:
         """Test that delete on a missing key does not raise."""
-        backend = RedisCacheBackend(URL, auto_register=False)
+        backend = RedisCacheBackend(URL)
         backend._redis = MagicMock()
         backend._redis.delete = AsyncMock(return_value=0)
 
@@ -271,7 +249,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_clear(self) -> None:
         """Test that clear scans and deletes all keys matching the prefix."""
-        backend = RedisCacheBackend(URL, prefix="p:", auto_register=False)
+        backend = RedisCacheBackend(URL, prefix="p:")
         mock_redis = MagicMock()
         mock_redis.delete = AsyncMock()
 
@@ -288,7 +266,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_clear_large_batch(self) -> None:
         """Test that clear deletes in batches when the key count exceeds batch size."""
-        backend = RedisCacheBackend(URL, prefix="p:", auto_register=False)
+        backend = RedisCacheBackend(URL, prefix="p:")
         mock_redis = MagicMock()
         mock_redis.delete = AsyncMock()
 
@@ -309,7 +287,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_clear_empty_store(self) -> None:
         """Test that clear on an empty store issues no delete calls."""
-        backend = RedisCacheBackend(URL, prefix="p:", auto_register=False)
+        backend = RedisCacheBackend(URL, prefix="p:")
         mock_redis = MagicMock()
         mock_redis.delete = AsyncMock()
 
@@ -326,7 +304,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_context_manager_closes_redis(self) -> None:
         """Test that the async context manager calls aclose on exit."""
-        backend = RedisCacheBackend(URL, auto_register=False)
+        backend = RedisCacheBackend(URL)
         backend._redis = MagicMock()
         backend._redis.aclose = AsyncMock()
 
@@ -337,7 +315,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_context_manager_returns_self(self) -> None:
         """Test that __aenter__ returns the backend instance itself."""
-        backend = RedisCacheBackend(URL, auto_register=False)
+        backend = RedisCacheBackend(URL)
         backend._redis = MagicMock()
         backend._redis.aclose = AsyncMock()
 

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -22,7 +22,7 @@ EXPECTED_UNLIMITED_COUNT = 1000
 @pytest.fixture
 def backend() -> MemoryCacheBackend:
     """Provide an isolated in-memory cache backend (not registered globally)."""
-    return MemoryCacheBackend(auto_register=False)
+    return MemoryCacheBackend()
 
 
 # ---------------------------------------------------------------------------
@@ -86,7 +86,7 @@ class TestInit:
     ) -> None:
         """Test that TTLCache uses the registered backend when none is provided."""
         # Arrange: register the backend
-        cache_backend_registry.set(backend)
+        cache_backend_registry.register(backend)
 
         # Act: create cache without explicit backend
         cache = TTLCache(maxsize=0, ttl=60)

--- a/tests/health/test_fastapi.py
+++ b/tests/health/test_fastapi.py
@@ -36,8 +36,10 @@ def _clean_registry() -> Generator[None]:
 
 @pytest.fixture
 def registry() -> HealthRegistry:
-    """Auto-registered health registry with caching disabled."""
-    return HealthRegistry(cache_ttl=0)
+    """Health registry with caching disabled, registered as the default."""
+    instance = HealthRegistry(cache_ttl=0)
+    health_registry.register(instance)
+    return instance
 
 
 @pytest.fixture
@@ -77,6 +79,7 @@ def test_livez_head_method(client: TestClient) -> None:
 def test_livez_never_runs_checkers() -> None:
     """A failing registered checker does not affect /livez."""
     registry = HealthRegistry(cache_ttl=0)
+    health_registry.register(registry)
     registry.add("db", unhealthy())
     app = FastAPI()
     app.include_router(health_router())
@@ -230,6 +233,7 @@ def test_healthz_details_hidden_by_default(
 def test_healthz_details_true_always_shown() -> None:
     """show_details=True always includes details."""
     registry = HealthRegistry(cache_ttl=0)
+    health_registry.register(registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
     app = FastAPI()
     app.include_router(health_router(show_details=True))
@@ -243,6 +247,7 @@ def test_healthz_details_true_always_shown() -> None:
 def test_healthz_details_dep_returns_false_strips() -> None:
     """A dep returning False strips details, endpoint returns 200."""
     registry = HealthRegistry(cache_ttl=0)
+    health_registry.register(registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow() -> bool:
@@ -261,6 +266,7 @@ def test_healthz_details_dep_returns_false_strips() -> None:
 def test_healthz_details_dep_returns_true_shows() -> None:
     """A dep returning True includes details."""
     registry = HealthRegistry(cache_ttl=0)
+    health_registry.register(registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow() -> bool:
@@ -278,6 +284,7 @@ def test_healthz_details_dep_returns_true_shows() -> None:
 def test_healthz_details_async_dep_shows() -> None:
     """An async dep is awaited by FastAPI's DI."""
     registry = HealthRegistry(cache_ttl=0)
+    health_registry.register(registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     async def allow_async() -> bool:
@@ -295,6 +302,7 @@ def test_healthz_details_async_dep_shows() -> None:
 def test_healthz_details_dep_with_request() -> None:
     """A Request-annotated dep receives the request via FastAPI DI."""
     registry = HealthRegistry(cache_ttl=0)
+    health_registry.register(registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow_if_admin(request: _Request) -> bool:
@@ -312,6 +320,7 @@ def test_healthz_details_dep_with_request() -> None:
 def test_healthz_details_dep_with_sub_dependency() -> None:
     """FastAPI sub-dependencies resolve through ``Depends`` chains."""
     registry = HealthRegistry(cache_ttl=0)
+    health_registry.register(registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def current_role(request: _Request) -> str:
@@ -332,6 +341,7 @@ def test_healthz_details_dep_with_sub_dependency() -> None:
 def test_healthz_details_dep_http_exception_blocks_endpoint() -> None:
     """Raising HTTPException in the dep blocks the endpoint (documented)."""
     registry = HealthRegistry(cache_ttl=0)
+    health_registry.register(registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def deny() -> bool:

--- a/tests/health/test_registry.py
+++ b/tests/health/test_registry.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import ValidationError
 
 from grelmicro._backends import BackendNotLoadedError
+from grelmicro.health import use_registry
 from grelmicro.health._backends import get_health_registry, health_registry
 from grelmicro.health._models import HealthStatus
 from grelmicro.health._registry import HealthRegistry
@@ -37,7 +38,7 @@ def _clean_registry() -> Generator[None]:
 
 async def test_empty_registry_is_ok() -> None:
     """An empty registry reports ok."""
-    registry = HealthRegistry(auto_register=False)
+    registry = HealthRegistry()
 
     report = await registry.run()
 
@@ -47,7 +48,7 @@ async def test_empty_registry_is_ok() -> None:
 
 async def test_add_and_run_single_healthy() -> None:
     """registry.add() + run() reports ok for a healthy check."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("db", healthy())
 
     report = await registry.run()
@@ -63,7 +64,7 @@ async def test_add_and_run_single_healthy() -> None:
 
 async def test_decorator_registers_check() -> None:
     """@registry.check(name) registers the decorated function."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
 
     @registry.check("database")
     async def _check_db() -> HealthDetails | None:
@@ -77,7 +78,7 @@ async def test_decorator_registers_check() -> None:
 
 async def test_sync_check_runs_in_thread() -> None:
     """A sync check function is executed via ``anyio.to_thread.run_sync``."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
 
     def sync_check() -> HealthDetails | None:
         return {"ran": "sync"}
@@ -92,7 +93,7 @@ async def test_sync_check_runs_in_thread() -> None:
 
 async def test_decorator_returns_function_unchanged() -> None:
     """The decorator returns the wrapped function as-is."""
-    registry = HealthRegistry(auto_register=False)
+    registry = HealthRegistry()
 
     async def _fn() -> HealthDetails | None:
         return {"ok": True}
@@ -104,7 +105,7 @@ async def test_decorator_returns_function_unchanged() -> None:
 
 async def test_decorator_with_options() -> None:
     """Decorator accepts critical and timeout kwargs."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0, timeout=5.0)
+    registry = HealthRegistry(cache_ttl=0, timeout=5.0)
 
     @registry.check("analytics", critical=False, timeout=0.1)
     async def _check() -> HealthDetails | None:
@@ -123,7 +124,7 @@ async def test_decorator_with_options() -> None:
 
 async def test_critical_failure_produces_error() -> None:
     """Critical failure produces aggregate error."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("redis", unhealthy())
 
     report = await registry.run()
@@ -137,7 +138,7 @@ async def test_critical_failure_produces_error() -> None:
 
 async def test_non_critical_failure_keeps_aggregate_ok() -> None:
     """Non-critical failures do not flip the aggregate."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("db", healthy())
     registry.add("external-api", unhealthy(), critical=False)
 
@@ -151,7 +152,7 @@ async def test_non_critical_failure_keeps_aggregate_ok() -> None:
 
 async def test_critical_failure_trumps_non_critical() -> None:
     """Any critical failure produces aggregate error."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("db", unhealthy(), critical=True)
     registry.add("analytics", unhealthy(), critical=False)
 
@@ -162,7 +163,7 @@ async def test_critical_failure_trumps_non_critical() -> None:
 
 async def test_all_non_critical_fail_aggregate_ok() -> None:
     """All non-critical failures keep the aggregate ok."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("a", unhealthy(), critical=False)
     registry.add("b", unhealthy(), critical=False)
 
@@ -173,7 +174,7 @@ async def test_all_non_critical_fail_aggregate_ok() -> None:
 
 async def test_check_with_details() -> None:
     """Checker details are captured in the result."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     report = await registry.run()
@@ -183,7 +184,7 @@ async def test_check_with_details() -> None:
 
 async def test_checks_sorted_by_name() -> None:
     """Checks are returned in alphabetical order."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("zeta", healthy())
     registry.add("alpha", healthy())
     registry.add("mu", healthy())
@@ -195,7 +196,7 @@ async def test_checks_sorted_by_name() -> None:
 
 async def test_critical_only_filter() -> None:
     """critical_only=True skips non-critical checks entirely."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("db", healthy())
     registry.add("analytics", unhealthy(), critical=False)
 
@@ -207,7 +208,7 @@ async def test_critical_only_filter() -> None:
 
 async def test_exclude_filter() -> None:
     """Exclude skips the named checks."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("db", healthy())
     registry.add("redis", unhealthy())
 
@@ -219,7 +220,7 @@ async def test_exclude_filter() -> None:
 
 async def test_global_timeout_applies() -> None:
     """Global timeout applies when no per-check timeout is set."""
-    registry = HealthRegistry(timeout=0.1, auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(timeout=0.1, cache_ttl=0)
     registry.add("slow", slow(delay=1.0))
 
     report = await registry.run()
@@ -235,7 +236,7 @@ async def test_global_timeout_applies() -> None:
 
 async def test_per_check_timeout_override_via_add() -> None:
     """Per-check timeout overrides the registry default via add()."""
-    registry = HealthRegistry(timeout=5.0, auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(timeout=5.0, cache_ttl=0)
     registry.add("slow", slow(delay=1.0), timeout=0.1, critical=False)
 
     started = time.monotonic()
@@ -251,7 +252,7 @@ async def test_concurrent_execution() -> None:
     """Checks run in parallel, not sequentially."""
     count = 3
     delay = 0.1
-    registry = HealthRegistry(timeout=2.0, auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(timeout=2.0, cache_ttl=0)
     for i in range(count):
         registry.add(f"c{i}", slow(delay=delay))
 
@@ -265,7 +266,7 @@ async def test_concurrent_execution() -> None:
 
 async def test_cache_hit_returns_same_result() -> None:
     """Within TTL, repeated calls return the cached result."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=10.0)
+    registry = HealthRegistry(cache_ttl=10.0)
     check = Counting()
     registry.add("db", check)
 
@@ -278,7 +279,7 @@ async def test_cache_hit_returns_same_result() -> None:
 
 async def test_cache_expires() -> None:
     """After TTL expires, the check runs again."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0.05)
+    registry = HealthRegistry(cache_ttl=0.05)
     check = Counting()
     registry.add("db", check)
 
@@ -292,7 +293,7 @@ async def test_cache_expires() -> None:
 
 async def test_cache_disabled_with_zero_ttl() -> None:
     """cache_ttl=0 disables the cache entirely."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     check = Counting()
     registry.add("db", check)
 
@@ -305,7 +306,7 @@ async def test_cache_disabled_with_zero_ttl() -> None:
 
 async def test_single_flight_coalesces_concurrent_calls() -> None:
     """Concurrent cache-fill requests share a single execution."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=1.0)
+    registry = HealthRegistry(cache_ttl=1.0)
     check = SlowCounting(delay=0.1)
     registry.add("db", check)
 
@@ -318,7 +319,7 @@ async def test_single_flight_coalesces_concurrent_calls() -> None:
 
 async def test_shared_cache_between_readyz_and_healthz_paths() -> None:
     """critical_only=True and full run share per-check cache."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=10.0)
+    registry = HealthRegistry(cache_ttl=10.0)
     critical = Counting()
     non_critical = Counting()
     registry.add("db", critical)
@@ -346,14 +347,14 @@ async def test_shared_cache_between_readyz_and_healthz_paths() -> None:
 )
 async def test_invalid_name_rejected(name: str) -> None:
     """Names must match ^[a-z0-9][a-z0-9:_-]*$."""
-    registry = HealthRegistry(auto_register=False)
+    registry = HealthRegistry()
     with pytest.raises(ValueError, match="Invalid health check name"):
         registry.add(name, healthy())
 
 
 async def test_namespaced_name_accepted() -> None:
     """Colon-separated names are allowed for namespacing."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("weather:circuitbreaker", healthy())
     report = await registry.run()
     assert "weather:circuitbreaker" in report["checks"]
@@ -361,21 +362,21 @@ async def test_namespaced_name_accepted() -> None:
 
 async def test_digit_leading_name_accepted() -> None:
     """Digits are valid as the leading character."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("0-primary", healthy())
     assert "0-primary" in (await registry.run())["checks"]
 
 
 async def test_name_too_long_rejected() -> None:
     """Names longer than 64 chars are rejected."""
-    registry = HealthRegistry(auto_register=False)
+    registry = HealthRegistry()
     with pytest.raises(ValueError, match="Invalid health check name"):
         registry.add("a" * 65, healthy())
 
 
 async def test_name_at_max_len_accepted() -> None:
     """A name of exactly 64 chars is accepted."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("a" * 64, healthy())
     report = await registry.run()
     assert "a" * 64 in report["checks"]
@@ -383,7 +384,7 @@ async def test_name_at_max_len_accepted() -> None:
 
 async def test_duplicate_name_raises_for_add() -> None:
     """Registering two checks with the same name via add() raises."""
-    registry = HealthRegistry(auto_register=False)
+    registry = HealthRegistry()
     registry.add("db", healthy())
 
     with pytest.raises(ValueError, match="already registered"):
@@ -392,7 +393,7 @@ async def test_duplicate_name_raises_for_add() -> None:
 
 async def test_duplicate_name_raises_for_decorator() -> None:
     """The decorator form also rejects duplicates."""
-    registry = HealthRegistry(auto_register=False)
+    registry = HealthRegistry()
 
     @registry.check("db")
     async def _first() -> HealthDetails | None:
@@ -407,7 +408,7 @@ async def test_duplicate_name_raises_for_decorator() -> None:
 
 async def test_health_error_exposes_message() -> None:
     """HealthError subclasses expose their message in the error field."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("db", unhealthy_with_health_error())
 
     report = await registry.run()
@@ -419,7 +420,7 @@ async def test_health_error_exposes_message() -> None:
 
 async def test_generic_exception_hides_message() -> None:
     """Non-HealthError exceptions get a generic message."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("redis", unhealthy())
 
     report = await registry.run()
@@ -431,7 +432,7 @@ async def test_health_error_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """HealthError failures log at WARNING with exc_info."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("db", unhealthy_with_health_error())
 
     with caplog.at_level(logging.WARNING, logger="grelmicro.health"):
@@ -449,7 +450,7 @@ async def test_generic_exception_logs_error(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Unexpected exceptions log at ERROR with a traceback."""
-    registry = HealthRegistry(auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(cache_ttl=0)
     registry.add("redis", unhealthy())
 
     with caplog.at_level(logging.WARNING, logger="grelmicro.health"):
@@ -464,7 +465,7 @@ async def test_timeout_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Timed-out checks log at WARNING with the per-check timeout."""
-    registry = HealthRegistry(timeout=0.05, auto_register=False, cache_ttl=0)
+    registry = HealthRegistry(timeout=0.05, cache_ttl=0)
     registry.add("slow", slow(delay=1.0))
 
     with caplog.at_level(logging.WARNING, logger="grelmicro.health"):
@@ -481,63 +482,72 @@ async def test_timeout_logs_warning(
 def test_timeout_zero_raises() -> None:
     """timeout=0 is rejected."""
     with pytest.raises(ValidationError, match="greater than 0"):
-        HealthRegistry(timeout=0, auto_register=False)
+        HealthRegistry(timeout=0)
 
 
 def test_timeout_negative_raises() -> None:
     """Negative timeout is rejected."""
     with pytest.raises(ValidationError, match="greater than 0"):
-        HealthRegistry(timeout=-1.0, auto_register=False)
+        HealthRegistry(timeout=-1.0)
 
 
 def test_cache_ttl_negative_raises() -> None:
     """Negative cache_ttl is rejected."""
     with pytest.raises(ValidationError):
-        HealthRegistry(cache_ttl=-1.0, auto_register=False)
+        HealthRegistry(cache_ttl=-1.0)
 
 
-def test_auto_register() -> None:
-    """HealthRegistry auto-registers as the global singleton."""
-    registry = HealthRegistry()
+async def test_async_context_manager_registers_and_unregisters() -> None:
+    """`async with HealthRegistry()` registers on enter, unregisters on exit."""
+    async with HealthRegistry() as registry:
+        assert get_health_registry() is registry
+    with pytest.raises(BackendNotLoadedError):
+        get_health_registry()
 
-    assert get_health_registry() is registry
 
-
-def test_auto_register_false() -> None:
-    """auto_register=False skips global registration."""
-    HealthRegistry(auto_register=False)
+def test_constructor_does_not_register() -> None:
+    """Constructing a HealthRegistry performs no registry writes."""
+    HealthRegistry()
 
     with pytest.raises(BackendNotLoadedError):
         get_health_registry()
 
 
+def test_use_registry_installs_singleton() -> None:
+    """`health.use_registry` installs the registry as the global default."""
+    registry = HealthRegistry()
+    use_registry(registry)
+
+    assert get_health_registry() is registry
+
+
 def test_get_health_registry_raises_when_not_loaded() -> None:
-    """get_health_registry raises before a registry is created."""
+    """get_health_registry raises before a registry is registered."""
     with pytest.raises(BackendNotLoadedError):
         get_health_registry()
 
 
 def test_overwrite_warns() -> None:
-    """Overwriting an existing registry emits a warning."""
-    HealthRegistry()
+    """Registering a different registry over an existing one warns."""
+    health_registry.register(HealthRegistry())
 
     with pytest.warns(UserWarning, match="Overwriting"):
-        HealthRegistry()
+        health_registry.register(HealthRegistry())
 
 
-def test_set_health_registry() -> None:
-    """health_registry.set installs the singleton."""
-    registry = HealthRegistry(auto_register=False)
+def test_register_health_registry() -> None:
+    """health_registry.register installs the singleton."""
+    registry = HealthRegistry()
 
-    health_registry.set(registry)
+    health_registry.register(registry)
 
     assert get_health_registry() is registry
 
 
 def test_reset_health_registry() -> None:
     """health_registry.reset removes the singleton."""
-    registry = HealthRegistry(auto_register=False)
-    health_registry.set(registry)
+    registry = HealthRegistry()
+    health_registry.register(registry)
 
     health_registry.reset()
 

--- a/tests/health/test_registry_config.py
+++ b/tests/health/test_registry_config.py
@@ -21,9 +21,7 @@ def _reset_registry() -> None:
 
 def test_programmatic_path_uses_kwargs() -> None:
     """Plain kwargs build a config, falling back to defaults."""
-    registry = HealthRegistry(
-        timeout=TIMEOUT_KWARG, cache_ttl=CACHE_TTL_KWARG, auto_register=False
-    )
+    registry = HealthRegistry(timeout=TIMEOUT_KWARG, cache_ttl=CACHE_TTL_KWARG)
     assert registry._config.timeout == TIMEOUT_KWARG
     assert registry._config.cache_ttl == CACHE_TTL_KWARG
 
@@ -31,7 +29,7 @@ def test_programmatic_path_uses_kwargs() -> None:
 def test_declarative_path_uses_from_config() -> None:
     """`HealthRegistry.from_config()` constructs from a pre-built config."""
     cfg = HealthRegistryConfig(timeout=TIMEOUT_KWARG, cache_ttl=CACHE_TTL_KWARG)
-    registry = HealthRegistry.from_config(cfg, auto_register=False)
+    registry = HealthRegistry.from_config(cfg)
     assert registry._config is cfg
 
 
@@ -39,7 +37,7 @@ def test_from_config_bypasses_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """`HealthRegistry.from_config()` ignores env even when set."""
     monkeypatch.setenv("GREL_HEALTH_TIMEOUT", str(TIMEOUT_ENV))
     cfg = HealthRegistryConfig(timeout=TIMEOUT_KWARG, cache_ttl=CACHE_TTL_KWARG)
-    registry = HealthRegistry.from_config(cfg, auto_register=False)
+    registry = HealthRegistry.from_config(cfg)
     assert registry._config.timeout == TIMEOUT_KWARG
 
 
@@ -49,7 +47,7 @@ def test_environmental_path_reads_grel_prefixed_env(
     """Env vars under ``GREL_HEALTH_*`` populate unset fields."""
     monkeypatch.setenv("GREL_HEALTH_TIMEOUT", str(TIMEOUT_ENV))
     monkeypatch.setenv("GREL_HEALTH_CACHE_TTL", str(CACHE_TTL_ENV))
-    registry = HealthRegistry(auto_register=False)
+    registry = HealthRegistry()
     assert registry._config.timeout == TIMEOUT_ENV
     assert registry._config.cache_ttl == CACHE_TTL_ENV
 
@@ -57,14 +55,14 @@ def test_environmental_path_reads_grel_prefixed_env(
 def test_kwargs_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Caller kwargs win over env vars."""
     monkeypatch.setenv("GREL_HEALTH_TIMEOUT", str(TIMEOUT_ENV))
-    registry = HealthRegistry(timeout=TIMEOUT_KWARG, auto_register=False)
+    registry = HealthRegistry(timeout=TIMEOUT_KWARG)
     assert registry._config.timeout == TIMEOUT_KWARG
 
 
 def test_env_prefix_override(monkeypatch: pytest.MonkeyPatch) -> None:
     """``env_prefix=`` replaces the auto-derived ``GREL_HEALTH_``."""
     monkeypatch.setenv("MYAPP_HEALTH_TIMEOUT", str(TIMEOUT_ENV))
-    registry = HealthRegistry(env_prefix="MYAPP_HEALTH_", auto_register=False)
+    registry = HealthRegistry(env_prefix="MYAPP_HEALTH_")
     assert registry._config.timeout == TIMEOUT_ENV
 
 
@@ -73,7 +71,7 @@ def test_read_env_false_ignores_env(
 ) -> None:
     """``read_env=False`` skips env reads entirely."""
     monkeypatch.setenv("GREL_HEALTH_TIMEOUT", str(TIMEOUT_ENV))
-    registry = HealthRegistry(read_env=False, auto_register=False)
+    registry = HealthRegistry(read_env=False)
     assert registry._config.timeout == DEFAULT_TIMEOUT
 
 
@@ -83,13 +81,13 @@ def test_zero_config_uses_health_defaults(
     """Without env or kwargs, HealthRegistryConfig defaults take over."""
     monkeypatch.delenv("GREL_HEALTH_TIMEOUT", raising=False)
     monkeypatch.delenv("GREL_HEALTH_CACHE_TTL", raising=False)
-    registry = HealthRegistry(auto_register=False)
+    registry = HealthRegistry()
     assert registry._config.timeout == DEFAULT_TIMEOUT
     assert registry._config.cache_ttl == DEFAULT_CACHE_TTL
 
 
-def test_from_config_auto_register() -> None:
-    """`from_config(..., auto_register=True)` registers the instance globally."""
+def test_from_config_does_not_register() -> None:
+    """`from_config(...)` is a pure constructor and does not register."""
     cfg = HealthRegistryConfig()
-    registry = HealthRegistry.from_config(cfg, auto_register=True)
-    assert health_registry.get() is registry
+    HealthRegistry.from_config(cfg)
+    assert health_registry.is_loaded is False

--- a/tests/resilience/test_errors.py
+++ b/tests/resilience/test_errors.py
@@ -51,6 +51,7 @@ def test_resilience_module_exports() -> None:
         "ResilienceError",
         "ResilienceSettingsValidationError",
         "TokenBucketConfig",
+        "use_backend",
     }
     assert set(resilience_mod.__all__) == expected
 

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -337,7 +337,7 @@ async def test_explicit_backend_bypasses_registry() -> None:
     """Test backend= arg wins over registered default."""
     # Arrange: registered backend rejects everything
     rejected = MemoryRateLimiterBackend()
-    my = MemoryRateLimiterBackend(auto_register=False)
+    my = MemoryRateLimiterBackend()
 
     # Act: limiter uses the explicit backend
     rl = RateLimiter(
@@ -578,7 +578,7 @@ async def test_gcra_strategy_evicts_expired_keys(
     """Test _MemoryGCRA eviction drops keys whose TAT has passed."""
     # Arrange
     monkeypatch.setattr("grelmicro.resilience.memory._EVICTION_THRESHOLD", 1)
-    backend = MemoryRateLimiterBackend(auto_register=False)
+    backend = MemoryRateLimiterBackend()
     limiter = RateLimiter(
         "evict",
         GCRAConfig(limit=LIMIT, window=WINDOW),
@@ -602,7 +602,7 @@ async def test_token_bucket_strategy_evicts_full_keys(
     """Test _MemoryTokenBucket eviction drops keys at full capacity."""
     # Arrange
     monkeypatch.setattr("grelmicro.resilience.memory._EVICTION_THRESHOLD", 2)
-    backend = MemoryRateLimiterBackend(auto_register=False)
+    backend = MemoryRateLimiterBackend()
     limiter = RateLimiter(
         "evict",
         TokenBucketConfig(capacity=CAPACITY, refill_rate=1),

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -334,12 +334,15 @@ async def test_invalid_cost(limiter: RateLimiter, cost: int) -> None:
 
 
 async def test_explicit_backend_bypasses_registry() -> None:
-    """Test backend= arg wins over registered default."""
-    # Arrange: registered backend rejects everything
-    rejected = MemoryRateLimiterBackend()
+    """Test backend= arg wins over a registered default."""
+    # Arrange: explicitly register a backend as the default, then build a
+    # RateLimiter with a different explicit backend.
+    registered = MemoryRateLimiterBackend()
+    rate_limiter_backend_registry.register(registered)
+    assert rate_limiter_backend_registry.get() is registered
     my = MemoryRateLimiterBackend()
 
-    # Act: limiter uses the explicit backend
+    # Act: limiter is built with the explicit backend instance
     rl = RateLimiter(
         "explicit",
         GCRAConfig(limit=LIMIT, window=WINDOW),
@@ -348,8 +351,7 @@ async def test_explicit_backend_bypasses_registry() -> None:
 
     # Assert: RateLimiter exposes the explicit backend, ignores the registered one
     assert rl.backend is my
-    _ = rejected  # keep the registered instance alive for the test scope
-    assert rl._backend is not rejected
+    assert rl.backend is not registered
 
 
 # --- Error class ---

--- a/tests/resilience/test_ratelimiter_backends.py
+++ b/tests/resilience/test_ratelimiter_backends.py
@@ -68,13 +68,10 @@ async def backend(
         async with RedisRateLimiterBackend(
             f"redis://localhost:{port}/0",
             prefix="test:",
-            auto_register=False,
         ) as redis_backend:
             yield redis_backend
     elif backend_name == "memory":
-        async with MemoryRateLimiterBackend(
-            auto_register=False,
-        ) as memory_backend:
+        async with MemoryRateLimiterBackend() as memory_backend:
             yield memory_backend
 
 

--- a/tests/resilience/test_ratelimiter_redis.py
+++ b/tests/resilience/test_ratelimiter_redis.py
@@ -76,17 +76,14 @@ def test_redis_env_var_settings_validation_error(
         RedisRateLimiterBackend()
 
 
-def test_auto_register_false(
+def test_constructor_does_not_register(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test auto_register=False does not register backend."""
-    # Arrange
+    """Constructing the backend performs no registry writes."""
     monkeypatch.setenv("REDIS_URL", URL)
 
-    # Act
-    RedisRateLimiterBackend(auto_register=False)
+    RedisRateLimiterBackend()
 
-    # Assert
     assert rate_limiter_backend_registry.is_loaded is False
 
 
@@ -96,7 +93,7 @@ def test_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("REDIS_URL", URL)
 
     # Act
-    backend = RedisRateLimiterBackend(prefix="myapp:", auto_register=False)
+    backend = RedisRateLimiterBackend(prefix="myapp:")
 
     # Assert
     assert backend._prefix == "myapp:"
@@ -105,7 +102,7 @@ def test_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_explicit_url() -> None:
     """Test explicit URL parameter."""
     # Act
-    backend = RedisRateLimiterBackend(URL, auto_register=False)
+    backend = RedisRateLimiterBackend(URL)
 
     # Assert
     assert backend._url == URL

--- a/tests/sync/test_backends.py
+++ b/tests/sync/test_backends.py
@@ -11,6 +11,7 @@ from testcontainers.core.container import DockerContainer
 from testcontainers.postgres import PostgresContainer
 from testcontainers.redis import RedisContainer
 
+from grelmicro.sync import use_backend
 from grelmicro.sync._backends import get_sync_backend, sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.errors import BackendNotLoadedError
@@ -391,14 +392,12 @@ async def test_owned_another(backend: SyncBackend) -> None:
 )
 @pytest.mark.usefixtures("clean_registry")
 def test_get_sync_backend(backend_factory: Callable[[], SyncBackend]) -> None:
-    """Test Get Synchronization Backend."""
-    # Arrange
+    """`use_backend` registers the constructed backend as the default."""
     expected_backend = backend_factory()
+    use_backend(expected_backend)
 
-    # Act
     backend = get_sync_backend()
 
-    # Assert
     assert backend is expected_backend
 
 
@@ -413,25 +412,21 @@ def test_get_sync_backend_not_loaded() -> None:
 @pytest.mark.parametrize(
     "backend_factory",
     [
-        lambda: MemorySyncBackend(auto_register=False),
-        lambda: RedisSyncBackend(
-            "redis://localhost:6379/0", auto_register=False
-        ),
+        MemorySyncBackend,
+        lambda: RedisSyncBackend("redis://localhost:6379/0"),
         lambda: PostgresSyncBackend(
-            "postgresql://user:password@localhost:5432/db", auto_register=False
+            "postgresql://user:password@localhost:5432/db"
         ),
-        lambda: SQLiteSyncBackend(":memory:", auto_register=False),
-        lambda: KubernetesSyncBackend(namespace="default", auto_register=False),
+        lambda: SQLiteSyncBackend(":memory:"),
+        lambda: KubernetesSyncBackend(namespace="default"),
     ],
 )
 @pytest.mark.usefixtures("clean_registry")
-def test_get_sync_backend_auto_register_disabled(
+def test_constructor_does_not_register(
     backend_factory: Callable[[], SyncBackend],
 ) -> None:
-    """Test Get Synchronization Backend."""
-    # Arrange
+    """Constructing any sync backend performs no registry writes."""
     backend_factory()
 
-    # Act / Assert
     with pytest.raises(BackendNotLoadedError):
         get_sync_backend()

--- a/tests/sync/test_kubernetes.py
+++ b/tests/sync/test_kubernetes.py
@@ -126,33 +126,15 @@ def test_kubernetes_env_var_settings_validation_error() -> None:
         KubernetesSyncBackend()
 
 
-# --- Auto register ---
+# --- Registration ---
 
 
-def test_sync_backend_auto_register() -> None:
-    """Test Synchronization Backend Auto Register."""
-    # Arrange
+def test_sync_backend_constructor_does_not_register() -> None:
+    """Constructing the backend performs no registry writes."""
     sync_backend_registry.reset()
 
-    # Act
     KubernetesSyncBackend(namespace="default")
 
-    # Assert
-    assert sync_backend_registry.is_loaded
-
-    # Cleanup
-    sync_backend_registry.reset()
-
-
-def test_sync_backend_auto_register_false() -> None:
-    """Test Synchronization Backend Auto Register Disabled."""
-    # Arrange
-    sync_backend_registry.reset()
-
-    # Act
-    KubernetesSyncBackend(namespace="default", auto_register=False)
-
-    # Assert
     assert not sync_backend_registry.is_loaded
 
 

--- a/tests/sync/test_leaderelection_config.py
+++ b/tests/sync/test_leaderelection_config.py
@@ -40,7 +40,7 @@ def test_backend_property_resolves_lazily_and_caches(
     mocker: MockerFixture,
 ) -> None:
     """First `le.backend` access resolves once, subsequent reads hit the cache."""
-    backend_instance = MemorySyncBackend(auto_register=False)
+    backend_instance = MemorySyncBackend()
     spy = mocker.patch(
         "grelmicro.sync.leaderelection.get_sync_backend",
         return_value=backend_instance,

--- a/tests/sync/test_lock_config.py
+++ b/tests/sync/test_lock_config.py
@@ -32,7 +32,7 @@ def test_backend_property_resolves_lazily_and_caches(
     mocker: MockerFixture,
 ) -> None:
     """First `lock.backend` access resolves once, subsequent reads hit the cache."""
-    backend_instance = MemorySyncBackend(auto_register=False)
+    backend_instance = MemorySyncBackend()
     spy = mocker.patch(
         "grelmicro.sync.lock.get_sync_backend", return_value=backend_instance
     )

--- a/tests/sync/test_postgres.py
+++ b/tests/sync/test_postgres.py
@@ -111,30 +111,12 @@ def test_postgres_env_var_settings_validation_error(
         PostgresSyncBackend()
 
 
-def test_sync_backend_auto_register() -> None:
-    """Test Synchronization Backend Auto Register."""
-    # Arrange
+def test_sync_backend_constructor_does_not_register() -> None:
+    """Constructing the backend performs no registry writes."""
     sync_backend_registry.reset()
 
-    # Act
     PostgresSyncBackend(url=URL)
 
-    # Assert
-    assert sync_backend_registry.is_loaded
-
-    # Cleanup
-    sync_backend_registry.reset()
-
-
-def test_sync_backend_auto_register_false() -> None:
-    """Test Synchronization Backend Auto Register Disabled."""
-    # Arrange
-    sync_backend_registry.reset()
-
-    # Act
-    PostgresSyncBackend(url=URL, auto_register=False)
-
-    # Assert
     assert not sync_backend_registry.is_loaded
 
 

--- a/tests/sync/test_sqlite.py
+++ b/tests/sync/test_sqlite.py
@@ -71,30 +71,12 @@ def test_sqlite_env_var_settings_validation_error() -> None:
         SQLiteSyncBackend()
 
 
-def test_sync_backend_auto_register() -> None:
-    """Test Synchronization Backend Auto Register."""
-    # Arrange
+def test_sync_backend_constructor_does_not_register() -> None:
+    """Constructing the backend performs no registry writes."""
     sync_backend_registry.reset()
 
-    # Act
     SQLiteSyncBackend(path=":memory:")
 
-    # Assert
-    assert sync_backend_registry.is_loaded
-
-    # Cleanup
-    sync_backend_registry.reset()
-
-
-def test_sync_backend_auto_register_false() -> None:
-    """Test Synchronization Backend Auto Register Disabled."""
-    # Arrange
-    sync_backend_registry.reset()
-
-    # Act
-    SQLiteSyncBackend(path=":memory:", auto_register=False)
-
-    # Assert
     assert not sync_backend_registry.is_loaded
 
 

--- a/tests/sync/test_tasklock_config.py
+++ b/tests/sync/test_tasklock_config.py
@@ -33,7 +33,7 @@ def test_backend_property_resolves_lazily_and_caches(
     mocker: MockerFixture,
 ) -> None:
     """First `task_lock.backend` access resolves once, subsequent reads hit the cache."""
-    backend_instance = MemorySyncBackend(auto_register=False)
+    backend_instance = MemorySyncBackend()
     spy = mocker.patch(
         "grelmicro.sync.tasklock.get_sync_backend",
         return_value=backend_instance,

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -1,11 +1,12 @@
-"""Regression tests: auto-registered backends unregister on shutdown.
+"""Backend lifecycle: explicit registration via ``async with``.
 
-A backend that registered itself as the process default during
-construction must clear the registry slot on ``__aexit__``, but only
-when the slot still points to the same backend (so a newer backend
-that replaced it is left alone).
+Constructors are pure: they perform no registry writes.
+Registration happens on ``__aenter__`` and unregistration on
+``__aexit__``. ``unregister`` uses an identity check, so a backend
+that was already replaced by a newer instance leaves the slot alone.
 """
 
+import warnings
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -14,6 +15,7 @@ from pytest_mock import MockerFixture
 from grelmicro.cache._backends import cache_backend_registry
 from grelmicro.cache.memory import MemoryCacheBackend
 from grelmicro.cache.redis import RedisCacheBackend
+from grelmicro.resilience import use_backend as resilience_use_backend
 from grelmicro.resilience._backends import rate_limiter_backend_registry
 from grelmicro.resilience.memory import MemoryRateLimiterBackend
 from grelmicro.resilience.redis import RedisRateLimiterBackend
@@ -57,7 +59,6 @@ def mock_redis(mocker: MockerFixture) -> MagicMock:
     mock_client = MagicMock()
     mock_client.aclose = AsyncMock()
     mock_client.register_script = MagicMock(return_value=AsyncMock())
-    # Patch at every call site so all backends share the same mock.
     mocker.patch(
         "grelmicro.sync.redis._create_redis_client",
         return_value=("redis://localhost", mock_client),
@@ -73,35 +74,45 @@ def mock_redis(mocker: MockerFixture) -> MagicMock:
     return mock_client
 
 
-# --- Sync (Memory) ---
+# --- Pure constructors ---
 
 
-async def test_sync_memory_backend_unregisters_on_exit() -> None:
-    """``async with MemorySyncBackend()`` clears the registry on exit."""
-    async with MemorySyncBackend():
-        assert sync_backend_registry.is_loaded is True
-
+def test_sync_memory_constructor_does_not_register() -> None:
+    """Constructing a sync backend performs no registry writes."""
+    MemorySyncBackend()
     assert sync_backend_registry.is_loaded is False
 
 
-async def test_sync_memory_backend_with_auto_register_false_does_not_touch_registry() -> (
-    None
-):
-    """A backend with ``auto_register=False`` never sets or clears the slot."""
-    async with MemorySyncBackend(auto_register=False):
-        assert sync_backend_registry.is_loaded is False
+def test_cache_memory_constructor_does_not_register() -> None:
+    """Constructing a cache backend performs no registry writes."""
+    MemoryCacheBackend()
+    assert cache_backend_registry.is_loaded is False
+
+
+def test_rate_limiter_memory_constructor_does_not_register() -> None:
+    """Constructing a rate limiter backend performs no registry writes."""
+    MemoryRateLimiterBackend()
+    assert rate_limiter_backend_registry.is_loaded is False
+
+
+# --- Sync (Memory) ---
+
+
+async def test_sync_memory_backend_round_trip() -> None:
+    """``async with`` registers on enter and unregisters on exit."""
+    async with MemorySyncBackend():
+        assert sync_backend_registry.is_loaded is True
     assert sync_backend_registry.is_loaded is False
 
 
 async def test_sync_memory_backend_does_not_evict_replacement() -> None:
-    """Exiting the first backend leaves a newer registered backend in place."""
+    """Exiting an older backend leaves a newer registered one in place."""
     backend_1 = MemorySyncBackend()
-    assert sync_backend_registry.get() is backend_1
-
-    backend_2 = MemorySyncBackend()  # replaces backend_1 in the slot
+    backend_2 = MemorySyncBackend()
+    sync_backend_registry.register(backend_1)
+    sync_backend_registry.register(backend_2)
     assert sync_backend_registry.get() is backend_2
 
-    # Exiting backend_1 must not evict backend_2 from the registry.
     await backend_1.__aexit__(None, None, None)
     assert sync_backend_registry.get() is backend_2
 
@@ -109,27 +120,19 @@ async def test_sync_memory_backend_does_not_evict_replacement() -> None:
 # --- Rate Limiter (Memory) ---
 
 
-async def test_rate_limiter_memory_backend_unregisters_on_exit() -> None:
-    """``async with MemoryRateLimiterBackend()`` clears the registry on exit."""
+async def test_rate_limiter_memory_backend_round_trip() -> None:
+    """``async with`` registers on enter and unregisters on exit."""
     async with MemoryRateLimiterBackend():
         assert rate_limiter_backend_registry.is_loaded is True
-
-    assert rate_limiter_backend_registry.is_loaded is False
-
-
-async def test_rate_limiter_memory_backend_with_auto_register_false() -> None:
-    """A rate limiter backend with ``auto_register=False`` is registry-neutral."""
-    async with MemoryRateLimiterBackend(auto_register=False):
-        assert rate_limiter_backend_registry.is_loaded is False
     assert rate_limiter_backend_registry.is_loaded is False
 
 
 async def test_rate_limiter_memory_backend_does_not_evict_replacement() -> None:
-    """Exiting the first rate limiter backend leaves a newer one in place."""
+    """Exiting an older rate limiter backend leaves a newer one in place."""
     backend_1 = MemoryRateLimiterBackend()
-    assert rate_limiter_backend_registry.get() is backend_1
-
     backend_2 = MemoryRateLimiterBackend()
+    rate_limiter_backend_registry.register(backend_1)
+    rate_limiter_backend_registry.register(backend_2)
     assert rate_limiter_backend_registry.get() is backend_2
 
     await backend_1.__aexit__(None, None, None)
@@ -139,8 +142,8 @@ async def test_rate_limiter_memory_backend_does_not_evict_replacement() -> None:
 # --- Sync (SQLite) ---
 
 
-async def test_sync_sqlite_backend_unregisters_on_exit(tmp_path) -> None:  # noqa: ANN001
-    """``async with SQLiteSyncBackend()`` clears the registry on exit."""
+async def test_sync_sqlite_backend_round_trip(tmp_path) -> None:  # noqa: ANN001
+    """``async with`` registers on enter and unregisters on exit."""
     db_path = tmp_path / "lock.db"
     async with SQLiteSyncBackend(db_path):
         assert sync_backend_registry.is_loaded is True
@@ -150,10 +153,10 @@ async def test_sync_sqlite_backend_unregisters_on_exit(tmp_path) -> None:  # noq
 # --- Sync (Redis) ---
 
 
-async def test_sync_redis_backend_unregisters_on_exit(
+async def test_sync_redis_backend_round_trip(
     mock_redis: MagicMock,  # noqa: ARG001
 ) -> None:
-    """``async with RedisSyncBackend()`` clears the registry on exit."""
+    """``async with`` registers on enter and unregisters on exit."""
     async with RedisSyncBackend("redis://localhost"):
         assert sync_backend_registry.is_loaded is True
     assert sync_backend_registry.is_loaded is False
@@ -162,10 +165,10 @@ async def test_sync_redis_backend_unregisters_on_exit(
 # --- Sync (PostgreSQL) ---
 
 
-async def test_sync_postgres_backend_unregisters_on_exit(
+async def test_sync_postgres_backend_round_trip(
     mocker: MockerFixture,
 ) -> None:
-    """``async with PostgresSyncBackend()`` clears the registry on exit."""
+    """``async with`` registers on enter and unregisters on exit."""
     mock_pool = MagicMock()
     mock_pool.execute = AsyncMock()
     mock_pool.close = AsyncMock()
@@ -182,10 +185,10 @@ async def test_sync_postgres_backend_unregisters_on_exit(
 # --- Rate Limiter (Redis) ---
 
 
-async def test_rate_limiter_redis_backend_unregisters_on_exit(
+async def test_rate_limiter_redis_backend_round_trip(
     mock_redis: MagicMock,  # noqa: ARG001
 ) -> None:
-    """``async with RedisRateLimiterBackend()`` clears the registry on exit."""
+    """``async with`` registers on enter and unregisters on exit."""
     async with RedisRateLimiterBackend("redis://localhost"):
         assert rate_limiter_backend_registry.is_loaded is True
     assert rate_limiter_backend_registry.is_loaded is False
@@ -194,10 +197,10 @@ async def test_rate_limiter_redis_backend_unregisters_on_exit(
 # --- Cache (Redis) ---
 
 
-async def test_cache_redis_backend_unregisters_on_exit(
+async def test_cache_redis_backend_round_trip(
     mock_redis: MagicMock,  # noqa: ARG001
 ) -> None:
-    """``async with RedisCacheBackend()`` clears the registry on exit."""
+    """``async with`` registers on enter and unregisters on exit."""
     async with RedisCacheBackend("redis://localhost"):
         assert cache_backend_registry.is_loaded is True
     assert cache_backend_registry.is_loaded is False
@@ -206,19 +209,19 @@ async def test_cache_redis_backend_unregisters_on_exit(
 # --- Cache (Memory) ---
 
 
-async def test_cache_memory_backend_unregisters_on_exit() -> None:
-    """``async with MemoryCacheBackend()`` clears the registry on exit."""
+async def test_cache_memory_backend_round_trip() -> None:
+    """``async with`` registers on enter and unregisters on exit."""
     async with MemoryCacheBackend():
         assert cache_backend_registry.is_loaded is True
     assert cache_backend_registry.is_loaded is False
 
 
 async def test_cache_memory_backend_does_not_evict_replacement() -> None:
-    """Exiting the first cache backend leaves a newer one in place."""
+    """Exiting an older cache backend leaves a newer one in place."""
     backend_1 = MemoryCacheBackend()
-    assert cache_backend_registry.get() is backend_1
-
     backend_2 = MemoryCacheBackend()
+    cache_backend_registry.register(backend_1)
+    cache_backend_registry.register(backend_2)
     assert cache_backend_registry.get() is backend_2
 
     await backend_1.__aexit__(None, None, None)
@@ -228,10 +231,10 @@ async def test_cache_memory_backend_does_not_evict_replacement() -> None:
 # --- Sync (Kubernetes) ---
 
 
-async def test_sync_kubernetes_backend_unregisters_on_exit(
+async def test_sync_kubernetes_backend_round_trip(
     mocker: MockerFixture,
 ) -> None:
-    """``async with KubernetesSyncBackend()`` clears the registry on exit."""
+    """``async with`` registers on enter and unregisters on exit."""
     mock_client = MagicMock()
     mock_client.close = AsyncMock()
 
@@ -248,3 +251,54 @@ async def test_sync_kubernetes_backend_unregisters_on_exit(
     async with KubernetesSyncBackend(namespace="default"):
         assert sync_backend_registry.is_loaded is True
     assert sync_backend_registry.is_loaded is False
+
+
+# --- Identity check on unregister ---
+
+
+def test_sync_registry_unregister_identity() -> None:
+    """register(a); register(b); unregister(a) leaves b as current."""
+    a = MemorySyncBackend()
+    b = MemorySyncBackend()
+    sync_backend_registry.register(a)
+    sync_backend_registry.register(b)
+    sync_backend_registry.unregister(a)
+    assert sync_backend_registry.get() is b
+
+
+def test_cache_registry_unregister_identity() -> None:
+    """register(a); register(b); unregister(a) leaves b as current."""
+    a = MemoryCacheBackend()
+    b = MemoryCacheBackend()
+    cache_backend_registry.register(a)
+    cache_backend_registry.register(b)
+    cache_backend_registry.unregister(a)
+    assert cache_backend_registry.get() is b
+
+
+def test_rate_limiter_registry_unregister_identity() -> None:
+    """register(a); register(b); unregister(a) leaves b as current."""
+    a = MemoryRateLimiterBackend()
+    b = MemoryRateLimiterBackend()
+    rate_limiter_backend_registry.register(a)
+    rate_limiter_backend_registry.register(b)
+    rate_limiter_backend_registry.unregister(a)
+    assert rate_limiter_backend_registry.get() is b
+
+
+def test_resilience_use_backend_registers() -> None:
+    """`resilience.use_backend` installs the rate limiter backend."""
+    rate_limiter_backend_registry.reset()
+    backend = MemoryRateLimiterBackend()
+    resilience_use_backend(backend)
+    assert rate_limiter_backend_registry.get() is backend
+
+
+def test_register_same_instance_is_noop() -> None:
+    """Re-registering the same instance does not warn or replace."""
+    backend = MemorySyncBackend()
+    sync_backend_registry.register(backend)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sync_backend_registry.register(backend)
+    assert sync_backend_registry.get() is backend


### PR DESCRIPTION
## Summary

- Removes `auto_register` from every backend constructor and from `HealthRegistry`. `__init__` is now pure: validates config, binds locals, no global writes.
- Adds module-level `use_backend(backend)` helpers on `grelmicro.sync`, `grelmicro.cache`, `grelmicro.resilience` (and `use_registry` on `grelmicro.health`) for explicit process-lifetime registration.
- `BackendRegistry.register/unregister` use an identity check so a stale backend cannot evict the one that replaced it.

Closes #116.

## Test plan
- [x] `MemorySyncBackend()` etc. perform zero registry writes
- [x] `async with backend:` round-trip leaves the registry empty (this PR)
- [x] Identity-checked `unregister` (`register(a); register(b); unregister(a); current is b`)
- [x] All existing primitive tests still pass with explicit registration