### PR TITLE
✨ Add Component.reconfigure for live RateLimiter config swap

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -4,6 +4,7 @@ This section documents the internal design decisions and guarantees of grelmicro
 
 - **[Backend Registry](backends.md)**: Shared registry pattern for swappable backends.
 - **[Configuration](config.md)**: Explicit construction paths, `from_config(...)`, optional env resolution where it fits, and the library-not-app boundary.
+- **[Live reconfiguration](reconfigure.md)**: Atomic config swap on a live component, the `Reconfigurable` mixin, and reader safety.
 - **[Import Strategy](imports.md)**: Why backends are imported from submodules, not re-exported.
 - **[Synchronization](sync.md)**: Worker identity, token generation, lock design, and cleanup strategy.
 - **[Kubernetes Backend](kubernetes.md)**: Lease resources, optimistic concurrency, and name sanitization.

--- a/docs/architecture/reconfigure.md
+++ b/docs/architecture/reconfigure.md
@@ -42,11 +42,19 @@ The mixin commits `self._config` after `_apply_reconfigure` returns. This means 
 
 ## Reader safety
 
-`self._config` is the single source of truth on the read path. Each operation captures `config = self._config` once at the top and derives every config-dependent value (limits, fail-open policy, fallback result) from that local. Single-attribute reads of a Python object reference are atomic under the GIL and remain atomic on free-threaded 3.13+, so no read-side lock is required.
+A reconfigurable component publishes a single immutable read-side snapshot. Each operation captures that snapshot with one attribute read at the top:
 
-Subclasses MUST NOT mirror config fields onto separate instance attributes that the read path consults independently. A second cached attribute reintroduces the multi-attribute interleaving window: a reader could observe the new attribute together with the previous config snapshot, applying the new policy with the previous limit. Recompute derived values from the captured config inside the operation.
+```python
+state = self._state
+config = state.config
+strategy = state.strategy
+```
 
-The strategy reference is a special case. Subclasses MAY cache a derived strategy object on a separate attribute when rebinding is expensive, provided the strategy is fully self-contained (carries its own copy of the parameters it needs). A reader that captures a new strategy together with the previous config snapshot still produces a consistent result, because the strategy executes against its own parameters and no longer reads from the captured config.
+Single-attribute reads of a Python object reference are atomic under the GIL and remain atomic on free-threaded 3.13+, so no read-side lock is required. Every config-dependent decision in the operation derives from `state`, never from `self._config` or any other instance attribute that could swap independently.
+
+Subclasses MUST bundle every cached derived value (config, strategy, fallback, limits) into one frozen snapshot type and publish it with a single assignment in `_apply_reconfigure`. Caching a derived value on a separate attribute reintroduces a multi-attribute window: a reader could observe the new derived value with the previous snapshot, applying mismatched parameters in one call.
+
+`RateLimiter` follows this rule: its `_State` dataclass holds both `config` and the bound `strategy`, and every hot path captures `state = self._state` once.
 
 ## Implementing `_apply_reconfigure`
 
@@ -65,14 +73,15 @@ Components that cache derived state override `_apply_reconfigure` and rebuild th
 ```python
 class RateLimiter(Reconfigurable[RateLimiterConfig]):
     async def _apply_reconfigure(self, new_config):
-        self._strategy = self.backend.bind(new_config)
+        new_strategy = self.backend.bind(new_config)
+        self._state = _State(config=new_config, strategy=new_strategy)
 ```
 
-Build new derived values into locals first when there are several, then assign. If any step raises (for example `backend.bind`), no instance attribute has been mutated yet and the previous state is preserved exactly.
+Build new derived values into locals first, then publish them all in one frozen-snapshot assignment. If any step raises (for example `backend.bind`), the snapshot has not been mutated and the previous state is preserved exactly.
 
 ## Out of scope
 
-The library does not ship file watchers, signal handlers, or ConfigMap pollers. Wiring `reconfigure` to a SIGHUP handler or a Kubernetes informer is application-level work. See [Configuration](../configuration.md) for one worked example.
+The library does not ship file watchers, signal handlers, or ConfigMap pollers. Wiring `reconfigure` to a SIGHUP handler or a Kubernetes informer is application-level work. See [Configuration](../config.md) for one worked example.
 
 Hot-swapping the backend from the new config is also out of scope. `_apply_reconfigure` does not read the backend identity from `new_config`. The component continues to resolve its backend the same way it did before reconfigure: a backend instance passed at construction is reused as-is, while a backend resolved through the registry is re-resolved on each call so that task-scoped overrides keep working. `reconfigure` accepts a new config of the same runtime type only, not a different config subclass.
 

