### PR TITLE
⚡ Speed up the test suite from 73s to 19s

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@
 ### Internal
 
 * ♻️ Add `grelmicro._config.env_opt_in_enabled()` helper that exposes the truthy `GREL_CONFIG_FROM_ENV` check (`1`, `true`, `yes`, `on`, case-insensitive). Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).
-* ⚡ Speed up the test suite from ~74s to ~13s by adding `pytest-xdist` (`-n auto` in `addopts`) and shrinking expiration sleeps in `tests/sync/test_backends.py`. Fix `--durations` reporting by scoping the `freeze_time` fixture to the tests that need it and passing `ignore=["_pytest"]` so freezegun no longer freezes pytest's own clock. Issue [#125](https://github.com/grelinfo/grelmicro/issues/125).
+* ⚡ Speed up the test suite from ~73s to ~19s by adding `pytest-xdist` (`-n auto` in `addopts`) and shrinking expiration sleeps in `tests/sync/test_backends.py`. Fix `--durations` reporting by removing the autouse `freeze_time` fixture: `@freeze_time()` decorator stays on the two tests that compare `datetime.now()`, the two tests that previously called `frozen_time.tick(...)` switch to `monkeypatch.setattr(circuitbreaker, "monotonic", ...)`. Issue [#125](https://github.com/grelinfo/grelmicro/issues/125).
 
 ## 0.18.0 - 2026-04-30
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@
 ### Internal
 
 * ♻️ Add `grelmicro._config.env_opt_in_enabled()` helper that exposes the truthy `GREL_CONFIG_FROM_ENV` check (`1`, `true`, `yes`, `on`, case-insensitive). Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).
+* ⚡ Speed up the test suite from ~74s to ~13s by adding `pytest-xdist` (`-n auto` in `addopts`) and shrinking expiration sleeps in `tests/sync/test_backends.py`. Fix `--durations` reporting by scoping the `freeze_time` fixture to the tests that need it and passing `ignore=["_pytest"]` so freezegun no longer freezes pytest's own clock. Issue [#125](https://github.com/grelinfo/grelmicro/issues/125).
 
 ## 0.18.0 - 2026-04-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ dev = [
     "aiosqlite>=0.20.0",
     "lightkube>=0.15.0",
     "uvicorn>=0.29.0",
