### PR TITLE
🐛 Address Copilot review on PR #144

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,9 +7,9 @@
 * 💥 The Environmental config path is now opt-in. Set `GREL_CONFIG_FROM_ENV=true` once at startup to enable env reads across every component, or pass `read_env=True` per call. The per-call value (`True`/`False`) always wins over the global flag. This stops grelmicro from silently picking up ambient env vars in unit tests or scripts. Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).
 * 💥 The `read_env` kwarg default flips from `True` to `None` on every component. `None` follows the global flag. `True` and `False` keep their meaning as explicit per-call overrides.
 
-### Features
+### Internal
 
-* ✨ Add `grelmicro._config.env_opt_in_enabled()` helper that exposes the truthy `GREL_CONFIG_FROM_ENV` check (`1`, `true`, `yes`, `on`, case-insensitive). Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).
+* ♻️ Add `grelmicro._config.env_opt_in_enabled()` helper that exposes the truthy `GREL_CONFIG_FROM_ENV` check (`1`, `true`, `yes`, `on`, case-insensitive). Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).
 
 ## 0.18.0 - 2026-04-30
 

--- a/grelmicro/health/_registry.py
+++ b/grelmicro/health/_registry.py
@@ -109,7 +109,8 @@ class HealthRegistry:
                 Default per-check timeout in seconds. Checks that
                 exceed this duration are reported as ``error``.
 
-                Default: 5.0. When unset, resolves from the
+                Default: 5.0. When unset and env reads are enabled (see ``read_env`` and
+                ``GREL_CONFIG_FROM_ENV``), resolves from the
                 environment variable ``GREL_HEALTH_TIMEOUT`` if
                 present, otherwise falls back to the
                 ``HealthRegistryConfig`` default.
@@ -122,7 +123,8 @@ class HealthRegistry:
                 """
                 Per-check cache TTL in seconds. Set to 0 to disable.
 
-                Default: 1.0. When unset, resolves from the
+                Default: 1.0. When unset and env reads are enabled (see ``read_env`` and
+                ``GREL_CONFIG_FROM_ENV``), resolves from the
                 environment variable ``GREL_HEALTH_CACHE_TTL`` if
                 present, otherwise falls back to the
                 ``HealthRegistryConfig`` default.

--- a/grelmicro/log/_dedup.py
+++ b/grelmicro/log/_dedup.py
@@ -117,7 +117,8 @@ class DuplicateFilter(Filter):
                 Maximum number of records per key that pass the
                 filter before subsequent records are dropped.
 
-                Default: 5. When unset, resolves from the environment
+                Default: 5. When unset and env reads are enabled (see ``read_env`` and
+                ``GREL_CONFIG_FROM_ENV``), resolves from the environment
                 variable ``GREL_DUPLICATE_FILTER_ALLOWED_REPETITIONS``
                 if present, otherwise falls back to the
                 ``DuplicateFilterConfig`` default.

--- a/grelmicro/log/_ratelimit.py
+++ b/grelmicro/log/_ratelimit.py
@@ -142,7 +142,8 @@ class RateLimitFilter(Filter):
                 """
                 Maximum burst size.
 
-                Default: 5. When unset, resolves from the environment
+                Default: 5. When unset and env reads are enabled (see ``read_env`` and
+                ``GREL_CONFIG_FROM_ENV``), resolves from the environment
                 variable ``GREL_RATE_LIMIT_FILTER_CAPACITY`` if
                 present, otherwise falls back to the
                 ``RateLimitFilterConfig`` default.

--- a/grelmicro/resilience/circuitbreaker.py
+++ b/grelmicro/resilience/circuitbreaker.py
@@ -190,9 +190,9 @@ class CircuitBreaker:
                 Errors of these types do not count toward `error_threshold`.
                 Accepts a single exception class, a tuple, or fully-qualified
                 import strings such as `"builtins.ValueError"` or
