### PR TITLE
✨ Add HealthRegistry.reconfigure with snapshot pattern

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,9 +4,9 @@
 
 ### Features
 
-* ✨ Add `reconfigure(new_config)` to `Lock`, `TaskLock`, and `LeaderElection` for atomic live config swap. The `worker` field is fixed for the lifetime of the instance: only timing fields can change. Issue [#158](https://github.com/grelinfo/grelmicro/issues/158).
-* ✨ Add `CircuitBreaker.reconfigure(new_config)` for atomic live config swap. Runtime state (current `CircuitBreakerState`, counters, `last_error`) is preserved across the swap. `log_level` changes propagate to the instance logger. Issue [#158](https://github.com/grelinfo/grelmicro/issues/158).
-* ✨ Add `HealthRegistry.reconfigure(new_config)` for atomic live config swap. The `cache_ttl` change applies on the next round; existing checks keep their per-check timeout resolved at registration time. Issue [#162](https://github.com/grelinfo/grelmicro/issues/162).
+* ✨ Add `reconfigure(new_config)` to `Lock`, `TaskLock`, and `LeaderElection`. Swap timing fields without restarting. The `worker` field cannot change. Issue [#158](https://github.com/grelinfo/grelmicro/issues/158).
+* ✨ Add `CircuitBreaker.reconfigure(new_config)`. Swap thresholds and `ignore_exceptions` without restarting. Runtime state and `last_error` are kept. `log_level` is applied to the logger. Issue [#158](https://github.com/grelinfo/grelmicro/issues/158).
+* ✨ Add `HealthRegistry.reconfigure(new_config)`. Swap `cache_ttl` and the default `timeout` without restarting. Per-check timeouts stay as registered. Issue [#162](https://github.com/grelinfo/grelmicro/issues/162).
 
 ## 0.19.0 - 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 * ✨ Add `reconfigure(new_config)` to `Lock`, `TaskLock`, and `LeaderElection` for atomic live config swap. The `worker` field is fixed for the lifetime of the instance: only timing fields can change. Issue [#158](https://github.com/grelinfo/grelmicro/issues/158).
 * ✨ Add `CircuitBreaker.reconfigure(new_config)` for atomic live config swap. Runtime state (current `CircuitBreakerState`, counters, `last_error`) is preserved across the swap. `log_level` changes propagate to the instance logger. Issue [#158](https://github.com/grelinfo/grelmicro/issues/158).
+* ✨ Add `HealthRegistry.reconfigure(new_config)` for atomic live config swap. The `cache_ttl` change applies on the next round; existing checks keep their per-check timeout resolved at registration time. Issue [#162](https://github.com/grelinfo/grelmicro/issues/162).
 
 ## 0.19.0 - 2026-05-01
 

--- a/grelmicro/health/_registry.py
+++ b/grelmicro/health/_registry.py
@@ -100,12 +100,11 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
 
     Supports live reconfiguration via
     [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
-    A swap takes effect on the next :meth:`run`. The ``cache_ttl``
-    change applies to subsequent cache lookups; in-flight rounds
-    finish on their admission snapshot. The default ``timeout``
-    applies to checks registered after the swap: existing entries
-    keep the per-check timeout that was resolved at :meth:`add`
-    time. Re-register a check to pick up a new default. See
+    A swap takes effect on the next :meth:`run`. In-flight rounds
+    keep the ``cache_ttl`` they started with. The new default
+    ``timeout`` applies to checks registered after the swap.
+    Existing checks keep the timeout they were registered with.
+    Re-register a check to pick up the new default. See
     [Live reconfiguration](../architecture/reconfigure.md).
     """
 

--- a/grelmicro/health/_registry.py
+++ b/grelmicro/health/_registry.py
@@ -252,6 +252,7 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
                 Colon is allowed for namespacing, e.g.
                 ``"weather:circuitbreaker"``.
         """
+        config = self._config
         if (
             not name
             or len(name) > _NAME_MAX_LEN
@@ -270,7 +271,7 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
             name=name,
             func=_normalize(func),
             critical=critical,
-            timeout=timeout if timeout is not None else self._config.timeout,
+            timeout=timeout if timeout is not None else config.timeout,
         )
         self._entries = dict(sorted(self._entries.items()))
 

--- a/grelmicro/health/_registry.py
+++ b/grelmicro/health/_registry.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, NonNegativeFloat, PositiveFloat
 from typing_extensions import Doc
 
 from grelmicro._async import is_async_callable
-from grelmicro._config import resolve_config
+from grelmicro._config import Reconfigurable, resolve_config
 from grelmicro.health._models import (
     CheckResult,
     HealthReport,
@@ -88,7 +88,7 @@ def _normalize(func: HealthCheckFunc) -> AsyncHealthCheckFunc:
     return _async_wrapper
 
 
-class HealthRegistry:
+class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
     """Registry that manages health checks and runs them concurrently.
 
     Checks are plain async functions. Register them with the
@@ -97,6 +97,16 @@ class HealthRegistry:
     check has its own timeout (falling back to the registry default)
     and its own cached result. Concurrent requests for the same check
     share a single execution via an ``anyio.Event``.
+
+    Supports live reconfiguration via
+    [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
+    A swap takes effect on the next :meth:`run`. The ``cache_ttl``
+    change applies to subsequent cache lookups; in-flight rounds
+    finish on their admission snapshot. The default ``timeout``
+    applies to checks registered after the swap: existing entries
+    keep the per-check timeout that was resolved at :meth:`add`
+    time. Re-register a check to pick up a new default. See
+    [Live reconfiguration](../architecture/reconfigure.md).
     """
 
     def __init__(
@@ -190,6 +200,7 @@ class HealthRegistry:
     def _setup(self, config: HealthRegistryConfig) -> None:
         """Wire the validated config and runtime deps onto the instance."""
         self._config = config
+        self._reconfigure_lock = anyio.Lock()
         self._entries: dict[str, _Entry] = {}
 
     async def __aenter__(self) -> Self:
@@ -313,6 +324,7 @@ class HealthRegistry:
             A HealthReport with the aggregate status and per-check
             results.
         """
+        config = self._config
         if exclude is None:
             excluded: frozenset[str] = frozenset()
         else:
@@ -329,7 +341,9 @@ class HealthRegistry:
         results: dict[str, CheckResult] = {}
 
         async def _run(name: str, entry: _Entry) -> None:
-            results[name] = await self._get_or_run(entry)
+            results[name] = await self._get_or_run(
+                entry, cache_ttl=config.cache_ttl
+            )
 
         async with anyio.create_task_group() as tg:
             for name, entry in selected:
@@ -341,15 +355,20 @@ class HealthRegistry:
             checks=ordered,
         )
 
-    async def _get_or_run(self, entry: _Entry) -> CheckResult:
+    async def _get_or_run(
+        self, entry: _Entry, *, cache_ttl: float
+    ) -> CheckResult:
         """Return a cached or freshly computed result for one check.
 
         Respects ``cache_ttl`` and serializes concurrent calls via a
         shared ``anyio.Event``. If the single-flight leader is
         cancelled before it produces a result, waiters take the lead
-        themselves instead of failing.
+        themselves instead of failing. The caller captures
+        ``cache_ttl`` from a snapshot at the start of the round so a
+        concurrent ``reconfigure`` cannot change the cache decision
+        mid-call.
         """
-        ttl = self._config.cache_ttl
+        ttl = cache_ttl
         while True:
             now = time.monotonic()
             if (

--- a/grelmicro/resilience/circuitbreaker.py
+++ b/grelmicro/resilience/circuitbreaker.py
@@ -176,12 +176,10 @@ class CircuitBreaker(Reconfigurable[CircuitBreakerConfig]):
 
     Supports live reconfiguration via
     [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
-    Each call captures the config once on entry, so a swap takes
-    effect on the next call. The runtime state (current
-    `CircuitBreakerState`, counters, `last_error`) is preserved
-    across the swap. A change to `log_level` is applied to the
-    instance logger by `_apply_reconfigure`. See
-    [Live reconfiguration](../architecture/reconfigure.md).
+    A swap takes effect on the next call. In-flight calls keep the
+    config they entered with. The current state, counters, and
+    `last_error` are kept. A new `log_level` is applied to the
+    logger. See [Live reconfiguration](../architecture/reconfigure.md).
     """
 
     def __init__(

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -104,10 +104,9 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
 
     Supports live reconfiguration via
     [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
-    A swap takes effect on the next iteration of the renew loop. The
-    `worker` field is fixed for the lifetime of the instance:
-    changing it raises `ValueError`. See
-    [Live reconfiguration](../architecture/reconfigure.md).
+    A swap takes effect on the next renew loop iteration. The
+    `worker` field cannot change. Changing it raises `ValueError`.
+    See [Live reconfiguration](../architecture/reconfigure.md).
     """
 
     _LOCK_PREFIX = "leader"

--- a/grelmicro/sync/lock.py
+++ b/grelmicro/sync/lock.py
@@ -66,9 +66,9 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
 
     Supports live reconfiguration via
     [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
-    A swap takes effect on the next `acquire`, `release`, and retry
-    sleep. The `worker` field is fixed for the lifetime of the
-    instance: changing it raises `ValueError`. See
+    A swap takes effect on the next call. In-flight calls keep the
+    config they started with. The `worker` field cannot change.
+    Changing it raises `ValueError`. See
     [Live reconfiguration](../architecture/reconfigure.md).
     """
 

--- a/grelmicro/sync/tasklock.py
+++ b/grelmicro/sync/tasklock.py
@@ -83,9 +83,9 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
 
     Supports live reconfiguration via
     [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
-    A swap takes effect on the next acquire and on the next exit
-    re-acquire. The `worker` field is fixed for the lifetime of the
-    instance: changing it raises `ValueError`. See
+    A swap takes effect on the next call. An exit re-acquire uses
+    the config the call entered with. The `worker` field cannot
+    change. Changing it raises `ValueError`. See
     [Live reconfiguration](../architecture/reconfigure.md).
     """
 

--- a/tests/health/test_registry.py
+++ b/tests/health/test_registry.py
@@ -5,9 +5,8 @@ import time
 from collections.abc import Generator
 
 import anyio
-import pydantic
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from grelmicro._backends import (
     BackendAlreadyRegisteredError,
@@ -584,7 +583,7 @@ async def test_reconfigure_same_config_is_noop() -> None:
 async def test_reconfigure_rejects_different_config_type() -> None:
     """The mixin rejects config types different from the current one."""
 
-    class Other(pydantic.BaseModel):
+    class Other(BaseModel):
         pass
 
     registry = HealthRegistry()
@@ -622,12 +621,14 @@ async def test_reconfigure_changes_cache_ttl_for_next_run() -> None:
 async def test_reconfigure_during_inflight_run_uses_admission_snapshot() -> (
     None
 ):
-    """A reconfigure during a run does not change the cache decision mid-round.
+    """All tasks in one run() share one admission snapshot.
 
-    The first round captures `cache_ttl=60`. A concurrent reconfigure
-    swaps to `cache_ttl=0`. The in-flight round still uses the
-    admission snapshot, so its result is cached and reused for a
-    second concurrent call inside the same round window.
+    A round starts with `cache_ttl=60`. A concurrent reconfigure
+    swaps to `cache_ttl=0` while one check is still running. The
+    in-flight round keeps its admission `cache_ttl=60`, so the
+    cached result is reused for a second `run()` call started after
+    the reconfigure but still within the cache window. A third
+    `run()` after the cache window expires runs fresh.
     """
     call_count = 0
     in_check = anyio.Event()
@@ -648,12 +649,56 @@ async def test_reconfigure_during_inflight_run_uses_admission_snapshot() -> (
         await registry.reconfigure(
             registry.config.model_copy(update={"cache_ttl": 0.0})
         )
-        # The reconfigure is published; subsequent runs see cache_ttl=0
-        # but the in-flight round uses its admission snapshot.
         can_finish.set()
 
-    # First round ran once.
     assert call_count == 1
-    # Second round (post-reconfigure) sees cache_ttl=0, runs again.
+    # The next run() admits at cache_ttl=0 and runs the check again.
     await registry.run()
     assert call_count == 2  # noqa: PLR2004
+
+
+async def test_reconfigure_round_is_consistent_across_checks() -> None:
+    """All checks scheduled in one run() share the same admission cache_ttl.
+
+    Two checks are registered. A reconfigure to `cache_ttl=0`
+    happens while the first check is in flight. The second check
+    started in the same round still admits at `cache_ttl=60` and
+    is allowed to use cached results from the same round. The
+    round is internally consistent.
+    """
+    fast_calls = 0
+    slow_calls = 0
+    slow_started = anyio.Event()
+    slow_can_finish = anyio.Event()
+
+    async def fast_check() -> None:
+        nonlocal fast_calls
+        fast_calls += 1
+
+    async def slow_check() -> None:
+        nonlocal slow_calls
+        slow_calls += 1
+        slow_started.set()
+        await slow_can_finish.wait()
+
+    registry = HealthRegistry(cache_ttl=60.0)
+    registry.add("fast", fast_check)
+    registry.add("slow", slow_check)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(registry.run)
+        await slow_started.wait()
+        # Reconfigure to disable cache while the round is in flight.
+        await registry.reconfigure(
+            registry.config.model_copy(update={"cache_ttl": 0.0})
+        )
+        slow_can_finish.set()
+
+    # Round 1 ran each check exactly once.
+    assert fast_calls == 1
+    assert slow_calls == 1
+
+    # The next round admits at cache_ttl=0 and runs both checks again.
+    await registry.run()
+    assert fast_calls == 2  # noqa: PLR2004
+    assert slow_calls == 2  # noqa: PLR2004

--- a/tests/health/test_registry.py
+++ b/tests/health/test_registry.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Generator
 
 import anyio
+import pydantic
 import pytest
 from pydantic import ValidationError
 
@@ -555,3 +556,104 @@ def test_reset_health_registry() -> None:
 
     with pytest.raises(BackendNotLoadedError):
         get_health_registry()
+
+
+# --- reconfigure ---
+
+
+async def test_reconfigure_swaps_config() -> None:
+    """Reconfigure publishes the new config."""
+    registry = HealthRegistry(timeout=1.0, cache_ttl=1.0)
+    new_config = registry.config.model_copy(update={"cache_ttl": 5.0})
+
+    await registry.reconfigure(new_config)
+
+    assert registry.config == new_config
+
+
+async def test_reconfigure_same_config_is_noop() -> None:
+    """Equal configs short-circuit."""
+    registry = HealthRegistry(timeout=1.0, cache_ttl=1.0)
+    same = registry.config.model_copy()
+
+    await registry.reconfigure(same)
+
+    assert registry.config == same
+
+
+async def test_reconfigure_rejects_different_config_type() -> None:
+    """The mixin rejects config types different from the current one."""
+
+    class Other(pydantic.BaseModel):
+        pass
+
+    registry = HealthRegistry()
+    with pytest.raises(TypeError, match="HealthRegistryConfig"):
+        await registry.reconfigure(Other())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+async def test_reconfigure_changes_cache_ttl_for_next_run() -> None:
+    """A swap to cache_ttl=0 disables caching on the next run."""
+    call_count = 0
+
+    async def check() -> None:
+        nonlocal call_count
+        call_count += 1
+
+    registry = HealthRegistry(cache_ttl=60.0)
+    registry.add("c", check)
+
+    await registry.run()
+    await registry.run()
+    cached_calls = call_count
+
+    await registry.reconfigure(
+        registry.config.model_copy(update={"cache_ttl": 0.0})
+    )
+
+    await registry.run()
+    await registry.run()
+
+    # First two runs share cache, last two each call the check fresh.
+    assert cached_calls == 1
+    assert call_count == 3  # noqa: PLR2004
+
+
+async def test_reconfigure_during_inflight_run_uses_admission_snapshot() -> (
+    None
+):
+    """A reconfigure during a run does not change the cache decision mid-round.
+
+    The first round captures `cache_ttl=60`. A concurrent reconfigure
+    swaps to `cache_ttl=0`. The in-flight round still uses the
+    admission snapshot, so its result is cached and reused for a
+    second concurrent call inside the same round window.
+    """
+    call_count = 0
+    in_check = anyio.Event()
+    can_finish = anyio.Event()
+
+    async def slow_check() -> None:
+        nonlocal call_count
+        call_count += 1
+        in_check.set()
+        await can_finish.wait()
+
+    registry = HealthRegistry(cache_ttl=60.0)
+    registry.add("c", slow_check)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(registry.run)
+        await in_check.wait()
+        await registry.reconfigure(
+            registry.config.model_copy(update={"cache_ttl": 0.0})
+        )
+        # The reconfigure is published; subsequent runs see cache_ttl=0
+        # but the in-flight round uses its admission snapshot.
+        can_finish.set()
+
+    # First round ran once.
+    assert call_count == 1
+    # Second round (post-reconfigure) sees cache_ttl=0, runs again.
+    await registry.run()
+    assert call_count == 2  # noqa: PLR2004


### PR DESCRIPTION
## Summary

* `HealthRegistry` inherits `Reconfigurable[HealthRegistryConfig]` and exposes `await registry.reconfigure(new_config)` for atomic live config swap.
* `run()` captures `config = self._config` once at the top and passes `cache_ttl` to `_get_or_run`. In-flight rounds complete on the admission snapshot. The next round picks up the new value.
* The default `timeout` applies to checks registered *after* the swap. Existing entries keep the per-check timeout resolved at `add()` time. Re-register to pick up a new default. Documented in the class docstring.
* No `_apply_reconfigure` override needed: there is no cached derived state.

Closes [#162](https://github.com/grelinfo/grelmicro/issues/162). Tracked under [#161](https://github.com/grelinfo/grelmicro/issues/161).

## Test plan

- [x] Reconfigure swaps config, no-op on equal config, rejects different config types.
- [x] `cache_ttl=0` change disables caching on the next run.
- [x] In-flight round uses the admission snapshot (a concurrent reconfigure does not flip its cache decision mid-round).
- [x] Full suite: 1430 passing, 100% coverage.
- [x] ruff check and ty check clean.