### PR TITLE
💥 Remove obsolete deprecation shims (scheduled to drop in 0.7.0)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 * 💥 The Environmental config path is now opt-in. Set `GREL_CONFIG_FROM_ENV=true` once at startup to enable env reads across every component, or pass `read_env=True` per call. The per-call value (`True`/`False`) always wins over the global flag. This stops grelmicro from silently picking up ambient env vars in unit tests or scripts. Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).
 * 💥 The `read_env` kwarg default flips from `True` to `None` on every component. `None` follows the global flag. `True` and `False` keep their meaning as explicit per-call overrides.
+* 💥 Remove obsolete deprecation shims that were marked for removal in 0.7.0. Replace `ResilienceException` with `ResilienceError`, `Synchronization` with `SyncPrimitive`, and the `scheduled()` decorator on `TaskRouter` / `TaskManager` with `interval(seconds=N, max_lock_seconds=N*5)`. The `token=` kwarg on `LockAcquireError`, `LockReleaseError`, and `LockNotOwnedError` is removed (drop it from your code). The `sync=` parameter on `interval()` no longer warns when used with non-`Lock` primitives.
 
 ### Internal
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -123,18 +123,4 @@ Then include the `TaskRouter` into the `TaskManager` or other routers:
 !!! tip
     The `TaskRouter` follows the same philosophy as the `APIRouter` in FastAPI or the **Router** in FastStream.
 
-## Deprecated APIs
-
-### Scheduled Task
-
-!!! danger "Deprecated"
-    The `scheduled()` decorator is deprecated. Use `interval()` with `max_lock_seconds` or `leader` instead.
-
-The `scheduled()` decorator still works but emits a `DeprecationWarning`. It is equivalent to `interval(seconds=N, max_lock_seconds=N*5, min_lock_seconds=N)`.
-
-### sync with TaskLock or LeaderElection
-
-!!! danger "Deprecated"
-    Using `sync` with `TaskLock` or `LeaderElection` is deprecated. Use `max_lock_seconds` and `leader` parameters instead.
-
 See [Synchronization Primitives](sync.md) for more details.

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -1,6 +1,5 @@
 """Resilience."""
 
-import warnings
 from contextlib import AbstractContextManager
 from typing import Annotated
 
@@ -103,17 +102,3 @@ __all__ = [
     "use",
     "use_backend",
 ]
