### PR TITLE
✨ Extend Reconfigurable to CircuitBreaker with snapshot pattern

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Features
 
 * ✨ Add `reconfigure(new_config)` to `Lock`, `TaskLock`, and `LeaderElection` for atomic live config swap. The `worker` field is fixed for the lifetime of the instance: only timing fields can change. Issue [#158](https://github.com/grelinfo/grelmicro/issues/158).
+* ✨ Add `CircuitBreaker.reconfigure(new_config)` for atomic live config swap. Runtime state (current `CircuitBreakerState`, counters, `last_error`) is preserved across the swap. `log_level` changes propagate to the instance logger. Issue [#158](https://github.com/grelinfo/grelmicro/issues/158).
 
 ## 0.19.0 - 2026-05-01
 

--- a/grelmicro/resilience/circuitbreaker.py
+++ b/grelmicro/resilience/circuitbreaker.py
@@ -2,7 +2,9 @@
 
 import functools
 import logging
+import threading
 from collections.abc import Callable
+from contextvars import ContextVar
 from datetime import UTC, datetime
 from enum import StrEnum
 from inspect import iscoroutinefunction
@@ -336,6 +338,14 @@ class CircuitBreaker(Reconfigurable[CircuitBreakerConfig]):
         self._name = name
         self._config = config
         self._reconfigure_lock = anyio.Lock()
+        # Per-call snapshot stack. Each `__aenter__` pushes the config
+        # captured at admission; `__aexit__` pops it and uses it for
+        # success/error classification. ContextVar isolates concurrent
+        # `async with cb:` calls across tasks and supports nesting in
+        # the same task.
+        self._enter_stack: ContextVar[tuple[CircuitBreakerConfig, ...]] = (
+            ContextVar(f"_cb_enter_stack_{id(self)}", default=())
+        )
         self._state = CircuitBreakerState.CLOSED
         self._consecutive_error_count = 0
         self._consecutive_success_count = 0
@@ -381,6 +391,7 @@ class CircuitBreaker(Reconfigurable[CircuitBreakerConfig]):
                 last_error_time=self._last_error_time,
                 last_error=self._last_error,
             )
+        self._enter_stack.set((*self._enter_stack.get(), config))
         return self
 
     async def __aexit__(
@@ -389,8 +400,17 @@ class CircuitBreaker(Reconfigurable[CircuitBreakerConfig]):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> bool | None:
-        """Exit the context manager."""
-        config = self._config
+        """Exit the context manager.
+
+        Uses the same config snapshot captured at `__aenter__` so the
+        success/error classification matches the admission decision
+        (the in-flight call completes on the previous config even if
+        `reconfigure` runs concurrently).
+        """
+        stack = self._enter_stack.get()
+        config = stack[-1]
+        self._enter_stack.set(stack[:-1])
+
         await self._release_call()
 
         if not exc_type or issubclass(exc_type, config.ignore_exceptions):
@@ -610,6 +630,10 @@ class _ThreadAdapter:
     def __init__(self, circuit_breaker: CircuitBreaker) -> None:
         """Initialize the adapter with a CircuitBreaker instance."""
         self._cb = circuit_breaker
+        # Per-thread snapshot stack. Each `__enter__` pushes the
+        # config captured at admission; `__exit__` pops it. Threading
+        # local isolates concurrent threads using the same adapter.
+        self._tls = threading.local()
 
     def __enter__(self) -> Self:
         """Enter the context manager, acquiring the circuit breaker lock."""
@@ -620,6 +644,11 @@ class _ThreadAdapter:
                 last_error_time=self._cb.last_error_time,
                 last_error=self._cb.last_error,
             )
+        stack = getattr(self._tls, "stack", None)
+        if stack is None:
+            stack = []
+            self._tls.stack = stack
+        stack.append(config)
         return self
 
     def __exit__(
@@ -628,8 +657,12 @@ class _ThreadAdapter:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> bool | None:
-        """Exit the context manager, releasing the circuit breaker lock."""
-        config = self._cb._config  # noqa: SLF001
+        """Exit the context manager, releasing the circuit breaker lock.
+
+        Uses the same config snapshot captured at `__enter__` so the
+        success/error classification matches the admission decision.
+        """
+        config = self._tls.stack.pop()
         from_thread.run(self._cb._release_call)  # noqa: SLF001
 
         if not exc_type or issubclass(exc_type, config.ignore_exceptions):

--- a/grelmicro/resilience/circuitbreaker.py
+++ b/grelmicro/resilience/circuitbreaker.py
@@ -15,6 +15,7 @@ from typing import (
     Self,
 )
 
+import anyio
 from anyio import from_thread
 from pydantic import (
     BaseModel,
@@ -27,7 +28,12 @@ from pydantic import (
 from pydantic_settings import NoDecode
 from typing_extensions import Doc
 
-from grelmicro._config import env_segment, parse_csv_or_json, resolve_config
+from grelmicro._config import (
+    Reconfigurable,
+    env_segment,
+    parse_csv_or_json,
+    resolve_config,
+)
 from grelmicro._types import LogLevel
 from grelmicro.resilience.errors import CircuitBreakerError
 
@@ -159,12 +165,21 @@ class CircuitBreakerConfig(BaseModel, frozen=True, extra="forbid"):
         return value
 
 
-class CircuitBreaker:
+class CircuitBreaker(Reconfigurable[CircuitBreakerConfig]):
     """Circuit Breaker.
 
     Implements the circuit breaker pattern. It watches calls to
     a protected service and blocks them when the service is
     failing, to avoid cascading errors.
+
+    Supports live reconfiguration via
+    [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
+    Each call captures the config once on entry, so a swap takes
+    effect on the next call. The runtime state (current
+    `CircuitBreakerState`, counters, `last_error`) is preserved
+    across the swap. A change to `log_level` is applied to the
+    instance logger by `_apply_reconfigure`. See
+    [Live reconfiguration](../architecture/reconfigure.md).
     """
 
     def __init__(
@@ -320,6 +335,7 @@ class CircuitBreaker:
         """Wire the validated config and runtime deps onto the instance."""
         self._name = name
         self._config = config
+        self._reconfigure_lock = anyio.Lock()
         self._state = CircuitBreakerState.CLOSED
         self._consecutive_error_count = 0
         self._consecutive_success_count = 0
@@ -358,7 +374,8 @@ class CircuitBreaker:
 
     async def __aenter__(self) -> Self:
         """Circuit breaker context manager."""
-        if not await self._try_acquire_call():
+        config = self._config
+        if not await self._try_acquire_call(config):
             raise CircuitBreakerError(
                 name=self.name,
                 last_error_time=self._last_error_time,
@@ -373,13 +390,14 @@ class CircuitBreaker:
         traceback: TracebackType | None,
     ) -> bool | None:
         """Exit the context manager."""
+        config = self._config
         await self._release_call()
 
-        if not exc_type or issubclass(exc_type, self._config.ignore_exceptions):
-            await self._on_success()
+        if not exc_type or issubclass(exc_type, config.ignore_exceptions):
+            await self._on_success(config)
 
         elif isinstance(exc_value, Exception):
-            await self._on_error(exc_value)
+            await self._on_error(config, exc_value)
 
         return None
 
@@ -410,11 +428,6 @@ class CircuitBreaker:
         """Return the time of the last error recorded by the circuit breaker."""
         return self._last_error_time
 
-    @property
-    def config(self) -> CircuitBreakerConfig:
-        """Return the circuit breaker configuration."""
-        return self._config
-
     def metrics(self) -> CircuitBreakerMetrics:
         """Return current metrics for this circuit breaker."""
         last_error = self._map_last_error()
@@ -436,41 +449,49 @@ class CircuitBreaker:
         self._total_success_count = 0
         self._last_error = None
         self._do_transition_to_state(
-            CircuitBreakerState.CLOSED, _TransitionCause.RESTART
+            self._config, CircuitBreakerState.CLOSED, _TransitionCause.RESTART
         )
 
     async def transition_to_closed(self) -> None:
         """Transition the circuit breaker to CLOSED state."""
         self._do_transition_to_state(
-            CircuitBreakerState.CLOSED, _TransitionCause.MANUAL
+            self._config, CircuitBreakerState.CLOSED, _TransitionCause.MANUAL
         )
 
     async def transition_to_open(self, until: float | None = None) -> None:
         """Transition the circuit breaker to OPEN state."""
         self._do_transition_to_state(
-            CircuitBreakerState.OPEN, _TransitionCause.MANUAL, open_until=until
+            self._config,
+            CircuitBreakerState.OPEN,
+            _TransitionCause.MANUAL,
+            open_until=until,
         )
 
     async def transition_to_half_open(self) -> None:
         """Transition the circuit breaker to HALF_OPEN state."""
         self._do_transition_to_state(
-            CircuitBreakerState.HALF_OPEN, _TransitionCause.MANUAL
+            self._config, CircuitBreakerState.HALF_OPEN, _TransitionCause.MANUAL
         )
 
     async def transition_to_forced_open(self) -> None:
         """Transition the circuit breaker to FORCED_OPEN state."""
         self._do_transition_to_state(
-            CircuitBreakerState.FORCED_OPEN, _TransitionCause.MANUAL
+            self._config,
+            CircuitBreakerState.FORCED_OPEN,
+            _TransitionCause.MANUAL,
         )
 
     async def transition_to_forced_closed(self) -> None:
         """Transition the circuit breaker to FORCED_CLOSED state."""
         self._do_transition_to_state(
-            CircuitBreakerState.FORCED_CLOSED, _TransitionCause.MANUAL
+            self._config,
+            CircuitBreakerState.FORCED_CLOSED,
+            _TransitionCause.MANUAL,
         )
 
     def _do_transition_to_state(
         self,
+        config: CircuitBreakerConfig,
         state: CircuitBreakerState,
         cause: _TransitionCause,
         open_until: float | None = None,
@@ -482,7 +503,7 @@ class CircuitBreaker:
 
         self._open_until_time = (
             monotonic()
-            + (self._config.reset_timeout if open_until is None else open_until)
+            + (config.reset_timeout if open_until is None else open_until)
             if state == CircuitBreakerState.OPEN
             else 0
         )
@@ -497,7 +518,7 @@ class CircuitBreaker:
             cause,
         )
 
-    async def _try_acquire_call(self) -> bool:
+    async def _try_acquire_call(self, config: CircuitBreakerConfig) -> bool:
         """Attempt to acquire a call in the circuit breaker."""
         if self._state in (
             CircuitBreakerState.CLOSED,
@@ -511,12 +532,14 @@ class CircuitBreaker:
             and monotonic() >= self._open_until_time
         ):
             self._do_transition_to_state(
-                CircuitBreakerState.HALF_OPEN, _TransitionCause.RESET_TIMEOUT
+                config,
+                CircuitBreakerState.HALF_OPEN,
+                _TransitionCause.RESET_TIMEOUT,
             )
 
         if (
             self._state == CircuitBreakerState.HALF_OPEN
-            and self._active_call_count < self._config.half_open_capacity
+            and self._active_call_count < config.half_open_capacity
         ):
             self._active_call_count += 1
             return True
@@ -527,7 +550,9 @@ class CircuitBreaker:
         if self._active_call_count > 0:
             self._active_call_count -= 1
 
-    async def _on_error(self, error: Exception) -> None:
+    async def _on_error(
+        self, config: CircuitBreakerConfig, error: Exception
+    ) -> None:
         """Record an error, update counts, and potentially transition state."""
         self._total_error_count += 1
         self._consecutive_error_count += 1
@@ -537,13 +562,15 @@ class CircuitBreaker:
 
         if (
             self._state != CircuitBreakerState.OPEN
-            and self._consecutive_error_count >= self._config.error_threshold
+            and self._consecutive_error_count >= config.error_threshold
         ):
             self._do_transition_to_state(
-                CircuitBreakerState.OPEN, _TransitionCause.ERROR_THRESHOLD
+                config,
+                CircuitBreakerState.OPEN,
+                _TransitionCause.ERROR_THRESHOLD,
             )
 
-    async def _on_success(self) -> None:
+    async def _on_success(self, config: CircuitBreakerConfig) -> None:
         """Record a success, update counts, and potentially transition state."""
         self._total_success_count += 1
         self._consecutive_error_count = 0
@@ -551,12 +578,19 @@ class CircuitBreaker:
 
         if (
             self._state == CircuitBreakerState.HALF_OPEN
-            and self._consecutive_success_count
-            >= self._config.success_threshold
+            and self._consecutive_success_count >= config.success_threshold
         ):
             self._do_transition_to_state(
-                CircuitBreakerState.CLOSED, _TransitionCause.SUCCESS_THRESHOLD
+                config,
+                CircuitBreakerState.CLOSED,
+                _TransitionCause.SUCCESS_THRESHOLD,
             )
+
+    async def _apply_reconfigure(
+        self, new_config: CircuitBreakerConfig
+    ) -> None:
+        """Update the instance logger level to match `new_config.log_level`."""
+        self._logger.setLevel(new_config.log_level)
 
     def _map_last_error(self) -> ErrorDetails | None:
         """Map the last error to ErrorDetails."""
@@ -579,7 +613,8 @@ class _ThreadAdapter:
 
     def __enter__(self) -> Self:
         """Enter the context manager, acquiring the circuit breaker lock."""
-        if not from_thread.run(self._cb._try_acquire_call):  # noqa: SLF001
+        config = self._cb._config  # noqa: SLF001
+        if not from_thread.run(self._cb._try_acquire_call, config):  # noqa: SLF001
             raise CircuitBreakerError(
                 name=self._cb.name,
                 last_error_time=self._cb.last_error_time,
@@ -594,16 +629,14 @@ class _ThreadAdapter:
         traceback: TracebackType | None,
     ) -> bool | None:
         """Exit the context manager, releasing the circuit breaker lock."""
+        config = self._cb._config  # noqa: SLF001
         from_thread.run(self._cb._release_call)  # noqa: SLF001
 
-        if not exc_type or issubclass(
-            exc_type,
-            self._cb._config.ignore_exceptions,  # noqa: SLF001
-        ):
-            from_thread.run(self._cb._on_success)  # noqa: SLF001
+        if not exc_type or issubclass(exc_type, config.ignore_exceptions):
+            from_thread.run(self._cb._on_success, config)  # noqa: SLF001
 
         elif isinstance(exc_value, Exception):
-            from_thread.run(self._cb._on_error, exc_value)  # noqa: SLF001
+            from_thread.run(self._cb._on_error, config, exc_value)  # noqa: SLF001
 
         return None
 

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -2,10 +2,12 @@
 
 import logging
 import sys
+import threading
 from contextlib import AsyncExitStack, suppress
 from datetime import UTC, datetime
 from typing import Literal
 
+import anyio
 import pydantic
 import pytest
 from anyio import to_thread
@@ -876,6 +878,79 @@ async def test_reconfigure_changes_error_threshold_for_next_call() -> None:
             raise boom
 
     assert cb.state == CircuitBreakerState.OPEN
+
+
+async def test_reconfigure_during_inflight_call_uses_admission_config() -> None:
+    """An in-flight call classifies its result against the admission config.
+
+    The call enters with `ignore_exceptions=(RuntimeError,)`, then a
+    concurrent reconfigure swaps to `ignore_exceptions=()`. The exit
+    must still treat the `RuntimeError` as ignored, leaving counters
+    unchanged: this is the documented "in-flight operations complete
+    on the previous config" guarantee.
+    """
+    cb = CircuitBreaker("rc", ignore_exceptions=RuntimeError, error_threshold=1)
+    boom = RuntimeError("boom")
+    enter_event = anyio.Event()
+    can_exit = anyio.Event()
+
+    async def call() -> None:
+        async def body() -> None:
+            async with cb:
+                enter_event.set()
+                await can_exit.wait()
+                raise boom
+
+        with pytest.raises(RuntimeError):
+            await body()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(call)
+        await enter_event.wait()
+        await cb.reconfigure(
+            cb.config.model_copy(update={"ignore_exceptions": ()})
+        )
+        can_exit.set()
+
+    # The call entered under the old `ignore_exceptions=(RuntimeError,)`
+    # so the exit must classify the RuntimeError as ignored: no error
+    # count, breaker stays CLOSED.
+    assert cb.state == CircuitBreakerState.CLOSED
+    assert cb.metrics().total_error_count == 0
+    assert cb.metrics().total_success_count == 1
+
+
+async def test_reconfigure_during_inflight_thread_call_uses_admission_config() -> (
+    None
+):
+    """The thread adapter preserves the admission snapshot across `__exit__`."""
+    cb = CircuitBreaker("rc", ignore_exceptions=RuntimeError, error_threshold=1)
+    boom = RuntimeError("boom")
+    entered = threading.Event()
+    can_exit = threading.Event()
+
+    def sync() -> None:
+        def body() -> None:
+            with cb.from_thread:
+                entered.set()
+                can_exit.wait()
+                raise boom
+
+        with pytest.raises(RuntimeError):
+            body()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(to_thread.run_sync, sync)
+        # Wait for the thread to enter the context manager.
+        await to_thread.run_sync(entered.wait)
+        await cb.reconfigure(
+            cb.config.model_copy(update={"ignore_exceptions": ()})
+        )
+        can_exit.set()
+
+    assert cb.state == CircuitBreakerState.CLOSED
+    assert cb.metrics().total_error_count == 0
+    assert cb.metrics().total_success_count == 1
 
 
 async def test_reconfigure_rejects_different_config_type() -> None:

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -1,10 +1,12 @@
 """Test CircuitBreaker implementation."""
 
+import logging
 import sys
 from contextlib import AsyncExitStack, suppress
 from datetime import UTC, datetime
 from typing import Literal
 
+import pydantic
 import pytest
 from anyio import to_thread
 from freezegun import freeze_time
@@ -101,7 +103,7 @@ async def circuit_call_not_permitted(
     # the slot below so any further call is rejected.
     cb = await create_circuit(request.param, half_open_capacity=1)
     if request.param == CircuitBreakerState.HALF_OPEN:
-        await cb._try_acquire_call()
+        await cb._try_acquire_call(cb.config)
     return cb
 
 
@@ -808,3 +810,80 @@ def test_circuitbreaker_log_level(
 
     # Assert
     assert cb.config.log_level == level
+
+
+# --- reconfigure ---
+
+
+async def test_reconfigure_swaps_config() -> None:
+    """Reconfigure publishes the new config."""
+    cb = CircuitBreaker("rc", error_threshold=5)
+    new_config = cb.config.model_copy(update={"error_threshold": 10})
+
+    await cb.reconfigure(new_config)
+
+    assert cb.config == new_config
+
+
+async def test_reconfigure_same_config_is_noop() -> None:
+    """Equal configs short-circuit."""
+    cb = CircuitBreaker("rc", error_threshold=5)
+    same = cb.config.model_copy()
+
+    await cb.reconfigure(same)
+
+    assert cb.config == same
+
+
+async def test_reconfigure_preserves_runtime_state() -> None:
+    """A swap does not reset state, counters, or last_error."""
+    cb = CircuitBreaker("rc", error_threshold=2)
+    boom = RuntimeError("boom")
+    with pytest.raises(RuntimeError):
+        async with cb:
+            raise boom
+
+    error_count_before = cb.metrics().total_error_count
+    last_error_before = cb.last_error
+
+    new_config = cb.config.model_copy(update={"error_threshold": 10})
+    await cb.reconfigure(new_config)
+
+    assert cb.metrics().total_error_count == error_count_before
+    assert cb.last_error is last_error_before
+
+
+async def test_reconfigure_updates_logger_level() -> None:
+    """`log_level` change propagates to the instance logger."""
+    cb = CircuitBreaker("rc", log_level="WARNING")
+    assert cb._logger.level == logging.WARNING
+
+    await cb.reconfigure(cb.config.model_copy(update={"log_level": "DEBUG"}))
+
+    assert cb._logger.level == logging.DEBUG
+
+
+async def test_reconfigure_changes_error_threshold_for_next_call() -> None:
+    """Error threshold change applies to the next call without resetting counters."""
+    cb = CircuitBreaker("rc", error_threshold=5)
+    new_config = cb.config.model_copy(update={"error_threshold": 1})
+
+    await cb.reconfigure(new_config)
+
+    boom = RuntimeError("boom")
+    with pytest.raises(RuntimeError):
+        async with cb:
+            raise boom
+
+    assert cb.state == CircuitBreakerState.OPEN
+
+
+async def test_reconfigure_rejects_different_config_type() -> None:
+    """The mixin rejects config types different from the current one."""
+
+    class Other(pydantic.BaseModel):
+        pass
+
+    cb = CircuitBreaker("rc")
+    with pytest.raises(TypeError, match="CircuitBreakerConfig"):
+        await cb.reconfigure(Other())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Summary

* `CircuitBreaker` inherits `Reconfigurable[CircuitBreakerConfig]` and exposes `await cb.reconfigure(new_config)` for atomic live config swap.
* Each call captures the config once on entry (`__aenter__`/decorator/thread adapter) and passes it through to `_try_acquire_call`, `_on_error`, `_on_success`, and `_do_transition_to_state`. This matches the snapshot-once-at-top pattern documented in [`docs/architecture/reconfigure.md`](https://github.com/grelinfo/grelmicro/blob/main/docs/architecture/reconfigure.md).
* Runtime state (current `CircuitBreakerState`, counters, `last_error`, `last_error_time`) is preserved across the swap.
* `_apply_reconfigure` propagates `log_level` changes to the instance logger.
* Drops the duplicate `config` property in favor of the one provided by the mixin.

Closes the live-reconfig story for `CircuitBreaker`. Tracked under [#158](https://github.com/grelinfo/grelmicro/issues/158).

## Test plan

- [x] Reconfigure swaps config, no-op on equal config, rejects different config types
- [x] Runtime state preserved across the swap (`total_error_count`, `last_error`)
- [x] `log_level` change reflected on `cb._logger.level`
- [x] `error_threshold` change applies on the next call without resetting counters
- [x] Full suite: 1423 passing, 100% coverage
- [x] `ruff check` and `ty check` clean