### PR TITLE
✨ Extend Reconfigurable to Lock, TaskLock, and LeaderElection

### DIFF
--- a/docs/architecture/reconfigure.md
+++ b/docs/architecture/reconfigure.md
@@ -42,7 +42,25 @@ The mixin commits `self._config` after `_apply_reconfigure` returns. This means 
 
 ## Reader safety
 
-A reconfigurable component publishes a single immutable read-side snapshot. Each operation captures that snapshot with one attribute read at the top:
+A reconfigurable component publishes a single immutable read-side snapshot. Every public operation captures that snapshot with one attribute read at the top, then derives every config-dependent decision from the local. The same rule applies to internal helpers called by an operation: they receive the snapshot as a parameter rather than re-reading `self._config`.
+
+Single-attribute reads of a Python object reference are atomic under the GIL and remain atomic on free-threaded 3.13+, so no read-side lock is required.
+
+The snapshot has two shapes depending on whether the component caches derived state.
+
+**Components without derived state** capture the config directly:
+
+```python
+async def acquire(self) -> None:
+    config = self._config
+    token = generate_task_token(config.worker)
+    while not await self.do_acquire(token, duration=config.lease_duration):
+        await sleep(config.retry_interval)
+```
+
+Pass the relevant fields (or the whole `config`) to internal helpers so a concurrent `reconfigure` cannot change behavior mid-call. `Lock`, `TaskLock`, and `LeaderElection` follow this pattern.
+
+**Components with cached derived state** publish a frozen snapshot type:
 
 ```python
 state = self._state
@@ -50,15 +68,13 @@ config = state.config
 strategy = state.strategy
 ```
 
-Single-attribute reads of a Python object reference are atomic under the GIL and remain atomic on free-threaded 3.13+, so no read-side lock is required. Every config-dependent decision in the operation derives from `state`, never from `self._config` or any other instance attribute that could swap independently.
-
 Subclasses MUST bundle every cached derived value (config, strategy, fallback, limits) into one frozen snapshot type and publish it with a single assignment in `_apply_reconfigure`. Caching a derived value on a separate attribute reintroduces a multi-attribute window: a reader could observe the new derived value with the previous snapshot, applying mismatched parameters in one call.
 
 `RateLimiter` follows this rule: its `_State` dataclass holds both `config` and the bound `strategy`, and every hot path captures `state = self._state` once.
 
 ## Implementing `_apply_reconfigure`
 