-                `"my_app.errors.PaymentError"`. When unset, resolves from the
-                env path or falls back to the `CircuitBreakerConfig` default
-                (empty tuple).
+                `"my_app.errors.PaymentError"`. When unset and env reads are enabled (see `read_env`
+                and `GREL_CONFIG_FROM_ENV`), resolves from the env path or
+                falls back to the `CircuitBreakerConfig` default (empty tuple).
                 """
             ),
         ] = None,
@@ -202,7 +202,8 @@ class CircuitBreaker:
                 """
                 Consecutive errors before the breaker opens.
 
-                Default: 5. When unset, resolves from
+                Default: 5. When unset and env reads are enabled (see `read_env`
+                and `GREL_CONFIG_FROM_ENV`), resolves from
                 `GREL_CIRCUIT_BREAKER_{NAME_UPPER}_ERROR_THRESHOLD` if
                 present, otherwise falls back to the
                 `CircuitBreakerConfig` default.

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -146,7 +146,8 @@ class LeaderElection(SyncPrimitive, Task):
 
                 Default: 15. If the worker becomes unavailable, the lock
                 can only be acquired by an other worker after it has
-                expired. When unset, resolves from the environment
+                expired. When unset and env reads are enabled (see ``read_env`` and
+                ``GREL_CONFIG_FROM_ENV``), resolves from the environment
                 variable
                 `GREL_LEADER_ELECTION_{NAME_UPPER}_LEASE_DURATION` if
                 present, otherwise falls back to the

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -145,7 +145,7 @@ class LeaderElection(SyncPrimitive, Task):
                 The duration in seconds after the lock will be released if not renewed.
 
                 Default: 15. If the worker becomes unavailable, the lock
-                can only be acquired by an other worker after it has
+                can only be acquired by another worker after it has
                 expired. When unset and env reads are enabled (see ``read_env`` and
                 ``GREL_CONFIG_FROM_ENV``), resolves from the environment
                 variable

--- a/grelmicro/sync/lock.py
+++ b/grelmicro/sync/lock.py
@@ -105,7 +105,8 @@ class Lock(BaseLock):
                 """
                 The duration in seconds for the lock to be held by default.
 
-                Default: 60. When unset, resolves from the environment
+                Default: 60. When unset and env reads are enabled (see ``read_env`` and
+                ``GREL_CONFIG_FROM_ENV``), resolves from the environment
                 variable `GREL_LOCK_{NAME_UPPER}_LEASE_DURATION` if
                 present, otherwise falls back to the `LockConfig`
                 default.
@@ -119,7 +120,8 @@ class Lock(BaseLock):
                 The duration in seconds between attempts to acquire the lock.
 
                 Default: 0.1. Must be >= 0.001 to prevent flooding
-                the lock backend. When unset, resolves from the
+                the lock backend. When unset and env reads are enabled (see ``read_env`` and
+                ``GREL_CONFIG_FROM_ENV``), resolves from the
                 environment variable
                 `GREL_LOCK_{NAME_UPPER}_RETRY_INTERVAL` if present,
                 otherwise falls back to the `LockConfig` default.

--- a/grelmicro/sync/tasklock.py
+++ b/grelmicro/sync/tasklock.py
@@ -123,7 +123,8 @@ class TaskLock(SyncPrimitive):
                 The minimum duration in seconds to hold the lock after task completion.
 
                 Default: 1. Prevents re-execution on other nodes
-                before this duration has elapsed. When unset,
+                before this duration has elapsed. When unset and env reads
+                are enabled (see `read_env` and `GREL_CONFIG_FROM_ENV`),
                 resolves from the environment variable
                 `GREL_TASK_LOCK_{NAME_UPPER}_MIN_LOCK_SECONDS` if
                 present, otherwise falls back to the
@@ -137,7 +138,8 @@ class TaskLock(SyncPrimitive):
                 """
                 The maximum duration in seconds to hold the lock (deadlock protection).
 