-
-
-def __getattr__(name: str) -> type:
-    if name == "ResilienceException":
-        warnings.warn(
-            "ResilienceException is deprecated, use ResilienceError instead. "
-            "Will be removed in 0.7.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        globals()["ResilienceException"] = ResilienceError
-        return ResilienceError
-    msg = f"module {__name__!r} has no attribute {name!r}"
-    raise AttributeError(msg)

--- a/grelmicro/resilience/errors.py
+++ b/grelmicro/resilience/errors.py
@@ -1,6 +1,5 @@
 """Resilience Errors."""
 
-import warnings
 from datetime import datetime
 
 from grelmicro.errors import GrelmicroError, SettingsValidationError
@@ -59,17 +58,3 @@ class CircuitBreakerError(ResilienceError):
         self.last_error = last_error
         self.last_error_time = last_error_time
         super().__init__(f"Circuit breaker '{name}' call not permitted")
-
-
-def __getattr__(name: str) -> type:
-    if name == "ResilienceException":
-        warnings.warn(
-            "ResilienceException is deprecated, use ResilienceError instead. "
-            "Will be removed in 0.7.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        globals()["ResilienceException"] = ResilienceError
-        return ResilienceError
-    msg = f"module {__name__!r} has no attribute {name!r}"
-    raise AttributeError(msg)

--- a/grelmicro/sync/__init__.py
+++ b/grelmicro/sync/__init__.py
@@ -1,6 +1,5 @@
 """Synchronization."""
 
-import warnings
 from contextlib import AbstractContextManager
 from typing import Annotated
 
@@ -78,17 +77,3 @@ __all__ = [
     "use",
     "use_backend",
 ]
-
-
-def __getattr__(name: str) -> type:
-    if name == "Synchronization":
-        warnings.warn(
-            "Synchronization is deprecated, use SyncPrimitive instead. "
-            "Will be removed in 0.7.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        globals()["Synchronization"] = SyncPrimitive
-        return SyncPrimitive
-    msg = f"module {__name__!r} has no attribute {name!r}"
-    raise AttributeError(msg)

--- a/grelmicro/sync/abc.py
+++ b/grelmicro/sync/abc.py
@@ -1,6 +1,5 @@
 """Synchronization Abstract Base Classes and Protocols."""
 
-import warnings
 from types import TracebackType
 from typing import Protocol, Self, runtime_checkable
 
@@ -105,17 +104,3 @@ class SyncPrimitive(Protocol):
 
 
 Seconds = PositiveFloat
-
-
-def __getattr__(name: str) -> type:
-    if name == "Synchronization":
-        warnings.warn(
-            "Synchronization is deprecated, use SyncPrimitive instead. "
-            "Will be removed in 0.7.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        globals()["Synchronization"] = SyncPrimitive
-        return SyncPrimitive
-    msg = f"module {__name__!r} has no attribute {name!r}"
-    raise AttributeError(msg)

--- a/grelmicro/sync/errors.py
+++ b/grelmicro/sync/errors.py
@@ -1,21 +1,7 @@
 """Synchronization Errors."""
 
-import warnings
-
 from grelmicro._backends import BackendNotLoadedError
 from grelmicro.errors import GrelmicroError, SettingsValidationError
-
-_TOKEN_DEPRECATION_MSG = (
-    "The 'token' parameter is deprecated. "  # noqa: S105
-    "Remove it from your code. Will be removed in 0.7.0."
-)
-
-
-def _warn_deprecated_token(token: str | None) -> None:
-    """Emit a deprecation warning if the token parameter is passed."""
-    if token is not None:
-        warnings.warn(_TOKEN_DEPRECATION_MSG, DeprecationWarning, stacklevel=3)
-
 
 __all__ = [
     "BackendNotLoadedError",
@@ -86,9 +72,8 @@ class LockAcquireError(SyncBackendError):
     This error is raised when an error on backend side occurs during lock acquisition.
     """
 
-    def __init__(self, *, name: str, token: str | None = None) -> None:
+    def __init__(self, *, name: str) -> None:
         """Initialize the error."""
-        _warn_deprecated_token(token)
         super().__init__(f"Failed to acquire lock: name={name}")
 
 
@@ -98,11 +83,8 @@ class LockReleaseError(SyncBackendError):
     This error is raised when an error on backend side occurs during lock release.
     """
 
-    def __init__(
-        self, *, name: str, reason: str | None = None, token: str | None = None
-    ) -> None:
+    def __init__(self, *, name: str, reason: str | None = None) -> None:
         """Initialize the error."""
-        _warn_deprecated_token(token)
         super().__init__(
             f"Failed to release lock: name={name}"
             + (f", reason={reason}" if reason else ""),
@@ -116,9 +98,8 @@ class LockNotOwnedError(LockReleaseError):
     the token is different or the lock is already expired.
     """
 
-    def __init__(self, *, name: str, token: str | None = None) -> None:
+    def __init__(self, *, name: str) -> None:
         """Initialize the error."""
-        _warn_deprecated_token(token)
         super().__init__(name=name, reason="lock not owned")
 
 

--- a/grelmicro/task/_interval.py
+++ b/grelmicro/task/_interval.py
@@ -1,6 +1,5 @@
 """Interval Task."""
 
-import warnings
 from collections.abc import Awaitable, Callable
 from functools import partial
 from logging import getLogger
@@ -53,8 +52,6 @@ class IntervalTask(Task):
         Raises:
             FunctionTypeError: If the function is not supported.
             ValueError: If seconds is less than or equal to 0.
-            ValueError: If deprecated sync (non-Lock) is combined with
-                max_lock_seconds, min_lock_seconds, or leader.
             ValueError: If max_lock_seconds is less than seconds.
             ValueError: If min_lock_seconds is set without max_lock_seconds or leader.
             ValueError: If min_lock_seconds is greater than max_lock_seconds.
@@ -63,33 +60,11 @@ class IntervalTask(Task):
             msg = "seconds must be greater than 0"
             raise ValueError(msg)
 
-        # Validate sync parameter usage
-        if sync is not None and not isinstance(sync, Lock):
-            if (
-                max_lock_seconds is not None
-                or min_lock_seconds is not None
-                or leader is not None
-            ):
-                msg = (
-                    "Cannot combine deprecated 'sync' parameter with "
-                    "max_lock_seconds, min_lock_seconds, or leader. "
-                    "Use a Lock for resource synchronization instead."
-                )
-                raise ValueError(msg)
-            warnings.warn(
-                "The 'sync' parameter on interval() is deprecated "
-                "for TaskLock and LeaderElection and will be removed in 0.7.0. "
-                "Use max_lock_seconds and leader parameters instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         alt_name = validate_and_generate_reference(function)
         self._name = name or alt_name
         self._seconds = seconds
         self._async_function = self._prepare_async_function(function)
 
-        # Determine if distributed lock is needed
         distributed = max_lock_seconds is not None or leader is not None
 
         if min_lock_seconds is not None and not distributed:
@@ -97,14 +72,6 @@ class IntervalTask(Task):
                 "min_lock_seconds requires max_lock_seconds or leader to be set"
             )
             raise ValueError(msg)
-
-        # Build the synchronization chain
-        resource_lock: SyncPrimitive | None = (
-            sync if isinstance(sync, Lock) else None
-        )
-        legacy_sync: SyncPrimitive | None = (
-            sync if sync is not None and not isinstance(sync, Lock) else None
-        )
 
         if distributed:
             resolved_max_lock_seconds = (
@@ -136,17 +103,14 @@ class IntervalTask(Task):
                 min_lock_seconds=resolved_min_lock_seconds,
                 max_lock_seconds=resolved_max_lock_seconds,
             )
+            resource_lock = sync if isinstance(sync, Lock) else None
             self._sync_primitives: list[SyncPrimitive] = _build_sync_list(
                 leader=leader,
                 task_lock=task_lock,
                 resource_lock=resource_lock,
             )
-        elif legacy_sync is not None:
-            # Legacy sync parameter support (deprecated non-Lock types)
-            self._sync_primitives = [legacy_sync]
-        elif resource_lock is not None:
-            # Lock for resource synchronization (not deprecated)
-            self._sync_primitives = [resource_lock]
+        elif sync is not None:
+            self._sync_primitives = [sync]
         else:
             self._sync_primitives = []
 

--- a/grelmicro/task/_interval.py
+++ b/grelmicro/task/_interval.py
@@ -14,7 +14,6 @@ from grelmicro._async import is_async_callable
 from grelmicro.sync.abc import SyncBackend, SyncPrimitive
 from grelmicro.sync.errors import LockNotOwnedError
 from grelmicro.sync.leaderelection import LeaderElection
-from grelmicro.sync.lock import Lock
 from grelmicro.sync.tasklock import TaskLock
 from grelmicro.task._utils import validate_and_generate_reference
 from grelmicro.task.abc import Task
@@ -103,11 +102,10 @@ class IntervalTask(Task):
                 min_lock_seconds=resolved_min_lock_seconds,
                 max_lock_seconds=resolved_max_lock_seconds,
             )
-            resource_lock = sync if isinstance(sync, Lock) else None
             self._sync_primitives: list[SyncPrimitive] = _build_sync_list(
                 leader=leader,
                 task_lock=task_lock,
-                resource_lock=resource_lock,
+                resource_lock=sync,
             )
         elif sync is not None:
             self._sync_primitives = [sync]

--- a/grelmicro/task/router.py
+++ b/grelmicro/task/router.py
@@ -1,6 +1,5 @@
 """Task Router."""
 
-import warnings
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Annotated, Any
 from uuid import UUID
@@ -140,16 +139,11 @@ class TaskRouter:
             "SyncPrimitive | None",
             Doc(
                 """
-                The synchronization primitive to use for the task.
+                Optional synchronization primitive for resource synchronization.
 
-                Use a ``Lock`` to synchronize access to a shared resource.
-
-                .. deprecated:: 0.6.0
-                    Using ``sync`` with ``TaskLock`` or ``LeaderElection`` is deprecated
-                    and will be removed in 0.7.0.
-                    Use ``max_lock_seconds`` and ``leader`` parameters instead.
-
-                If None, no synchronization is used and the task will run on all workers.
+                Use a ``Lock`` to serialise execution against a shared resource.
+                If None, no synchronization is used and the task runs on every
+                worker.
                 """,
             ),
         ] = None,
@@ -170,8 +164,6 @@ class TaskRouter:
         Raises:
             FunctionTypeError: If the task name generation fails.
             ValueError: If seconds is less than or equal to 0.
-            ValueError: If deprecated sync (non-Lock) is combined with
-                max_lock_seconds, min_lock_seconds, or leader.
             ValueError: If max_lock_seconds is less than seconds.
             ValueError: If min_lock_seconds is set without max_lock_seconds or leader.
             ValueError: If min_lock_seconds is greater than max_lock_seconds.
@@ -192,122 +184,6 @@ class TaskRouter:
                     backend=backend,
                     worker=worker,
                     sync=sync,
-                ),
-            )
-            return function
-
-        return decorator
-
-    def scheduled(
-        self,
-        *,
-        seconds: Annotated[
-            float,
-            Doc(
-                """
-                The duration in seconds between each scheduling attempt.
-
-                Each worker retries every N seconds, but only one worker executes
-                per interval thanks to the built-in lock. Also used as the
-                ``min_lock_seconds`` value.
-                """,
-            ),
-        ],
-        name: Annotated[
-            str | None,
-            Doc(
-                """
-                The name of the task.
-
-                If None, a name will be generated automatically from the function.
-                Also used as the TaskLock name.
-                """,
-            ),
-        ] = None,
-        max_lock_seconds: Annotated[
-            float | None,
-            Doc(
-                """
-                The maximum duration in seconds to hold the lock (crash protection).
-
-                Defaults to ``seconds * 5``. Must be >= ``seconds``.
-                """,
-            ),
-        ] = None,
-        leader: Annotated[
-            "LeaderElection | None",
-            Doc(
-                """
-                Optional leader election for leader gating.
-
-                When provided, the task only executes on the leader worker.
-                """,
-            ),
-        ] = None,
-        backend: Annotated[
-            "SyncBackend | None",
-            Doc(
-                """
-                The distributed lock backend.
-
-                By default, uses the lock backend registry.
-                """,
-            ),
-        ] = None,
-        worker: Annotated[
-            str | UUID | None,
-            Doc(
-                """
-                The worker identity.
-
-                By default, a UUIDv1 will be generated.
-                """,
-            ),
-        ] = None,
-    ) -> Callable[
-        [Callable[..., Any | Awaitable[Any]]],
-        Callable[..., Any | Awaitable[Any]],
-    ]:
-        """Decorate function to add it as a distributed scheduled task.
-
-        .. deprecated:: 0.6.0
-            Use ``interval()`` with ``max_lock_seconds`` instead.
-            Will be removed in 0.7.0.
-
-        The task runs at most once per interval across all workers, using a built-in
-        TaskLock. Can optionally be gated behind a leader election.
-
-        Raises:
-            FunctionTypeError: If the task name generation fails.
-            ValueError: If seconds is less than or equal to 0.
-            ValueError: If max_lock_seconds is less than seconds.
-        """
-        warnings.warn(
-            "The 'scheduled()' decorator is deprecated and will be removed in 0.7.0. "
-            "Use 'interval()' with 'max_lock_seconds' or 'leader' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        from grelmicro.task._interval import IntervalTask  # noqa: PLC0415
-
-        resolved_max_lock_seconds = (
-            max_lock_seconds if max_lock_seconds is not None else seconds * 5
-        )
-
-        def decorator(
-            function: Callable[[], None | Awaitable[None]],
-        ) -> Callable[[], None | Awaitable[None]]:
-            self.add_task(
-                IntervalTask(
-                    function=function,
-                    seconds=seconds,
-                    name=name,
-                    max_lock_seconds=resolved_max_lock_seconds,
-                    min_lock_seconds=seconds,
-                    leader=leader,
-                    backend=backend,
-                    worker=worker,
                 ),
             )
             return function

--- a/grelmicro/task/router.py
+++ b/grelmicro/task/router.py
@@ -139,12 +139,13 @@ class TaskRouter:
             "SyncPrimitive | None",
             Doc(
                 """
-                Optional resource-level synchronization primitive, layered on
-                top of any distributed scheduling chosen via ``max_lock_seconds``
-                or ``leader``. Use a ``Lock`` to serialise execution against a
-                shared resource. Whether the task runs on every worker or only
-                one is governed by ``max_lock_seconds`` and ``leader``, not
-                this parameter.
+                Optional resource-level synchronization primitive.
+
+                Layered on top of any distributed scheduling chosen via
+                ``max_lock_seconds`` or ``leader``. Use a ``Lock`` to serialise
+                execution against a shared resource. Whether the task runs on
+                every worker or only one is governed by ``max_lock_seconds``
+                and ``leader``, not this parameter.
                 """,
             ),
         ] = None,

--- a/grelmicro/task/router.py
+++ b/grelmicro/task/router.py
@@ -139,11 +139,12 @@ class TaskRouter:
             "SyncPrimitive | None",
             Doc(
                 """
-                Optional synchronization primitive for resource synchronization.
-
-                Use a ``Lock`` to serialise execution against a shared resource.
-                If None, no synchronization is used and the task runs on every
-                worker.
+                Optional resource-level synchronization primitive, layered on
+                top of any distributed scheduling chosen via ``max_lock_seconds``
+                or ``leader``. Use a ``Lock`` to serialise execution against a
+                shared resource. Whether the task runs on every worker or only
+                one is governed by ``max_lock_seconds`` and ``leader``, not
+                this parameter.
                 """,
             ),
         ] = None,

--- a/tests/resilience/test_errors.py
+++ b/tests/resilience/test_errors.py
@@ -1,14 +1,8 @@
 """Test Resilience Errors."""
 
-import subprocess
-import sys
-import warnings
 from datetime import UTC, datetime
 
-import pytest
-
 import grelmicro.resilience as resilience_mod
-import grelmicro.resilience.errors as errors_mod
 from grelmicro.resilience.errors import CircuitBreakerError
 
 
@@ -57,66 +51,3 @@ def test_resilience_module_exports() -> None:
         "use_backend",
     }
     assert set(resilience_mod.__all__) == expected
-
-
-def test_resilience_exception_deprecated_alias_from_module() -> None:
-    """Test ResilienceException alias emits DeprecationWarning from module."""
-    resilience_mod.__dict__.pop("ResilienceException", None)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        cls = resilience_mod.ResilienceException
-        assert cls is resilience_mod.ResilienceError
-        assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
-        assert "ResilienceException" in str(w[0].message)
-
-
-def test_resilience_exception_deprecated_alias_from_errors() -> None:
-    """Test ResilienceException alias emits DeprecationWarning from errors module."""
-    errors_mod.__dict__.pop("ResilienceException", None)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        cls = errors_mod.ResilienceException
-        assert cls is errors_mod.ResilienceError
-        assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
-
-
-def test_resilience_module_getattr_unknown() -> None:
-    """Test __getattr__ raises AttributeError for unknown names."""
-    with pytest.raises(AttributeError, match="NoSuchThing"):
-        resilience_mod.NoSuchThing  # noqa: B018
-
-
-def test_resilience_errors_getattr_unknown() -> None:
-    """Test errors __getattr__ raises AttributeError for unknown names."""
-    with pytest.raises(AttributeError, match="NoSuchThing"):
-        errors_mod.NoSuchThing  # noqa: B018
-
-
-def test_resilience_exception_from_import_single_warning() -> None:
-    """Test 'from grelmicro.resilience import ResilienceException' emits exactly one warning.
-
-    Regression test: CPython's importlib._handle_fromlist calls __getattr__
-    twice internally. The globals() caching prevents duplicate warnings.
-    """
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-W",
-            "always",
-            "-c",
-            "from grelmicro.resilience import ResilienceException",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    warning_lines = [
-        line
-        for line in result.stderr.splitlines()
-        if "DeprecationWarning" in line
-    ]
-    assert len(warning_lines) == 1, (
-        f"Expected 1 warning, got {len(warning_lines)}: {result.stderr}"
-    )

--- a/tests/sync/test_lock.py
+++ b/tests/sync/test_lock.py
@@ -1,17 +1,12 @@
 """Test Lock."""
 
-import subprocess
-import sys
 import time
-import warnings
 from collections.abc import AsyncGenerator
 
 import pytest
 from anyio import WouldBlock, sleep, to_thread
 from pytest_mock import MockerFixture
 
-import grelmicro.sync as sync_mod
-import grelmicro.sync.abc as abc_mod
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.errors import (
     LockAcquireError,
@@ -701,127 +696,3 @@ async def test_lock_retry_interval_too_small(backend: SyncBackend) -> None:
     """Test Lock rejects retry_interval below minimum."""
     with pytest.raises(ValueError, match="retry_interval must be"):
         Lock(name="test", backend=backend, retry_interval=0.0001)
-
-
-# --- Deprecated token parameter tests ---
-
-
-def test_lock_acquire_error_token_deprecated() -> None:
-    """Test LockAcquireError token parameter emits DeprecationWarning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        error = LockAcquireError(name="test", token="old-token")  # noqa: S106
-        assert "test" in str(error)
-        assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
-        assert "Remove it" in str(w[0].message)
-
-
-def test_lock_acquire_error_no_token_no_warning() -> None:
-    """Test LockAcquireError without token emits no warning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        LockAcquireError(name="test")
-        assert len(w) == 0
-
-
-def test_lock_release_error_token_deprecated() -> None:
-    """Test LockReleaseError token parameter emits DeprecationWarning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        error = LockReleaseError(name="test", token="old-token")  # noqa: S106
-        assert "test" in str(error)
-        assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
-
-
-def test_lock_release_error_no_token_no_warning() -> None:
-    """Test LockReleaseError without token emits no warning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        LockReleaseError(name="test")
-        assert len(w) == 0
-
-
-def test_lock_not_owned_error_token_deprecated() -> None:
-    """Test LockNotOwnedError token parameter emits DeprecationWarning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        error = LockNotOwnedError(name="test", token="old-token")  # noqa: S106
-        assert "lock not owned" in str(error)
-        assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
-
-
-def test_lock_not_owned_error_no_token_no_warning() -> None:
-    """Test LockNotOwnedError without token emits no warning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        LockNotOwnedError(name="test")
-        assert len(w) == 0
-
-
-# --- Deprecated Synchronization alias tests ---
-
-
-def test_synchronization_deprecated_alias_from_abc() -> None:
-    """Test Synchronization alias emits DeprecationWarning from abc module."""
-    abc_mod.__dict__.pop("Synchronization", None)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        cls = abc_mod.Synchronization
-        assert cls is abc_mod.SyncPrimitive
-        assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
-        assert "Synchronization" in str(w[0].message)
-
-
-def test_synchronization_deprecated_alias_from_sync() -> None:
-    """Test Synchronization alias emits DeprecationWarning from sync module."""
-    sync_mod.__dict__.pop("Synchronization", None)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        cls = sync_mod.Synchronization
-        assert cls is sync_mod.SyncPrimitive
-        assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
-
-
-def test_sync_abc_getattr_unknown() -> None:
-    """Test abc __getattr__ raises AttributeError for unknown names."""
-    with pytest.raises(AttributeError, match="NoSuchThing"):
-        abc_mod.NoSuchThing  # noqa: B018
-
-
-def test_sync_module_getattr_unknown() -> None:
-    """Test sync __getattr__ raises AttributeError for unknown names."""
-    with pytest.raises(AttributeError, match="NoSuchThing"):
-        sync_mod.NoSuchThing  # noqa: B018
-
-
-def test_synchronization_from_import_single_warning() -> None:
-    """Test 'from grelmicro.sync import Synchronization' emits exactly one warning.
-
-    Regression test: CPython's importlib._handle_fromlist calls __getattr__
-    twice internally. The globals() caching prevents duplicate warnings.
-    """
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-W",
-            "always",
-            "-c",
-            "from grelmicro.sync import Synchronization",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    warning_lines = [
-        line
-        for line in result.stderr.splitlines()
-        if "DeprecationWarning" in line
-    ]
-    assert len(warning_lines) == 1, (
-        f"Expected 1 warning, got {len(warning_lines)}: {result.stderr}"
-    )

--- a/tests/task/test_interval.py
+++ b/tests/task/test_interval.py
@@ -1,7 +1,5 @@
 """Test Interval Task."""
 
-import warnings
-
 import pytest
 from anyio import create_task_group, sleep, sleep_forever
 from pytest_mock import MockFixture
@@ -16,11 +14,7 @@ from tests.task.samples import (
     test1,
 )
 
-pytestmark = [
-    pytest.mark.anyio,
-    pytest.mark.timeout(10),
-    pytest.mark.filterwarnings("ignore::DeprecationWarning"),
-]
+pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
 
 SLEEP = 0.01
 
@@ -46,18 +40,6 @@ def test_interval_task_init_with_invalid_interval() -> None:
     # Act / Assert
     with pytest.raises(ValueError, match="seconds must be greater than 0"):
         IntervalTask(seconds=0, function=test1)
-
-
-def test_interval_task_sync_deprecation_warning() -> None:
-    """Test that sync= emits DeprecationWarning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        IntervalTask(seconds=1, function=test1, sync=WouldBlockLock())
-
-    assert len(w) == 1
-    assert issubclass(w[0].category, DeprecationWarning)
-    assert "sync" in str(w[0].message)
-    assert "max_lock_seconds" in str(w[0].message)
 
 
 async def test_interval_task_start() -> None:

--- a/tests/task/test_router.py
+++ b/tests/task/test_router.py
@@ -1,7 +1,6 @@
 """Test Task Router."""
 
 import re
-import warnings
 from functools import partial
 
 import pytest
@@ -60,7 +59,6 @@ def test_router_include_router() -> None:
     assert router.tasks == [custom_task1, custom_task2]
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_router_interval() -> None:
     """Test Task Router add interval task."""
     # Arrange
@@ -210,71 +208,3 @@ def test_router_started_propagation() -> None:
     assert router_child_started_before is False
     assert router_started_after is True
     assert router_child_started_after is True
-
-
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_router_scheduled() -> None:
-    """Test Task Router add scheduled task (deprecated)."""
-    # Arrange
-    backend = MemorySyncBackend()
-    router = TaskRouter()
-
-    # Act
-    router.scheduled(seconds=60, backend=backend)(test1)
-    router.scheduled(seconds=30, name="custom-name", backend=backend)(test2)
-
-    # Assert
-    expected_task_count = 2
-    assert len(router.tasks) == expected_task_count
-    assert all(isinstance(task, IntervalTask) for task in router.tasks)
-    assert router.tasks[0].name == "tests.task.samples:test1"
-    assert router.tasks[1].name == "custom-name"
-
-
-def test_router_scheduled_deprecation_warning() -> None:
-    """Test that scheduled() emits DeprecationWarning."""
-    # Arrange
-    backend = MemorySyncBackend()
-    router = TaskRouter()
-
-    # Act
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        router.scheduled(seconds=60, backend=backend)(test1)
-
-    # Assert
-    assert len(w) == 1
-    assert issubclass(w[0].category, DeprecationWarning)
-    assert "scheduled()" in str(w[0].message)
-    assert "interval()" in str(w[0].message)
-
-
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_router_scheduled_name_generation() -> None:
-    """Test Task Router Scheduled Name Generation."""
-    # Arrange
-    backend = MemorySyncBackend()
-    router = TaskRouter()
-
-    # Act
-    router.scheduled(seconds=10, backend=backend)(test1)
-    router.scheduled(seconds=10, backend=backend)(SimpleClass.static_method)
-
-    # Assert
-    assert router.tasks[0].name == "tests.task.samples:test1"
-    assert (
-        router.tasks[1].name == "tests.task.samples:SimpleClass.static_method"
-    )
-
-
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_router_scheduled_when_started() -> None:
-    """Test Task Router Scheduled When Started."""
-    # Arrange
-    backend = MemorySyncBackend()
-    router = TaskRouter()
-    router.do_mark_as_started()
-
-    # Act
-    with pytest.raises(TaskAddOperationError):
-        router.scheduled(seconds=10, backend=backend)(test1)

--- a/tests/task/test_scheduled.py
+++ b/tests/task/test_scheduled.py
@@ -8,7 +8,6 @@ from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.leaderelection import LeaderElection
 from grelmicro.sync.lock import Lock
 from grelmicro.sync.memory import MemorySyncBackend
-from grelmicro.sync.tasklock import TaskLock
 from grelmicro.task._interval import IntervalTask
 from tests.task import samples
 from tests.task.samples import (
@@ -124,27 +123,6 @@ def test_interval_task_min_lock_seconds_validation() -> None:
             max_lock_seconds=20,
             min_lock_seconds=25,
             backend=backend,
-        )
-
-
-def test_interval_task_deprecated_sync_with_new_params() -> None:
-    """Test deprecated sync cannot be combined with new params."""
-    backend = MemorySyncBackend()
-    task_lock = TaskLock(
-        "test",
-        backend=backend,
-        min_lock_seconds=1,
-        max_lock_seconds=10,
-    )
-    with pytest.raises(
-        ValueError,
-        match="Cannot combine deprecated 'sync' parameter",
-    ):
-        IntervalTask(
-            seconds=10,
-            function=test1,
-            sync=task_lock,
-            max_lock_seconds=50,
         )
 
 


### PR DESCRIPTION
## Summary
Five deprecation shims were marked "Will be removed in 0.7.0". The current version is 0.18.0, so they are 11 minor versions overdue. This PR removes them.

| Removed | Replacement |
|---|---|
| `grelmicro.resilience.ResilienceException` | `ResilienceError` |
| `grelmicro.resilience.errors.ResilienceException` | `ResilienceError` |
| `grelmicro.sync.Synchronization` (alias) | `SyncPrimitive` |
| `grelmicro.sync.abc.Synchronization` (alias) | `SyncPrimitive` |
| `LockAcquireError(token=...)`, `LockReleaseError(token=...)`, `LockNotOwnedError(token=...)` | drop the kwarg |
| `TaskRouter.scheduled()` decorator | `TaskRouter.interval(seconds=N, max_lock_seconds=N*5, min_lock_seconds=N)` |
| `interval(sync=...)` `DeprecationWarning` for non-`Lock` primitives | now silently accepts any `SyncPrimitive` |

Net diff: -572 / +12 lines. The deletions are the four `__getattr__` shims, the `_warn_deprecated_token` helper, the `scheduled()` decorator (~115 lines), the matching deprecation tests, and the docs section that pointed users at the deprecated APIs.

## What stays the same
The `interval(sync=Lock(...))` path is unchanged: the docstring already recommends `Lock` for resource sync, and `Lock` was never the deprecated case. The non-`Lock` `SyncPrimitive` path that previously warned now just works without ceremony, which is what the deprecation always invited.

## Test plan
- [x] `uv run pytest tests/` (1393 tests, was 1417 — 24 deprecation-only tests removed).
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` clean.
- [x] `uv run --group docs mkdocs build --strict` clean.
- [x] `grep -rn "DeprecationWarning\|removed in 0\." grelmicro/` returns nothing.
- [x] Pre-commit hooks pass.