### PR TITLE
✨ Make Environmental config path opt-in via GREL_CONFIG_FROM_ENV (#142)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Breaking
+
+* 💥 The Environmental config path is now opt-in. Set `GREL_CONFIG_FROM_ENV=true` once at startup to enable env reads across every component, or pass `read_env=True` per call. The per-call value (`True`/`False`) always wins over the global flag. This stops grelmicro from silently picking up ambient env vars in unit tests or scripts. Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).
+* 💥 The `read_env` kwarg default flips from `True` to `None` on every component. `None` follows the global flag. `True` and `False` keep their meaning as explicit per-call overrides.
+
+### Features
+
+* ✨ Add `grelmicro._config.env_opt_in_enabled()` helper that exposes the truthy `GREL_CONFIG_FROM_ENV` check (`1`, `true`, `yes`, `on`, case-insensitive). Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).
+
 ## 0.18.0 - 2026-04-30
 
 M2 milestone closed: backend wiring is now fully explicit. Construction is pure (no global writes), registration is named (`<module>.register(backend, "name")`), and `grelmicro.lifespan(*ad_hoc, exclude=...)` walks every registry that has been imported and opens its registered backends in one call. Task-scoped overrides via `with <module>.use(...):` swap backends per request or per test through `contextvars`.

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -16,6 +16,7 @@ name-as-namespace convention, is documented in
 
 from __future__ import annotations
 
+import os
 import re
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -89,13 +90,29 @@ def env_segment(name: str) -> str:
     return cleaned
 
 
+_ENV_OPT_IN_VAR = "GREL_CONFIG_FROM_ENV"
+_ENV_OPT_IN_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def env_opt_in_enabled() -> bool:
+    """Return True when env-driven configuration is opted in process-wide.
+
+    Reads ``GREL_CONFIG_FROM_ENV`` and accepts ``1``, ``true``, ``yes``,
+    ``on`` (case-insensitive) as truthy.
+    """
+    return (
+        os.environ.get(_ENV_OPT_IN_VAR, "").strip().lower()
+        in _ENV_OPT_IN_TRUTHY
+    )
+
+
 def resolve_config(
     config_cls: type[C],
     *,
     explicit: C | None,
     kwargs: Mapping[str, object | None],
     env_prefix: str,
-    read_env: bool = True,
+    read_env: bool | None = None,
 ) -> C:
     """Build a validated ``config_cls`` from an explicit instance or kwargs and env.
 
@@ -106,11 +123,16 @@ def resolve_config(
     non-``None`` kwargs win over environment variables, and
     environment variables win over defaults declared on ``config_cls``.
 
+    The env path is opt-in. When ``read_env`` is ``None`` (the
+    default), the process-wide ``GREL_CONFIG_FROM_ENV`` flag decides:
+    env reads run only when it is set to a truthy value. Pass
+    ``read_env=True`` or ``read_env=False`` on the call to override
+    the flag for that construction.
+
     The env path constructs a one-off ``BaseSettings`` subclass that
     inherits ``config_cls`` so its validators, ``frozen``, and
     ``extra`` flags are preserved. Only the ``env_prefix`` is added.
-    Pass ``read_env=False`` to skip the env path entirely. Validation
-    failures surface as ``pydantic.ValidationError``.
+    Validation failures surface as ``pydantic.ValidationError``.
 
     See `docs/architecture/config.md` for the full contract,
     including the name-as-namespace convention used to derive
@@ -123,6 +145,9 @@ def resolve_config(
             msg = "pass a pre-built config OR individual kwargs, not both"
             raise TypeError(msg)
         return explicit
+
+    if read_env is None:
+        read_env = env_opt_in_enabled()
 
     if not read_env:
         return config_cls.model_validate(provided)

--- a/grelmicro/health/_registry.py
+++ b/grelmicro/health/_registry.py
@@ -140,17 +140,17 @@ class HealthRegistry:
             ),
         ] = None,
         read_env: Annotated[
-            bool,
+            bool | None,
             Doc(
                 """
                 Whether to read environment variables.
 
-                Default: True. Set to False when every field is
-                already supplied via kwargs and the environment
-                must not influence construction.
+                When None (the default), follow the process-wide
+                ``GREL_CONFIG_FROM_ENV`` flag. Pass True or False to
+                override the flag for this construction.
                 """
             ),
-        ] = True,
+        ] = None,
     ) -> None:
         """Initialize the health registry."""
         config = resolve_config(

--- a/grelmicro/log/__init__.py
+++ b/grelmicro/log/__init__.py
@@ -81,11 +81,13 @@ def configure(
         ),
     ] = None,
     read_env: Annotated[
-        bool,
+        bool | None,
         Doc(
-            "Whether to read `GREL_LOG_*` environment variables. Default: True."
+            "Whether to read `GREL_LOG_*` environment variables. "
+            "When None (default), follow `GREL_CONFIG_FROM_ENV`. "
+            "Pass True or False to override."
         ),
-    ] = True,
+    ] = None,
 ) -> LoggingConfig:
     """Configure logging with the selected backend.
 

