### PR TITLE
✨ Multi-name registry with ContextVar overrides + grelmicro.lifespan()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,16 +299,17 @@ If you adapt code from another project, even a snippet:
   ...) has a matching `XBackend` Protocol under the package's
   `_protocol.py`, with at least a Memory and a Redis
   implementation.
-- Backends are registered in a shared registry
+- Backends live in a multi-name registry
   (`grelmicro/_backends.py::BackendRegistry`). Construction is
-  pure: `__init__` performs no registry writes. User code picks a
-  backend either by entering it as an async context manager
-  (`async with` registers on enter, unregisters on exit), by
-  calling the module-level `use_backend` helper for process-
-  lifetime registration, or by passing `backend=` explicitly to
-  the primitive's constructor.
-- Primitives expose the `backend=` override even when they also
-  fall back to the registry.
+  pure: `__init__` performs no registry writes and no I/O. User
+  code wires a backend by calling `<module>.register(backend)`
+  (defaults to the `"default"` name) or
+  `<module>.register(backend, "analytics")` for a named entry,
+  then opens every registered backend via
+  `grelmicro.lifespan()`. Primitives accept `backend=` as an
+  instance override or `backend="<name>"` for a named lookup;
+  the registry is consulted on every call so that
+  `<module>.use(...)` overrides take effect.
 
 ### About grelmicro versions
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 
+import grelmicro
+from grelmicro import cache, resilience, sync
 from grelmicro.cache import JsonSerializer, TTLCache, cached
 from grelmicro.cache.redis import RedisCacheBackend
 from grelmicro.logging import configure_logging
@@ -94,20 +96,21 @@ logger = logging.getLogger(__name__)
 
 # === grelmicro ===
 task = TaskManager()
-sync_backend = RedisSyncBackend("redis://localhost:6379/0")
-cache_backend = RedisCacheBackend("redis://localhost:6379/0", prefix="myapp:")
-rate_limit_backend = RedisRateLimiterBackend("redis://localhost:6379/0")
+sync.register(RedisSyncBackend("redis://localhost:6379/0"))
+cache.register(RedisCacheBackend("redis://localhost:6379/0", prefix="myapp:"))
+resilience.register(RedisRateLimiterBackend("redis://localhost:6379/0"))
+
 leader_election = LeaderElection("leader-election")
 task.add_task(leader_election)
 
-cache = TTLCache(ttl=300, serializer=JsonSerializer())
+ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer())
 
 
 # === FastAPI ===
 @asynccontextmanager
 async def lifespan(app):
     configure_logging()
-    async with sync_backend, cache_backend, rate_limit_backend, task:
+    async with grelmicro.lifespan(task):
         yield
 
 
@@ -115,7 +118,7 @@ app = FastAPI(lifespan=lifespan)
 
 
 # --- Cache: avoid redundant database queries ---