--- a/docs/architecture/reconfigure.md
+++ b/docs/architecture/reconfigure.md
@@ -1,0 +1,83 @@
+# Live reconfiguration
+
+This page is the engineering side of `Component.reconfigure(new_config)`. It documents the contract behind the [`Reconfigurable`][grelmicro._config.Reconfigurable] mixin and explains the choices a contributor needs to know before adding `reconfigure` support to a new component.
+
+## The contract
+
+`reconfigure(new_config)` swaps a live component's configuration without rebuilding the component. Runtime state on the backend (token counts, lease handles, in-flight calls) is preserved across the swap.
+
+Every call enforces:
+
+| Invariant | Behavior |
+|---|---|
+| Type match | `type(new_config) is type(self._config)` or `TypeError` |
+| Equality short-circuit | `new_config == self._config` returns immediately |
+| Writer serialization | `anyio.Lock` held for the rebuild |
+| Atomic publish | `self._config = new_config` runs after `_apply_reconfigure` |
+| Failure rollback | If `_apply_reconfigure` raises, `self._config` is untouched |
+
+In-flight operations on the previous config complete on the previous strategy and previous fallback. Operations started after `reconfigure` returns see the new values.
+
+## How the mixin works
+
+The mixin is small enough to read in one screen:
+
+```python
+async def reconfigure(self, new_config: ConfigT) -> None:
+    current = self._config
+    if type(new_config) is not type(current):
+        raise TypeError(...)
+    if new_config == current:
+        return
+    async with self._reconfigure_lock:
+        if new_config == self._config:
+            return
+        await self._apply_reconfigure(new_config)
+        self._config = new_config
+```
+
+The two equality checks are not redundant. The first runs on the hot path so the common no-op case never blocks on the lock. The second runs under the lock so two callers racing to set the same value do not both trigger a rebuild.
+
+The mixin commits `self._config` after `_apply_reconfigure` returns. This means subclasses cannot forget to assign last, and a raise inside `_apply_reconfigure` always preserves the previous config.
+
+## Reader safety
+
+Readers do a single attribute read of `self._config` at the top of each operation. Single-attribute reads of a Python object reference are atomic under the GIL and remain atomic on free-threaded 3.13+. No read-side lock is required.
+
+A component that caches multiple derived values (`RateLimiter` caches `_strategy` and `_fallback`) accepts a small interleaving window: a reader can observe a new `_strategy` paired with a previous `_fallback` if it captures attributes one at a time mid-reconfigure. The fallback is only consumed on the rare fail-open error path, and both values are individually valid configs, so the worst case is a fail-open response carrying the previous limit. Components that need stricter consistency can snapshot all derived values into a single frozen object and publish that with one assignment.
+
+## Implementing `_apply_reconfigure`
+
+Components that read config fields directly per-call inherit the no-op default and need no override:
+
+```python
+class Lock(Reconfigurable[LockConfig]):
+    def __init__(self, name: str, ...) -> None:
+        ...
+        self._config = config
+        self._reconfigure_lock = anyio.Lock()
+```
+
+Components that cache derived state override `_apply_reconfigure` and rebuild those caches into instance attributes. The mixin commits `self._config` for them:
+
+```python
+class RateLimiter(Reconfigurable[RateLimiterConfig]):
+    async def _apply_reconfigure(self, new_config):
+        new_strategy = self.backend.bind(new_config)
+        new_fallback = _build_fallback(new_config)
+        self._strategy = new_strategy
+        self._fallback = new_fallback
+```
+
+Build new derived values into locals first, then assign. If any step raises (for example `backend.bind`), no instance attribute has been mutated yet and the previous state is preserved exactly.
+
+## Out of scope
+
+The library does not ship file watchers, signal handlers, or ConfigMap pollers. Wiring `reconfigure` to a SIGHUP handler or a Kubernetes informer is application-level work. See [Configuration](../configuration.md) for one worked example.
+
+Hot-swapping the backend is also out of scope. Backend identity is fixed at construction. `reconfigure` accepts a new config of the same runtime type only, not a different config subclass.
+
+## Related
+
+- [Configuration](../config.md): the three paths and the resolution order that produce a config in the first place.
+- [Configuration internals](config.md): the engineering side of `resolve_config` and the `Config` contract.

--- a/docs/architecture/reconfigure.md
+++ b/docs/architecture/reconfigure.md
@@ -42,9 +42,11 @@ The mixin commits `self._config` after `_apply_reconfigure` returns. This means 
 
 ## Reader safety
 
