### PR TITLE
📝 Document the no-field-mirroring decision (closes #113)

### DIFF
--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -63,7 +63,7 @@ Runtime reconfiguration, when added, will atomically swap the `self._config` poi
 
 ### Why we don't copy fields to plain instance attrs
 
-`BaseModel.__getattr__` is measurably slower than a plain instance attribute lookup. The shortcut is to mirror every frozen field onto the component (`self._name = self._config.name`, ...) so hot paths read `self._name`. We don't take it, on purpose.
+Pydantic model attribute access is measurably slower than a plain instance attribute lookup, because field reads go through Pydantic's customized `__getattribute__` and `__pydantic_fields__` machinery. The shortcut is to mirror every frozen field onto the component (`self._name = self._config.name`, ...) so hot paths read `self._name`. We don't take it, on purpose.
 
 Typical numbers from `benchmarks/config_attr_benchmark.py` (Issue [#113](https://github.com/grelinfo/grelmicro/issues/113)) on a developer laptop:
 

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -53,13 +53,41 @@ A name that produces an empty segment or one starting with a digit is rejected a
 
 ## Hot-path discipline
 
-The config model is a frozen `BaseModel` with `extra="forbid"`. Field reads cost ~2 ns and account for ~1% of a 255 ns `RateLimitFilter.filter` call. This is the budget the design protects:
+The config model is a frozen `BaseModel` with `extra="forbid"`. The hot path holds one reference to that instance and reads attributes off it. This is the budget the design protects:
 
 - Validation runs once at construction, never on a request.
 - Env reads happen at construction, never on a request.
-- The hot path holds a reference to one Pydantic instance and reads attributes.
+- Resolution (kwargs > env > default) materialises into `self._config` and is never re-evaluated.
 
-This is why the resolution table (kwargs > env > default) is materialised into `self._config` and never re-evaluated. Runtime reconfiguration, when added, will atomically swap the `self._config` pointer without touching the resolution machinery.
+Runtime reconfiguration, when added, will atomically swap the `self._config` pointer without touching the resolution machinery.
+
+### Why we don't copy fields to plain instance attrs
+
+`BaseModel.__getattr__` is measurably slower than a plain instance attribute lookup. The shortcut is to mirror every frozen field onto the component (`self._name = self._config.name`, ...) so hot paths read `self._name`. We don't take it, on purpose.
+
+Typical numbers from `benchmarks/config_attr_benchmark.py` (Issue [#113](https://github.com/grelinfo/grelmicro/issues/113)) on a developer laptop:
+
+| Read pattern | ns / field | Ratio |
+|---|---:|---:|
+| Pydantic attr (`self._config.x`) | ~11 | 1.5× |
+| Plain attr (`self._x`) | ~7 | 1.0× |
+| Frozen slotted dataclass | ~8 | 1.2× |
+
+Realistic hot path: `RateLimitFilter.filter` per log record (~250 ns total):
+
+| | ns / call | Share |
+|---|---:|---:|
+| Total call | ~250 | 100% |
+| Minus the one config read | ~248 | ~99% |
+| **Config read cost** | **~2** | **<1%** |
+
+A ~2 ns saving per call disappears in the surrounding dict, lock, and math work. Against that:
+
+- **Duplicated state.** Each mirrored field stores its value twice (once on the frozen `BaseModel`, once in the component's `__dict__`). Trivial in absolute bytes, but two sources of truth where one would do.
+- **Code surface.** 43 hot-path reads across 5 modules become 43 mirror copies plus a duplication rule every new field has to follow.
+- **Desync risk.** A contributor who updates the Pydantic field and forgets the mirror introduces silent drift between `cb.config.x` and the cached `cb._x`.
+
+We keep `self._config` as the single source of truth. If a future profile shows config attribute access on the critical path of a tight loop where it actually matters, revisit per-call site, not as a sweeping refactor.
 
 ## Why `from_config` skips the env layer
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@
 ### Internal
 
 * ♻️ Add `grelmicro._config.env_opt_in_enabled()` helper that exposes the truthy `GREL_CONFIG_FROM_ENV` check (`1`, `true`, `yes`, `on`, case-insensitive). Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).
+* 📝 Document the "no field-mirroring" decision in `docs/architecture/config.md` with the benchmark numbers from `benchmarks/config_attr_benchmark.py`. Closes Issue [#113](https://github.com/grelinfo/grelmicro/issues/113) without code changes: hot-path config reads cost <1% of a real call (~2 ns out of ~250 ns), so we keep `self._config` as the single source of truth instead of copying frozen fields onto the component.
 * ⚡ Speed up the test suite from ~73s to ~19s by adding `pytest-xdist` (`-n auto` in `addopts`) and shrinking expiration sleeps in `tests/sync/test_backends.py`. Fix `--durations` reporting by removing the autouse `freeze_time` fixture: `@freeze_time()` decorator stays on the two tests that compare `datetime.now()`, the two tests that previously called `frozen_time.tick(...)` switch to `monkeypatch.setattr(circuitbreaker, "monotonic", ...)`. Issue [#125](https://github.com/grelinfo/grelmicro/issues/125).
 
 ## 0.18.0 - 2026-04-30


### PR DESCRIPTION
## Summary
Resolve issue #113 with documentation, not code. The issue asked whether to copy frozen `BaseModel` fields onto plain instance attrs to skip Pydantic's `__getattr__` overhead in hot paths, and explicitly invited closing the issue if the benchmark showed the win was negligible.

The benchmark already lives at `benchmarks/config_attr_benchmark.py`. Numbers (developer laptop):

| Read pattern | ns / field | Ratio |
|---|---:|---:|
| Pydantic attr (`self._config.x`) | ~11 | 1.5× |
| Plain attr (`self._x`) | ~7 | 1.0× |
| Frozen slotted dataclass | ~8 | 1.2× |

Realistic hot path (`RateLimitFilter.filter`, ~250 ns/call):

| | ns / call | Share |
|---|---:|---:|
| Total call | ~250 | 100% |
| Minus the one config read | ~248 | ~99% |
| **Config read cost** | **~2** | **<1%** |

A ~2 ns saving per call is lost in the dict / lock / math noise around it, while the field-copy pattern would add 43 mirror lines across 5 modules, duplicate state on every component instance, and create silent-desync risk for every new field.

## What changed
- New `### Why we don't copy fields to plain instance attrs` subsection in `docs/architecture/config.md` with the tables above and the three reasons (duplicated state, code surface, desync risk).
- Changelog entry under Unreleased > Internal explaining that #113 is closed without code changes and pointing future readers at the rationale.

## Test plan
- [x] `uv run --group docs mkdocs build --strict` clean.
- [x] No semicolons or em-dashes in the diff (sweep done).
- [x] Pre-commit hooks pass.