-Components that read config fields directly per-call inherit the no-op default and need no override:
+Components without cached derived state inherit the no-op default. The only requirement on the subclass is to capture `self._config` once at the top of every public operation, as described in [Reader safety](#reader-safety):
 
 ```python
 class Lock(Reconfigurable[LockConfig]):
@@ -66,6 +82,14 @@ class Lock(Reconfigurable[LockConfig]):
         ...
         self._config = config
         self._reconfigure_lock = anyio.Lock()
+```
+
+A subclass MAY still override `_apply_reconfigure` to enforce per-field invariants on the swap. `Lock`, `TaskLock`, and `LeaderElection` reject changes to `worker` because the field is part of the live token identity:
+
+```python
+async def _apply_reconfigure(self, new_config: LockConfig) -> None:
+    if new_config.worker != self._config.worker:
+        raise ValueError(...)
 ```
 
 Components that cache derived state override `_apply_reconfigure` and rebuild those caches into instance attributes. The mixin commits `self._config` for them:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+* ✨ Add `reconfigure(new_config)` to `Lock`, `TaskLock`, and `LeaderElection` for atomic live config swap. The `worker` field is fixed for the lifetime of the instance: only timing fields can change. Issue [#158](https://github.com/grelinfo/grelmicro/issues/158).
+
 ## 0.19.0 - 2026-05-01
 
 Cleans out the long-deprecated APIs (`ResilienceException`, `Synchronization`, `scheduled()`, the `token=` kwarg) ahead of the 1.0.0 design work, ships a 3.4× speedup on env-driven config construction, and brings the test suite under 20s for contributors.

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -376,7 +376,7 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
         """
         if not self._is_leader:
             return False
-        return not self._is_renew_deadline_reached()
+        return not self._is_renew_deadline_reached(self._config)
 
     async def wait_for_leader(self) -> None:
         """Wait until the current worker is the leader."""
@@ -387,7 +387,10 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
     async def wait_lose_leader(self) -> None:
         """Wait until the current worker is no longer the leader."""
         while self.is_leader():
-            with move_on_after(self._seconds_before_expiration_deadline()):
+            config = self._config
+            with move_on_after(
+                self._seconds_before_expiration_deadline(config)
+            ):
                 async with self._state_change_condition:
                     await self._state_change_condition.wait()
 
@@ -403,8 +406,9 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
         logger.info("Leader Election started: %s", self.name)
         try:
             while True:
-                await self._try_acquire_or_renew()
-                await sleep(self._config.retry_interval)
+                config = self._config
+                await self._try_acquire_or_renew(config)
+                await sleep(config.retry_interval)
         except get_cancelled_exc_class():
             logger.info("Leader Election stopped: %s", self.name)
             raise
@@ -438,22 +442,22 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
         async with self._state_change_condition:
             self._state_change_condition.notify_all()
 
-    async def _try_acquire_or_renew(self) -> None:
-        """Try to acquire leadership."""
+    async def _try_acquire_or_renew(self, config: LeaderElectionConfig) -> None:
+        """Try to acquire leadership using `config` as the operation snapshot."""
         backend = self.backend
         try:
-            with fail_after(self._config.backend_timeout):
+            with fail_after(config.backend_timeout):
                 is_leader = await backend.acquire(
                     name=self._lock_name,
-                    token=str(self._config.worker),
-                    duration=self._config.lease_duration,
+                    token=str(config.worker),
+                    duration=config.lease_duration,
                 )
         except Exception:
-            if self._check_error_interval():
+            if self._check_error_interval(config):
                 logger.exception(
                     "Leader Election failed to acquire lock: %s", self.name
                 )
-            if self._is_renew_deadline_reached():
+            if self._is_renew_deadline_reached(config):
                 await self._update_state(
                     is_leader=False,
                     reason_if_no_more_leader="renew deadline reached",
@@ -464,26 +468,25 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
                 reason_if_no_more_leader="lock not acquired",
             )
 
-    def _seconds_before_expiration_deadline(self) -> float:
+    def _seconds_before_expiration_deadline(
+        self, config: LeaderElectionConfig
+    ) -> float:
         return max(
-            self._state_updated_at + self._config.lease_duration - monotonic(),
+            self._state_updated_at + config.lease_duration - monotonic(),
             0,
         )
 
-    def _check_error_interval(self) -> bool:
+    def _check_error_interval(self, config: LeaderElectionConfig) -> bool:
         """Check if the cooldown interval allows to log the error."""
         is_logging_allowed = (
             not self._error_logged_at
-            or (monotonic() - self._error_logged_at)
-            > self._config.error_interval
+            or (monotonic() - self._error_logged_at) > config.error_interval
         )
         self._error_logged_at = monotonic()
         return is_logging_allowed
 
-    def _is_renew_deadline_reached(self) -> bool:
-        return (
-            monotonic() - self._state_updated_at
-        ) >= self._config.renew_deadline
+    def _is_renew_deadline_reached(self, config: LeaderElectionConfig) -> bool:
+        return (monotonic() - self._state_updated_at) >= config.renew_deadline
 
     def guard(self) -> "_LeaderGuard":
         """Return a non-blocking synchronization guard.
@@ -513,11 +516,12 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
         if backend is None:
             # Nothing was acquired, nothing to release.
             return
+        config = self._config
         try:
-            with fail_after(self._config.backend_timeout):
+            with fail_after(config.backend_timeout):
                 if not (
                     await backend.release(
-                        name=self._lock_name, token=str(self._config.worker)
+                        name=self._lock_name, token=str(config.worker)
                     )
                 ):
                     logger.info(

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -6,6 +6,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Annotated, Self
 from uuid import UUID
 
+import anyio
 from anyio import (
     TASK_STATUS_IGNORED,
     CancelScope,
@@ -20,7 +21,7 @@ from anyio.abc import TaskStatus
 from pydantic import model_validator
 from typing_extensions import Doc
 
-from grelmicro._config import env_segment, resolve_config
+from grelmicro._config import Reconfigurable, env_segment, resolve_config
 from grelmicro.sync._backends import get_sync_backend
 from grelmicro.sync._base import BaseLockConfig
 from grelmicro.sync.abc import Seconds, SyncBackend, SyncPrimitive
@@ -95,11 +96,18 @@ class LeaderElectionConfig(BaseLockConfig, frozen=True, extra="forbid"):  # ty: 
         return self
 
 
-class LeaderElection(SyncPrimitive, Task):
+class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
     """Leader Election.
 
     The leader election is a synchronization primitive with the worker as scope.
     It runs as a task to acquire or renew the distributed lock.
+
+    Supports live reconfiguration via
+    [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
+    A swap takes effect on the next iteration of the renew loop. The
+    `worker` field is fixed for the lifetime of the instance:
+    changing it raises `ValueError`. See
+    [Live reconfiguration](../architecture/reconfigure.md).
     """
 
     _LOCK_PREFIX = "leader"
@@ -303,6 +311,7 @@ class LeaderElection(SyncPrimitive, Task):
         """Wire the validated config and runtime deps onto the instance."""
         self._name = name
         self._config = config
+        self._reconfigure_lock = anyio.Lock()
         self._lock_name = f"{self._LOCK_PREFIX}:{name}"
         self._backend: SyncBackend | None = (
             backend if not isinstance(backend, str) else None
@@ -318,11 +327,6 @@ class LeaderElection(SyncPrimitive, Task):
         self._error_logged_at: float | None = None
         self._task_group: TaskGroup | None = None
         self._exit_stack: AsyncExitStack | None = None
-
-    @property
-    def config(self) -> LeaderElectionConfig:
-        """Return the leader election config."""
-        return self._config
 
     async def __aenter__(self) -> Self:
         """Wait for the leader with the context manager."""
@@ -491,6 +495,18 @@ class LeaderElection(SyncPrimitive, Task):
         the guard skips the current tick and retries on the next interval.
         """
         return _LeaderGuard(self)
+
+    async def _apply_reconfigure(
+        self, new_config: LeaderElectionConfig
+    ) -> None:
+        """Validate the immutable `worker` field before publishing `new_config`."""
+        if new_config.worker != self._config.worker:
+            msg = (
+                f"reconfigure cannot change worker "
+                f"({self._config.worker!r} -> {new_config.worker!r}). "
+                f"Reuse the existing worker on the new config."
+            )
+            raise ValueError(msg)
 
     async def _release(self) -> None:
         backend = self._backend

--- a/grelmicro/sync/lock.py
+++ b/grelmicro/sync/lock.py
@@ -298,12 +298,14 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             LockAcquireError: If the lock cannot be acquired due to an error on the backend.
 
         """
+        config = self._config
         task_id = get_current_task().id
         if task_id in self._held_by_tasks:
             raise LockReentrantError(name=self._name)
-        token = generate_task_token(self._config.worker)
-        while not await self.do_acquire(token=token):  # noqa: ASYNC110 // Polling is intentional
-            await sleep(self._config.retry_interval)
+        token = generate_task_token(config.worker)
+        duration = config.lease_duration
+        while not await self.do_acquire(token=token, duration=duration):  # noqa: ASYNC110 // Polling is intentional
+            await sleep(config.retry_interval)
         self._held_by_tasks.add(task_id)
 
     async def acquire_nowait(self) -> None:
@@ -314,11 +316,14 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             WouldBlock: If the lock cannot be acquired without blocking.
             LockAcquireError: If the lock cannot be acquired due to an error on the backend.
         """
+        config = self._config
         task_id = get_current_task().id
         if task_id in self._held_by_tasks:
             raise LockReentrantError(name=self._name)
-        token = generate_task_token(self._config.worker)
-        if not await self.do_acquire(token=token):
+        token = generate_task_token(config.worker)
+        if not await self.do_acquire(
+            token=token, duration=config.lease_duration
+        ):
             msg = f"Lock not acquired: name={self._name}, token={token}"
             raise WouldBlock(msg)
         self._held_by_tasks.add(task_id)
@@ -361,10 +366,18 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         """
         return await self.do_owned(generate_task_token(self._config.worker))
 
-    async def do_acquire(self, token: str) -> bool:
+    async def do_acquire(self, token: str, *, duration: Seconds) -> bool:
         """Acquire the lock.
 
         This method should not be called directly. Use `acquire` instead.
+
+        Args:
+            token: The token to register on the backend.
+            duration: The lease duration to request, in seconds. The
+                caller captures this from `self._config.lease_duration`
+                at the start of the operation so the request is
+                consistent across retries even when `reconfigure`
+                runs concurrently.
 
         Returns:
             bool: True if the lock was acquired, False if the lock was not acquired.
@@ -377,7 +390,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             return await backend.acquire(
                 name=self._lock_name,
                 token=token,
-                duration=self._config.lease_duration,
+                duration=duration,
             )
         except Exception as exc:
             raise LockAcquireError(name=self._name) from exc
@@ -426,9 +439,9 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             )
             raise ValueError(msg)
 
-    def _thread_token(self, thread_id: int) -> str:
-        """Build a thread token from the worker identity and the given thread ID."""
-        return f"{self._config.worker}:thread:{thread_id}"
+    def _thread_token(self, thread_id: int, worker: str | UUID) -> str:
+        """Build a thread token from a worker identity and the given thread ID."""
+        return f"{worker}:thread:{thread_id}"
 
     async def do_thread_acquire(self, thread_id: int) -> None:
         """Acquire the lock from a worker thread (blocking).
@@ -440,11 +453,13 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
             LockAcquireError: If the lock cannot be acquired due to an error on the backend.
         """
+        config = self._config
         if thread_id in self._held_by_threads:
             raise LockReentrantError(name=self._name)
-        token = self._thread_token(thread_id)
-        while not await self.do_acquire(token=token):  # noqa: ASYNC110 // Polling is intentional
-            await sleep(self._config.retry_interval)
+        token = self._thread_token(thread_id, config.worker)
+        duration = config.lease_duration
+        while not await self.do_acquire(token=token, duration=duration):  # noqa: ASYNC110 // Polling is intentional
+            await sleep(config.retry_interval)
         self._held_by_threads.add(thread_id)
 
     async def do_thread_acquire_nowait(self, thread_id: int) -> None:
@@ -458,10 +473,13 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             WouldBlock: If the lock cannot be acquired without blocking.
             LockAcquireError: If the lock cannot be acquired due to an error on the backend.
         """
+        config = self._config
         if thread_id in self._held_by_threads:
             raise LockReentrantError(name=self._name)
-        token = self._thread_token(thread_id)
-        if not await self.do_acquire(token=token):
+        token = self._thread_token(thread_id, config.worker)
+        if not await self.do_acquire(
+            token=token, duration=config.lease_duration
+        ):
             msg = f"Lock not acquired: name={self._name}, token={token}"
             raise WouldBlock(msg)
         self._held_by_threads.add(thread_id)
@@ -476,7 +494,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             LockNotOwnedError: If the lock is not owned by the current token.
             LockReleaseError: If the lock cannot be released due to an error on the backend.
         """
-        token = self._thread_token(thread_id)
+        token = self._thread_token(thread_id, self._config.worker)
         # Local ownership is cleared only after the backend has
         # responded. A backend error keeps the marker so the caller
         # can retry release.
@@ -552,5 +570,5 @@ class ThreadLockAdapter:
         """Return True if the lock is currently held by the current worker thread."""
         return from_thread.run(
             self._lock.do_owned,
-            self._lock._thread_token(get_ident()),  # noqa: SLF001
+            self._lock._thread_token(get_ident(), self._lock._config.worker),  # noqa: SLF001
         )

--- a/grelmicro/sync/lock.py
+++ b/grelmicro/sync/lock.py
@@ -5,11 +5,12 @@ from types import TracebackType
 from typing import Annotated, Self
 from uuid import UUID
 
+import anyio
 from anyio import WouldBlock, from_thread, get_current_task, sleep
 from pydantic import model_validator
 from typing_extensions import Doc
 
-from grelmicro._config import env_segment, resolve_config
+from grelmicro._config import Reconfigurable, env_segment, resolve_config
 from grelmicro.sync._backends import get_sync_backend
 from grelmicro.sync._base import BaseLock, BaseLockConfig
 from grelmicro.sync._tokens import generate_task_token
@@ -56,12 +57,19 @@ class LockConfig(BaseLockConfig, frozen=True, extra="forbid"):  # ty: ignore[inv
         return self
 
 
-class Lock(BaseLock):
+class Lock(Reconfigurable[LockConfig], BaseLock):
     """Lock.
 
     This lock is a distributed lock that is used to acquire a resource across multiple workers. The
     lock is acquired asynchronously and can be extended multiple times manually. The lock is
     automatically released after a duration if not extended.
+
+    Supports live reconfiguration via
+    [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
+    A swap takes effect on the next `acquire`, `release`, and retry
+    sleep. The `worker` field is fixed for the lifetime of the
+    instance: changing it raises `ValueError`. See
+    [Live reconfiguration](../architecture/reconfigure.md).
     """
 
     _LOCK_PREFIX = "lock"
@@ -220,6 +228,7 @@ class Lock(BaseLock):
         """Wire the validated config and runtime deps onto the instance."""
         self._name = name
         self._config = config
+        self._reconfigure_lock = anyio.Lock()
         self._lock_name = f"{self._LOCK_PREFIX}:{name}"
         self._backend: SyncBackend | None = (
             backend if not isinstance(backend, str) else None
@@ -273,11 +282,6 @@ class Lock(BaseLock):
 
         """
         await self.release()
-
-    @property
-    def config(self) -> LockConfig:
-        """Return the lock config."""
-        return self._config
 
     @property
     def from_thread(self) -> "ThreadLockAdapter":
@@ -411,6 +415,16 @@ class Lock(BaseLock):
             return await backend.owned(name=self._lock_name, token=token)
         except Exception as exc:
             raise LockOwnedCheckError(name=self._name) from exc
+
+    async def _apply_reconfigure(self, new_config: LockConfig) -> None:
+        """Validate the immutable `worker` field before publishing `new_config`."""
+        if new_config.worker != self._config.worker:
+            msg = (
+                f"reconfigure cannot change worker "
+                f"({self._config.worker!r} -> {new_config.worker!r}). "
+                f"Reuse the existing worker on the new config."
+            )
+            raise ValueError(msg)
 
     def _thread_token(self, thread_id: int) -> str:
         """Build a thread token from the worker identity and the given thread ID."""

--- a/grelmicro/sync/tasklock.py
+++ b/grelmicro/sync/tasklock.py
@@ -11,11 +11,12 @@ from types import TracebackType
 from typing import Annotated, Self
 from uuid import UUID
 
+import anyio
 from anyio import WouldBlock, from_thread
 from pydantic import model_validator
 from typing_extensions import Doc
 
-from grelmicro._config import env_segment, resolve_config
+from grelmicro._config import Reconfigurable, env_segment, resolve_config
 from grelmicro.sync._backends import get_sync_backend
 from grelmicro.sync._base import BaseLockConfig
 from grelmicro.sync._tokens import (
@@ -67,7 +68,7 @@ class TaskLockConfig(BaseLockConfig, frozen=True, extra="forbid"):  # ty: ignore
         return self
 
 
-class TaskLock(SyncPrimitive):
+class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
     """Task Lock.
 
     A distributed lock for scheduled tasks. Unlike a regular Lock,
@@ -79,6 +80,13 @@ class TaskLock(SyncPrimitive):
     The lock relies entirely on the TTL (`max_lock_seconds`) set at acquire time.
 
     This lock is designed to be used as the `sync` parameter of `IntervalTask`.
+
+    Supports live reconfiguration via
+    [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
+    A swap takes effect on the next acquire and on the next exit
+    re-acquire. The `worker` field is fixed for the lifetime of the
+    instance: changing it raises `ValueError`. See
+    [Live reconfiguration](../architecture/reconfigure.md).
     """
 
     _LOCK_PREFIX = "tasklock"
@@ -239,6 +247,7 @@ class TaskLock(SyncPrimitive):
         """Wire the validated config and runtime deps onto the instance."""
         self._name = name
         self._config = config
+        self._reconfigure_lock = anyio.Lock()
         self._lock_name = f"{self._LOCK_PREFIX}:{name}"
         self._backend: SyncBackend | None = (
             backend if not isinstance(backend, str) else None
@@ -302,11 +311,6 @@ class TaskLock(SyncPrimitive):
         """
         token = generate_task_token(self._config.worker, self._token_nonce)
         await self.do_exit(token)
-
-    @property
-    def config(self) -> TaskLockConfig:
-        """Return the task lock config."""
-        return self._config
 
     @property
     def from_thread(self) -> "ThreadTaskLockAdapter":
@@ -420,6 +424,16 @@ class TaskLock(SyncPrimitive):
         """
         token = generate_thread_token(self._config.worker, self._token_nonce)
         await self.do_exit(token)
+
+    async def _apply_reconfigure(self, new_config: TaskLockConfig) -> None:
+        """Validate the immutable `worker` field before publishing `new_config`."""
+        if new_config.worker != self._config.worker:
+            msg = (
+                f"reconfigure cannot change worker "
+                f"({self._config.worker!r} -> {new_config.worker!r}). "
+                f"Reuse the existing worker on the new config."
+            )
+            raise ValueError(msg)
 
     async def do_exit(self, token: str) -> None:
         """Handle exit logic: release or re-acquire based on elapsed time."""

--- a/grelmicro/sync/tasklock.py
+++ b/grelmicro/sync/tasklock.py
@@ -285,11 +285,12 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
             LockAcquireError: If the lock cannot be acquired due to a backend error.
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
         """
+        config = self._config
         if self._acquired_at is not None:
             raise LockReentrantError(name=self._name)
 
-        token = generate_task_token(self._config.worker, self._token_nonce)
-        if not await self.do_acquire(token):
+        token = generate_task_token(config.worker, self._token_nonce)
+        if not await self.do_acquire(token, duration=config.max_lock_seconds):
             msg = f"Task lock not acquired: name={self._name}, token={token}"
             raise WouldBlock(msg)
 
@@ -309,8 +310,9 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
         Raises:
             LockReleaseError: If the lock cannot be released due to a backend error.
         """
-        token = generate_task_token(self._config.worker, self._token_nonce)
-        await self.do_exit(token)
+        config = self._config
+        token = generate_task_token(config.worker, self._token_nonce)
+        await self.do_exit(token, min_lock_seconds=config.min_lock_seconds)
 
     @property
     def from_thread(self) -> "ThreadTaskLockAdapter":
@@ -331,10 +333,18 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
         except Exception as exc:
             raise LockLockedCheckError(name=self._name) from exc
 
-    async def do_acquire(self, token: str) -> bool:
+    async def do_acquire(self, token: str, *, duration: Seconds) -> bool:
         """Acquire the lock.
 
         This method should not be called directly. Use the context manager instead.
+
+        Args:
+            token: The token to register on the backend.
+            duration: The lease duration to request, in seconds. The
+                caller captures this from
+                `self._config.max_lock_seconds` at the start of the
+                operation so a concurrent `reconfigure` cannot change
+                the duration mid-acquire.
 
         Returns:
             bool: True if the lock was acquired, False if the lock was not acquired.
@@ -347,7 +357,7 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
             acquired = await backend.acquire(
                 name=self._lock_name,
                 token=token,
-                duration=self._config.max_lock_seconds,
+                duration=duration,
             )
         except Exception as exc:
             raise LockAcquireError(name=self._name) from exc
@@ -405,11 +415,12 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
             LockAcquireError: If the lock cannot be acquired due to a backend error.
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
         """
+        config = self._config
         if self._acquired_at is not None:
             raise LockReentrantError(name=self._name)
 
-        token = generate_thread_token(self._config.worker, self._token_nonce)
-        if not await self.do_acquire(token):
+        token = generate_thread_token(config.worker, self._token_nonce)
+        if not await self.do_acquire(token, duration=config.max_lock_seconds):
             msg = f"Task lock not acquired: name={self._name}, token={token}"
             raise WouldBlock(msg)
 
@@ -422,8 +433,9 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
         Raises:
             LockReleaseError: If the lock cannot be released due to a backend error.
         """
-        token = generate_thread_token(self._config.worker, self._token_nonce)
-        await self.do_exit(token)
+        config = self._config
+        token = generate_thread_token(config.worker, self._token_nonce)
+        await self.do_exit(token, min_lock_seconds=config.min_lock_seconds)
 
     async def _apply_reconfigure(self, new_config: TaskLockConfig) -> None:
         """Validate the immutable `worker` field before publishing `new_config`."""
@@ -435,8 +447,17 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
             )
             raise ValueError(msg)
 
-    async def do_exit(self, token: str) -> None:
-        """Handle exit logic: release or re-acquire based on elapsed time."""
+    async def do_exit(self, token: str, *, min_lock_seconds: Seconds) -> None:
+        """Handle exit logic: release or re-acquire based on elapsed time.
+
+        Args:
+            token: The token used to release or re-acquire the lock.
+            min_lock_seconds: The minimum hold duration to enforce, in
+                seconds. The caller captures this from
+                `self._config.min_lock_seconds` at the start of the
+                operation so the comparison and the
+                remaining-duration calculation always agree.
+        """
         if self._acquired_at is None:
             raise LockNotOwnedError(name=self._name)
 
@@ -444,7 +465,7 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
         self._acquired_at = None
         self._token_nonce = generate_token_nonce()
 
-        if elapsed >= self._config.min_lock_seconds:
+        if elapsed >= min_lock_seconds:
             # Task took longer than min_lock_seconds, release immediately
             released = await self.do_release(token)
             if not released:
@@ -452,7 +473,7 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
         else:
             # Re-acquire with remaining duration so the lock is held
             # until min_lock_seconds.
-            remaining = self._config.min_lock_seconds - elapsed
+            remaining = min_lock_seconds - elapsed
             re_acquired = await self.do_reacquire(token, remaining)
             if not re_acquired:
                 raise LockNotOwnedError(name=self._name)

--- a/tests/sync/test_leaderelection.py
+++ b/tests/sync/test_leaderelection.py
@@ -242,7 +242,7 @@ async def test_leadership_abandon_on_renew_deadline_reached(
     # renew deadline elapses without state updates.
     is_leader_before_start = leader_election.is_leader()
 
-    async def _block_forever() -> None:
+    async def _block_forever(_: LeaderElectionConfig) -> None:
         await sleep(math.inf)
 
     # Act

--- a/tests/sync/test_leaderelection.py
+++ b/tests/sync/test_leaderelection.py
@@ -554,3 +554,61 @@ async def test_guard_raises_would_block_after_losing_leadership(
     with pytest.raises(WouldBlock):
         async with guard:
             pass
+
+
+# --- reconfigure ---
+
+
+async def test_leader_reconfigure_swaps_config(
+    leader_election: LeaderElection,
+) -> None:
+    """Reconfigure publishes the new config."""
+    new_config = leader_election.config.model_copy(
+        update={"lease_duration": 0.04, "renew_deadline": 0.03},
+    )
+
+    await leader_election.reconfigure(new_config)
+
+    assert leader_election.config == new_config
+
+
+async def test_leader_reconfigure_same_config_is_noop(
+    leader_election: LeaderElection,
+) -> None:
+    """Equal configs short-circuit."""
+    same = leader_election.config.model_copy()
+
+    await leader_election.reconfigure(same)
+
+    assert leader_election.config == same
+
+
+async def test_leader_reconfigure_rejects_worker_change(
+    leader_election: LeaderElection,
+) -> None:
+    """Changing `worker` is not allowed: the lease is held under that token."""
+    new_config = leader_election.config.model_copy(
+        update={"worker": "other-worker"},
+    )
+
+    with pytest.raises(ValueError, match="cannot change worker"):
+        await leader_election.reconfigure(new_config)
+
+
+async def test_leader_reconfigure_takes_effect_on_next_iteration(
+    leader_election: LeaderElection,
+) -> None:
+    """A swap during the renew loop is observed on the next read."""
+    new_error_interval = 0.5
+    async with create_task_group() as tg:
+        await tg.start(leader_election)
+        await leader_election.wait_for_leader()
+
+        new_config = leader_election.config.model_copy(
+            update={"error_interval": new_error_interval},
+        )
+        await leader_election.reconfigure(new_config)
+
+        assert leader_election.config.error_interval == new_error_interval
+
+        tg.cancel_scope.cancel()

--- a/tests/sync/test_lock.py
+++ b/tests/sync/test_lock.py
@@ -696,3 +696,63 @@ async def test_lock_retry_interval_too_small(backend: SyncBackend) -> None:
     """Test Lock rejects retry_interval below minimum."""
     with pytest.raises(ValueError, match="retry_interval must be"):
         Lock(name="test", backend=backend, retry_interval=0.0001)
+
+
+# --- reconfigure ---
+
+
+async def test_reconfigure_swaps_config(lock: Lock) -> None:
+    """Reconfigure publishes the new config."""
+    new_config = lock.config.model_copy(
+        update={"lease_duration": 5, "retry_interval": 0.05},
+    )
+
+    await lock.reconfigure(new_config)
+
+    assert lock.config == new_config
+
+
+async def test_reconfigure_same_config_is_noop(lock: Lock) -> None:
+    """Equal configs short-circuit."""
+    same = lock.config.model_copy()
+
+    await lock.reconfigure(same)
+
+    assert lock.config == same
+
+
+async def test_reconfigure_rejects_worker_change(lock: Lock) -> None:
+    """Changing `worker` is not allowed because the token identity is live."""
+    new_config = lock.config.model_copy(update={"worker": "other-worker"})
+
+    with pytest.raises(ValueError, match="cannot change worker"):
+        await lock.reconfigure(new_config)
+
+    assert lock.config.worker != "other-worker"
+
+
+async def test_reconfigure_changes_lease_duration_for_next_acquire(
+    lock: Lock,
+    backend: SyncBackend,
+    mocker: MockerFixture,
+) -> None:
+    """Acquire after reconfigure passes the new lease_duration to the backend."""
+    spy = mocker.spy(backend, "acquire")
+    new_config = lock.config.model_copy(update={"lease_duration": 42})
+
+    await lock.reconfigure(new_config)
+    await lock.acquire()
+    await lock.release()
+
+    assert spy.call_args.kwargs["duration"] == 42  # noqa: PLR2004
+
+
+async def test_reconfigure_while_held_keeps_release_working(lock: Lock) -> None:
+    """A swap during a held lease does not break the release path."""
+    new_config = lock.config.model_copy(update={"lease_duration": 5})
+
+    await lock.acquire()
+    await lock.reconfigure(new_config)
+    await lock.release()
+
+    assert await lock.locked() is False

--- a/tests/sync/test_tasklock.py
+++ b/tests/sync/test_tasklock.py
@@ -16,7 +16,7 @@ from grelmicro.sync.errors import (
     LockReentrantError,
     LockReleaseError,
 )
-from grelmicro.sync.lock import Lock
+from grelmicro.sync.lock import Lock, LockConfig
 from grelmicro.sync.memory import MemorySyncBackend
 from grelmicro.sync.tasklock import TaskLock, TaskLockConfig
 
@@ -690,3 +690,100 @@ async def test_task_lock_exit_without_acquire(backend: SyncBackend) -> None:
     )
     with pytest.raises(LockNotOwnedError):
         await task_lock.__aexit__(None, None, None)
+
+
+# --- reconfigure ---
+
+
+async def test_tasklock_reconfigure_swaps_config(backend: SyncBackend) -> None:
+    """Reconfigure publishes the new config."""
+    task_lock = TaskLock(
+        LOCK_NAME,
+        backend=backend,
+        worker=WORKER_1,
+        min_lock_seconds=1,
+        max_lock_seconds=10,
+    )
+    new_config = task_lock.config.model_copy(
+        update={"min_lock_seconds": 2, "max_lock_seconds": 20},
+    )
+
+    await task_lock.reconfigure(new_config)
+
+    assert task_lock.config == new_config
+
+
+async def test_tasklock_reconfigure_same_config_is_noop(
+    backend: SyncBackend,
+) -> None:
+    """Equal configs short-circuit."""
+    task_lock = TaskLock(
+        LOCK_NAME,
+        backend=backend,
+        worker=WORKER_1,
+        min_lock_seconds=1,
+        max_lock_seconds=10,
+    )
+    same = task_lock.config.model_copy()
+
+    await task_lock.reconfigure(same)
+
+    assert task_lock.config == same
+
+
+async def test_tasklock_reconfigure_rejects_worker_change(
+    backend: SyncBackend,
+) -> None:
+    """Changing `worker` is not allowed: it is part of the live token."""
+    task_lock = TaskLock(
+        LOCK_NAME,
+        backend=backend,
+        worker=WORKER_1,
+        min_lock_seconds=1,
+        max_lock_seconds=10,
+    )
+    new_config = task_lock.config.model_copy(update={"worker": WORKER_2})
+
+    with pytest.raises(ValueError, match="cannot change worker"):
+        await task_lock.reconfigure(new_config)
+
+
+async def test_tasklock_reconfigure_changes_max_lock_for_next_acquire(
+    backend: SyncBackend,
+    mocker: MockerFixture,
+) -> None:
+    """Acquire after reconfigure passes the new max_lock_seconds to the backend."""
+    task_lock = TaskLock(
+        LOCK_NAME,
+        backend=backend,
+        worker=WORKER_1,
+        min_lock_seconds=1,
+        max_lock_seconds=10,
+    )
+    spy = mocker.spy(backend, "acquire")
+    new_config = task_lock.config.model_copy(update={"max_lock_seconds": 42})
+
+    await task_lock.reconfigure(new_config)
+    async with task_lock:
+        pass
+
+    # First call is the entry acquire (uses max_lock_seconds);
+    # the second is the exit re-acquire that holds the lock until
+    # min_lock_seconds elapsed.
+    assert spy.call_args_list[0].kwargs["duration"] == 42  # noqa: PLR2004
+
+
+async def test_tasklock_reconfigure_rejects_different_config_type(
+    backend: SyncBackend,
+) -> None:
+    """The mixin rejects config types different from the current one."""
+    task_lock = TaskLock(
+        LOCK_NAME,
+        backend=backend,
+        worker=WORKER_1,
+        min_lock_seconds=1,
+        max_lock_seconds=10,
+    )
+
+    with pytest.raises(TypeError, match="TaskLockConfig"):
+        await task_lock.reconfigure(LockConfig(worker=WORKER_1))  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Summary

* `Lock`, `TaskLock`, and `LeaderElection` now inherit `Reconfigurable[*Config]` and expose `await component.reconfigure(new_config)` for atomic live config swap, matching the contract documented in [`docs/architecture/reconfigure.md`](https://github.com/grelinfo/grelmicro/blob/main/docs/architecture/reconfigure.md).
* `worker` is fixed for the lifetime of an instance (the token identity is bound to it). Each subclass overrides `_apply_reconfigure` to raise `ValueError` if the new config tries to change it. Timing fields (`lease_duration`, `retry_interval`, `min_lock_seconds`, `max_lock_seconds`, `renew_deadline`, `backend_timeout`, `error_interval`) take effect on the next operation or on the next iteration of the renew loop for `LeaderElection`.
* The duplicate `config` property on each class is removed in favor of the property provided by the mixin.

Closes the live-reconfig story for sync primitives. Tracked under [#158](https://github.com/grelinfo/grelmicro/issues/158).

## Test plan

- [x] `test_reconfigure_swaps_config` for each primitive
- [x] `test_reconfigure_same_config_is_noop` for each primitive
- [x] `test_reconfigure_rejects_worker_change` for each primitive
- [x] `test_reconfigure_changes_*_for_next_acquire` (Lock, TaskLock) verifies the new value reaches the backend
- [x] `test_reconfigure_while_held_keeps_release_working` (Lock) covers the swap-while-held path
- [x] `test_leader_reconfigure_takes_effect_on_next_iteration` covers the live renew loop
- [x] `test_tasklock_reconfigure_rejects_different_config_type` covers the mixin's `TypeError` guard
- [x] Full suite: 1417 passing
- [x] `ruff check` and `ty check` clean