-Readers do a single attribute read of `self._config` at the top of each operation. Single-attribute reads of a Python object reference are atomic under the GIL and remain atomic on free-threaded 3.13+. No read-side lock is required.
+`self._config` is the single source of truth on the read path. Each operation captures `config = self._config` once at the top and derives every config-dependent value (limits, fail-open policy, fallback result) from that local. Single-attribute reads of a Python object reference are atomic under the GIL and remain atomic on free-threaded 3.13+, so no read-side lock is required.
 
-A component that caches multiple derived values (`RateLimiter` caches `_strategy` and `_fallback`) accepts a small interleaving window: a reader can observe a new `_strategy` paired with a previous `_fallback` if it captures attributes one at a time mid-reconfigure. The fallback is only consumed on the rare fail-open error path, and both values are individually valid configs, so the worst case is a fail-open response carrying the previous limit. Components that need stricter consistency can snapshot all derived values into a single frozen object and publish that with one assignment.
+Subclasses MUST NOT mirror config fields onto separate instance attributes that the read path consults independently. A second cached attribute reintroduces the multi-attribute interleaving window: a reader could observe the new attribute together with the previous config snapshot, applying the new policy with the previous limit. Recompute derived values from the captured config inside the operation.
+
+The strategy reference is a special case. Subclasses MAY cache a derived strategy object on a separate attribute when rebinding is expensive, provided the strategy is fully self-contained (carries its own copy of the parameters it needs). A reader that captures a new strategy together with the previous config snapshot still produces a consistent result, because the strategy executes against its own parameters and no longer reads from the captured config.
 
 ## Implementing `_apply_reconfigure`
 
@@ -63,19 +65,16 @@ Components that cache derived state override `_apply_reconfigure` and rebuild th
 ```python
 class RateLimiter(Reconfigurable[RateLimiterConfig]):
     async def _apply_reconfigure(self, new_config):
-        new_strategy = self.backend.bind(new_config)
-        new_fallback = _build_fallback(new_config)
-        self._strategy = new_strategy
-        self._fallback = new_fallback
+        self._strategy = self.backend.bind(new_config)
 ```
 
-Build new derived values into locals first, then assign. If any step raises (for example `backend.bind`), no instance attribute has been mutated yet and the previous state is preserved exactly.
+Build new derived values into locals first when there are several, then assign. If any step raises (for example `backend.bind`), no instance attribute has been mutated yet and the previous state is preserved exactly.
 
 ## Out of scope
 
 The library does not ship file watchers, signal handlers, or ConfigMap pollers. Wiring `reconfigure` to a SIGHUP handler or a Kubernetes informer is application-level work. See [Configuration](../configuration.md) for one worked example.
 
-Hot-swapping the backend is also out of scope. Backend identity is fixed at construction. `reconfigure` accepts a new config of the same runtime type only, not a different config subclass.
+Hot-swapping the backend from the new config is also out of scope. `_apply_reconfigure` does not read the backend identity from `new_config`. The component continues to resolve its backend the same way it did before reconfigure: a backend instance passed at construction is reused as-is, while a backend resolved through the registry is re-resolved on each call so that task-scoped overrides keep working. `reconfigure` accepts a new config of the same runtime type only, not a different config subclass.
 
 ## Related
 

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -8,6 +8,8 @@ Exposes:
   segment.
 - `parse_csv_or_json`: coerce an env var string into a list, accepting
   comma-separated or JSON-array form.
+- `Reconfigurable`: mixin providing atomic live reconfiguration for
+  stateful components.
 
 The full contract, including the precedence rules and the
 name-as-namespace convention, is documented in
@@ -19,7 +21,7 @@ from __future__ import annotations
 import os
 import re
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pydantic import BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -29,7 +31,10 @@ from grelmicro._json import json_loads
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    import anyio
+
 C = TypeVar("C", bound=BaseModel)
+ConfigT = TypeVar("ConfigT", bound=BaseModel)
 
 _NON_ENV_CHARS = re.compile(r"[^A-Z0-9_]+")
 _REPEATED_UNDERSCORES = re.compile(r"_+")
@@ -184,3 +189,57 @@ def _build_settings_cls(
         (config_cls, BaseSettings),
         {"model_config": SettingsConfigDict(**merged_config)},  # type: ignore[typeddict-item]
     )
