### PR TITLE
📝 docs: Release 0.19.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.19.0 - 2026-05-01
+
+Cleans out the long-deprecated APIs (`ResilienceException`, `Synchronization`, `scheduled()`, the `token=` kwarg) ahead of the 1.0.0 design work, ships a 3.4× speedup on env-driven config construction, and brings the test suite under 20s for contributors.
+
 ### Breaking
 
 * 💥 The Environmental config path is now opt-in. Set `GREL_CONFIG_FROM_ENV=true` once at startup to enable env reads across every component, or pass `read_env=True` per call. The per-call value (`True`/`False`) always wins over the global flag. This stops grelmicro from silently picking up ambient env vars in unit tests or scripts. Issue [#142](https://github.com/grelinfo/grelmicro/issues/142).


### PR DESCRIPTION
## Summary
Stage the 0.19.0 release by promoting the `Unreleased` section in `docs/changelog.md` to `## 0.19.0 - 2026-05-01` and adding a one-line headline. No code changes.

## Headline

> Cleans out the long-deprecated APIs (\`ResilienceException\`, \`Synchronization\`, \`scheduled()\`, the \`token=\` kwarg) ahead of the 1.0.0 design work, ships a 3.4× speedup on env-driven config construction, and brings the test suite under 20s for contributors.

## Contents

3 breaking changes:
- Environmental config opt-in (`GREL_CONFIG_FROM_ENV`) (#142)
- `read_env=` default `True` → `None`
- Removed obsolete deprecation shims marked for 0.7.0 (#149)

6 internal:
- `env_opt_in_enabled()` helper (#142)
- Test suite 73s → 19s with pytest-xdist + freeze_time fixes (#125)
- `_build_settings_cls` `lru_cache(maxsize=256)`, 3.4× faster `Lock("cart")` env-path (#119)
- Rename `parent_config` → `merged_config`, document `# type: ignore` (#127)
- No-field-mirroring decision documented in `docs/architecture/config.md` (#113)
- Zero test warnings (testcontainers banner filtered, unawaited-sleep mock fixed)

## Out of scope
The 0.18.0 milestone closes 5/5 with #127 closed alongside this PR (effectively done in #147 — see issue comment for the rationale).

## Test plan
- [x] `mkdocs build --strict` clean.
- [x] Pre-commit hooks pass.