### PR TITLE
♻️ Namespace resilience registries, prefix-match in lifespan exclude

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 * 💥 Drop AnyIO. grelmicro now targets `asyncio` directly. Issue [#183](https://github.com/grelinfo/grelmicro/issues/183).
 * 💥 `CircuitBreaker` now takes a backend (``CircuitBreakerBackend``). The in-memory backend (``MemoryCircuitBreakerBackend``) is the default. A future Redis-backed implementation will share state across replicas (issue #188). The async API stays primary, sync code goes through ``cb.from_thread``.
 * 💥 The sync adapters on `Lock`, `TaskLock`, `TTLCache`, and `CircuitBreaker` now require the backend to be opened (``async with backend:`` or ``grelmicro.lifespan()``). The backend captures the running loop and the sync adapter dispatches through it. Zero hot-path overhead.
+* 💥 Resilience registries are now namespaced. The rate limiter registry name moves from ``"resilience"`` to ``"resilience.ratelimiter"`` and the circuit breaker registry is ``"resilience.circuitbreaker"``. ``grelmicro.lifespan(exclude=...)`` now matches by dotted prefix, so ``exclude={"resilience"}`` still skips both registries.
 
 ### Features
 

--- a/grelmicro/__init__.py
+++ b/grelmicro/__init__.py
@@ -24,19 +24,27 @@ async def lifespan(
 
     Modules whose registry has not been imported are skipped:
     importing ``grelmicro`` alone walks nothing. Importing
-    ``grelmicro.sync`` makes the sync registry visible. Use
-    ``exclude={"<module>"}`` to skip a module or
-    ``exclude={"<module>.<name>"}`` to skip one named entry.
+    ``grelmicro.sync`` makes the sync registry visible.
+
+    ``exclude`` matches by dotted prefix. ``{"resilience"}`` skips
+    every ``resilience.*`` registry (rate limiter and circuit
+    breaker). ``{"resilience.ratelimiter"}`` skips only that
+    registry. ``{"resilience.ratelimiter.analytics"}`` skips just
+    the named entry inside that registry.
     """
     from grelmicro._backends import _ALL_REGISTRIES  # noqa: PLC0415
 
     excluded = frozenset(exclude)
+
+    def is_excluded(path: str) -> bool:
+        return any(path == ex or path.startswith(f"{ex}.") for ex in excluded)
+
     async with AsyncExitStack() as stack:
         for module_name, registry in _ALL_REGISTRIES.items():
-            if module_name in excluded:
+            if is_excluded(module_name):
                 continue
             for entry_name, backend in registry.items():
-                if f"{module_name}.{entry_name}" in excluded:
+                if is_excluded(f"{module_name}.{entry_name}"):
                     continue
                 await stack.enter_async_context(backend)
         for ctx in ad_hoc:

--- a/grelmicro/resilience/_backends.py
+++ b/grelmicro/resilience/_backends.py
@@ -7,7 +7,7 @@ from grelmicro.resilience._protocol import (
 )
 
 rate_limiter_backend_registry: BackendRegistry[RateLimiterBackend] = (
-    BackendRegistry(name="resilience")
+    BackendRegistry(name="resilience.ratelimiter")
 )
 
 circuit_breaker_backend_registry: BackendRegistry[CircuitBreakerBackend] = (

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -20,8 +20,14 @@ from grelmicro.cache.memory import MemoryCacheBackend
 from grelmicro.cache.redis import RedisCacheBackend
 from grelmicro.health._backends import health_registry
 from grelmicro.health._registry import HealthRegistry
-from grelmicro.resilience._backends import rate_limiter_backend_registry
-from grelmicro.resilience.memory import MemoryRateLimiterBackend
+from grelmicro.resilience._backends import (
+    circuit_breaker_backend_registry,
+    rate_limiter_backend_registry,
+)
+from grelmicro.resilience.memory import (
+    MemoryCircuitBreakerBackend,
+    MemoryRateLimiterBackend,
+)
 from grelmicro.resilience.redis import RedisRateLimiterBackend
 from grelmicro.sync import Lock
 from grelmicro.sync._backends import sync_backend_registry
@@ -46,6 +52,7 @@ def _clean_registries() -> None:
     sync_backend_registry.reset()
     cache_backend_registry.reset()
     rate_limiter_backend_registry.reset()
+    circuit_breaker_backend_registry.reset()
 
 
 @pytest.fixture
@@ -248,13 +255,29 @@ async def test_lifespan_excludes_named_entry() -> None:
 
 
 async def test_lifespan_excludes_resilience_module_key() -> None:
-    """``exclude={"resilience"}`` matches the rate limiter registry."""
+    """``exclude={"resilience"}`` skips every ``resilience.*`` registry."""
     rate_limiter_backend_registry.register(
         MemoryRateLimiterBackend(), "default"
+    )
+    circuit_breaker_backend_registry.register(
+        MemoryCircuitBreakerBackend(), "default"
     )
     sync_backend_registry.register(MemorySyncBackend(), "default")
     async with grelmicro.lifespan(exclude={"resilience"}):
         assert sync_backend_registry.is_loaded
+
+
+async def test_lifespan_excludes_specific_resilience_registry() -> None:
+    """``exclude={"resilience.ratelimiter"}`` skips only that registry."""
+    rate_limiter_backend_registry.register(
+        MemoryRateLimiterBackend(), "default"
+    )
+    cb = MemoryCircuitBreakerBackend()
+    circuit_breaker_backend_registry.register(cb, "default")
+    async with grelmicro.lifespan(exclude={"resilience.ratelimiter"}):
+        # CB backend was opened (its loop is captured), rate limiter
+        # was skipped.
+        assert cb._loop is not None
 
 
 def test_lock_resolves_named_backend_from_registry() -> None:

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -1,6 +1,7 @@
 """Backend lifecycle: explicit named registration, scoped overrides, lifespan."""
 
 import warnings
+from typing import Self
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -254,29 +255,42 @@ async def test_lifespan_excludes_named_entry() -> None:
         assert sync_backend_registry.get("primary") is primary
 
 
+class _CountingRateLimiterBackend(MemoryRateLimiterBackend):
+    """``MemoryRateLimiterBackend`` that tracks ``__aenter__`` calls."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.entered = 0
+
+    async def __aenter__(self) -> Self:
+        self.entered += 1
+        await super().__aenter__()
+        return self
+
+
 async def test_lifespan_excludes_resilience_module_key() -> None:
     """``exclude={"resilience"}`` skips every ``resilience.*`` registry."""
-    rate_limiter_backend_registry.register(
-        MemoryRateLimiterBackend(), "default"
-    )
-    circuit_breaker_backend_registry.register(
-        MemoryCircuitBreakerBackend(), "default"
-    )
+    rl = _CountingRateLimiterBackend()
+    cb = MemoryCircuitBreakerBackend()
+    rate_limiter_backend_registry.register(rl, "default")
+    circuit_breaker_backend_registry.register(cb, "default")
     sync_backend_registry.register(MemorySyncBackend(), "default")
     async with grelmicro.lifespan(exclude={"resilience"}):
         assert sync_backend_registry.is_loaded
+        # Neither resilience backend was entered.
+        assert rl.entered == 0
+        assert cb._loop is None
 
 
 async def test_lifespan_excludes_specific_resilience_registry() -> None:
     """``exclude={"resilience.ratelimiter"}`` skips only that registry."""
-    rate_limiter_backend_registry.register(
-        MemoryRateLimiterBackend(), "default"
-    )
+    rl = _CountingRateLimiterBackend()
     cb = MemoryCircuitBreakerBackend()
+    rate_limiter_backend_registry.register(rl, "default")
     circuit_breaker_backend_registry.register(cb, "default")
     async with grelmicro.lifespan(exclude={"resilience.ratelimiter"}):
-        # CB backend was opened (its loop is captured), rate limiter
-        # was skipped.
+        # Rate limiter was skipped, CB was opened.
+        assert rl.entered == 0
         assert cb._loop is not None
 
 


### PR DESCRIPTION
## Summary

- Rename the rate limiter registry from `"resilience"` to `"resilience.ratelimiter"` so it matches the dotted naming the circuit breaker registry already uses (`"resilience.circuitbreaker"`).
- Make `grelmicro.lifespan(exclude=...)` match by dotted prefix, so `exclude={"resilience"}` still skips every `resilience.*` registry. `exclude={"resilience.ratelimiter"}` skips only that registry. `exclude={"resilience.ratelimiter.analytics"}` keeps skipping a single named entry.

## Test plan

- [x] `uv run pytest` (1437 passed)
- [x] `uv run ruff check` / `uv run ty check`
- [x] New test covers `exclude={"resilience"}` skipping both registries and `exclude={"resilience.ratelimiter"}` skipping only the rate limiter