### PR TITLE
⚡ Cache _build_settings_cls with lru_cache(maxsize=256)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@
 
 * ♻️ Add `grelmicro._config.env_opt_in_enabled()` helper that exposes the truthy `GREL_CONFIG_FROM_ENV` check (`1`, `true`, `yes`, `on`, case-insensitive). Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).
 * ⚡ Speed up the test suite from ~73s to ~19s by adding `pytest-xdist` (`-n auto` in `addopts`) and shrinking expiration sleeps in `tests/sync/test_backends.py`. Fix `--durations` reporting by removing the autouse `freeze_time` fixture: `@freeze_time()` decorator stays on the two tests that compare `datetime.now()`, the two tests that previously called `frozen_time.tick(...)` switch to `monkeypatch.setattr(circuitbreaker, "monotonic", ...)`. Issue [#125](https://github.com/grelinfo/grelmicro/issues/125).
+* ⚡ Cache the dynamic `BaseSettings` subclass built by `grelmicro._config._build_settings_cls` with `@functools.lru_cache(maxsize=256)`. The env path of `resolve_config` now reuses the same `_<Config>Settings` subclass across calls instead of rebuilding it every time, which makes `Lock("cart")`-style construction ~3.4× faster (232 µs/op → 68 µs/op). The bound is a safety net for long-running processes that might derive prefixes from runtime inputs. Issue [#119](https://github.com/grelinfo/grelmicro/issues/119).
+* ♻️ Rename the local `parent_config` to `merged_config` in `_build_settings_cls` and document why the existing `# type: ignore` comments are needed. Issue [#127](https://github.com/grelinfo/grelmicro/issues/127).
 
 ## 0.18.0 - 2026-04-30
 

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import re
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from pydantic import BaseModel
@@ -156,6 +157,7 @@ def resolve_config(
     return settings_cls(**provided)  # type: ignore[return-value, arg-type]  # ty: ignore[invalid-return-type, invalid-argument-type]
 
 
+@lru_cache(maxsize=256)
 def _build_settings_cls(
     config_cls: type[C],
     env_prefix: str,
@@ -165,11 +167,20 @@ def _build_settings_cls(
     The dynamic class inherits ``config_cls`` so all fields,
     validators, and ``model_config`` flags (``frozen``, ``extra``)
     are preserved. Only the ``env_prefix`` is added.
+
+    Cached on ``(config_cls, env_prefix)`` with a bounded LRU. The
+    expected keyspace is small (one entry per declared component
+    instance per process); the bound is a safety net for long-
+    running processes that derive prefixes from runtime inputs.
     """
-    parent_config: dict[str, object] = {**(config_cls.model_config or {})}  # type: ignore[dict-item]
-    parent_config["env_prefix"] = env_prefix
+    # `model_config` is a TypedDict (`SettingsConfigDict`/`ConfigDict`);
+    # spreading it into a plain dict so we can add `env_prefix` widens
+    # it to `dict[str, object]`, which the downstream constructors
+    # accept but the type checker can't narrow back.
+    merged_config: dict[str, object] = {**(config_cls.model_config or {})}  # type: ignore[dict-item]
+    merged_config["env_prefix"] = env_prefix
     return type(
         f"_{config_cls.__name__}Settings",
         (config_cls, BaseSettings),
-        {"model_config": SettingsConfigDict(**parent_config)},  # type: ignore[typeddict-item]
+        {"model_config": SettingsConfigDict(**merged_config)},  # type: ignore[typeddict-item]
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import pytest
 from pydantic import BaseModel, ConfigDict, PositiveFloat, ValidationError
 
-from grelmicro._config import env_segment, parse_csv_or_json, resolve_config
+from grelmicro._config import (
+    _build_settings_cls,
+    env_segment,
+    parse_csv_or_json,
+    resolve_config,
+)
 
 DEFAULT_TIMEOUT = 5.0
 DEFAULT_RETRIES = 3
@@ -270,3 +275,22 @@ def test_env_segment_rejects_leading_digit(bad: str) -> None:
 def test_parse_csv_or_json(value: object, expected: object) -> None:
     """CSV strings split on commas, JSON arrays parse, others pass through."""
     assert parse_csv_or_json(value) == expected
+
+
+# --- _build_settings_cls cache ---
+
+
+def test_build_settings_cls_returns_same_class_for_same_inputs() -> None:
+    """The dynamic Settings subclass is memoized on (config_cls, env_prefix)."""
+    first = _build_settings_cls(_Sample, "GREL_SAMPLE_")
+    second = _build_settings_cls(_Sample, "GREL_SAMPLE_")
+    assert first is second
+
+
+def test_build_settings_cls_distinct_prefixes_get_distinct_classes() -> None:
+    """Different prefixes still produce distinct Settings subclasses."""
+    a = _build_settings_cls(_Sample, "GREL_SAMPLE_A_")
+    b = _build_settings_cls(_Sample, "GREL_SAMPLE_B_")
+    assert a is not b
+    assert a.model_config["env_prefix"] == "GREL_SAMPLE_A_"
+    assert b.model_config["env_prefix"] == "GREL_SAMPLE_B_"


### PR DESCRIPTION
## Summary
- Memoize `grelmicro._config._build_settings_cls` with `@functools.lru_cache(maxsize=256)` so the env path of `resolve_config` reuses the same `_<Config>Settings` subclass instead of rebuilding it every time.
- Rename the local `parent_config` → `merged_config` and document why the two `# type: ignore` entries can't be removed (TypedDict→`dict[str, object]` widening through dict-spread).
- Add two identity-equality tests covering both the cache hit and the distinct-prefix path.

Closes #119, addresses tasks 2 & 3 of #127.

## Benchmarks
`resolve_config(LockConfig, ..., read_env=True)` over 100k iterations:

| | µs/op | ops/sec |
|---|---|---|
| Baseline (no cache) | 232.96 | 4,293 |
| `@lru_cache(maxsize=256)` | 68.40 | 14,621 |
| **Speedup** | **3.4×** | — |

The remaining 68 µs/op is `BaseSettings.__init__` reading and validating env vars — that work has to happen on every call regardless. `maxsize=256` is large enough that any sensible application's component instances all stay cache-resident, while still capping memory in long-running processes that might derive prefixes from runtime inputs.

## Out of scope
Issue #127 task 1 (extract `RateLimiter._setup`) was investigated but does not apply: `RateLimiter.__init__` already takes a pre-built config (no env-resolution path), and `from_config` just calls `cls(name, config, backend=backend)`. There is no duplicated logic to extract today.

## Test plan
- [x] `uv run pytest tests/test_config.py` (51 tests, was 49 — two new identity tests).
- [x] `uv run pytest tests/` (1417 tests, 100% coverage).
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` clean.
- [x] Pre-commit hooks pass.