### PR TITLE
🙈 Ignore xdist coverage shards and HTML coverage in git and VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@ wheels/
 
 # Coverage
 cov.xml
+coverage.xml
 .coverage
+.coverage.*
+htmlcov/
 
 # Mkdocs
 site/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,11 @@
     "**/.mypy_cache": true,
     "**/.pytest_cache": true,
     "**/.ruff_cache": true,
-    ".coverage": true
+    "**/.coverage": true,
+    "**/.coverage.*": true,
+    "**/coverage.xml": true,
+    "**/cov.xml": true,
+    "**/htmlcov": true
   },
 
   // Python settings


### PR DESCRIPTION
## Summary
With `pytest-xdist` enabled by default (PR #146), each worker writes a sharded `.coverage.HOSTNAME.PID.RANDOM` file before pytest-cov combines them. Those shards were not in `.gitignore`, so a Ctrl-C run leaves them in the working tree. Same story for the optional `htmlcov/` directory and the `coverage.xml` filename pytest-cov uses by default (we already had `cov.xml`, but tooling can produce either).

VSCode's `files.exclude` was hiding the root `.coverage` only; switched all coverage entries to `**/<pattern>` so they match nested too, and added the same set covered by `.gitignore`.

## Diff
- `.gitignore`: add `coverage.xml`, `.coverage.*`, `htmlcov/`.
- `.vscode/settings.json`: switch `.coverage` to `**/.coverage`; add `**/.coverage.*`, `**/coverage.xml`, `**/cov.xml`, `**/htmlcov`.

## Test plan
- [x] Pre-commit hooks pass.