--- a/grelmicro/log/_dedup.py
+++ b/grelmicro/log/_dedup.py
@@ -172,15 +172,17 @@ class DuplicateFilter(Filter):
             ),
         ] = None,
         read_env: Annotated[
-            bool,
+            bool | None,
             Doc(
                 """
                 Whether to read environment variables.
 
-                Default: True.
+                When None (the default), follow the process-wide
+                ``GREL_CONFIG_FROM_ENV`` flag. Pass True or False to
+                override the flag for this construction.
                 """
             ),
-        ] = True,
+        ] = None,
     ) -> None:
         """Initialize the filter."""
         config = resolve_config(

--- a/grelmicro/log/_ratelimit.py
+++ b/grelmicro/log/_ratelimit.py
@@ -200,15 +200,17 @@ class RateLimitFilter(Filter):
             ),
         ] = None,
         read_env: Annotated[
-            bool,
+            bool | None,
             Doc(
                 """
                 Whether to read environment variables.
 
-                Default: True.
+                When None (the default), follow the process-wide
+                ``GREL_CONFIG_FROM_ENV`` flag. Pass True or False to
+                override the flag for this construction.
                 """
             ),
-        ] = True,
+        ] = None,
     ) -> None:
         """Initialize the filter."""
         config = resolve_config(

--- a/grelmicro/resilience/circuitbreaker.py
+++ b/grelmicro/resilience/circuitbreaker.py
@@ -260,15 +260,17 @@ class CircuitBreaker:
             ),
         ] = None,
         read_env: Annotated[
-            bool,
+            bool | None,
             Doc(
                 """
                 Whether to read environment variables.
 
-                Default: True.
+                When None (the default), follow the process-wide
+                ``GREL_CONFIG_FROM_ENV`` flag. Pass True or False to
+                override the flag for this construction.
                 """
             ),
-        ] = True,
+        ] = None,
     ) -> None:
         """Initialize the circuit breaker."""
         config = resolve_config(

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -219,17 +219,17 @@ class LeaderElection(SyncPrimitive, Task):
             ),
         ] = None,
         read_env: Annotated[
-            bool,
+            bool | None,
             Doc(
                 """
                 Whether to read environment variables.
 
-                Default: True. Set to False when every field is
-                already supplied via kwargs and the environment
-                must not influence construction.
+                When None (the default), follow the process-wide
+                ``GREL_CONFIG_FROM_ENV`` flag. Pass True or False to
+                override the flag for this construction.
                 """,
             ),
-        ] = True,
+        ] = None,
     ) -> None:
         """Initialize the leader election."""
         config = resolve_config(

--- a/grelmicro/sync/lock.py
+++ b/grelmicro/sync/lock.py
@@ -139,17 +139,17 @@ class Lock(BaseLock):
             ),
         ] = None,
         read_env: Annotated[
-            bool,
+            bool | None,
             Doc(
                 """
                 Whether to read environment variables.
 
-                Default: True. Set to False when every field is
-                already supplied via kwargs and the environment
-                must not influence construction.
+                When None (the default), follow the process-wide
+                ``GREL_CONFIG_FROM_ENV`` flag. Pass True or False to
+                override the flag for this construction.
                 """,
             ),
-        ] = True,
+        ] = None,
     ) -> None:
         """Initialize the lock."""
         config = resolve_config(

--- a/grelmicro/sync/tasklock.py
+++ b/grelmicro/sync/tasklock.py
@@ -158,17 +158,17 @@ class TaskLock(SyncPrimitive):
             ),
         ] = None,
         read_env: Annotated[
-            bool,
+            bool | None,
             Doc(
                 """
                 Whether to read environment variables.
 
-                Default: True. Set to False when every field is
-                already supplied via kwargs and the environment
-                must not influence construction.
+                When None (the default), follow the process-wide
+                ``GREL_CONFIG_FROM_ENV`` flag. Pass True or False to
+                override the flag for this construction.
                 """
             ),
-        ] = True,
+        ] = None,
     ) -> None:
         """Initialize the task lock."""
         config = resolve_config(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,3 +7,17 @@ import pytest
 def anyio_backend() -> str:
     """AnyIO Backend."""
     return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _opt_in_env_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enable the Environmental config path for all tests by default.
+
+    Production code requires ``GREL_CONFIG_FROM_ENV=true`` to read
+    env-driven config. The test suite was written before that opt-in
+    existed and assumes env reads run by default. This fixture
+    preserves that assumption. Tests that exercise the OFF behavior
+    delete the var explicitly with
+    ``monkeypatch.delenv("GREL_CONFIG_FROM_ENV", raising=False)``.
+    """
+    monkeypatch.setenv("GREL_CONFIG_FROM_ENV", "true")

--- a/tests/test_env_opt_in.py
+++ b/tests/test_env_opt_in.py
@@ -1,0 +1,107 @@
+"""Tests for the GREL_CONFIG_FROM_ENV opt-in flag."""
+
+import pytest
+
+from grelmicro._config import env_opt_in_enabled, resolve_config
+from grelmicro.sync.lock import Lock, LockConfig
+from grelmicro.sync.memory import MemorySyncBackend
+
+LEASE_OVERRIDE = 999.0
+LEASE_FROM_ENV = 42.0
+
+
+@pytest.fixture
+def backend() -> MemorySyncBackend:
+    """Memory backend usable without an event loop."""
+    return MemorySyncBackend()
+
+
+@pytest.fixture
+def _no_env_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Override the autouse fixture and turn the global flag off."""
+    monkeypatch.delenv("GREL_CONFIG_FROM_ENV", raising=False)
+
+
+@pytest.mark.parametrize("value", ["1", "true", "True", "TRUE", "yes", "on"])
+def test_env_opt_in_truthy_values(
+    value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Truthy values turn the global flag on."""
+    monkeypatch.setenv("GREL_CONFIG_FROM_ENV", value)
+    assert env_opt_in_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "anything"])
+def test_env_opt_in_falsy_values(
+    value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anything else keeps the flag off."""
+    monkeypatch.setenv("GREL_CONFIG_FROM_ENV", value)
+    assert env_opt_in_enabled() is False
+
+
+@pytest.mark.usefixtures("_no_env_opt_in")
+def test_env_ignored_when_flag_off(
+    backend: MemorySyncBackend,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the global flag, env vars are not read."""
+    monkeypatch.setenv(
+        "GREL_LOCK_CART_LEASE_DURATION", str(int(LEASE_OVERRIDE))
+    )
+    lock = Lock("cart", backend=backend)
+    assert lock.config.lease_duration != LEASE_OVERRIDE
+
+
+@pytest.mark.usefixtures("_no_env_opt_in")
+def test_per_call_read_env_true_overrides_flag_off(
+    backend: MemorySyncBackend,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`read_env=True` reads env even when the global flag is off."""
+    monkeypatch.setenv(
+        "GREL_LOCK_CART_LEASE_DURATION", str(int(LEASE_OVERRIDE))
+    )
+    lock = Lock("cart", backend=backend, read_env=True)
+    assert lock.config.lease_duration == LEASE_OVERRIDE
+
+
+def test_per_call_read_env_false_overrides_flag_on(
+    backend: MemorySyncBackend,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`read_env=False` ignores env even when the global flag is on."""
+    # autouse fixture sets GREL_CONFIG_FROM_ENV=true
+    monkeypatch.setenv(
+        "GREL_LOCK_CART_LEASE_DURATION", str(int(LEASE_OVERRIDE))
+    )
+    lock = Lock("cart", backend=backend, read_env=False)
+    assert lock.config.lease_duration != LEASE_OVERRIDE
+
+
+@pytest.mark.usefixtures("_no_env_opt_in")
+def test_resolve_config_respects_global_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`resolve_config(read_env=None)` follows the global flag."""
+    monkeypatch.setenv(
+        "GREL_LOCK_TEST_LEASE_DURATION", str(int(LEASE_FROM_ENV))
+    )
+    cfg = resolve_config(
+        LockConfig,
+        explicit=None,
+        kwargs={},
+        env_prefix="GREL_LOCK_TEST_",
+        read_env=None,
+    )
+    assert cfg.lease_duration != LEASE_FROM_ENV  # flag off, env ignored
+
+    monkeypatch.setenv("GREL_CONFIG_FROM_ENV", "true")
+    cfg2 = resolve_config(
+        LockConfig,
+        explicit=None,
+        kwargs={},
+        env_prefix="GREL_LOCK_TEST_",
+        read_env=None,
+    )
+    assert cfg2.lease_duration == LEASE_FROM_ENV  # flag on, env read


### PR DESCRIPTION
Closes #142.

## Summary

The Environmental config path used to be on by default. `Lock("cart")` in a unit test would silently pick up `GREL_LOCK_CART_*` env vars from the developer's shell or CI runner. This PR makes env reading opt-in, with a per-call override for tests that exercise the env path.

## Behavior

- `GREL_CONFIG_FROM_ENV=true` (process-wide, accepts `1`, `true`, `yes`, `on` case-insensitive): turns env reads on for every grelmicro component constructor.
- `read_env=True` (per call): forces env reads on for that construction even when the global flag is off.
- `read_env=False` (per call): forces env reads off for that construction even when the global flag is on.
- `read_env=None` (the new default for every component): follow the global flag.

## Migration

Pre-1.0, MINOR breaking change. Apps that rely on env config add one line at startup:

```python
os.environ.setdefault("GREL_CONFIG_FROM_ENV", "true")
```

Or set it in the deployment manifest / Dockerfile.

## Test plan
- [x] `env_opt_in_enabled()` returns True for `1`, `true`, `yes`, `on` (case-insensitive); False otherwise.
- [x] `Lock("cart")` ignores env when the flag is off.
- [x] `read_env=True` overrides flag-off; `read_env=False` overrides flag-on.
- [x] `resolve_config(read_env=None)` follows the global flag.
- [x] tests/conftest.py opts in by default so the existing 1300+ tests keep their assumed semantics.

Pairs with PR #143 (docs split). Doc text for the new flag will land in #143 once merged.