### PR TITLE
📝 Replace "Production-ready" with "Railguarded" in README and landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is built for any Python application that coordinates work across processes, w
 - **Fast**: small footprint by design. We keep the layers thin so your code stays quick.
 - **Async-first**: every I/O call is `async` / `await`. Drops into FastAPI, FastStream, and any AnyIO-based stack.
 - **Backend-agnostic**: each primitive is a protocol. Swap Redis for PostgreSQL or SQLite without touching application code.
-- **Production-ready**: 100% test coverage and full type hints. Pre-1.0 API may shift on minor bumps. `1.x` will commit to standard semver.
+- **Railguarded**: 100% pytest coverage, ty-checked, ruff-linted, Pydantic-validated. Pre-1.0 API may shift on minor bumps. `1.x` commits to standard semver.
 
 ## Modules
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ It is built for any Python application that coordinates work across processes, w
 - **Fast**: small footprint by design. We keep the layers thin so your code stays quick.
 - **Async-first**: every I/O call is `async` / `await`. Drops into FastAPI, FastStream, and any AnyIO-based stack.
 - **Backend-agnostic**: each primitive is a protocol. Swap Redis for PostgreSQL or SQLite without touching application code.
-- **Production-ready**: 100% test coverage and full type hints. Pre-1.0 API may shift on minor bumps. `1.x` will commit to standard semver.
+- **Railguarded**: 100% pytest coverage, ty-checked, ruff-linted, Pydantic-validated. Pre-1.0 API may shift on minor bumps. `1.x` commits to standard semver.
 
 ## Modules
 


### PR DESCRIPTION
## Summary

Drop the "Production-ready" label from the README and the docs landing page. Pre-1.0 grelmicro has not been battle-tested at scale; the claim was overstated.

Replace it with a tag that names the actual rails enforced on every PR:

> **Railguarded**: 100% pytest coverage, ty-checked, ruff-linted, Pydantic-validated. Pre-1.0 API may shift on minor bumps. `1.x` commits to standard semver.

This is honest about what we guarantee today (a strict CI bar across coverage, types, lint, and runtime validation) without overpromising production proof we have not yet earned.

## Test plan

- [x] No code changes. README and `docs/index.md` only.