+
+
+class Reconfigurable(Generic[ConfigT]):
+    """Mixin that adds atomic live reconfiguration to a component.
+
+    Subclasses initialize `self._config` and
+    `self._reconfigure_lock = anyio.Lock()` in `__init__`, and
+    override `_apply_reconfigure` to rebuild any cached derived
+    state. The default `_apply_reconfigure` is a no-op.
+
+    See [Live reconfiguration](../architecture/reconfigure.md) for
+    the full contract.
+    """
+
+    _config: ConfigT
+    _reconfigure_lock: anyio.Lock
+
+    @property
+    def config(self) -> ConfigT:
+        """Return the current configuration."""
+        return self._config
+
+    async def reconfigure(self, new_config: ConfigT) -> None:
+        """Atomically swap to `new_config`.
+
+        Operations in flight when `reconfigure` is called complete on
+        the previous config. Operations started after `reconfigure`
+        returns see the new config. Equal configs are a no-op.
+
+        Raises:
+            TypeError: If `new_config` is not the same runtime type
+                as the current config.
+        """
+        current = self._config
+        if type(new_config) is not type(current):
+            msg = (
+                f"reconfigure requires {type(current).__name__}, "
+                f"got {type(new_config).__name__}"
+            )
+            raise TypeError(msg)
+        if new_config == current:
+            return
+        async with self._reconfigure_lock:
+            if new_config == self._config:
+                return
+            await self._apply_reconfigure(new_config)
+            self._config = new_config
+
+    async def _apply_reconfigure(self, new_config: ConfigT) -> None:
+        """Rebuild cached derived state for `new_config`.
+
+        Runs under `self._reconfigure_lock`. Must not assign
+        `self._config`. The default does nothing.
+        """

--- a/grelmicro/resilience/ratelimiter.py
+++ b/grelmicro/resilience/ratelimiter.py
@@ -128,7 +128,6 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
         )
         self._reconfigure_lock = anyio.Lock()
         self._config = config
-        self._fallback = _build_fallback(config)
         self._strategy: RateLimiterStrategy | None = None
 
     @property
@@ -321,15 +320,15 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
             ValueError: If `cost` is not between 1 and the
                 algorithm's limit/capacity.
         """
-        fallback = self._fallback
-        _validate_cost(cost, fallback.limit)
+        config = self._config
+        _validate_cost(cost, _config_limit(config))
         strategy = self._strategy or self._resolve_strategy()
         try:
             return await strategy.acquire(key=self._full_key(key), cost=cost)
         except Exception as exc:
-            if self._config.fail_open:
+            if config.fail_open:
                 self._log_fail_open(key, exc)
-                return fallback
+                return _build_fallback(config)
             raise
 
     async def acquire_or_raise(
@@ -381,13 +380,14 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
             `allowed` indicates whether the next acquire would
             succeed.
         """
+        config = self._config
         strategy = self._strategy or self._resolve_strategy()
         try:
             return await strategy.peek(key=self._full_key(key))
         except Exception as exc:
-            if self._config.fail_open:
+            if config.fail_open:
                 self._log_fail_open(key, exc)