-                Default: 60. Acts as the TTL on acquire. When unset,
+                Default: 60. Acts as the TTL on acquire. When unset and env reads
+                are enabled (see `read_env` and `GREL_CONFIG_FROM_ENV`),
                 resolves from the environment variable
                 `GREL_TASK_LOCK_{NAME_UPPER}_MAX_LOCK_SECONDS` if
                 present, otherwise falls back to the

--- a/tests/test_env_opt_in.py
+++ b/tests/test_env_opt_in.py
@@ -8,7 +8,7 @@ from grelmicro.sync.memory import MemorySyncBackend
 
 LEASE_OVERRIDE = 999.0
 LEASE_FROM_ENV = 42.0
-DEFAULT_LEASE = 60.0  # LockConfig.lease_duration default
+DEFAULT_LEASE = LockConfig.model_fields["lease_duration"].default
 
 
 @pytest.fixture

--- a/tests/test_env_opt_in.py
+++ b/tests/test_env_opt_in.py
@@ -8,6 +8,7 @@ from grelmicro.sync.memory import MemorySyncBackend
 
 LEASE_OVERRIDE = 999.0
 LEASE_FROM_ENV = 42.0
+DEFAULT_LEASE = 60.0  # LockConfig.lease_duration default
 
 
 @pytest.fixture
@@ -50,7 +51,7 @@ def test_env_ignored_when_flag_off(
         "GREL_LOCK_CART_LEASE_DURATION", str(int(LEASE_OVERRIDE))
     )
     lock = Lock("cart", backend=backend)
-    assert lock.config.lease_duration != LEASE_OVERRIDE
+    assert lock.config.lease_duration == DEFAULT_LEASE
 
 
 @pytest.mark.usefixtures("_no_env_opt_in")
@@ -76,7 +77,7 @@ def test_per_call_read_env_false_overrides_flag_on(
         "GREL_LOCK_CART_LEASE_DURATION", str(int(LEASE_OVERRIDE))
     )
     lock = Lock("cart", backend=backend, read_env=False)
-    assert lock.config.lease_duration != LEASE_OVERRIDE
+    assert lock.config.lease_duration == DEFAULT_LEASE
 
 
 @pytest.mark.usefixtures("_no_env_opt_in")
@@ -94,7 +95,7 @@ def test_resolve_config_respects_global_flag(
         env_prefix="GREL_LOCK_TEST_",
         read_env=None,
     )
-    assert cfg.lease_duration != LEASE_FROM_ENV  # flag off, env ignored
+    assert cfg.lease_duration == DEFAULT_LEASE  # flag off, env ignored
 
     monkeypatch.setenv("GREL_CONFIG_FROM_ENV", "true")
     cfg2 = resolve_config(


### PR DESCRIPTION
Follow-up to merged PR #144 with Copilot's 11 findings.

## Fixes

**Changelog**
- Move `env_opt_in_enabled()` from Features to Internal (it lives in `grelmicro._config`, a private module).

**Per-field docstrings on every component that exposes `read_env`**
Updated the `Annotated[..., Doc(...)]` blocks for fields like `lease_duration`, `min_lock_seconds`, `max_lock_seconds`, `error_threshold`, `ignore_exceptions`, `timeout`, `cache_ttl`. Wording was "resolves from the environment variable `GREL_*` if present" — now reads "resolves from the environment variable `GREL_*` **when env reads are enabled (see `read_env` and `GREL_CONFIG_FROM_ENV`)**". Matches the new opt-in behavior so the docs don't imply env is always consulted.

Files: `grelmicro/sync/lock.py`, `grelmicro/sync/tasklock.py`, `grelmicro/sync/leaderelection.py`, `grelmicro/health/_registry.py`, `grelmicro/resilience/circuitbreaker.py`, `grelmicro/log/_dedup.py`, `grelmicro/log/_ratelimit.py`.

**Tests**
Strengthen 3 weak assertions in `tests/test_env_opt_in.py`. Replace `!= LEASE_OVERRIDE` with `== DEFAULT_LEASE` so the tests verify the exact fallback value, not just "anything but the env value".