-@cached(cache)
+@cached(ttl_cache)
 async def get_user(user_id: int) -> dict:
     return {"id": user_id, "name": "Alice"}
 

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -8,51 +8,110 @@ All backends use **async** methods because they perform network or disk I/O (Red
 
 ## Design
 
-The `BackendRegistry[T]` is a generic, typed container that holds a single default backend instance. Each module maintains its own registry:
+`BackendRegistry[T]` is a generic, typed, multi-name container with task-scoped overrides. Each module maintains its own registry. The registry key matches the module name and is the value to use in `lifespan(exclude={...})`:
 
-| Module | Registry | Protocol | Backends |
+| Module | Registry key | Protocol / Type | Backends |
 |---|---|---|---|
-| `sync` | `sync_backend_registry` | `SyncBackend` | Redis, PostgreSQL, SQLite, Kubernetes, Memory |
-| `cache` | `cache_backend_registry` | `CacheBackend` | Redis, Memory |
+| `grelmicro.sync` | `sync` | `SyncBackend` | Redis, PostgreSQL, SQLite, Kubernetes, Memory |
+| `grelmicro.cache` | `cache` | `CacheBackend` | Redis, Memory |
+| `grelmicro.resilience` | `resilience` | `RateLimiterBackend` | Redis, Memory |
+| `grelmicro.health` | `health` | `HealthRegistry` | (any number of named registries) |
+
+A registry holds zero or more named entries. Backends are looked up by name at call time, and each entry is independent. The `"default"` slot is the implicit name when no `backend=` is passed.
 
 ## Construction vs registration
 
-Construction and registration are two distinct steps. `__init__` is pure: it validates configuration and binds locals, but never touches the global registry. Registration is explicit and reversible.
+Construction and registration are two distinct steps. `__init__` is pure: it validates configuration and binds locals. It performs no registry writes and no I/O. Registration is explicit and reversible.
 
-There are three ways to register a backend:
+There are three ways to wire a backend:
 
-**1. Scoped registration via `async with` (recommended).** `__aenter__` registers the backend, `__aexit__` unregisters it. The registry is empty after the context exits.
+**1. Register and open via `grelmicro.lifespan()` (recommended for apps).** Register synchronously at startup, then open every registered backend with one call:
 
 ```python
-async with RedisSyncBackend() as backend:
-    # backend is the default for Lock, TaskLock, LeaderElection here
+import grelmicro
+from grelmicro import sync, cache
+
+sync.register(RedisSyncBackend())             # implicit "default"
+cache.register(RedisCacheBackend())
+
+async with grelmicro.lifespan():
+    # every registered backend is open here
     ...
-# unregistered on exit
+# every registered backend is closed on exit (LIFO)
 ```
 
-**2. Process-lifetime registration via `use_backend`.** Each module exposes a small helper for `main()` or lifespan wiring:
+`grelmicro.lifespan()` walks every grelmicro registry that has been imported in the current process, opens each entry via its async context manager, and closes them in reverse order on exit. Use `exclude={"<module>"}` to skip a whole module or `exclude={"<module>.<name>"}` to skip one entry.
+
+**2. Module-level `use_backend` shorthand.** Equivalent to `register("default", backend)`:
 
 ```python
 from grelmicro import sync
 
-backend = RedisSyncBackend()
-sync.use_backend(backend)  # idempotent on the same instance
+sync.use_backend(RedisSyncBackend())
 ```
 
-The helpers are: `grelmicro.sync.use_backend`, `grelmicro.cache.use_backend`, `grelmicro.resilience.use_backend`, `grelmicro.health.use_registry`.
+Available as `grelmicro.sync.use_backend`, `grelmicro.cache.use_backend`, `grelmicro.resilience.use_backend`, and `grelmicro.health.use_registry`.
 
-**3. Pure construction without registration.** Pass the backend explicitly to consumers and skip the registry entirely:
+**3. Pure construction with explicit pass-through.** Skip the registry entirely:
 
 ```python
-backend = MemorySyncBackend()
-lock = Lock(name="my-lock", backend=backend)
+async with RedisSyncBackend() as backend:
+    lock = Lock(name="my-lock", backend=backend)
+    async with lock:
+        ...
 ```
 
-Consumers that accept an optional `backend` parameter fall back to the registry when none is provided.
+`async with` opens the connection only. The backend is not registered.
 
-### Identity-checked unregister
+## Named backends and per-call selection
 
-`registry.unregister(backend)` only clears the slot when the registered instance is identical to the one passed in. Calling it on a non-current instance is a no-op. This means a stale backend's `__aexit__` cannot evict a newer backend that replaced it.
+Register multiple backends under different names and pick one at the call site:
+
+```python
+sync.register(RedisSyncBackend())                              # → "default"
+sync.register(PostgresSyncBackend("postgres://..."), "analytics")
+
+Lock("cart")                          # → "default" (Redis)
+Lock("audit", backend="analytics")     # → "analytics" (Postgres)
+Lock("cart", backend=my_instance)      # → explicit instance, bypasses names
+```
+
+Resolution order, in priority:
+
+1. Explicit instance (`backend=instance`).
+2. Task-scoped override for the requested name (set via `<module>.use(...)`).
+3. Registered entry under the requested name.
+4. When the requested name is `"default"` and exactly one backend is registered: that sole entry.
+5. Otherwise raise `BackendNotLoadedError`.
+
+## Task-scoped overrides
+
+`<module>.use(...)` installs a per-task override for the duration of a `with` block. Stacks LIFO via `contextvars`:
+
+```python
+from grelmicro import sync
+
+with sync.use(MemorySyncBackend()):           # overrides "default" only
+    Lock("cart")                              # → MemorySyncBackend
+
+with sync.use(default=mem, analytics=fake):   # overrides multiple names
+    ...
+
+# Tests
+async def test_checkout():
+    with sync.use(MemorySyncBackend()):
+        await checkout()
+```
+
+The override propagates downward through `await`, `start_soon`, and `to_thread.run_sync` (AnyIO copies the context at every concurrency boundary). Set the override on the side that *calls into* the registry: an override set inside a worker thread is invisible to `from_thread.run` callbacks (which run on the loop's context).
+
+## Lazy registration and zero-RAM-cost for unused modules
+
+Each `BackendRegistry` subscribes itself into a process-wide map *when its module is imported*. Modules you never import never create their registry, never appear in `grelmicro.lifespan()`, and never consume RAM. `import grelmicro` alone is ~6 ms; the per-component cost is paid only when the user imports that component.
+
+## Identity-checked unregister
+
+`registry.unregister(name, backend)` clears the entry only when the registered instance is identical to the one passed in. Calling on a non-current instance is a no-op. A stale backend's teardown cannot evict a newer backend that replaced it under the same name.
 
 ## Protocol-Based Polymorphism
 
@@ -80,6 +139,12 @@ Shared Redis configuration (URL resolution from environment variables) is dedupl
 Accessing a registry before any backend is registered raises `BackendNotLoadedError` with a descriptive message:
 
 ```
-No lock backend loaded. Initialize a backend first
-(e.g. with ``async with`` a backend instance).
+No sync backend loaded for name 'default'.
+```
+
+Or, when multiple backends are registered without a `"default"`:
+
+```
+No default sync backend: multiple are registered
+(['analytics', 'primary']), none named 'default'.
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,13 +4,22 @@
 
 ### Breaking
 
-* 💥 Backend constructors are now pure: `__init__` performs no registry writes. The `auto_register` kwarg is removed from `MemorySyncBackend`, `RedisSyncBackend`, `PostgresSyncBackend`, `SQLiteSyncBackend`, `KubernetesSyncBackend`, `MemoryCacheBackend`, `RedisCacheBackend`, `MemoryRateLimiterBackend`, `RedisRateLimiterBackend`, and `HealthRegistry`. Register via `async with` (scoped) or the new `use_backend` / `use_registry` helpers (process lifetime). PR [#138](https://github.com/grelinfo/grelmicro/pull/138).
+* 💥 Backend constructors are now pure: `__init__` performs no registry writes. The `auto_register` kwarg is removed from every backend and from `HealthRegistry`. PR [#138](https://github.com/grelinfo/grelmicro/pull/138).
 * 💥 `BackendRegistry.set` is renamed `register` and `BackendRegistry.unregister` is added with an identity check. `reset` remains for test fixtures. PR [#138](https://github.com/grelinfo/grelmicro/pull/138).
+* 💥 `async with backend` opens the connection but no longer registers. Call `register(backend)` (or `use_backend(backend)`) to register, or open everything at once with `grelmicro.lifespan()`. PR [#139](https://github.com/grelinfo/grelmicro/pull/139).
+* 💥 `BackendRegistry` is now multi-name: `register(backend, name="default")`, `unregister(name, backend=None)`, `get(name="default")`. PR [#139](https://github.com/grelinfo/grelmicro/pull/139).
+* 💥 The sync registry name changed from `"lock"` to `"sync"` (used in error messages and `lifespan()` exclude keys); the rate limiter registry from `"rate_limiter"` to `"resilience"`. PR [#139](https://github.com/grelinfo/grelmicro/pull/139).
+* 💥 Overwriting a registered name with a different instance now raises `BackendAlreadyRegisteredError` (was: warning + replace). Re-registering the same instance stays a no-op. PR [#139](https://github.com/grelinfo/grelmicro/pull/139).
 
 ### Features
 
 * ✨ Add `grelmicro.sync.use_backend`, `grelmicro.cache.use_backend`, `grelmicro.resilience.use_backend`, and `grelmicro.health.use_registry` for explicit, idempotent process-lifetime registration. PR [#138](https://github.com/grelinfo/grelmicro/pull/138).
-* ✨ Backends register on `__aenter__` and unregister on `__aexit__` with identity-checked unregister, so a stale backend cannot evict the one that replaced it. PR [#138](https://github.com/grelinfo/grelmicro/pull/138).
+* ✨ `grelmicro.lifespan(*ad_hoc, exclude=...)` opens every registered backend across every imported module in one call, with reverse-order shutdown. PR [#139](https://github.com/grelinfo/grelmicro/pull/139).
+* ✨ Per-module helpers `register`, `unregister`, `use_backend`, `use` on `grelmicro.sync`, `grelmicro.cache`, `grelmicro.resilience` (and `use_registry`, `use` on `grelmicro.health`). PR [#139](https://github.com/grelinfo/grelmicro/pull/139).
+* ✨ Task-scoped overrides via `<module>.use(backend)` or `<module>.use(default=a, analytics=b)`. Stacks LIFO via `contextvars` for per-test and per-request substitution. PR [#139](https://github.com/grelinfo/grelmicro/pull/139).
+* ✨ Primitives accept `backend=` as either a backend instance or a registered name (`Lock("audit", backend="analytics")`). The registry is consulted on each call so `<module>.use(...)` overrides apply. PR [#139](https://github.com/grelinfo/grelmicro/pull/139).
+* ✨ Registries subscribe themselves on import: `lifespan()` walks only modules that are actually imported, so unused components have zero RAM cost and zero startup work. PR [#139](https://github.com/grelinfo/grelmicro/pull/139).
+* ✨ Lookup falls back to the sole registered entry when no `"default"` is named, so the single-backend case stays one-call. PR [#139](https://github.com/grelinfo/grelmicro/pull/139).
 
 ## 0.17.0 - 2026-04-29
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 
+import grelmicro
+from grelmicro import cache, resilience, sync
 from grelmicro.cache import JsonSerializer, TTLCache, cached
 from grelmicro.cache.redis import RedisCacheBackend
 from grelmicro.logging import configure_logging
@@ -94,20 +96,21 @@ logger = logging.getLogger(__name__)
 
 # === grelmicro ===
 task = TaskManager()
-sync_backend = RedisSyncBackend("redis://localhost:6379/0")
-cache_backend = RedisCacheBackend("redis://localhost:6379/0", prefix="myapp:")
-rate_limit_backend = RedisRateLimiterBackend("redis://localhost:6379/0")
+sync.register(RedisSyncBackend("redis://localhost:6379/0"))
+cache.register(RedisCacheBackend("redis://localhost:6379/0", prefix="myapp:"))
+resilience.register(RedisRateLimiterBackend("redis://localhost:6379/0"))
+
 leader_election = LeaderElection("leader-election")
 task.add_task(leader_election)
 
-cache = TTLCache(ttl=300, serializer=JsonSerializer())
+ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer())
 
 
 # === FastAPI ===
 @asynccontextmanager
 async def lifespan(app):
     configure_logging()
-    async with sync_backend, cache_backend, rate_limit_backend, task:
+    async with grelmicro.lifespan(task):
         yield
 
 
@@ -115,7 +118,7 @@ app = FastAPI(lifespan=lifespan)
 
 
 # --- Cache: avoid redundant database queries ---
-@cached(cache)
+@cached(ttl_cache)
 async def get_user(user_id: int) -> dict:
     return {"id": user_id, "name": "Alice"}
 

--- a/grelmicro/__init__.py
+++ b/grelmicro/__init__.py
@@ -1,1 +1,47 @@
 """grelmicro is a lightweight framework/toolkit which is ideal for building async microservices in Python."""  # noqa: E501
+
+from collections.abc import AsyncIterator, Iterable
+from contextlib import (
+    AbstractAsyncContextManager,
+    AsyncExitStack,
+    asynccontextmanager,
+)
+
+
+@asynccontextmanager
+async def lifespan(
+    *ad_hoc: AbstractAsyncContextManager[object],
+    exclude: Iterable[str] = (),
+) -> AsyncIterator[None]:
+    """Open every registered backend, close them all on exit.
+
+    Walks every grelmicro backend registry that has been imported
+    in the current process and enters each registered backend that
+    is not listed in ``exclude``. Positional arguments are entered
+    after the registered backends. On exit (or any failure during
+    startup) every entered context manager is closed in reverse
+    order.
+
+    Modules whose registry has not been imported are skipped:
+    importing ``grelmicro`` alone walks nothing. Importing
+    ``grelmicro.sync`` makes the sync registry visible. Use
+    ``exclude={"<module>"}`` to skip a module or
+    ``exclude={"<module>.<name>"}`` to skip one named entry.
+    """
+    from grelmicro._backends import _ALL_REGISTRIES  # noqa: PLC0415
+
+    excluded = frozenset(exclude)
+    async with AsyncExitStack() as stack:
+        for module_name, registry in _ALL_REGISTRIES.items():
+            if module_name in excluded:
+                continue
+            for entry_name, backend in registry.items():
+                if f"{module_name}.{entry_name}" in excluded:
+                    continue
+                await stack.enter_async_context(backend)
+        for ctx in ad_hoc:
+            await stack.enter_async_context(ctx)
+        yield
+
+
+__all__ = ["lifespan"]

--- a/grelmicro/_backends.py
+++ b/grelmicro/_backends.py
@@ -1,11 +1,15 @@
 """Backend Registry."""
 
-from collections.abc import Iterator
+from __future__ import annotations
+
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from grelmicro.errors import GrelmicroError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 T = TypeVar("T")
 
@@ -13,7 +17,7 @@ DEFAULT_NAME = "default"
 
 # Subscribed at construction time so ``grelmicro.lifespan()`` walks
 # only the registries whose modules were actually imported.
-_ALL_REGISTRIES: dict[str, "BackendRegistry"] = {}
+_ALL_REGISTRIES: dict[str, BackendRegistry[Any]] = {}
 
 
 class BackendRegistry(Generic[T]):

--- a/grelmicro/_backends.py
+++ b/grelmicro/_backends.py
@@ -1,6 +1,5 @@
 """Backend Registry."""
 
-import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -33,25 +32,31 @@ class BackendRegistry(Generic[T]):
         """Return the current task-scoped overrides (read-only view)."""
         return self._overrides.get() or {}
 
-    def register(self, name: str, backend: T) -> None:
+    def register(self, backend: T, name: str = DEFAULT_NAME) -> None:
         """Register ``backend`` under ``name``.
 
-        Re-registering the same instance is a no-op. Registering
-        a different instance under an existing name warns and
-        replaces.
+        Re-registering the same instance under the same name is
+        a no-op.
+
+        Raises:
+            BackendAlreadyRegisteredError: If a different instance
+                is already registered under ``name``. Call
+                ``unregister`` first to swap.
         """
         existing = self._backends.get(name)
         if existing is backend:
             return
         if existing is not None:
-            warnings.warn(
-                f"Overwriting already-registered {self._name} "
-                f"backend {name!r}.",
-                stacklevel=2,
+            msg = (
+                f"{self._name} backend {name!r} is already "
+                f"registered. Call unregister() first to swap."
             )
+            raise BackendAlreadyRegisteredError(msg)
         self._backends[name] = backend
 
-    def unregister(self, name: str, backend: T | None = None) -> None:
+    def unregister(
+        self, name: str = DEFAULT_NAME, backend: T | None = None
+    ) -> None:
         """Remove the entry for ``name``.
 
         When ``backend`` is provided, the slot is cleared only
@@ -134,3 +139,7 @@ class BackendRegistry(Generic[T]):
 
 class BackendNotLoadedError(GrelmicroError, RuntimeError):
     """Raised when a backend is accessed before being registered."""
+
+
+class BackendAlreadyRegisteredError(GrelmicroError, RuntimeError):
+    """Raised when registering a different instance under an existing name."""

--- a/grelmicro/_backends.py
+++ b/grelmicro/_backends.py
@@ -1,89 +1,135 @@
-"""Backend Registry.
-
-A generic registry for backend instances. Each module (sync, cache)
-maintains its own registry instance with a typed key.
-"""
+"""Backend Registry."""
 
 import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Generic, TypeVar
 
 from grelmicro.errors import GrelmicroError
 
 T = TypeVar("T")
 
+DEFAULT_NAME = "default"
+
+# Subscribed at construction time so ``grelmicro.lifespan()`` walks
+# only the registries whose modules were actually imported.
+_ALL_REGISTRIES: dict[str, "BackendRegistry"] = {}
+
 
 class BackendRegistry(Generic[T]):
-    """Generic backend registry.
-
-    Stores a single default backend instance per named slot.
-    Registration is explicit: callers invoke
-    :meth:`register` (typically from a module-level
-    ``use_backend`` helper or a backend's ``__aenter__``).
-    Consumers look up the default via :meth:`get`.
-    """
+    """Multi-name backend registry with task-scoped overrides."""
 
     def __init__(self, *, name: str) -> None:
-        """Initialize the registry.
-
-        Args:
-            name: Human-readable name for error messages
-                  (e.g. "lock", "cache").
-        """
+        """Initialize the registry."""
         self._name = name
-        self._backend: T | None = None
+        self._backends: dict[str, T] = {}
+        self._overrides: ContextVar[dict[str, T] | None] = ContextVar(
+            f"{name}_backend_overrides", default=None
+        )
+        _ALL_REGISTRIES[name] = self
 
-    def register(self, backend: T) -> None:
-        """Register a backend as the default.
+    def _current_overrides(self) -> dict[str, T]:
+        """Return the current task-scoped overrides (read-only view)."""
+        return self._overrides.get() or {}
 
-        Warns if a different backend is already registered.
-        Re-registering the same instance is a no-op.
+    def register(self, name: str, backend: T) -> None:
+        """Register ``backend`` under ``name``.
+
+        Re-registering the same instance is a no-op. Registering
+        a different instance under an existing name warns and
+        replaces.
         """
-        if self._backend is backend:
+        existing = self._backends.get(name)
+        if existing is backend:
             return
-        if self._backend is not None:
+        if existing is not None:
             warnings.warn(
-                f"Overwriting already-registered {self._name} backend.",
+                f"Overwriting already-registered {self._name} "
+                f"backend {name!r}.",
                 stacklevel=2,
             )
-        self._backend = backend
+        self._backends[name] = backend
 
-    def unregister(self, backend: T) -> None:
-        """Unregister ``backend`` if it is the current default.
+    def unregister(self, name: str, backend: T | None = None) -> None:
+        """Remove the entry for ``name``.
 
-        Identity check: clears the slot only when
-        ``self._backend is backend``. Calling on a non-current
-        instance is a no-op.
+        When ``backend`` is provided, the slot is cleared only
+        if the registered instance is identical.
         """
-        if self._backend is backend:
-            self._backend = None
+        existing = self._backends.get(name)
+        if existing is None:
+            return
+        if backend is not None and existing is not backend:
+            return
+        del self._backends[name]
 
-    def get(self) -> T:
-        """Return the registered backend.
+    def items(self) -> Iterator[tuple[str, T]]:
+        """Iterate over registered (name, backend) pairs."""
+        return iter(self._backends.items())
+
+    def get(self, name: str = DEFAULT_NAME) -> T:
+        """Resolve a backend by ``name``.
+
+        Lookup order:
+
+        1. Task-scoped override for ``name``.
+        2. Registered entry under ``name``.
+        3. When ``name`` is ``"default"`` and exactly one
+           backend is registered: that sole entry.
 
         Raises:
-            BackendNotLoadedError: If no backend has been registered.
+            BackendNotLoadedError: If nothing resolves.
         """
-        if self._backend is None:
+        overrides = self._current_overrides()
+        if name in overrides:
+            return overrides[name]
+        if name in self._backends:
+            return self._backends[name]
+        if name == DEFAULT_NAME and len(self._backends) == 1:
+            return next(iter(self._backends.values()))
+        if name == DEFAULT_NAME and len(self._backends) > 1:
+            registered = sorted(self._backends)
             msg = (
-                f"No {self._name} backend loaded. "
-                f"Initialize a backend first "
-                f"(e.g. with ``async with`` a backend instance)."
+                f"No default {self._name} backend: multiple are "
+                f"registered ({registered}), none named "
+                f"{DEFAULT_NAME!r}."
             )
             raise BackendNotLoadedError(msg)
-        return self._backend
+        msg = f"No {self._name} backend loaded for name {name!r}."
+        raise BackendNotLoadedError(msg)
 
     @property
     def is_loaded(self) -> bool:
-        """Return True if a backend is registered."""
-        return self._backend is not None
+        """Return True if any backend is registered."""
+        return bool(self._backends)
 
     def reset(self) -> None:
-        """Remove the registered backend unconditionally.
+        """Clear every registered backend."""
+        self._backends.clear()
 
-        Intended for test fixtures. Production code should call
-        :meth:`unregister` with the instance to clear.
+    @contextmanager
+    def use(
+        self,
+        backend: T | None = None,
+        /,
+        **named: T,
+    ) -> Iterator[None]:
+        """Install task-scoped overrides for the duration of the block.
+
+        ``use(backend)`` overrides the ``"default"`` slot.
+        ``use(default=a, analytics=b)`` overrides multiple names.
+        Inner blocks shadow outer ones for the names they specify.
         """
-        self._backend = None
+        overlay: dict[str, T] = dict(self._current_overrides())
+        if backend is not None:
+            overlay[DEFAULT_NAME] = backend
+        overlay.update(named)
+        token = self._overrides.set(overlay)
+        try:
+            yield
+        finally:
+            self._overrides.reset(token)
 
 
 class BackendNotLoadedError(GrelmicroError, RuntimeError):

--- a/grelmicro/cache/__init__.py
+++ b/grelmicro/cache/__init__.py
@@ -20,15 +20,19 @@ from grelmicro.cache.ttl import CacheInfo, TTLCache
 
 
 def register(
-    name: Annotated[str, Doc("Name to register the backend under.")],
     backend: Annotated[CacheBackend, Doc("The cache backend.")],
+    name: Annotated[
+        str, Doc("Name to register the backend under.")
+    ] = DEFAULT_NAME,
 ) -> None:
-    """Register ``backend`` under ``name``."""
-    cache_backend_registry.register(name, backend)
+    """Register ``backend`` under ``name`` (defaults to ``"default"``)."""
+    cache_backend_registry.register(backend, name)
 
 
 def unregister(
-    name: Annotated[str, Doc("Name of the registered backend to remove.")],
+    name: Annotated[
+        str, Doc("Name of the registered backend to remove.")
+    ] = DEFAULT_NAME,
     backend: Annotated[
         CacheBackend | None,
         Doc("Optional backend instance for an identity-checked removal."),
@@ -45,7 +49,7 @@ def use_backend(
     ],
 ) -> None:
     """Register ``backend`` under the ``"default"`` name."""
-    cache_backend_registry.register(DEFAULT_NAME, backend)
+    cache_backend_registry.register(backend, DEFAULT_NAME)
 
 
 def use(

--- a/grelmicro/cache/__init__.py
+++ b/grelmicro/cache/__init__.py
@@ -1,9 +1,11 @@
 """Cache."""
 
+from contextlib import AbstractContextManager
 from typing import Annotated
 
 from typing_extensions import Doc
 
+from grelmicro._backends import DEFAULT_NAME
 from grelmicro.cache._backends import cache_backend_registry
 from grelmicro.cache._protocol import CacheBackend
 from grelmicro.cache.cached import cached
@@ -17,18 +19,45 @@ from grelmicro.cache.serializers import (
 from grelmicro.cache.ttl import CacheInfo, TTLCache
 
 
+def register(
+    name: Annotated[str, Doc("Name to register the backend under.")],
+    backend: Annotated[CacheBackend, Doc("The cache backend.")],
+) -> None:
+    """Register ``backend`` under ``name``."""
+    cache_backend_registry.register(name, backend)
+
+
+def unregister(
+    name: Annotated[str, Doc("Name of the registered backend to remove.")],
+    backend: Annotated[
+        CacheBackend | None,
+        Doc("Optional backend instance for an identity-checked removal."),
+    ] = None,
+) -> None:
+    """Remove the registered backend under ``name``."""
+    cache_backend_registry.unregister(name, backend)
+
+
 def use_backend(
     backend: Annotated[
         CacheBackend,
         Doc("The cache backend to register as the default."),
     ],
 ) -> None:
-    """Register `backend` as the default cache backend.
+    """Register ``backend`` under the ``"default"`` name."""
+    cache_backend_registry.register(DEFAULT_NAME, backend)
 
-    Idempotent: re-registering the same instance is a no-op.
-    Registering a different instance warns and replaces.
-    """
-    cache_backend_registry.register(backend)
+
+def use(
+    backend: Annotated[
+        CacheBackend | None,
+        Doc('Override the ``"default"`` slot for the duration of the block.'),
+    ] = None,
+    /,
+    **named: CacheBackend,
+) -> AbstractContextManager[None]:
+    """Install task-scoped backend overrides."""
+    return cache_backend_registry.use(backend, **named)
 
 
 __all__ = [
@@ -42,5 +71,8 @@ __all__ = [
     "PydanticSerializer",
     "TTLCache",
     "cached",
+    "register",
+    "unregister",
+    "use",
     "use_backend",
 ]

--- a/grelmicro/cache/_backends.py
+++ b/grelmicro/cache/_backends.py
@@ -1,6 +1,6 @@
 """Cache Backend Registry."""
 
-from grelmicro._backends import BackendRegistry
+from grelmicro._backends import DEFAULT_NAME, BackendRegistry
 from grelmicro.cache._protocol import CacheBackend
 
 cache_backend_registry: BackendRegistry[CacheBackend] = BackendRegistry(
@@ -8,10 +8,10 @@ cache_backend_registry: BackendRegistry[CacheBackend] = BackendRegistry(
 )
 
 
-def get_cache_backend() -> CacheBackend:
-    """Get the default cache backend.
+def get_cache_backend(name: str = DEFAULT_NAME) -> CacheBackend:
+    """Resolve a cache backend by ``name``.
 
     Raises:
-        BackendNotLoadedError: If no cache backend has been registered.
+        BackendNotLoadedError: If no backend resolves.
     """
-    return cache_backend_registry.get()
+    return cache_backend_registry.get(name)

--- a/grelmicro/cache/memory.py
+++ b/grelmicro/cache/memory.py
@@ -4,8 +4,6 @@ from time import monotonic
 from types import TracebackType
 from typing import Self
 
-from grelmicro.cache._backends import cache_backend_registry
-
 
 class MemoryCacheBackend:
     """In-memory cache backend.
@@ -19,8 +17,7 @@ class MemoryCacheBackend:
         self._data: dict[str, tuple[bytes, float]] = {}
 
     async def __aenter__(self) -> Self:
-        """Open the cache backend and register it as the default."""
-        cache_backend_registry.register(self)
+        """Open the cache backend."""
         return self
 
     async def __aexit__(
@@ -29,9 +26,8 @@ class MemoryCacheBackend:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the cache backend and unregister it."""
+        """Close the cache backend."""
         self._data.clear()
-        cache_backend_registry.unregister(self)
 
     async def get(self, *, key: str) -> bytes | None:
         """Get raw bytes by key.

--- a/grelmicro/cache/redis.py
+++ b/grelmicro/cache/redis.py
@@ -7,7 +7,6 @@ from pydantic import RedisDsn
 from typing_extensions import Doc
 
 from grelmicro._redis import _create_redis_client
-from grelmicro.cache._backends import cache_backend_registry
 from grelmicro.cache.errors import CacheSettingsValidationError
 
 _CLEAR_BATCH_SIZE = 1000
@@ -53,8 +52,7 @@ class RedisCacheBackend:
         self._prefix = prefix
 
     async def __aenter__(self) -> Self:
-        """Open the cache connection and register the backend as default."""
-        cache_backend_registry.register(self)
+        """Open the cache connection."""
         return self
 
     async def __aexit__(
@@ -63,9 +61,8 @@ class RedisCacheBackend:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the cache connection and unregister the backend."""
+        """Close the cache connection."""
         await self._redis.aclose()
-        cache_backend_registry.unregister(self)
 
     async def get(self, *, key: str) -> bytes | None:
         """Get raw bytes by key.

--- a/grelmicro/health/__init__.py
+++ b/grelmicro/health/__init__.py
@@ -18,15 +18,19 @@ from grelmicro.health.errors import HealthError
 
 
 def register(
-    name: Annotated[str, Doc("Name to register the registry under.")],
     registry: Annotated[HealthRegistry, Doc("The health registry instance.")],
+    name: Annotated[
+        str, Doc("Name to register the registry under.")
+    ] = DEFAULT_NAME,
 ) -> None:
-    """Register ``registry`` under ``name``."""
-    health_registry.register(name, registry)
+    """Register ``registry`` under ``name`` (defaults to ``"default"``)."""
+    health_registry.register(registry, name)
 
 
 def unregister(
-    name: Annotated[str, Doc("Name of the registered instance to remove.")],
+    name: Annotated[
+        str, Doc("Name of the registered instance to remove.")
+    ] = DEFAULT_NAME,
     registry: Annotated[
         HealthRegistry | None,
         Doc("Optional instance for an identity-checked removal."),
@@ -43,7 +47,7 @@ def use_registry(
     ],
 ) -> None:
     """Register ``registry`` under the ``"default"`` name."""
-    health_registry.register(DEFAULT_NAME, registry)
+    health_registry.register(registry, DEFAULT_NAME)
 
 
 def use(

--- a/grelmicro/health/__init__.py
+++ b/grelmicro/health/__init__.py
@@ -1,9 +1,11 @@
 """Health Check Registry."""
 
+from contextlib import AbstractContextManager
 from typing import Annotated
 
 from typing_extensions import Doc
 
+from grelmicro._backends import DEFAULT_NAME
 from grelmicro.health._backends import get_health_registry, health_registry
 from grelmicro.health._models import (
     CheckResult,
@@ -15,18 +17,45 @@ from grelmicro.health._types import HealthCheckFunc, HealthDetails
 from grelmicro.health.errors import HealthError
 
 
+def register(
+    name: Annotated[str, Doc("Name to register the registry under.")],
+    registry: Annotated[HealthRegistry, Doc("The health registry instance.")],
+) -> None:
+    """Register ``registry`` under ``name``."""
+    health_registry.register(name, registry)
+
+
+def unregister(
+    name: Annotated[str, Doc("Name of the registered instance to remove.")],
+    registry: Annotated[
+        HealthRegistry | None,
+        Doc("Optional instance for an identity-checked removal."),
+    ] = None,
+) -> None:
+    """Remove the registered instance under ``name``."""
+    health_registry.unregister(name, registry)
+
+
 def use_registry(
     registry: Annotated[
         HealthRegistry,
         Doc("The health registry to install as the global default."),
     ],
 ) -> None:
-    """Register `registry` as the global default health registry.
+    """Register ``registry`` under the ``"default"`` name."""
+    health_registry.register(DEFAULT_NAME, registry)
 
-    Idempotent: re-registering the same instance is a no-op.
-    Registering a different instance warns and replaces.
-    """
-    health_registry.register(registry)
+
+def use(
+    registry: Annotated[
+        HealthRegistry | None,
+        Doc('Override the ``"default"`` slot for the duration of the block.'),
+    ] = None,
+    /,
+    **named: HealthRegistry,
+) -> AbstractContextManager[None]:
+    """Install task-scoped registry overrides."""
+    return health_registry.use(registry, **named)
 
 
 __all__ = [
@@ -39,5 +68,8 @@ __all__ = [
     "HealthReport",
     "HealthStatus",
     "get_health_registry",
+    "register",
+    "unregister",
+    "use",
     "use_registry",
 ]

--- a/grelmicro/health/_backends.py
+++ b/grelmicro/health/_backends.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from grelmicro._backends import BackendRegistry
+from grelmicro._backends import DEFAULT_NAME, BackendRegistry
 
 if TYPE_CHECKING:
     from grelmicro.health._registry import HealthRegistry
@@ -14,10 +14,10 @@ health_registry: BackendRegistry[HealthRegistry] = BackendRegistry(
 )
 
 
-def get_health_registry() -> HealthRegistry:
-    """Get the default health registry.
+def get_health_registry(name: str = DEFAULT_NAME) -> HealthRegistry:
+    """Resolve a health registry by ``name``.
 
     Raises:
-        BackendNotLoadedError: If no health registry has been registered.
+        BackendNotLoadedError: If no registry resolves.
     """
-    return health_registry.get()
+    return health_registry.get(name)

--- a/grelmicro/health/_registry.py
+++ b/grelmicro/health/_registry.py
@@ -14,7 +14,6 @@ from typing_extensions import Doc
 
 from grelmicro._async import is_async_callable
 from grelmicro._config import resolve_config
-from grelmicro.health._backends import health_registry
 from grelmicro.health._models import (
     CheckResult,
     HealthReport,
@@ -192,8 +191,7 @@ class HealthRegistry:
         self._entries: dict[str, _Entry] = {}
 
     async def __aenter__(self) -> Self:
-        """Register this registry as the global default."""
-        health_registry.register(self)
+        """Open the health registry."""
         return self
 
     async def __aexit__(
@@ -202,8 +200,7 @@ class HealthRegistry:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Unregister this registry."""
-        health_registry.unregister(self)
+        """Close the health registry."""
 
     def add(
         self,

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -36,15 +36,19 @@ from grelmicro.resilience.ratelimiter import RateLimiter
 
 
 def register(
-    name: Annotated[str, Doc("Name to register the backend under.")],
     backend: Annotated[RateLimiterBackend, Doc("The rate limiter backend.")],
+    name: Annotated[
+        str, Doc("Name to register the backend under.")
+    ] = DEFAULT_NAME,
 ) -> None:
-    """Register ``backend`` under ``name``."""
-    rate_limiter_backend_registry.register(name, backend)
+    """Register ``backend`` under ``name`` (defaults to ``"default"``)."""
+    rate_limiter_backend_registry.register(backend, name)
 
 
 def unregister(
-    name: Annotated[str, Doc("Name of the registered backend to remove.")],
+    name: Annotated[
+        str, Doc("Name of the registered backend to remove.")
+    ] = DEFAULT_NAME,
     backend: Annotated[
         RateLimiterBackend | None,
         Doc("Optional backend instance for an identity-checked removal."),
@@ -61,7 +65,7 @@ def use_backend(
     ],
 ) -> None:
     """Register ``backend`` under the ``"default"`` name."""
-    rate_limiter_backend_registry.register(DEFAULT_NAME, backend)
+    rate_limiter_backend_registry.register(backend, DEFAULT_NAME)
 
 
 def use(

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -1,10 +1,12 @@
 """Resilience."""
 
 import warnings
+from contextlib import AbstractContextManager
 from typing import Annotated
 
 from typing_extensions import Doc
 
+from grelmicro._backends import DEFAULT_NAME
 from grelmicro.resilience._backends import rate_limiter_backend_registry
 from grelmicro.resilience._protocol import (
     RateLimiterBackend,
@@ -33,18 +35,45 @@ from grelmicro.resilience.memory import MemoryTokenBucket
 from grelmicro.resilience.ratelimiter import RateLimiter
 
 
+def register(
+    name: Annotated[str, Doc("Name to register the backend under.")],
+    backend: Annotated[RateLimiterBackend, Doc("The rate limiter backend.")],
+) -> None:
+    """Register ``backend`` under ``name``."""
+    rate_limiter_backend_registry.register(name, backend)
+
+
+def unregister(
+    name: Annotated[str, Doc("Name of the registered backend to remove.")],
+    backend: Annotated[
+        RateLimiterBackend | None,
+        Doc("Optional backend instance for an identity-checked removal."),
+    ] = None,
+) -> None:
+    """Remove the registered backend under ``name``."""
+    rate_limiter_backend_registry.unregister(name, backend)
+
+
 def use_backend(
     backend: Annotated[
         RateLimiterBackend,
         Doc("The rate limiter backend to register as the default."),
     ],
 ) -> None:
-    """Register `backend` as the default rate limiter backend.
+    """Register ``backend`` under the ``"default"`` name."""
+    rate_limiter_backend_registry.register(DEFAULT_NAME, backend)
 
-    Idempotent: re-registering the same instance is a no-op.
-    Registering a different instance warns and replaces.
-    """
-    rate_limiter_backend_registry.register(backend)
+
+def use(
+    backend: Annotated[
+        RateLimiterBackend | None,
+        Doc('Override the ``"default"`` slot for the duration of the block.'),
+    ] = None,
+    /,
+    **named: RateLimiterBackend,
+) -> AbstractContextManager[None]:
+    """Install task-scoped backend overrides."""
+    return rate_limiter_backend_registry.use(backend, **named)
 
 
 __all__ = [
@@ -65,6 +94,9 @@ __all__ = [
     "ResilienceError",
     "ResilienceSettingsValidationError",
     "TokenBucketConfig",
+    "register",
+    "unregister",
+    "use",
     "use_backend",
 ]
 

--- a/grelmicro/resilience/_backends.py
+++ b/grelmicro/resilience/_backends.py
@@ -1,6 +1,6 @@
 """Rate Limiter Backend Registry."""
 
-from grelmicro._backends import BackendRegistry
+from grelmicro._backends import DEFAULT_NAME, BackendRegistry
 from grelmicro.resilience._protocol import RateLimiterBackend
 
 rate_limiter_backend_registry: BackendRegistry[RateLimiterBackend] = (
@@ -8,10 +8,10 @@ rate_limiter_backend_registry: BackendRegistry[RateLimiterBackend] = (
 )
 
 
-def get_rate_limiter_backend() -> RateLimiterBackend:
-    """Get the default rate limiter backend.
+def get_rate_limiter_backend(name: str = DEFAULT_NAME) -> RateLimiterBackend:
+    """Resolve a rate limiter backend by ``name``.
 
     Raises:
-        BackendNotLoadedError: If no rate limiter backend has been registered.
+        BackendNotLoadedError: If no backend resolves.
     """
-    return rate_limiter_backend_registry.get()
+    return rate_limiter_backend_registry.get(name)

--- a/grelmicro/resilience/_backends.py
+++ b/grelmicro/resilience/_backends.py
@@ -4,7 +4,7 @@ from grelmicro._backends import DEFAULT_NAME, BackendRegistry
 from grelmicro.resilience._protocol import RateLimiterBackend
 
 rate_limiter_backend_registry: BackendRegistry[RateLimiterBackend] = (
-    BackendRegistry(name="rate_limiter")
+    BackendRegistry(name="resilience")
 )
 
 

--- a/grelmicro/resilience/memory.py
+++ b/grelmicro/resilience/memory.py
@@ -8,7 +8,6 @@ from typing import Annotated, Self, assert_never
 
 from typing_extensions import Doc
 
-from grelmicro.resilience._backends import rate_limiter_backend_registry
 from grelmicro.resilience._protocol import (
     RateLimiterBackend,
     RateLimiterStrategy,
@@ -196,8 +195,7 @@ class MemoryRateLimiterBackend(RateLimiterBackend):
         self._lock = Lock()
 
     async def __aenter__(self) -> Self:
-        """Open the rate limiter backend and register it as the default."""
-        rate_limiter_backend_registry.register(self)
+        """Open the rate limiter backend."""
         return self
 
     async def __aexit__(
@@ -206,11 +204,10 @@ class MemoryRateLimiterBackend(RateLimiterBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the rate limiter backend and unregister it."""
+        """Close the rate limiter backend."""
         with self._lock:
             self._token_bucket_state.clear()
             self._gcra_state.clear()
-        rate_limiter_backend_registry.unregister(self)
 
     def bind(self, config: RateLimiterConfig) -> RateLimiterStrategy:
         """Build a strategy for the given algorithm config.

--- a/grelmicro/resilience/ratelimiter.py
+++ b/grelmicro/resilience/ratelimiter.py
@@ -103,7 +103,7 @@ class RateLimiter:
         ],
         *,
         backend: Annotated[
-            RateLimiterBackend | None,
+            RateLimiterBackend | str | None,
             Doc(
                 """
                 An explicit backend instance. When `None` (the
@@ -119,7 +119,12 @@ class RateLimiter:
         """Initialize the rate limiter."""
         self._name = name
         self._config = config
-        self._backend: RateLimiterBackend | None = backend
+        self._backend: RateLimiterBackend | None = (
+            backend if not isinstance(backend, str) else None
+        )
+        self._backend_name: str | None = (
+            backend if isinstance(backend, str) else None
+        )
         self._strategy: RateLimiterStrategy | None = None
         self._fail_open = config.fail_open
         self._fallback = _build_fallback(config)
@@ -136,14 +141,16 @@ class RateLimiter:
 
     @property
     def backend(self) -> RateLimiterBackend:
-        """Bound rate-limiter backend, resolved lazily on first access."""
-        return self._backend or self._resolve_backend()
+        """Bound rate-limiter backend, resolved on each call.
 
-    def _resolve_backend(self) -> RateLimiterBackend:
-        """Resolve the backend from the global registry and cache it."""
-        backend = get_rate_limiter_backend()
-        self._backend = backend
-        return backend
+        When a backend instance was passed at construction it is
+        always returned. Otherwise the registry is consulted on
+        every access so that task-scoped ``resilience.use(...)``
+        overrides take effect.
+        """
+        if self._backend is not None:
+            return self._backend
+        return get_rate_limiter_backend(self._backend_name or "default")
 
     def _resolve_strategy(self) -> RateLimiterStrategy:
         """Bind the algorithm config to the backend and cache the strategy."""
@@ -164,7 +171,7 @@ class RateLimiter:
         ],
         *,
         backend: Annotated[
-            RateLimiterBackend | None,
+            RateLimiterBackend | str | None,
             Doc(
                 """
                 An explicit backend instance. When `None` (the
@@ -210,7 +217,7 @@ class RateLimiter:
             ),
         ] = False,
         backend: Annotated[
-            RateLimiterBackend | None,
+            RateLimiterBackend | str | None,
             Doc(
                 """
                 An explicit backend instance. When `None` (the
@@ -258,7 +265,7 @@ class RateLimiter:
             ),
         ] = False,
         backend: Annotated[
-            RateLimiterBackend | None,
+            RateLimiterBackend | str | None,
             Doc(
                 """
                 An explicit backend instance. When `None` (the

--- a/grelmicro/resilience/redis.py
+++ b/grelmicro/resilience/redis.py
@@ -8,7 +8,6 @@ from redis.asyncio import Redis
 from typing_extensions import Doc
 
 from grelmicro._redis import _create_redis_client
-from grelmicro.resilience._backends import rate_limiter_backend_registry
 from grelmicro.resilience._protocol import (
     RateLimiterBackend,
     RateLimiterStrategy,
@@ -84,8 +83,7 @@ class RedisRateLimiterBackend(RateLimiterBackend):
         self._prefix = prefix
 
     async def __aenter__(self) -> Self:
-        """Open the rate limiter backend and register it as the default."""
-        rate_limiter_backend_registry.register(self)
+        """Open the rate limiter backend."""
         return self
 
     async def __aexit__(
@@ -94,9 +92,8 @@ class RedisRateLimiterBackend(RateLimiterBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the rate limiter backend and unregister it."""
+        """Close the rate limiter backend."""
         await self._redis.aclose()
-        rate_limiter_backend_registry.unregister(self)
 
     def bind(self, config: RateLimiterConfig) -> RateLimiterStrategy:
         """Build a strategy for the given algorithm config.

--- a/grelmicro/sync/__init__.py
+++ b/grelmicro/sync/__init__.py
@@ -1,10 +1,12 @@
 """Synchronization."""
 
 import warnings
+from contextlib import AbstractContextManager
 from typing import Annotated
 
 from typing_extensions import Doc
 
+from grelmicro._backends import DEFAULT_NAME
 from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend, SyncPrimitive
 from grelmicro.sync.errors import SyncError, SyncSettingsValidationError
@@ -13,18 +15,51 @@ from grelmicro.sync.lock import Lock
 from grelmicro.sync.tasklock import TaskLock
 
 
+def register(
+    name: Annotated[str, Doc("Name to register the backend under.")],
+    backend: Annotated[SyncBackend, Doc("The synchronization backend.")],
+) -> None:
+    """Register ``backend`` under ``name``."""
+    sync_backend_registry.register(name, backend)
+
+
+def unregister(
+    name: Annotated[str, Doc("Name of the registered backend to remove.")],
+    backend: Annotated[
+        SyncBackend | None,
+        Doc("Optional backend instance for an identity-checked removal."),
+    ] = None,
+) -> None:
+    """Remove the registered backend under ``name``."""
+    sync_backend_registry.unregister(name, backend)
+
+
 def use_backend(
     backend: Annotated[
         SyncBackend,
         Doc("The synchronization backend to register as the default."),
     ],
 ) -> None:
-    """Register `backend` as the default synchronization backend.
+    """Register ``backend`` under the ``"default"`` name."""
+    sync_backend_registry.register(DEFAULT_NAME, backend)
 
-    Idempotent: re-registering the same instance is a no-op.
-    Registering a different instance warns and replaces.
+
+def use(
+    backend: Annotated[
+        SyncBackend | None,
+        Doc('Override the ``"default"`` slot for the duration of the block.'),
+    ] = None,
+    /,
+    **named: SyncBackend,
+) -> AbstractContextManager[None]:
+    """Install task-scoped backend overrides.
+
+    Use as a context manager:
+
+        with sync.use(MemorySyncBackend()):
+            ...
     """
-    sync_backend_registry.register(backend)
+    return sync_backend_registry.use(backend, **named)
 
 
 __all__ = [
@@ -34,6 +69,9 @@ __all__ = [
     "SyncPrimitive",
     "SyncSettingsValidationError",
     "TaskLock",
+    "register",
+    "unregister",
+    "use",
     "use_backend",
 ]
 

--- a/grelmicro/sync/__init__.py
+++ b/grelmicro/sync/__init__.py
@@ -16,15 +16,19 @@ from grelmicro.sync.tasklock import TaskLock
 
 
 def register(
-    name: Annotated[str, Doc("Name to register the backend under.")],
     backend: Annotated[SyncBackend, Doc("The synchronization backend.")],
+    name: Annotated[
+        str, Doc("Name to register the backend under.")
+    ] = DEFAULT_NAME,
 ) -> None:
-    """Register ``backend`` under ``name``."""
-    sync_backend_registry.register(name, backend)
+    """Register ``backend`` under ``name`` (defaults to ``"default"``)."""
+    sync_backend_registry.register(backend, name)
 
 
 def unregister(
-    name: Annotated[str, Doc("Name of the registered backend to remove.")],
+    name: Annotated[
+        str, Doc("Name of the registered backend to remove.")
+    ] = DEFAULT_NAME,
     backend: Annotated[
         SyncBackend | None,
         Doc("Optional backend instance for an identity-checked removal."),
@@ -41,7 +45,7 @@ def use_backend(
     ],
 ) -> None:
     """Register ``backend`` under the ``"default"`` name."""
-    sync_backend_registry.register(DEFAULT_NAME, backend)
+    sync_backend_registry.register(backend, DEFAULT_NAME)
 
 
 def use(

--- a/grelmicro/sync/_backends.py
+++ b/grelmicro/sync/_backends.py
@@ -1,17 +1,17 @@
 """Synchronization Backend Registry."""
 
-from grelmicro._backends import BackendRegistry
+from grelmicro._backends import DEFAULT_NAME, BackendRegistry
 from grelmicro.sync.abc import SyncBackend
 
 sync_backend_registry: BackendRegistry[SyncBackend] = BackendRegistry(
-    name="lock"
+    name="sync"
 )
 
 
-def get_sync_backend() -> SyncBackend:
-    """Get the default sync backend.
+def get_sync_backend(name: str = DEFAULT_NAME) -> SyncBackend:
+    """Resolve a sync backend by ``name``.
 
     Raises:
-        BackendNotLoadedError: If no lock backend has been registered.
+        BackendNotLoadedError: If no backend resolves.
     """
-    return sync_backend_registry.get()
+    return sync_backend_registry.get(name)

--- a/grelmicro/sync/kubernetes.py
+++ b/grelmicro/sync/kubernetes.py
@@ -16,7 +16,6 @@ from pydantic_settings import BaseSettings
 from typing_extensions import Doc
 
 from grelmicro.errors import OutOfContextError
-from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.errors import SyncSettingsValidationError
 
@@ -106,12 +105,11 @@ class KubernetesSyncBackend(SyncBackend):
         self._client: AsyncClient | None = None
 
     async def __aenter__(self) -> Self:
-        """Enter the lock backend and register it as the default."""
+        """Open the lock backend."""
         config = (
             KubeConfig.from_file(self._kubeconfig) if self._kubeconfig else None
         )
         self._client = AsyncClient(config=config)
-        sync_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -120,7 +118,7 @@ class KubernetesSyncBackend(SyncBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Exit the lock backend and unregister it."""
+        """Close the lock backend."""
         if self._client:
             # Clean up expired leases managed by grelmicro
             now = datetime.now(tz=UTC)
@@ -144,7 +142,6 @@ class KubernetesSyncBackend(SyncBackend):
                             raise
             await self._client.close()
             self._client = None
-        sync_backend_registry.unregister(self)
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire a lock."""

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -119,7 +119,7 @@ class LeaderElection(SyncPrimitive, Task):
         ],
         *,
         backend: Annotated[
-            SyncBackend | None,
+            SyncBackend | str | None,
             Doc(
                 """
                 The distributed lock backend used to acquire and release the lock.
@@ -278,7 +278,7 @@ class LeaderElection(SyncPrimitive, Task):
         ],
         *,
         backend: Annotated[
-            SyncBackend | None,
+            SyncBackend | str | None,
             Doc(
                 """
                 The distributed lock backend used to acquire and release the lock.
@@ -297,13 +297,18 @@ class LeaderElection(SyncPrimitive, Task):
         self,
         name: str,
         config: LeaderElectionConfig,
-        backend: SyncBackend | None,
+        backend: SyncBackend | str | None,
     ) -> None:
         """Wire the validated config and runtime deps onto the instance."""
         self._name = name
         self._config = config
         self._lock_name = f"{self._LOCK_PREFIX}:{name}"
-        self._backend: SyncBackend | None = backend
+        self._backend: SyncBackend | None = (
+            backend if not isinstance(backend, str) else None
+        )
+        self._backend_name: str | None = (
+            backend if isinstance(backend, str) else None
+        )
 
         self._service_running = False
         self._state_change_condition: Condition = Condition()
@@ -339,14 +344,16 @@ class LeaderElection(SyncPrimitive, Task):
 
     @property
     def backend(self) -> SyncBackend:
-        """Bound sync backend, resolved lazily on first access."""
-        return self._backend or self._resolve_backend()
+        """Bound sync backend, resolved on each call.
 
-    def _resolve_backend(self) -> SyncBackend:
-        """Resolve the backend from the global registry and cache it."""
-        backend = get_sync_backend()
-        self._backend = backend
-        return backend
+        When a backend instance was passed at construction it is
+        always returned. Otherwise the registry is consulted on
+        every access so that task-scoped ``sync.use(...)``
+        overrides take effect.
+        """
+        if self._backend is not None:
+            return self._backend
+        return get_sync_backend(self._backend_name or "default")
 
     def is_running(self) -> bool:
         """Check if the leader election task is running."""
@@ -428,7 +435,7 @@ class LeaderElection(SyncPrimitive, Task):
 
     async def _try_acquire_or_renew(self) -> None:
         """Try to acquire leadership."""
-        backend = self._backend or self._resolve_backend()
+        backend = self.backend
         try:
             with fail_after(self._config.backend_timeout):
                 is_leader = await backend.acquire(

--- a/grelmicro/sync/lock.py
+++ b/grelmicro/sync/lock.py
@@ -80,11 +80,13 @@ class Lock(BaseLock):
         ],
         *,
         backend: Annotated[
-            SyncBackend | None,
+            SyncBackend | str | None,
             Doc("""
                 The distributed lock backend used to acquire and release the lock.
 
-                By default, it will use the lock backend registry to get the default lock backend.
+                Accepts a backend instance, the name of a registered backend
+                (e.g. `"analytics"`), or `None` to use the registered
+                `"default"` backend.
                 """),
         ] = None,
         worker: Annotated[
@@ -192,11 +194,13 @@ class Lock(BaseLock):
         ],
         *,
         backend: Annotated[
-            SyncBackend | None,
+            SyncBackend | str | None,
             Doc("""
                 The distributed lock backend used to acquire and release the lock.
 
-                By default, it will use the lock backend registry to get the default lock backend.
+                Accepts a backend instance, the name of a registered backend
+                (e.g. `"analytics"`), or `None` to use the registered
+                `"default"` backend.
                 """),
         ] = None,
     ) -> Self:
@@ -209,13 +213,18 @@ class Lock(BaseLock):
         self,
         name: str,
         config: LockConfig,
-        backend: SyncBackend | None,
+        backend: SyncBackend | str | None,
     ) -> None:
         """Wire the validated config and runtime deps onto the instance."""
         self._name = name
         self._config = config
         self._lock_name = f"{self._LOCK_PREFIX}:{name}"
-        self._backend: SyncBackend | None = backend
+        self._backend: SyncBackend | None = (
+            backend if not isinstance(backend, str) else None
+        )
+        self._backend_name: str | None = (
+            backend if isinstance(backend, str) else None
+        )
         self._held_by_tasks: set[int] = set()
         self._held_by_threads: set[int] = set()
         self._from_thread: ThreadLockAdapter | None = None
@@ -227,14 +236,16 @@ class Lock(BaseLock):
 
     @property
     def backend(self) -> SyncBackend:
-        """Bound sync backend, resolved lazily on first access."""
-        return self._backend or self._resolve_backend()
+        """Bound sync backend, resolved on each call.
 
-    def _resolve_backend(self) -> SyncBackend:
-        """Resolve the backend from the global registry and cache it."""
-        backend = get_sync_backend()
-        self._backend = backend
-        return backend
+        When a backend instance was passed at construction it is
+        always returned. Otherwise the registry is consulted on
+        every access so that task-scoped ``sync.use(...)``
+        overrides take effect.
+        """
+        if self._backend is not None:
+            return self._backend
+        return get_sync_backend(self._backend_name or "default")
 
     async def __aenter__(self) -> Self:
         """Acquire the lock with the async context manager.
@@ -330,7 +341,7 @@ class Lock(BaseLock):
         Raises:
             LockLockedCheckError: If the lock cannot be checked due to an error on the backend.
         """
-        backend = self._backend or self._resolve_backend()
+        backend = self.backend
         try:
             return await backend.locked(name=self._lock_name)
         except Exception as exc:
@@ -355,7 +366,7 @@ class Lock(BaseLock):
         Raises:
             LockAcquireError: If the lock cannot be acquired due to an error on the backend.
         """
-        backend = self._backend or self._resolve_backend()
+        backend = self.backend
         try:
             return await backend.acquire(
                 name=self._lock_name,
@@ -376,7 +387,7 @@ class Lock(BaseLock):
         Raises:
             LockReleaseError: Cannot release the lock due to backend error.
         """
-        backend = self._backend or self._resolve_backend()
+        backend = self.backend
         try:
             return await backend.release(name=self._lock_name, token=token)
         except Exception as exc:
@@ -393,7 +404,7 @@ class Lock(BaseLock):
         Raises:
             LockOwnedCheckError: Cannot check if the lock is owned due to backend error.
         """
-        backend = self._backend or self._resolve_backend()
+        backend = self.backend
         try:
             return await backend.owned(name=self._lock_name, token=token)
         except Exception as exc:

--- a/grelmicro/sync/memory.py
+++ b/grelmicro/sync/memory.py
@@ -4,7 +4,6 @@ from time import monotonic
 from types import TracebackType
 from typing import Self
 
-from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 
 
@@ -20,8 +19,7 @@ class MemorySyncBackend(SyncBackend):
         self._locks: dict[str, tuple[str | None, float]] = {}
 
     async def __aenter__(self) -> Self:
-        """Enter the lock backend and register it as the default."""
-        sync_backend_registry.register(self)
+        """Open the lock backend."""
         return self
 
     async def __aexit__(
@@ -30,9 +28,8 @@ class MemorySyncBackend(SyncBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Exit the lock backend and unregister it."""
+        """Close the lock backend."""
         self._locks.clear()
-        sync_backend_registry.unregister(self)
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire the lock."""

--- a/grelmicro/sync/postgres.py
+++ b/grelmicro/sync/postgres.py
@@ -11,7 +11,6 @@ from pydantic_settings import BaseSettings
 from typing_extensions import Doc
 
 from grelmicro.errors import OutOfContextError
-from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.errors import SyncSettingsValidationError
 
@@ -139,14 +138,13 @@ class PostgresSyncBackend(SyncBackend):
         self._pool: Pool | None = None
 
     async def __aenter__(self) -> Self:
-        """Enter the lock backend and register it as the default."""
+        """Open the lock backend."""
         self._pool = await create_pool(str(self._url))
         await self._pool.execute(
             self._SQL_CREATE_TABLE_IF_NOT_EXISTS.format(
                 table_name=self._table_name
             ),
         )
-        sync_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -155,7 +153,7 @@ class PostgresSyncBackend(SyncBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Exit the lock backend and unregister it."""
+        """Close the lock backend."""
         if self._pool:
             await self._pool.execute(
                 self._SQL_RELEASE_ALL_EXPIRED.format(
@@ -163,7 +161,6 @@ class PostgresSyncBackend(SyncBackend):
                 ),
             )
             await self._pool.close()
-        sync_backend_registry.unregister(self)
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire a lock."""

--- a/grelmicro/sync/redis.py
+++ b/grelmicro/sync/redis.py
@@ -7,7 +7,6 @@ from pydantic import RedisDsn
 from typing_extensions import Doc
 
 from grelmicro._redis import _create_redis_client
-from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.errors import SyncSettingsValidationError
 
@@ -68,8 +67,7 @@ class RedisSyncBackend(SyncBackend):
         )
 
     async def __aenter__(self) -> Self:
-        """Open the lock backend and register it as the default."""
-        sync_backend_registry.register(self)
+        """Open the lock backend."""
         return self
 
     async def __aexit__(
@@ -78,9 +76,8 @@ class RedisSyncBackend(SyncBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the lock backend and unregister it."""
+        """Close the lock backend."""
         await self._redis.aclose()
-        sync_backend_registry.unregister(self)
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire the lock."""

--- a/grelmicro/sync/sqlite.py
+++ b/grelmicro/sync/sqlite.py
@@ -11,7 +11,6 @@ from pydantic_settings import BaseSettings
 from typing_extensions import Doc
 
 from grelmicro.errors import OutOfContextError
-from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.errors import SyncSettingsValidationError
 
@@ -110,7 +109,7 @@ class SQLiteSyncBackend(SyncBackend):
         self._conn: aiosqlite.Connection | None = None
 
     async def __aenter__(self) -> Self:
-        """Enter the lock backend and register it as the default."""
+        """Open the lock backend."""
         self._conn = await aiosqlite.connect(self._path)
         await self._conn.execute("PRAGMA journal_mode=WAL;")
         await self._conn.execute(
@@ -119,7 +118,6 @@ class SQLiteSyncBackend(SyncBackend):
             ),
         )
         await self._conn.commit()
-        sync_backend_registry.register(self)
         return self
 
     async def __aexit__(
@@ -128,7 +126,7 @@ class SQLiteSyncBackend(SyncBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Exit the lock backend and unregister it."""
+        """Close the lock backend."""
         if self._conn:
             await self._conn.execute(
                 self._SQL_RELEASE_ALL_EXPIRED.format(
@@ -138,7 +136,6 @@ class SQLiteSyncBackend(SyncBackend):
             await self._conn.commit()
             await self._conn.close()
             self._conn = None
-        sync_backend_registry.unregister(self)
 
     async def acquire(self, *, name: str, token: str, duration: float) -> bool:
         """Acquire a lock."""

--- a/grelmicro/sync/tasklock.py
+++ b/grelmicro/sync/tasklock.py
@@ -97,7 +97,7 @@ class TaskLock(SyncPrimitive):
         ],
         *,
         backend: Annotated[
-            SyncBackend | None,
+            SyncBackend | str | None,
             Doc(
                 """
                 The distributed lock backend used to acquire and release the lock.
@@ -213,7 +213,7 @@ class TaskLock(SyncPrimitive):
         ],
         *,
         backend: Annotated[
-            SyncBackend | None,
+            SyncBackend | str | None,
             Doc(
                 """
                 The distributed lock backend used to acquire and release the lock.
@@ -232,13 +232,18 @@ class TaskLock(SyncPrimitive):
         self,
         name: str,
         config: TaskLockConfig,
-        backend: SyncBackend | None,
+        backend: SyncBackend | str | None,
     ) -> None:
         """Wire the validated config and runtime deps onto the instance."""
         self._name = name
         self._config = config
         self._lock_name = f"{self._LOCK_PREFIX}:{name}"
-        self._backend: SyncBackend | None = backend
+        self._backend: SyncBackend | None = (
+            backend if not isinstance(backend, str) else None
+        )
+        self._backend_name: str | None = (
+            backend if isinstance(backend, str) else None
+        )
         self._acquired_at: float | None = None
         self._token_nonce = generate_token_nonce()
         self._from_thread: ThreadTaskLockAdapter | None = None
@@ -250,14 +255,16 @@ class TaskLock(SyncPrimitive):
 
     @property
     def backend(self) -> SyncBackend:
-        """Bound sync backend, resolved lazily on first access."""
-        return self._backend or self._resolve_backend()
+        """Bound sync backend, resolved on each call.
 
-    def _resolve_backend(self) -> SyncBackend:
-        """Resolve the backend from the global registry and cache it."""
-        backend = get_sync_backend()
-        self._backend = backend
-        return backend
+        When a backend instance was passed at construction it is
+        always returned. Otherwise the registry is consulted on
+        every access so that task-scoped ``sync.use(...)``
+        overrides take effect.
+        """
+        if self._backend is not None:
+            return self._backend
+        return get_sync_backend(self._backend_name or "default")
 
     async def __aenter__(self) -> Self:
         """Acquire the lock with duration=max_lock_seconds.
@@ -312,7 +319,7 @@ class TaskLock(SyncPrimitive):
         Raises:
             LockLockedCheckError: If the lock cannot be checked due to an error on the backend.
         """
-        backend = self._backend or self._resolve_backend()
+        backend = self.backend
         try:
             return await backend.locked(name=self._lock_name)
         except Exception as exc:
@@ -329,7 +336,7 @@ class TaskLock(SyncPrimitive):
         Raises:
             LockAcquireError: If the lock cannot be acquired due to an error on the backend.
         """
-        backend = self._backend or self._resolve_backend()
+        backend = self.backend
         try:
             acquired = await backend.acquire(
                 name=self._lock_name,
@@ -353,7 +360,7 @@ class TaskLock(SyncPrimitive):
         Raises:
             LockReleaseError: Cannot release the lock due to backend error.
         """
-        backend = self._backend or self._resolve_backend()
+        backend = self.backend
         try:
             return await backend.release(name=self._lock_name, token=token)
         except Exception as exc:
@@ -370,7 +377,7 @@ class TaskLock(SyncPrimitive):
         Raises:
             LockReleaseError: Cannot re-acquire the lock due to backend error.
         """
-        backend = self._backend or self._resolve_backend()
+        backend = self.backend
         try:
             return await backend.acquire(
                 name=self._lock_name,

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -86,7 +86,7 @@ class TestInit:
     ) -> None:
         """Test that TTLCache uses the registered backend when none is provided."""
         # Arrange: register the backend
-        cache_backend_registry.register("default", backend)
+        cache_backend_registry.register(backend, "default")
 
         # Act: create cache without explicit backend
         cache = TTLCache(maxsize=0, ttl=60)

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -86,7 +86,7 @@ class TestInit:
     ) -> None:
         """Test that TTLCache uses the registered backend when none is provided."""
         # Arrange: register the backend
-        cache_backend_registry.register(backend)
+        cache_backend_registry.register("default", backend)
 
         # Act: create cache without explicit backend
         cache = TTLCache(maxsize=0, ttl=60)

--- a/tests/health/test_fastapi.py
+++ b/tests/health/test_fastapi.py
@@ -38,7 +38,7 @@ def _clean_registry() -> Generator[None]:
 def registry() -> HealthRegistry:
     """Health registry with caching disabled, registered as the default."""
     instance = HealthRegistry(cache_ttl=0)
-    health_registry.register(instance)
+    health_registry.register("default", instance)
     return instance
 
 
@@ -79,7 +79,7 @@ def test_livez_head_method(client: TestClient) -> None:
 def test_livez_never_runs_checkers() -> None:
     """A failing registered checker does not affect /livez."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry)
+    health_registry.register("default", registry)
     registry.add("db", unhealthy())
     app = FastAPI()
     app.include_router(health_router())
@@ -233,7 +233,7 @@ def test_healthz_details_hidden_by_default(
 def test_healthz_details_true_always_shown() -> None:
     """show_details=True always includes details."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry)
+    health_registry.register("default", registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
     app = FastAPI()
     app.include_router(health_router(show_details=True))
@@ -247,7 +247,7 @@ def test_healthz_details_true_always_shown() -> None:
 def test_healthz_details_dep_returns_false_strips() -> None:
     """A dep returning False strips details, endpoint returns 200."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry)
+    health_registry.register("default", registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow() -> bool:
@@ -266,7 +266,7 @@ def test_healthz_details_dep_returns_false_strips() -> None:
 def test_healthz_details_dep_returns_true_shows() -> None:
     """A dep returning True includes details."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry)
+    health_registry.register("default", registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow() -> bool:
@@ -284,7 +284,7 @@ def test_healthz_details_dep_returns_true_shows() -> None:
 def test_healthz_details_async_dep_shows() -> None:
     """An async dep is awaited by FastAPI's DI."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry)
+    health_registry.register("default", registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     async def allow_async() -> bool:
@@ -302,7 +302,7 @@ def test_healthz_details_async_dep_shows() -> None:
 def test_healthz_details_dep_with_request() -> None:
     """A Request-annotated dep receives the request via FastAPI DI."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry)
+    health_registry.register("default", registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow_if_admin(request: _Request) -> bool:
@@ -320,7 +320,7 @@ def test_healthz_details_dep_with_request() -> None:
 def test_healthz_details_dep_with_sub_dependency() -> None:
     """FastAPI sub-dependencies resolve through ``Depends`` chains."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry)
+    health_registry.register("default", registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def current_role(request: _Request) -> str:
@@ -341,7 +341,7 @@ def test_healthz_details_dep_with_sub_dependency() -> None:
 def test_healthz_details_dep_http_exception_blocks_endpoint() -> None:
     """Raising HTTPException in the dep blocks the endpoint (documented)."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry)
+    health_registry.register("default", registry)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def deny() -> bool:

--- a/tests/health/test_fastapi.py
+++ b/tests/health/test_fastapi.py
@@ -38,7 +38,7 @@ def _clean_registry() -> Generator[None]:
 def registry() -> HealthRegistry:
     """Health registry with caching disabled, registered as the default."""
     instance = HealthRegistry(cache_ttl=0)
-    health_registry.register("default", instance)
+    health_registry.register(instance, "default")
     return instance
 
 
@@ -79,7 +79,7 @@ def test_livez_head_method(client: TestClient) -> None:
 def test_livez_never_runs_checkers() -> None:
     """A failing registered checker does not affect /livez."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register("default", registry)
+    health_registry.register(registry, "default")
     registry.add("db", unhealthy())
     app = FastAPI()
     app.include_router(health_router())
@@ -233,7 +233,7 @@ def test_healthz_details_hidden_by_default(
 def test_healthz_details_true_always_shown() -> None:
     """show_details=True always includes details."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register("default", registry)
+    health_registry.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
     app = FastAPI()
     app.include_router(health_router(show_details=True))
@@ -247,7 +247,7 @@ def test_healthz_details_true_always_shown() -> None:
 def test_healthz_details_dep_returns_false_strips() -> None:
     """A dep returning False strips details, endpoint returns 200."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register("default", registry)
+    health_registry.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow() -> bool:
@@ -266,7 +266,7 @@ def test_healthz_details_dep_returns_false_strips() -> None:
 def test_healthz_details_dep_returns_true_shows() -> None:
     """A dep returning True includes details."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register("default", registry)
+    health_registry.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow() -> bool:
@@ -284,7 +284,7 @@ def test_healthz_details_dep_returns_true_shows() -> None:
 def test_healthz_details_async_dep_shows() -> None:
     """An async dep is awaited by FastAPI's DI."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register("default", registry)
+    health_registry.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     async def allow_async() -> bool:
@@ -302,7 +302,7 @@ def test_healthz_details_async_dep_shows() -> None:
 def test_healthz_details_dep_with_request() -> None:
     """A Request-annotated dep receives the request via FastAPI DI."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register("default", registry)
+    health_registry.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow_if_admin(request: _Request) -> bool:
@@ -320,7 +320,7 @@ def test_healthz_details_dep_with_request() -> None:
 def test_healthz_details_dep_with_sub_dependency() -> None:
     """FastAPI sub-dependencies resolve through ``Depends`` chains."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register("default", registry)
+    health_registry.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def current_role(request: _Request) -> str:
@@ -341,7 +341,7 @@ def test_healthz_details_dep_with_sub_dependency() -> None:
 def test_healthz_details_dep_http_exception_blocks_endpoint() -> None:
     """Raising HTTPException in the dep blocks the endpoint (documented)."""
     registry = HealthRegistry(cache_ttl=0)
-    health_registry.register("default", registry)
+    health_registry.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def deny() -> bool:

--- a/tests/health/test_registry.py
+++ b/tests/health/test_registry.py
@@ -8,7 +8,10 @@ import anyio
 import pytest
 from pydantic import ValidationError
 
-from grelmicro._backends import BackendNotLoadedError
+from grelmicro._backends import (
+    BackendAlreadyRegisteredError,
+    BackendNotLoadedError,
+)
 from grelmicro.health import use_registry
 from grelmicro.health._backends import get_health_registry, health_registry
 from grelmicro.health._models import HealthStatus
@@ -526,19 +529,19 @@ def test_get_health_registry_raises_when_not_loaded() -> None:
         get_health_registry()
 
 
-def test_overwrite_warns() -> None:
-    """Registering a different registry over an existing one warns."""
-    health_registry.register("default", HealthRegistry())
+def test_overwrite_raises() -> None:
+    """Registering a different registry over an existing one raises."""
+    health_registry.register(HealthRegistry(), "default")
 
-    with pytest.warns(UserWarning, match="Overwriting"):
-        health_registry.register("default", HealthRegistry())
+    with pytest.raises(BackendAlreadyRegisteredError):
+        health_registry.register(HealthRegistry(), "default")
 
 
 def test_register_health_registry() -> None:
     """health_registry.register installs the singleton."""
     registry = HealthRegistry()
 
-    health_registry.register("default", registry)
+    health_registry.register(registry, "default")
 
     assert get_health_registry() is registry
 
@@ -546,7 +549,7 @@ def test_register_health_registry() -> None:
 def test_reset_health_registry() -> None:
     """health_registry.reset removes the singleton."""
     registry = HealthRegistry()
-    health_registry.register("default", registry)
+    health_registry.register(registry, "default")
 
     health_registry.reset()
 

--- a/tests/health/test_registry.py
+++ b/tests/health/test_registry.py
@@ -497,12 +497,11 @@ def test_cache_ttl_negative_raises() -> None:
         HealthRegistry(cache_ttl=-1.0)
 
 
-async def test_async_context_manager_registers_and_unregisters() -> None:
-    """`async with HealthRegistry()` registers on enter, unregisters on exit."""
-    async with HealthRegistry() as registry:
-        assert get_health_registry() is registry
-    with pytest.raises(BackendNotLoadedError):
-        get_health_registry()
+async def test_async_context_manager_does_not_register() -> None:
+    """``async with HealthRegistry()`` opens but does not register."""
+    async with HealthRegistry():
+        with pytest.raises(BackendNotLoadedError):
+            get_health_registry()
 
 
 def test_constructor_does_not_register() -> None:
@@ -529,17 +528,17 @@ def test_get_health_registry_raises_when_not_loaded() -> None:
 
 def test_overwrite_warns() -> None:
     """Registering a different registry over an existing one warns."""
-    health_registry.register(HealthRegistry())
+    health_registry.register("default", HealthRegistry())
 
     with pytest.warns(UserWarning, match="Overwriting"):
-        health_registry.register(HealthRegistry())
+        health_registry.register("default", HealthRegistry())
 
 
 def test_register_health_registry() -> None:
     """health_registry.register installs the singleton."""
     registry = HealthRegistry()
 
-    health_registry.register(registry)
+    health_registry.register("default", registry)
 
     assert get_health_registry() is registry
 
@@ -547,7 +546,7 @@ def test_register_health_registry() -> None:
 def test_reset_health_registry() -> None:
     """health_registry.reset removes the singleton."""
     registry = HealthRegistry()
-    health_registry.register(registry)
+    health_registry.register("default", registry)
 
     health_registry.reset()
 

--- a/tests/resilience/test_errors.py
+++ b/tests/resilience/test_errors.py
@@ -51,6 +51,9 @@ def test_resilience_module_exports() -> None:
         "ResilienceError",
         "ResilienceSettingsValidationError",
         "TokenBucketConfig",
+        "register",
+        "unregister",
+        "use",
         "use_backend",
     }
     assert set(resilience_mod.__all__) == expected

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -42,7 +42,7 @@ def _reset_registry() -> None:
 async def _backend() -> AsyncGenerator[MemoryRateLimiterBackend]:
     """Create and register a memory rate limiter backend."""
     async with MemoryRateLimiterBackend() as b:
-        rate_limiter_backend_registry.register("default", b)
+        rate_limiter_backend_registry.register(b, "default")
         yield b
 
 
@@ -54,7 +54,7 @@ def _sync_backend() -> MemoryRateLimiterBackend:
     (pytest-anyio doesn't bridge them).
     """
     backend = MemoryRateLimiterBackend()
-    rate_limiter_backend_registry.register("default", backend)
+    rate_limiter_backend_registry.register(backend, "default")
     return backend
 
 

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -42,6 +42,7 @@ def _reset_registry() -> None:
 async def _backend() -> AsyncGenerator[MemoryRateLimiterBackend]:
     """Create and register a memory rate limiter backend."""
     async with MemoryRateLimiterBackend() as b:
+        rate_limiter_backend_registry.register("default", b)
         yield b
 
 
@@ -52,7 +53,9 @@ def _sync_backend() -> MemoryRateLimiterBackend:
     Sync tests can't consume the async `_backend` fixture
     (pytest-anyio doesn't bridge them).
     """
-    return MemoryRateLimiterBackend()
+    backend = MemoryRateLimiterBackend()
+    rate_limiter_backend_registry.register("default", backend)
+    return backend
 
 
 @pytest.fixture

--- a/tests/sync/test_leaderelection_config.py
+++ b/tests/sync/test_leaderelection_config.py
@@ -39,7 +39,7 @@ def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
 def test_backend_property_resolves_on_every_call(
     mocker: MockerFixture,
 ) -> None:
-    """First `le.backend` access resolves once, subsequent reads hit the cache."""
+    """`le.backend` consults the registry on each read so `sync.use(...)` overrides apply."""
     backend_instance = MemorySyncBackend()
     spy = mocker.patch(
         "grelmicro.sync.leaderelection.get_sync_backend",

--- a/tests/sync/test_leaderelection_config.py
+++ b/tests/sync/test_leaderelection_config.py
@@ -36,7 +36,7 @@ def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
     assert spy.call_count == 0
 
 
-def test_backend_property_resolves_lazily_and_caches(
+def test_backend_property_resolves_on_every_call(
     mocker: MockerFixture,
 ) -> None:
     """First `le.backend` access resolves once, subsequent reads hit the cache."""
@@ -49,7 +49,8 @@ def test_backend_property_resolves_lazily_and_caches(
     assert spy.call_count == 0
     assert le.backend is backend_instance
     assert le.backend is backend_instance
-    assert spy.call_count == 1
+    expected_calls = 2
+    assert spy.call_count == expected_calls
 
 
 def test_programmatic_path_uses_kwargs(backend: SyncBackend) -> None:

--- a/tests/sync/test_lock_config.py
+++ b/tests/sync/test_lock_config.py
@@ -28,10 +28,10 @@ def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
     assert spy.call_count == 0
 
 
-def test_backend_property_resolves_lazily_and_caches(
+def test_backend_property_resolves_on_every_call(
     mocker: MockerFixture,
 ) -> None:
-    """First `lock.backend` access resolves once, subsequent reads hit the cache."""
+    """`lock.backend` consults the registry on each read so `sync.use(...)` overrides apply."""
     backend_instance = MemorySyncBackend()
     spy = mocker.patch(
         "grelmicro.sync.lock.get_sync_backend", return_value=backend_instance
@@ -40,7 +40,8 @@ def test_backend_property_resolves_lazily_and_caches(
     assert spy.call_count == 0
     assert lock.backend is backend_instance
     assert lock.backend is backend_instance
-    assert spy.call_count == 1
+    expected_calls = 2
+    assert spy.call_count == expected_calls
 
 
 def test_programmatic_path_uses_kwargs(backend: SyncBackend) -> None:

--- a/tests/sync/test_tasklock_config.py
+++ b/tests/sync/test_tasklock_config.py
@@ -29,10 +29,10 @@ def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
     assert spy.call_count == 0
 
 
-def test_backend_property_resolves_lazily_and_caches(
+def test_backend_property_resolves_on_every_call(
     mocker: MockerFixture,
 ) -> None:
-    """First `task_lock.backend` access resolves once, subsequent reads hit the cache."""
+    """`task_lock.backend` consults the registry on each read so `sync.use(...)` overrides apply."""
     backend_instance = MemorySyncBackend()
     spy = mocker.patch(
         "grelmicro.sync.tasklock.get_sync_backend",
@@ -42,7 +42,8 @@ def test_backend_property_resolves_lazily_and_caches(
     assert spy.call_count == 0
     assert task_lock.backend is backend_instance
     assert task_lock.backend is backend_instance
-    assert spy.call_count == 1
+    expected_calls = 2
+    assert spy.call_count == expected_calls
 
 
 def test_programmatic_path_uses_kwargs(backend: SyncBackend) -> None:

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -1,10 +1,4 @@
-"""Backend lifecycle: explicit registration via ``async with``.
-
-Constructors are pure: they perform no registry writes.
-Registration happens on ``__aenter__`` and unregistration on
-``__aexit__``. ``unregister`` uses an identity check, so a backend
-that was already replaced by a newer instance leaves the slot alone.
-"""
+"""Backend lifecycle: explicit named registration, scoped overrides, lifespan."""
 
 import warnings
 from unittest.mock import AsyncMock, MagicMock
@@ -12,10 +6,17 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+import grelmicro
+from grelmicro import cache as cache_mod
+from grelmicro import health as health_mod
+from grelmicro import resilience as resilience_mod
+from grelmicro import sync as sync_mod
+from grelmicro._backends import BackendNotLoadedError
 from grelmicro.cache._backends import cache_backend_registry
 from grelmicro.cache.memory import MemoryCacheBackend
 from grelmicro.cache.redis import RedisCacheBackend
-from grelmicro.resilience import use_backend as resilience_use_backend
+from grelmicro.health._backends import health_registry
+from grelmicro.health._registry import HealthRegistry
 from grelmicro.resilience._backends import rate_limiter_backend_registry
 from grelmicro.resilience.memory import MemoryRateLimiterBackend
 from grelmicro.resilience.redis import RedisRateLimiterBackend
@@ -36,21 +37,11 @@ def anyio_backend() -> str:
 
 
 @pytest.fixture(autouse=True)
-def _clean_sync_registry() -> None:
-    """Reset the sync backend registry between tests."""
+def _clean_registries() -> None:
+    """Reset every backend registry between tests."""
     sync_backend_registry.reset()
-
-
-@pytest.fixture(autouse=True)
-def _clean_rate_limiter_registry() -> None:
-    """Reset the rate limiter backend registry between tests."""
-    rate_limiter_backend_registry.reset()
-
-
-@pytest.fixture(autouse=True)
-def _clean_cache_registry() -> None:
-    """Reset the cache backend registry between tests."""
     cache_backend_registry.reset()
+    rate_limiter_backend_registry.reset()
 
 
 @pytest.fixture
@@ -74,101 +65,207 @@ def mock_redis(mocker: MockerFixture) -> MagicMock:
     return mock_client
 
 
-# --- Pure constructors ---
+# --- Pure constructors (no registry writes) ---
 
 
-def test_sync_memory_constructor_does_not_register() -> None:
-    """Constructing a sync backend performs no registry writes."""
+def test_sync_constructor_does_not_register() -> None:
+    """Sync constructor does not register."""
     MemorySyncBackend()
-    assert sync_backend_registry.is_loaded is False
+    assert not sync_backend_registry.is_loaded
 
 
-def test_cache_memory_constructor_does_not_register() -> None:
-    """Constructing a cache backend performs no registry writes."""
+def test_cache_constructor_does_not_register() -> None:
+    """Cache constructor does not register."""
     MemoryCacheBackend()
-    assert cache_backend_registry.is_loaded is False
+    assert not cache_backend_registry.is_loaded
 
 
-def test_rate_limiter_memory_constructor_does_not_register() -> None:
-    """Constructing a rate limiter backend performs no registry writes."""
+def test_rate_limiter_constructor_does_not_register() -> None:
+    """Rate limiter constructor does not register."""
     MemoryRateLimiterBackend()
-    assert rate_limiter_backend_registry.is_loaded is False
+    assert not rate_limiter_backend_registry.is_loaded
 
 
-# --- Sync (Memory) ---
+# --- async with opens the backend but does NOT register ---
 
 
-async def test_sync_memory_backend_round_trip() -> None:
-    """``async with`` registers on enter and unregisters on exit."""
+async def test_sync_memory_async_with_does_not_register() -> None:
+    """Sync memory async with does not register."""
     async with MemorySyncBackend():
-        assert sync_backend_registry.is_loaded is True
-    assert sync_backend_registry.is_loaded is False
+        assert not sync_backend_registry.is_loaded
 
 
-async def test_sync_memory_backend_does_not_evict_replacement() -> None:
-    """Exiting an older backend leaves a newer registered one in place."""
-    backend_1 = MemorySyncBackend()
-    backend_2 = MemorySyncBackend()
-    sync_backend_registry.register(backend_1)
-    sync_backend_registry.register(backend_2)
-    assert sync_backend_registry.get() is backend_2
-
-    await backend_1.__aexit__(None, None, None)
-    assert sync_backend_registry.get() is backend_2
+async def test_cache_memory_async_with_does_not_register() -> None:
+    """Cache memory async with does not register."""
+    async with MemoryCacheBackend():
+        assert not cache_backend_registry.is_loaded
 
 
-# --- Rate Limiter (Memory) ---
+# --- Explicit register / unregister ---
 
 
-async def test_rate_limiter_memory_backend_round_trip() -> None:
-    """``async with`` registers on enter and unregisters on exit."""
-    async with MemoryRateLimiterBackend():
-        assert rate_limiter_backend_registry.is_loaded is True
-    assert rate_limiter_backend_registry.is_loaded is False
+def test_register_and_get() -> None:
+    """Register and get."""
+    backend = MemorySyncBackend()
+    sync_backend_registry.register("default", backend)
+    assert sync_backend_registry.get() is backend
 
 
-async def test_rate_limiter_memory_backend_does_not_evict_replacement() -> None:
-    """Exiting an older rate limiter backend leaves a newer one in place."""
-    backend_1 = MemoryRateLimiterBackend()
-    backend_2 = MemoryRateLimiterBackend()
-    rate_limiter_backend_registry.register(backend_1)
-    rate_limiter_backend_registry.register(backend_2)
-    assert rate_limiter_backend_registry.get() is backend_2
-
-    await backend_1.__aexit__(None, None, None)
-    assert rate_limiter_backend_registry.get() is backend_2
+def test_register_named_and_get_by_name() -> None:
+    """Register named and get by name."""
+    primary = MemorySyncBackend()
+    analytics = MemorySyncBackend()
+    sync_backend_registry.register("primary", primary)
+    sync_backend_registry.register("analytics", analytics)
+    assert sync_backend_registry.get("primary") is primary
+    assert sync_backend_registry.get("analytics") is analytics
 
 
-# --- Sync (SQLite) ---
+def test_get_default_falls_back_to_sole_entry() -> None:
+    """Get default falls back to sole entry."""
+    only = MemorySyncBackend()
+    sync_backend_registry.register("primary", only)
+    assert sync_backend_registry.get() is only
 
 
-async def test_sync_sqlite_backend_round_trip(tmp_path) -> None:  # noqa: ANN001
-    """``async with`` registers on enter and unregisters on exit."""
-    db_path = tmp_path / "lock.db"
-    async with SQLiteSyncBackend(db_path):
-        assert sync_backend_registry.is_loaded is True
-    assert sync_backend_registry.is_loaded is False
+def test_get_default_raises_when_multiple_no_default() -> None:
+    """Get default raises when multiple no default."""
+    sync_backend_registry.register("primary", MemorySyncBackend())
+    sync_backend_registry.register("analytics", MemorySyncBackend())
+    with pytest.raises(BackendNotLoadedError, match="multiple"):
+        sync_backend_registry.get()
 
 
-# --- Sync (Redis) ---
+def test_register_same_instance_is_noop() -> None:
+    """Register same instance is noop."""
+    backend = MemorySyncBackend()
+    sync_backend_registry.register("default", backend)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sync_backend_registry.register("default", backend)
+    assert sync_backend_registry.get() is backend
 
 
-async def test_sync_redis_backend_round_trip(
+def test_register_different_instance_warns() -> None:
+    """Register different instance warns."""
+    sync_backend_registry.register("default", MemorySyncBackend())
+    with pytest.warns(UserWarning, match="Overwriting"):
+        sync_backend_registry.register("default", MemorySyncBackend())
+
+
+def test_unregister_with_identity_check() -> None:
+    """Unregister with identity check."""
+    a = MemorySyncBackend()
+    b = MemorySyncBackend()
+    sync_backend_registry.register("default", a)
+    sync_backend_registry.unregister("default", b)  # wrong instance: no-op
+    assert sync_backend_registry.get() is a
+    sync_backend_registry.unregister("default", a)  # right instance: clears
+    assert not sync_backend_registry.is_loaded
+
+
+def test_unregister_unknown_name_is_noop() -> None:
+    """Unregister unknown name is noop."""
+    sync_backend_registry.unregister("missing")
+    assert not sync_backend_registry.is_loaded
+
+
+# --- ContextVar use() override ---
+
+
+def test_use_overrides_default() -> None:
+    """Use overrides default."""
+    registered = MemorySyncBackend()
+    override = MemorySyncBackend()
+    sync_backend_registry.register("default", registered)
+    with sync_backend_registry.use(override):
+        assert sync_backend_registry.get() is override
+    assert sync_backend_registry.get() is registered
+
+
+def test_use_overrides_named() -> None:
+    """Use overrides named."""
+    sync_backend_registry.register("primary", MemorySyncBackend())
+    sync_backend_registry.register("analytics", MemorySyncBackend())
+    fake_analytics = MemorySyncBackend()
+    with sync_backend_registry.use(analytics=fake_analytics):
+        assert sync_backend_registry.get("analytics") is fake_analytics
+
+
+def test_use_stacks_lifo() -> None:
+    """Use stacks lifo."""
+    inner = MemorySyncBackend()
+    outer = MemorySyncBackend()
+    sync_backend_registry.register("default", MemorySyncBackend())
+    with sync_backend_registry.use(outer):
+        with sync_backend_registry.use(inner):
+            assert sync_backend_registry.get() is inner
+        assert sync_backend_registry.get() is outer
+
+
+# --- grelmicro.lifespan() walks every registry ---
+
+
+async def test_lifespan_opens_registered_backends() -> None:
+    """Lifespan opens registered backends."""
+    sync_b = MemorySyncBackend()
+    cache_b = MemoryCacheBackend()
+    rl_b = MemoryRateLimiterBackend()
+    sync_backend_registry.register("default", sync_b)
+    cache_backend_registry.register("default", cache_b)
+    rate_limiter_backend_registry.register("default", rl_b)
+
+    async with grelmicro.lifespan():
+        # backends remain registered while open
+        assert sync_backend_registry.get() is sync_b
+        assert cache_backend_registry.get() is cache_b
+        assert rate_limiter_backend_registry.get() is rl_b
+
+
+async def test_lifespan_excludes_module() -> None:
+    """Lifespan excludes module."""
+    sync_backend_registry.register("default", MemorySyncBackend())
+    cache_backend_registry.register("default", MemoryCacheBackend())
+    async with grelmicro.lifespan(exclude={"cache"}):
+        # cache backend was not entered (we cannot easily detect this
+        # for memory backends; the contract is that entries in
+        # ``exclude`` are skipped — verified at unit level in registry)
+        pass
+
+
+async def test_lifespan_excludes_named_entry() -> None:
+    """Lifespan excludes named entry."""
+    primary = MemorySyncBackend()
+    analytics = MemorySyncBackend()
+    sync_backend_registry.register("primary", primary)
+    sync_backend_registry.register("analytics", analytics)
+    async with grelmicro.lifespan(exclude={"sync.analytics"}):
+        assert sync_backend_registry.get("primary") is primary
+
+
+async def test_lifespan_with_ad_hoc_backend() -> None:
+    """Lifespan with ad hoc backend."""
+    ad_hoc = MemorySyncBackend()
+    async with grelmicro.lifespan(ad_hoc):
+        # ad-hoc enters the async ctx but is not registered
+        assert not sync_backend_registry.is_loaded
+
+
+# --- Backends still work as standalone async context managers ---
+
+
+async def test_sync_redis_async_with_round_trip(
     mock_redis: MagicMock,  # noqa: ARG001
 ) -> None:
-    """``async with`` registers on enter and unregisters on exit."""
+    """Sync redis async with round trip."""
     async with RedisSyncBackend("redis://localhost"):
-        assert sync_backend_registry.is_loaded is True
-    assert sync_backend_registry.is_loaded is False
+        pass
 
 
-# --- Sync (PostgreSQL) ---
-
-
-async def test_sync_postgres_backend_round_trip(
+async def test_sync_postgres_async_with_round_trip(
     mocker: MockerFixture,
 ) -> None:
-    """``async with`` registers on enter and unregisters on exit."""
+    """Sync postgres async with round trip."""
     mock_pool = MagicMock()
     mock_pool.execute = AsyncMock()
     mock_pool.close = AsyncMock()
@@ -176,65 +273,20 @@ async def test_sync_postgres_backend_round_trip(
         "grelmicro.sync.postgres.create_pool",
         AsyncMock(return_value=mock_pool),
     )
-
     async with PostgresSyncBackend("postgresql://localhost/db"):
-        assert sync_backend_registry.is_loaded is True
-    assert sync_backend_registry.is_loaded is False
+        pass
 
 
-# --- Rate Limiter (Redis) ---
+async def test_sync_sqlite_async_with_round_trip(tmp_path) -> None:  # noqa: ANN001
+    """Sync sqlite async with round trip."""
+    async with SQLiteSyncBackend(tmp_path / "lock.db"):
+        pass
 
 
-async def test_rate_limiter_redis_backend_round_trip(
-    mock_redis: MagicMock,  # noqa: ARG001
-) -> None:
-    """``async with`` registers on enter and unregisters on exit."""
-    async with RedisRateLimiterBackend("redis://localhost"):
-        assert rate_limiter_backend_registry.is_loaded is True
-    assert rate_limiter_backend_registry.is_loaded is False
-
-
-# --- Cache (Redis) ---
-
-
-async def test_cache_redis_backend_round_trip(
-    mock_redis: MagicMock,  # noqa: ARG001
-) -> None:
-    """``async with`` registers on enter and unregisters on exit."""
-    async with RedisCacheBackend("redis://localhost"):
-        assert cache_backend_registry.is_loaded is True
-    assert cache_backend_registry.is_loaded is False
-
-
-# --- Cache (Memory) ---
-
-
-async def test_cache_memory_backend_round_trip() -> None:
-    """``async with`` registers on enter and unregisters on exit."""
-    async with MemoryCacheBackend():
-        assert cache_backend_registry.is_loaded is True
-    assert cache_backend_registry.is_loaded is False
-
-
-async def test_cache_memory_backend_does_not_evict_replacement() -> None:
-    """Exiting an older cache backend leaves a newer one in place."""
-    backend_1 = MemoryCacheBackend()
-    backend_2 = MemoryCacheBackend()
-    cache_backend_registry.register(backend_1)
-    cache_backend_registry.register(backend_2)
-    assert cache_backend_registry.get() is backend_2
-
-    await backend_1.__aexit__(None, None, None)
-    assert cache_backend_registry.get() is backend_2
-
-
-# --- Sync (Kubernetes) ---
-
-
-async def test_sync_kubernetes_backend_round_trip(
+async def test_sync_kubernetes_async_with_round_trip(
     mocker: MockerFixture,
 ) -> None:
-    """``async with`` registers on enter and unregisters on exit."""
+    """Sync kubernetes async with round trip."""
     mock_client = MagicMock()
     mock_client.close = AsyncMock()
 
@@ -247,58 +299,101 @@ async def test_sync_kubernetes_backend_round_trip(
         "grelmicro.sync.kubernetes.AsyncClient",
         return_value=mock_client,
     )
-
     async with KubernetesSyncBackend(namespace="default"):
-        assert sync_backend_registry.is_loaded is True
-    assert sync_backend_registry.is_loaded is False
+        pass
 
 
-# --- Identity check on unregister ---
+async def test_cache_redis_async_with_round_trip(
+    mock_redis: MagicMock,  # noqa: ARG001
+) -> None:
+    """Cache redis async with round trip."""
+    async with RedisCacheBackend("redis://localhost"):
+        pass
 
 
-def test_sync_registry_unregister_identity() -> None:
-    """register(a); register(b); unregister(a) leaves b as current."""
-    a = MemorySyncBackend()
-    b = MemorySyncBackend()
-    sync_backend_registry.register(a)
-    sync_backend_registry.register(b)
-    sync_backend_registry.unregister(a)
-    assert sync_backend_registry.get() is b
+async def test_rate_limiter_redis_async_with_round_trip(
+    mock_redis: MagicMock,  # noqa: ARG001
+) -> None:
+    """Rate limiter redis async with round trip."""
+    async with RedisRateLimiterBackend("redis://localhost"):
+        pass
 
 
-def test_cache_registry_unregister_identity() -> None:
-    """register(a); register(b); unregister(a) leaves b as current."""
-    a = MemoryCacheBackend()
-    b = MemoryCacheBackend()
-    cache_backend_registry.register(a)
-    cache_backend_registry.register(b)
-    cache_backend_registry.unregister(a)
-    assert cache_backend_registry.get() is b
+# --- Module-level helpers ---
 
 
-def test_rate_limiter_registry_unregister_identity() -> None:
-    """register(a); register(b); unregister(a) leaves b as current."""
-    a = MemoryRateLimiterBackend()
-    b = MemoryRateLimiterBackend()
-    rate_limiter_backend_registry.register(a)
-    rate_limiter_backend_registry.register(b)
-    rate_limiter_backend_registry.unregister(a)
-    assert rate_limiter_backend_registry.get() is b
+def test_sync_use_backend_registers_default() -> None:
+    """Sync use backend registers default."""
+    backend = MemorySyncBackend()
+    sync_mod.use_backend(backend)
+    assert sync_backend_registry.get() is backend
 
 
-def test_resilience_use_backend_registers() -> None:
-    """`resilience.use_backend` installs the rate limiter backend."""
-    rate_limiter_backend_registry.reset()
+def test_cache_use_backend_registers_default() -> None:
+    """Cache use backend registers default."""
+    backend = MemoryCacheBackend()
+    cache_mod.use_backend(backend)
+    assert cache_backend_registry.get() is backend
+
+
+def test_resilience_use_backend_registers_default() -> None:
+    """Resilience use backend registers default."""
     backend = MemoryRateLimiterBackend()
-    resilience_use_backend(backend)
+    resilience_mod.use_backend(backend)
     assert rate_limiter_backend_registry.get() is backend
 
 
-def test_register_same_instance_is_noop() -> None:
-    """Re-registering the same instance does not warn or replace."""
+def test_sync_register_and_unregister_module_helpers() -> None:
+    """Sync register and unregister module helpers."""
     backend = MemorySyncBackend()
-    sync_backend_registry.register(backend)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        sync_backend_registry.register(backend)
-    assert sync_backend_registry.get() is backend
+    sync_mod.register("primary", backend)
+    assert sync_backend_registry.get("primary") is backend
+    sync_mod.unregister("primary", backend)
+    assert not sync_backend_registry.is_loaded
+
+
+def test_sync_use_module_helper() -> None:
+    """Sync use module helper."""
+    sync_backend_registry.register("default", MemorySyncBackend())
+    override = MemorySyncBackend()
+    with sync_mod.use(override):
+        assert sync_backend_registry.get() is override
+
+
+def test_cache_register_unregister_use_module_helpers() -> None:
+    """Cache register, unregister, and use module helpers."""
+    backend = MemoryCacheBackend()
+    cache_mod.register("primary", backend)
+    assert cache_backend_registry.get("primary") is backend
+    override = MemoryCacheBackend()
+    with cache_mod.use(override):
+        assert cache_backend_registry.get() is override
+    cache_mod.unregister("primary", backend)
+    assert not cache_backend_registry.is_loaded
+
+
+def test_resilience_register_unregister_use_module_helpers() -> None:
+    """Resilience register, unregister, and use module helpers."""
+    backend = MemoryRateLimiterBackend()
+    resilience_mod.register("primary", backend)
+    assert rate_limiter_backend_registry.get("primary") is backend
+    override = MemoryRateLimiterBackend()
+    with resilience_mod.use(override):
+        assert rate_limiter_backend_registry.get() is override
+    resilience_mod.unregister("primary", backend)
+    assert not rate_limiter_backend_registry.is_loaded
+
+
+def test_health_register_unregister_use_module_helpers() -> None:
+    """Health register, unregister, use, and use_registry helpers."""
+    health_registry.reset()
+    registry = HealthRegistry()
+    health_mod.register("primary", registry)
+    assert health_registry.get("primary") is registry
+    override = HealthRegistry()
+    with health_mod.use(override):
+        assert health_registry.get() is override
+    health_mod.use_registry(registry)
+    assert health_registry.get() is registry
+    health_mod.unregister("primary", registry)
+    health_registry.reset()

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -11,7 +11,10 @@ from grelmicro import cache as cache_mod
 from grelmicro import health as health_mod
 from grelmicro import resilience as resilience_mod
 from grelmicro import sync as sync_mod
-from grelmicro._backends import BackendNotLoadedError
+from grelmicro._backends import (
+    BackendAlreadyRegisteredError,
+    BackendNotLoadedError,
+)
 from grelmicro.cache._backends import cache_backend_registry
 from grelmicro.cache.memory import MemoryCacheBackend
 from grelmicro.cache.redis import RedisCacheBackend
@@ -20,6 +23,7 @@ from grelmicro.health._registry import HealthRegistry
 from grelmicro.resilience._backends import rate_limiter_backend_registry
 from grelmicro.resilience.memory import MemoryRateLimiterBackend
 from grelmicro.resilience.redis import RedisRateLimiterBackend
+from grelmicro.sync import Lock
 from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.kubernetes import KubernetesSyncBackend
 from grelmicro.sync.memory import MemorySyncBackend
@@ -107,7 +111,7 @@ async def test_cache_memory_async_with_does_not_register() -> None:
 def test_register_and_get() -> None:
     """Register and get."""
     backend = MemorySyncBackend()
-    sync_backend_registry.register("default", backend)
+    sync_backend_registry.register(backend, "default")
     assert sync_backend_registry.get() is backend
 
 
@@ -115,8 +119,8 @@ def test_register_named_and_get_by_name() -> None:
     """Register named and get by name."""
     primary = MemorySyncBackend()
     analytics = MemorySyncBackend()
-    sync_backend_registry.register("primary", primary)
-    sync_backend_registry.register("analytics", analytics)
+    sync_backend_registry.register(primary, "primary")
+    sync_backend_registry.register(analytics, "analytics")
     assert sync_backend_registry.get("primary") is primary
     assert sync_backend_registry.get("analytics") is analytics
 
@@ -124,14 +128,14 @@ def test_register_named_and_get_by_name() -> None:
 def test_get_default_falls_back_to_sole_entry() -> None:
     """Get default falls back to sole entry."""
     only = MemorySyncBackend()
-    sync_backend_registry.register("primary", only)
+    sync_backend_registry.register(only, "primary")
     assert sync_backend_registry.get() is only
 
 
 def test_get_default_raises_when_multiple_no_default() -> None:
     """Get default raises when multiple no default."""
-    sync_backend_registry.register("primary", MemorySyncBackend())
-    sync_backend_registry.register("analytics", MemorySyncBackend())
+    sync_backend_registry.register(MemorySyncBackend(), "primary")
+    sync_backend_registry.register(MemorySyncBackend(), "analytics")
     with pytest.raises(BackendNotLoadedError, match="multiple"):
         sync_backend_registry.get()
 
@@ -139,25 +143,25 @@ def test_get_default_raises_when_multiple_no_default() -> None:
 def test_register_same_instance_is_noop() -> None:
     """Register same instance is noop."""
     backend = MemorySyncBackend()
-    sync_backend_registry.register("default", backend)
+    sync_backend_registry.register(backend, "default")
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        sync_backend_registry.register("default", backend)
+        sync_backend_registry.register(backend, "default")
     assert sync_backend_registry.get() is backend
 
 
-def test_register_different_instance_warns() -> None:
-    """Register different instance warns."""
-    sync_backend_registry.register("default", MemorySyncBackend())
-    with pytest.warns(UserWarning, match="Overwriting"):
-        sync_backend_registry.register("default", MemorySyncBackend())
+def test_register_different_instance_raises() -> None:
+    """Register different instance raises BackendAlreadyRegisteredError."""
+    sync_backend_registry.register(MemorySyncBackend(), "default")
+    with pytest.raises(BackendAlreadyRegisteredError):
+        sync_backend_registry.register(MemorySyncBackend(), "default")
 
 
 def test_unregister_with_identity_check() -> None:
     """Unregister with identity check."""
     a = MemorySyncBackend()
     b = MemorySyncBackend()
-    sync_backend_registry.register("default", a)
+    sync_backend_registry.register(a, "default")
     sync_backend_registry.unregister("default", b)  # wrong instance: no-op
     assert sync_backend_registry.get() is a
     sync_backend_registry.unregister("default", a)  # right instance: clears
@@ -177,7 +181,7 @@ def test_use_overrides_default() -> None:
     """Use overrides default."""
     registered = MemorySyncBackend()
     override = MemorySyncBackend()
-    sync_backend_registry.register("default", registered)
+    sync_backend_registry.register(registered, "default")
     with sync_backend_registry.use(override):
         assert sync_backend_registry.get() is override
     assert sync_backend_registry.get() is registered
@@ -185,8 +189,8 @@ def test_use_overrides_default() -> None:
 
 def test_use_overrides_named() -> None:
     """Use overrides named."""
-    sync_backend_registry.register("primary", MemorySyncBackend())
-    sync_backend_registry.register("analytics", MemorySyncBackend())
+    sync_backend_registry.register(MemorySyncBackend(), "primary")
+    sync_backend_registry.register(MemorySyncBackend(), "analytics")
     fake_analytics = MemorySyncBackend()
     with sync_backend_registry.use(analytics=fake_analytics):
         assert sync_backend_registry.get("analytics") is fake_analytics
@@ -196,7 +200,7 @@ def test_use_stacks_lifo() -> None:
     """Use stacks lifo."""
     inner = MemorySyncBackend()
     outer = MemorySyncBackend()
-    sync_backend_registry.register("default", MemorySyncBackend())
+    sync_backend_registry.register(MemorySyncBackend(), "default")
     with sync_backend_registry.use(outer):
         with sync_backend_registry.use(inner):
             assert sync_backend_registry.get() is inner
@@ -211,9 +215,9 @@ async def test_lifespan_opens_registered_backends() -> None:
     sync_b = MemorySyncBackend()
     cache_b = MemoryCacheBackend()
     rl_b = MemoryRateLimiterBackend()
-    sync_backend_registry.register("default", sync_b)
-    cache_backend_registry.register("default", cache_b)
-    rate_limiter_backend_registry.register("default", rl_b)
+    sync_backend_registry.register(sync_b, "default")
+    cache_backend_registry.register(cache_b, "default")
+    rate_limiter_backend_registry.register(rl_b, "default")
 
     async with grelmicro.lifespan():
         # backends remain registered while open
@@ -224,8 +228,8 @@ async def test_lifespan_opens_registered_backends() -> None:
 
 async def test_lifespan_excludes_module() -> None:
     """Lifespan excludes module."""
-    sync_backend_registry.register("default", MemorySyncBackend())
-    cache_backend_registry.register("default", MemoryCacheBackend())
+    sync_backend_registry.register(MemorySyncBackend(), "default")
+    cache_backend_registry.register(MemoryCacheBackend(), "default")
     async with grelmicro.lifespan(exclude={"cache"}):
         # cache backend was not entered (we cannot easily detect this
         # for memory backends; the contract is that entries in
@@ -237,10 +241,44 @@ async def test_lifespan_excludes_named_entry() -> None:
     """Lifespan excludes named entry."""
     primary = MemorySyncBackend()
     analytics = MemorySyncBackend()
-    sync_backend_registry.register("primary", primary)
-    sync_backend_registry.register("analytics", analytics)
+    sync_backend_registry.register(primary, "primary")
+    sync_backend_registry.register(analytics, "analytics")
     async with grelmicro.lifespan(exclude={"sync.analytics"}):
         assert sync_backend_registry.get("primary") is primary
+
+
+async def test_lifespan_excludes_resilience_module_key() -> None:
+    """``exclude={"resilience"}`` matches the rate limiter registry."""
+    rate_limiter_backend_registry.register(
+        MemoryRateLimiterBackend(), "default"
+    )
+    sync_backend_registry.register(MemorySyncBackend(), "default")
+    async with grelmicro.lifespan(exclude={"resilience"}):
+        assert sync_backend_registry.is_loaded
+
+
+def test_lock_resolves_named_backend_from_registry() -> None:
+    """``Lock(backend="analytics")`` resolves the named entry on each call."""
+    primary = MemorySyncBackend()
+    analytics = MemorySyncBackend()
+    sync_backend_registry.register(primary, "primary")
+    sync_backend_registry.register(analytics, "analytics")
+
+    lock = Lock("cart", backend="analytics")
+    assert lock.backend is analytics
+
+
+def test_lock_named_backend_honors_use_override() -> None:
+    """``sync.use(...)`` overrides a named backend selection per task."""
+    real_analytics = MemorySyncBackend()
+    fake_analytics = MemorySyncBackend()
+    sync_backend_registry.register(real_analytics, "analytics")
+
+    lock = Lock("audit", backend="analytics")
+    assert lock.backend is real_analytics
+    with sync_mod.use(analytics=fake_analytics):
+        assert lock.backend is fake_analytics
+    assert lock.backend is real_analytics
 
 
 async def test_lifespan_with_ad_hoc_backend() -> None:
@@ -346,7 +384,7 @@ def test_resilience_use_backend_registers_default() -> None:
 def test_sync_register_and_unregister_module_helpers() -> None:
     """Sync register and unregister module helpers."""
     backend = MemorySyncBackend()
-    sync_mod.register("primary", backend)
+    sync_mod.register(backend, "primary")
     assert sync_backend_registry.get("primary") is backend
     sync_mod.unregister("primary", backend)
     assert not sync_backend_registry.is_loaded
@@ -354,7 +392,7 @@ def test_sync_register_and_unregister_module_helpers() -> None:
 
 def test_sync_use_module_helper() -> None:
     """Sync use module helper."""
-    sync_backend_registry.register("default", MemorySyncBackend())
+    sync_backend_registry.register(MemorySyncBackend(), "default")
     override = MemorySyncBackend()
     with sync_mod.use(override):
         assert sync_backend_registry.get() is override
@@ -363,7 +401,7 @@ def test_sync_use_module_helper() -> None:
 def test_cache_register_unregister_use_module_helpers() -> None:
     """Cache register, unregister, and use module helpers."""
     backend = MemoryCacheBackend()
-    cache_mod.register("primary", backend)
+    cache_mod.register(backend, "primary")
     assert cache_backend_registry.get("primary") is backend
     override = MemoryCacheBackend()
     with cache_mod.use(override):
@@ -375,7 +413,7 @@ def test_cache_register_unregister_use_module_helpers() -> None:
 def test_resilience_register_unregister_use_module_helpers() -> None:
     """Resilience register, unregister, and use module helpers."""
     backend = MemoryRateLimiterBackend()
-    resilience_mod.register("primary", backend)
+    resilience_mod.register(backend, "primary")
     assert rate_limiter_backend_registry.get("primary") is backend
     override = MemoryRateLimiterBackend()
     with resilience_mod.use(override):
@@ -388,7 +426,7 @@ def test_health_register_unregister_use_module_helpers() -> None:
     """Health register, unregister, use, and use_registry helpers."""
     health_registry.reset()
     registry = HealthRegistry()
-    health_mod.register("primary", registry)
+    health_mod.register(registry, "primary")
     assert health_registry.get("primary") is registry
     override = HealthRegistry()
     with health_mod.use(override):


### PR DESCRIPTION
**Stacked on top of #138 (closes issue #116). Merge that one first.**

## Summary

- `BackendRegistry` becomes multi-name with task-scoped overrides: `register(backend, name="default")`, `unregister(name, backend=None)`, `get(name)`, `items()`, `use(...)` — ContextVar-backed.
- `grelmicro.lifespan(*ad_hoc, exclude=...)` opens every registered backend across imported modules and closes them in reverse on exit. `import grelmicro` stays at ~6 ms via lazy import + subscribe-on-import (unused components consume zero RAM).
- Per-module helpers `register`, `unregister`, `use_backend`, `use` on `grelmicro.sync`, `grelmicro.cache`, `grelmicro.resilience` (and `use_registry`, `use` on `grelmicro.health`).
- Primitives accept `backend: T | str | None`. `Lock("audit", backend="analytics")` resolves the named entry on each call so `<module>.use(...)` overrides take effect.
- Sole-registered entry serves as the default when only one backend is registered (Django/Spring `@Primary` shape).
- Resilience registry renamed `rate_limiter` → `resilience` so the module name matches the `lifespan(exclude={...})` key everywhere.
- Overwrite raises `BackendAlreadyRegisteredError` (was: warning + replace). Same instance is still a no-op.
- README, `docs/architecture/backends.md`, `CONTRIBUTING.md`, changelog updated to the new shape.

## Test plan
- [x] `MemorySyncBackend()` performs zero registry writes
- [x] `register(b)` registers as `"default"`; `register(b, "analytics")` for named
- [x] Different-instance overwrite raises; same instance is no-op
- [x] `<module>.use(...)` ContextVar override stacks LIFO
- [x] `grelmicro.lifespan()` opens every registered backend in registration order
- [x] `exclude={"resilience"}` skips the rate limiter registry (regression test for module-name mismatch)
- [x] `Lock("audit", backend="analytics")` resolves the named entry
- [x] `Lock(backend="analytics")` honors `sync.use(analytics=fake)` per task
- [x] `import grelmicro` stays under 10ms with lazy `_registries()`