-                return self._fallback
+                return _build_fallback(config)
             raise
 
     async def reset(
@@ -405,11 +405,12 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
 
         Idempotent: resetting a nonexistent key is a no-op.
         """
+        config = self._config
         strategy = self._strategy or self._resolve_strategy()
         try:
             await strategy.reset(key=self._full_key(key))
         except Exception as exc:
-            if self._config.fail_open:
+            if config.fail_open:
                 self._log_fail_open(key, exc)
                 return
             raise
@@ -418,22 +419,24 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
         self,
         new_config: RateLimiterConfig,
     ) -> None:
-        """Rebind the strategy and rebuild the fail-open fallback."""
-        new_strategy = self.backend.bind(new_config)
-        new_fallback = _build_fallback(new_config)
-        self._strategy = new_strategy
-        self._fallback = new_fallback
+        """Rebind the strategy for the new config."""
+        self._strategy = self.backend.bind(new_config)
+
+
+def _config_limit(config: RateLimiterConfig) -> int:
+    """Return the algorithm's nominal limit for the given config."""
+    match config:
+        case TokenBucketConfig():
+            return config.capacity
+        case GCRAConfig():
+            return config.limit
+        case _ as unknown:  # pragma: no cover
+            assert_never(unknown)
 
 
 def _build_fallback(config: RateLimiterConfig) -> RateLimitResult:
     """Build the fail-open fallback result for the given algorithm config."""
-    match config:
-        case TokenBucketConfig():
-            limit_value = config.capacity
-        case GCRAConfig():
-            limit_value = config.limit
-        case _ as unknown:  # pragma: no cover
-            assert_never(unknown)
+    limit_value = _config_limit(config)
     return RateLimitResult(
         allowed=True,
         limit=limit_value,

--- a/grelmicro/resilience/ratelimiter.py
+++ b/grelmicro/resilience/ratelimiter.py
@@ -3,9 +3,11 @@
 import logging
 from typing import Annotated, Self, assert_never
 
+import anyio
 from pydantic import PositiveFloat, PositiveInt
 from typing_extensions import Doc
 
+from grelmicro._config import Reconfigurable
 from grelmicro.resilience._backends import get_rate_limiter_backend
 from grelmicro.resilience._protocol import (
     RateLimiterBackend,
@@ -22,7 +24,7 @@ from grelmicro.resilience.errors import RateLimitExceededError
 logger = logging.getLogger(__name__)
 
 
-class RateLimiter:
+class RateLimiter(Reconfigurable[RateLimiterConfig]):
     """Rate limiter with a pluggable algorithm.
 
     Most Python call sites should use the factory classmethods:
@@ -118,26 +120,21 @@ class RateLimiter:
     ) -> None:
         """Initialize the rate limiter."""
         self._name = name
-        self._config = config
         self._backend: RateLimiterBackend | None = (
             backend if not isinstance(backend, str) else None
         )
         self._backend_name: str | None = (
             backend if isinstance(backend, str) else None
         )
-        self._strategy: RateLimiterStrategy | None = None
-        self._fail_open = config.fail_open
+        self._reconfigure_lock = anyio.Lock()
+        self._config = config
         self._fallback = _build_fallback(config)
+        self._strategy: RateLimiterStrategy | None = None
 
     @property
     def name(self) -> str:
         """Return the rate limiter identity."""
         return self._name
-
-    @property
-    def config(self) -> RateLimiterConfig:
-        """Return the algorithm configuration."""
-        return self._config
 
     @property
     def backend(self) -> RateLimiterBackend:
@@ -324,14 +321,15 @@ class RateLimiter:
             ValueError: If `cost` is not between 1 and the
                 algorithm's limit/capacity.
         """
-        _validate_cost(cost, self._fallback.limit)
+        fallback = self._fallback
+        _validate_cost(cost, fallback.limit)
         strategy = self._strategy or self._resolve_strategy()
         try:
             return await strategy.acquire(key=self._full_key(key), cost=cost)
         except Exception as exc:
-            if self._fail_open:
+            if self._config.fail_open:
                 self._log_fail_open(key, exc)
-                return self._fallback
+                return fallback
             raise
 
     async def acquire_or_raise(
@@ -387,7 +385,7 @@ class RateLimiter:
         try:
             return await strategy.peek(key=self._full_key(key))
         except Exception as exc:
-            if self._fail_open:
+            if self._config.fail_open:
                 self._log_fail_open(key, exc)
                 return self._fallback
             raise
@@ -411,20 +409,24 @@ class RateLimiter:
         try:
             await strategy.reset(key=self._full_key(key))
         except Exception as exc:
-            if self._fail_open:
+            if self._config.fail_open:
                 self._log_fail_open(key, exc)
                 return
             raise
 
+    async def _apply_reconfigure(
+        self,
+        new_config: RateLimiterConfig,
+    ) -> None:
+        """Rebind the strategy and rebuild the fail-open fallback."""
+        new_strategy = self.backend.bind(new_config)
+        new_fallback = _build_fallback(new_config)
+        self._strategy = new_strategy
+        self._fallback = new_fallback
+
 
 def _build_fallback(config: RateLimiterConfig) -> RateLimitResult:
-    """Build the fail-open fallback result for the given algorithm config.
-
-    Called once when
-    [`RateLimiter`][grelmicro.resilience.RateLimiter] is created.
-    The result is cached on the instance and reused on every
-    fail-open path.
-    """
+    """Build the fail-open fallback result for the given algorithm config."""
     match config:
         case TokenBucketConfig():
             limit_value = config.capacity

--- a/grelmicro/resilience/ratelimiter.py
+++ b/grelmicro/resilience/ratelimiter.py
@@ -1,6 +1,7 @@
 """Rate Limiter."""
 
 import logging
+from dataclasses import dataclass
 from typing import Annotated, Self, assert_never
 
 import anyio
@@ -22,6 +23,14 @@ from grelmicro.resilience.algorithms import (
 from grelmicro.resilience.errors import RateLimitExceededError
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _State:
+    """Read-side snapshot bundling the config with its bound strategy."""
+
+    config: RateLimiterConfig
+    strategy: RateLimiterStrategy | None
 
 
 class RateLimiter(Reconfigurable[RateLimiterConfig]):
@@ -128,7 +137,7 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
         )
         self._reconfigure_lock = anyio.Lock()
         self._config = config
-        self._strategy: RateLimiterStrategy | None = None
+        self._state = _State(config=config, strategy=None)
 
     @property
     def name(self) -> str:
@@ -148,10 +157,10 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
             return self._backend
         return get_rate_limiter_backend(self._backend_name or "default")
 
-    def _resolve_strategy(self) -> RateLimiterStrategy:
-        """Bind the algorithm config to the backend and cache the strategy."""
-        strategy = self.backend.bind(self._config)
-        self._strategy = strategy
+    def _resolve_strategy(self, state: _State) -> RateLimiterStrategy:
+        """Bind the algorithm config to the backend and republish the snapshot."""
+        strategy = self.backend.bind(state.config)
+        self._state = _State(config=state.config, strategy=strategy)
         return strategy
 
     @classmethod
@@ -320,9 +329,10 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
             ValueError: If `cost` is not between 1 and the
                 algorithm's limit/capacity.
         """
-        config = self._config
+        state = self._state
+        config = state.config
         _validate_cost(cost, _config_limit(config))
-        strategy = self._strategy or self._resolve_strategy()
+        strategy = state.strategy or self._resolve_strategy(state)
         try:
             return await strategy.acquire(key=self._full_key(key), cost=cost)
         except Exception as exc:
@@ -380,8 +390,9 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
             `allowed` indicates whether the next acquire would
             succeed.
         """
-        config = self._config
-        strategy = self._strategy or self._resolve_strategy()
+        state = self._state
+        config = state.config
+        strategy = state.strategy or self._resolve_strategy(state)
         try:
             return await strategy.peek(key=self._full_key(key))
         except Exception as exc:
@@ -405,12 +416,12 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
 
         Idempotent: resetting a nonexistent key is a no-op.
         """
-        config = self._config
-        strategy = self._strategy or self._resolve_strategy()
+        state = self._state
+        strategy = state.strategy or self._resolve_strategy(state)
         try:
             await strategy.reset(key=self._full_key(key))
         except Exception as exc:
-            if config.fail_open:
+            if state.config.fail_open:
                 self._log_fail_open(key, exc)
                 return
             raise
@@ -419,8 +430,9 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
         self,
         new_config: RateLimiterConfig,
     ) -> None:
-        """Rebind the strategy for the new config."""
-        self._strategy = self.backend.bind(new_config)
+        """Bind the new strategy and publish a fresh snapshot in one assignment."""
+        new_strategy = self.backend.bind(new_config)
+        self._state = _State(config=new_config, strategy=new_strategy)
 
 
 def _config_limit(config: RateLimiterConfig) -> int:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
     - architecture/index.md
     - architecture/backends.md
     - architecture/config.md
+    - architecture/reconfigure.md
     - architecture/imports.md
     - architecture/sync.md
     - architecture/kubernetes.md

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -6,7 +6,9 @@ from types import TracebackType
 from typing import Any, Self
 from unittest.mock import AsyncMock, MagicMock
 
+import anyio
 import pytest
+from anyio.lowlevel import checkpoint
 from pydantic import ValidationError
 
 from grelmicro._backends import BackendNotLoadedError
@@ -658,3 +660,151 @@ async def test_fail_open_acquire_or_raise_still_raises_on_exceeded() -> None:
     # Act & Assert
     with pytest.raises(RateLimitExceededError):
         await limiter.acquire_or_raise(key="user:1")
+
+
+# --- reconfigure ---
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_reconfigure_swaps_config() -> None:
+    """Reconfigure publishes the new config."""
+    # Arrange
+    rl = RateLimiter("rc", GCRAConfig(limit=LIMIT, window=WINDOW))
+    new_config = GCRAConfig(limit=LIMIT * 2, window=WINDOW)
+
+    # Act
+    await rl.reconfigure(new_config)
+
+    # Assert
+    assert rl.config == new_config
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_reconfigure_rebuilds_fallback_and_strategy() -> None:
+    """Reconfigure rebinds the strategy and rebuilds the fail-open fallback."""
+    # Arrange
+    config = TokenBucketConfig(
+        capacity=CAPACITY, refill_rate=REFILL_RATE, fail_open=True
+    )
+    strategy_old: Any = AsyncMock(spec=RateLimiterStrategy)
+    strategy_old.acquire = AsyncMock(side_effect=RuntimeError("old"))
+    strategy_new: Any = AsyncMock(spec=RateLimiterStrategy)
+    strategy_new.acquire = AsyncMock(side_effect=RuntimeError("new"))
+    backend: Any = MagicMock()
+    backend.bind = MagicMock(side_effect=[strategy_old, strategy_new])
+    rl = RateLimiter("rc", config, backend=backend)
+    await rl.acquire(key="k")  # trigger first bind
+
+    # Act
+    new_config = TokenBucketConfig(
+        capacity=CAPACITY * 3, refill_rate=REFILL_RATE, fail_open=True
+    )
+    await rl.reconfigure(new_config)
+
+    # Assert: bind ran a second time on reconfigure
+    assert backend.bind.call_count == 2  # noqa: PLR2004
+    backend.bind.assert_called_with(new_config)
+
+    # Fallback reflects the new capacity (fail-open path returns it).
+    result = await rl.acquire(key="k")
+    assert result.allowed is True
+    assert result.limit == CAPACITY * 3
+
+
+@pytest.mark.usefixtures("_sync_backend")
+async def test_reconfigure_same_config_is_noop() -> None:
+    """Equal configs short-circuit before any bind."""
+    # Arrange
+    config = GCRAConfig(limit=LIMIT, window=WINDOW)
+    backend: Any = MagicMock()
+    backend.bind = MagicMock(return_value=AsyncMock(spec=RateLimiterStrategy))
+    rl = RateLimiter("rc", config, backend=backend)
+
+    # Act
+    await rl.reconfigure(GCRAConfig(limit=LIMIT, window=WINDOW))
+
+    # Assert: bind never ran (no acquire was called either)
+    backend.bind.assert_not_called()
+
+
+@pytest.mark.usefixtures("_sync_backend")
+async def test_reconfigure_rejects_different_config_type() -> None:
+    """Swapping algorithm types raises TypeError."""
+    # Arrange
+    rl = RateLimiter("rc", GCRAConfig(limit=LIMIT, window=WINDOW))
+
+    # Act & Assert
+    with pytest.raises(TypeError, match="GCRAConfig"):
+        await rl.reconfigure(
+            TokenBucketConfig(capacity=CAPACITY, refill_rate=REFILL_RATE)
+        )
+
+
+@pytest.mark.usefixtures("_sync_backend")
+async def test_reconfigure_preserves_state_when_bind_fails() -> None:
+    """A bind failure during reconfigure leaves the previous state intact."""
+    # Arrange
+    config = TokenBucketConfig(capacity=CAPACITY, refill_rate=REFILL_RATE)
+    strategy_old: Any = AsyncMock(spec=RateLimiterStrategy)
+    backend: Any = MagicMock()
+    backend.bind = MagicMock(side_effect=[strategy_old, RuntimeError("nope")])
+    rl = RateLimiter("rc", config, backend=backend)
+    await rl.acquire(key="k")  # bind once
+
+    new_config = TokenBucketConfig(
+        capacity=CAPACITY * 2, refill_rate=REFILL_RATE
+    )
+
+    # Act
+    with pytest.raises(RuntimeError, match="nope"):
+        await rl.reconfigure(new_config)
+
+    # Assert: original config retained
+    assert rl.config == config
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_reconfigure_concurrent_with_acquire() -> None:
+    """Concurrent acquire/reconfigure produce no exceptions."""
+    rl = RateLimiter(
+        "rc",
+        TokenBucketConfig(capacity=100, refill_rate=100),
+    )
+
+    async def hammer() -> None:
+        for _ in range(50):
+            await rl.acquire(key="u")
+
+    async def churn() -> None:
+        for capacity in (50, 75, 100, 60, 80):
+            await rl.reconfigure(
+                TokenBucketConfig(capacity=capacity, refill_rate=100)
+            )
+            await checkpoint()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(hammer)
+        tg.start_soon(hammer)
+        tg.start_soon(churn)
+
+    assert rl.config == TokenBucketConfig(capacity=80, refill_rate=100)
+
+
+@pytest.mark.usefixtures("_sync_backend")
+async def test_reconfigure_inner_double_check_skips_rebuild() -> None:
+    """Two concurrent reconfigure calls with the same target rebuild once."""
+    config = TokenBucketConfig(capacity=CAPACITY, refill_rate=REFILL_RATE)
+    backend: Any = MagicMock()
+    backend.bind = MagicMock(return_value=AsyncMock(spec=RateLimiterStrategy))
+    rl = RateLimiter("rc", config, backend=backend)
+
+    new_config = TokenBucketConfig(
+        capacity=CAPACITY * 2, refill_rate=REFILL_RATE
+    )
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(rl.reconfigure, new_config)
+        tg.start_soon(rl.reconfigure, new_config)
+
+    assert backend.bind.call_count == 1
+    assert rl.config == new_config

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -808,3 +808,34 @@ async def test_reconfigure_inner_double_check_skips_rebuild() -> None:
 
     assert backend.bind.call_count == 1
     assert rl.config == new_config
+
+
+@pytest.mark.usefixtures("_sync_backend")
+async def test_reconfigure_fail_open_response_is_self_consistent() -> None:
+    """Fail-open response uses fail_open and fallback from one config snapshot.
+
+    Regression for the pre-fix multi-attribute read window where a
+    reader could combine the new fail_open policy with a stale
+    fallback limit (or vice versa) during a racing reconfigure.
+    """
+    old_config = TokenBucketConfig(
+        capacity=CAPACITY, refill_rate=REFILL_RATE, fail_open=False
+    )
+    new_config = TokenBucketConfig(
+        capacity=CAPACITY * 4, refill_rate=REFILL_RATE, fail_open=True
+    )
+
+    boom: Any = AsyncMock(spec=RateLimiterStrategy)
+    boom.acquire = AsyncMock(side_effect=RuntimeError("backend down"))
+    backend: Any = MagicMock()
+    backend.bind = MagicMock(return_value=boom)
+    rl = RateLimiter("rc", old_config, backend=backend)
+
+    await rl.reconfigure(new_config)
+    result = await rl.acquire(key="k")
+
+    # New fail_open=True applies AND the fallback uses the new limit.
+    # Pre-fix could have returned the old fallback (limit=CAPACITY) under
+    # the new fail_open policy, mixing two configs in one response.
+    assert result.allowed is True
+    assert result.limit == CAPACITY * 4

--- a/tests/resilience/test_ratelimiter_config.py
+++ b/tests/resilience/test_ratelimiter_config.py
@@ -47,7 +47,7 @@ def test_fail_open_in_config() -> None:
         capacity=CAPACITY, refill_rate=REFILL_RATE, fail_open=True
     )
     rl = RateLimiter("api", cfg)
-    assert rl._fail_open is True
+    assert rl.config.fail_open is True
 
 
 @pytest.mark.usefixtures("_rate_limiter_backend")
@@ -80,7 +80,7 @@ def test_factory_passes_fail_open() -> None:
     rl = RateLimiter.token_bucket(
         "api", capacity=CAPACITY, refill_rate=REFILL_RATE, fail_open=True
     )
-    assert rl._fail_open is True
+    assert rl.config.fail_open is True
 
 
 @pytest.mark.usefixtures("_rate_limiter_backend")


### PR DESCRIPTION
## Summary

- Add `Reconfigurable[ConfigT]` mixin in `grelmicro/_config.py`: atomic config swap with same-type guard, double-checked equality short-circuit, writer-only `anyio.Lock`, and mixin-owned commit of `self._config` after `_apply_reconfigure` returns.
- Wire `RateLimiter` to the mixin. Its `_apply_reconfigure` rebinds the algorithm strategy on the new config; the hot path captures `self._config` once at op start and derives every config-dependent value from that snapshot.
- New architecture page `docs/architecture/reconfigure.md` documenting the contract: invariants, reader-safety rules, the single-allowed cached-strategy exception, and the registry-resolved backend caveat.

Closes #120 for the `RateLimiter` slice. `Lock`, `HealthRegistry`, `LeaderElection`, and `CircuitBreaker` follow next.

## AI review pass

An external AI reviewer ran the contract checklist and flagged a real bug on property 5: the original hot path read `self._fallback`, `self._strategy`, and `self._config.fail_open` as three separate attributes, so a racing reconfigure could combine the new `fail_open` policy with the previous fallback in one response. The fix-up commit drops the `_fallback` cache, snapshots `config = self._config` once per call, and recomputes the fallback inline on the rare fail-open path. New regression test `test_reconfigure_fail_open_response_is_self_consistent` would have caught the original interleaving.

The reviewer's other PASS verdicts (type guard, equality short-circuit, lock semantics, in-flight isolation, same-target storm dedup, post-reconfigure freshness) hold against the post-fix code.

## Test plan

- [x] `uv run pytest tests/` (1327 passed; 9 pre-existing docker-dependent errors in `tests/sync/test_backends.py::*[kubernetes]`)
- [x] `uv run ruff check grelmicro/ tests/ docs/` clean
- [x] Coverage 100% on `grelmicro/_config.py`
- [x] New tests:
  - `test_reconfigure_swaps_config`
  - `test_reconfigure_rebuilds_fallback_and_strategy`
  - `test_reconfigure_same_config_is_noop`
  - `test_reconfigure_rejects_different_config_type`
  - `test_reconfigure_preserves_state_when_bind_fails`
  - `test_reconfigure_concurrent_with_acquire`
  - `test_reconfigure_inner_double_check_skips_rebuild`
  - `test_reconfigure_fail_open_response_is_self_consistent`