+    "pytest-xdist>=3.8.0",
 ]
 docs = [
     "mkdocs-material>=9.5.44",
@@ -210,6 +211,7 @@ exclude = [
 addopts = """
     --strict-config
     --strict-markers
+    -n auto
 """
 markers = """
     integration: mark a test as an integration test

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -1,22 +1,15 @@
 """Test CircuitBreaker implementation."""
 
 import sys
-from collections.abc import Iterator
 from contextlib import AsyncExitStack, suppress
-from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Literal, Union
+from datetime import UTC, datetime
+from typing import Literal
 
 import pytest
 from anyio import to_thread
 from freezegun import freeze_time
 
-if TYPE_CHECKING:
-    from freezegun.api import (
-        FrozenDateTimeFactory,
-        StepTickTimeFactory,
-        TickingDateTimeFactory,
-    )
-
+from grelmicro.resilience import circuitbreaker
 from grelmicro.resilience.circuitbreaker import (
     CircuitBreaker,
     CircuitBreakerError,
@@ -31,10 +24,6 @@ class SentinelError(Exception):
 
 
 sentinel_error = SentinelError("Sentinel error for testing")
-
-FrozenTimeType = Union[
-    "StepTickTimeFactory", "TickingDateTimeFactory", "FrozenDateTimeFactory"
-]
 
 ALL_STATES = [
     CircuitBreakerState.CLOSED,
@@ -95,13 +84,6 @@ async def generate_error(cb: CircuitBreaker) -> None:
     with suppress(SentinelError):
         async with cb:
             raise sentinel_error
-
-
-@pytest.fixture(autouse=True)
-def frozen_time() -> Iterator[FrozenTimeType]:
-    """Freeze time for the duration of the test."""
-    with freeze_time() as frozen:
-        yield frozen
 
 
 @pytest.fixture(
@@ -377,14 +359,16 @@ async def test_circuit_transition_to_open(error_count: int) -> None:
 
 
 async def test_circuit_transition_to_half_open_after_timeout(
-    frozen_time: FrozenTimeType,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test circuit breaker transitions to half-open after reset timeout."""
     # Arrange
     cb = await create_circuit(
         CircuitBreakerState.OPEN, success_threshold=2
     )  # Ensure it doesn't close immediately
-    frozen_time.tick(timedelta(seconds=cb.config.reset_timeout))
+    monkeypatch.setattr(
+        circuitbreaker, "monotonic", lambda: cb._open_until_time
+    )
 
     # Act
     await generate_success(cb)
@@ -395,16 +379,16 @@ async def test_circuit_transition_to_half_open_after_timeout(
 
 @pytest.mark.parametrize("reset_timeout", [0.5, 1, 30])
 async def test_circuit_not_transition_to_half_open_before_timeout(
-    frozen_time: FrozenTimeType, reset_timeout: float
+    monkeypatch: pytest.MonkeyPatch, reset_timeout: float
 ) -> None:
     """Test circuit breaker does not transition to half-open before reset timeout."""
     # Arrange
     cb = await create_circuit(
         CircuitBreakerState.OPEN, reset_timeout=reset_timeout
     )
-    frozen_time.tick(
-        timedelta(seconds=cb.config.reset_timeout) - timedelta(milliseconds=1)
-    )  # Ensure not enough time has passed
+    monkeypatch.setattr(
+        circuitbreaker, "monotonic", lambda: cb._open_until_time - 0.001
+    )
 
     # Act & Assert
     with pytest.raises(CircuitBreakerError):
@@ -521,6 +505,7 @@ async def test_circuit_from_thread_with_ignore_exceptions(
         await to_thread.run_sync(sync)
 
 
+@freeze_time()
 async def test_circuit_breaker_last_error() -> None:
     """Test error info is properly recorded."""
     # Arrange
@@ -584,6 +569,7 @@ async def test_circuit_metrics_counters_with_successes(
 
 
 @pytest.mark.parametrize("error_count", [1, 3, 5])
+@freeze_time()
 async def test_circuit_metrics_with_errors(
     circuit_call_permitted: CircuitBreaker,
     error_count: int,

--- a/tests/sync/test_backends.py
+++ b/tests/sync/test_backends.py
@@ -136,6 +136,27 @@ def container(
 
 
 @pytest.fixture(scope="module")
+def expire_duration(backend_name: str) -> float:
+    """Lock duration for expiration tests, scaled per backend.
+
+    SQLite and Kubernetes round the duration up to whole seconds, and the
+    networked backends need enough margin to survive container-side clock
+    drift; only the in-process Memory backend can use a sub-second value.
+    """
+    if backend_name == "memory":
+        return 0.2
+    return 1.0
+
+
+@pytest.fixture(scope="module")
+def expire_wait(backend_name: str, expire_duration: float) -> float:
+    """Sleep duration to wait past lock expiration."""
+    if backend_name in ("sqlite", "kubernetes"):
+        return expire_duration + 1.0
+    return expire_duration + 0.3
+
+
+@pytest.fixture(scope="module")
 async def backend(
     backend_name: str, container: DockerContainer | None
 ) -> AsyncGenerator[SyncBackend]:
@@ -209,35 +230,45 @@ async def test_acquire_already_acquired(backend: SyncBackend) -> None:
     assert not result2
 
 
-async def test_acquire_expired(backend: SyncBackend) -> None:
+async def test_acquire_expired(
+    backend: SyncBackend, expire_duration: float, expire_wait: float
+) -> None:
     """Test acquire when expired."""
     # Arrange
     name = "test_acquire_expired"
     token = uuid4().hex
-    duration = 1
 
     # Act
-    result = await backend.acquire(name=name, token=token, duration=duration)
-    await sleep(duration + 1.5)
-    result2 = await backend.acquire(name=name, token=token, duration=duration)
+    result = await backend.acquire(
+        name=name, token=token, duration=expire_duration
+    )
+    await sleep(expire_wait)
+    result2 = await backend.acquire(
+        name=name, token=token, duration=expire_duration
+    )
 
     # Assert
     assert result
     assert result2
 
 
-async def test_acquire_already_acquired_expired(backend: SyncBackend) -> None:
+async def test_acquire_already_acquired_expired(
+    backend: SyncBackend, expire_duration: float, expire_wait: float
+) -> None:
     """Test acquire when already acquired but expired."""
     # Arrange
     name = "test_acquire_already_acquired_expired" + uuid4().hex
     token1 = uuid4().hex
     token2 = uuid4().hex
-    duration = 1
 
     # Act
-    result = await backend.acquire(name=name, token=token1, duration=duration)
-    await sleep(duration + 1.5)
-    result2 = await backend.acquire(name=name, token=token2, duration=duration)
+    result = await backend.acquire(
+        name=name, token=token1, duration=expire_duration
+    )
+    await sleep(expire_wait)
+    result2 = await backend.acquire(
+        name=name, token=token2, duration=expire_duration
+    )
 
     # Assert
     assert token1 != token2
@@ -292,16 +323,19 @@ async def test_release_not_reantrant(backend: SyncBackend) -> None:
     assert not result3
 
 
-async def test_release_acquired_expired(backend: SyncBackend) -> None:
+async def test_release_acquired_expired(
+    backend: SyncBackend, expire_duration: float, expire_wait: float
+) -> None:
     """Test release when acquired but expired."""
     # Arrange
     name = "test_release_acquired_expired" + uuid4().hex
     token = uuid4().hex
-    duration = 1
 
     # Act
-    result1 = await backend.acquire(name=name, token=token, duration=duration)
-    await sleep(duration + 1.5)
+    result1 = await backend.acquire(
+        name=name, token=token, duration=expire_duration
+    )
+    await sleep(expire_wait)
     result2 = await backend.release(name=name, token=token)
 
     # Assert
@@ -309,16 +343,19 @@ async def test_release_acquired_expired(backend: SyncBackend) -> None:
     assert not result2
 
 
-async def test_release_not_acquired_expired(backend: SyncBackend) -> None:
+async def test_release_not_acquired_expired(
+    backend: SyncBackend, expire_duration: float, expire_wait: float
+) -> None:
     """Test release when not acquired but expired."""
     # Arrange
     name = "test_release_not_acquired_expired" + uuid4().hex
     token = uuid4().hex
-    duration = 1
 
     # Act
-    result1 = await backend.acquire(name=name, token=token, duration=duration)
-    await sleep(duration + 1.5)
+    result1 = await backend.acquire(
+        name=name, token=token, duration=expire_duration
+    )
+    await sleep(expire_wait)
     result2 = await backend.release(name=name, token=token)
 
     # Assert

--- a/uv.lock
+++ b/uv.lock
@@ -387,6 +387,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fast-depends"
 version = "3.0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -537,6 +546,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "redis" },
     { name = "ruff" },
     { name = "structlog" },
@@ -591,6 +601,7 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "ruff", specifier = ">=0.7.4" },
     { name = "structlog", specifier = ">=24.1.0" },
@@ -1479,6 +1490,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `pytest-xdist` and run with `-n auto` by default so the full suite (1415 tests) runs in parallel.
- Scope `freeze_time` to the four circuit-breaker tests that need it: `@freeze_time()` on the two that compare `datetime.now()`, `monkeypatch` on `circuitbreaker.monotonic` for the two that previously called `frozen_time.tick(...)`. Removes the `autouse` fixture that was breaking pytest's `--durations` reporter (freezegun was freezing `time.perf_counter`).
- Replace the hardcoded `duration=1; sleep(2.5)` in `tests/sync/test_backends.py` expiration tests with per-backend `expire_duration` / `expire_wait` fixtures (memory: 0.2s+0.3s, sqlite/k8s: 1.0s+1.0s, redis/postgres: 1.0s+0.3s).

Closes #125.

## Before / after
| | Before | After |
|---|---|---|
| Full suite (`uv run pytest tests/`) | 73.28s | 19.19s |
| `--durations` output | every entry shows `1777481796.77s setup` (frozen epoch) | real numbers, slowest test ~2.6s |
| Coverage | 100% | 100% |

## Test plan
- [x] `uv run pytest tests/` passes (1415 tests, 100% coverage).
- [x] `uv run pytest tests/ --durations=10` reports real durations.
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` all clean.
- [x] Pre-commit hooks (`pytest-unit`, `pytest-integration`, `coverage-report`) pass.