### PR TITLE
📝 Document asyncio runtime, drop AnyIO completely

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,6 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "uvicorn"
         update-types: ["version-update:semver-major"]
-      - dependency-name: "anyio"
-        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "⬆️ "
       prefix-development: "⬆️ "

--- a/docs/architecture/asyncio.md
+++ b/docs/architecture/asyncio.md
@@ -10,4 +10,5 @@ asyncio is in the standard library. Every Python web framework grelmicro is mean
 
 - Use `asyncio.run(main())` or `uvloop.run(main())`. The `standard` extra ships uvloop on Linux and macOS.
 - Sync code that needs to call a primitive uses the per-component sync adapter (`lock.from_thread`, `cb.from_thread`, `@cached(...)`). It does not need a separate runtime bridge.
-- AnyIO is not a dependency at all. The test suite runs on `pytest-asyncio` with `asyncio_mode = "auto"`.
+- grelmicro does not import or depend on AnyIO directly. AnyIO may still be present in the environment transitively (for example through `fast-depends`), but no grelmicro code uses it.
+- The test suite runs on `pytest-asyncio` with `asyncio_mode = "auto"`.

--- a/docs/architecture/asyncio.md
+++ b/docs/architecture/asyncio.md
@@ -1,0 +1,13 @@
+# Concurrency runtime
+
+grelmicro targets `asyncio` directly. Trio and the AnyIO compatibility layer are not supported.
+
+## Why asyncio only
+
+asyncio is in the standard library. Every Python web framework grelmicro is meant to plug into (FastAPI, Starlette, Litestar, Sanic, AIOHTTP) runs on asyncio. Targeting one runtime keeps the bridge code small: backends capture the running loop in `__aenter__` and the sync adapters dispatch through `asyncio.run_coroutine_threadsafe` with no abstraction in the hot path. See [Sync from thread](sync-from-thread.md) for how that bridge works.
+
+## What this means in practice
+
+- Use `asyncio.run(main())` or `uvloop.run(main())`. The `standard` extra ships uvloop on Linux and macOS.
+- Sync code that needs to call a primitive uses the per-component sync adapter (`lock.from_thread`, `cb.from_thread`, `@cached(...)`). It does not need a separate runtime bridge.
+- AnyIO is not a dependency at all. The test suite runs on `pytest-asyncio` with `asyncio_mode = "auto"`.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -2,6 +2,7 @@
 
 This section documents the internal design decisions and guarantees of grelmicro.
 
+- **[Concurrency runtime](asyncio.md)**: Why grelmicro targets asyncio directly and not Trio or AnyIO.
 - **[Backend Registry](backends.md)**: Shared registry pattern for swappable backends.
 - **[Configuration](config.md)**: Explicit construction paths, `from_config(...)`, optional env resolution where it fits, and the library-not-app boundary.
 - **[Live reconfiguration](reconfigure.md)**: Atomic config swap on a live component, the `Reconfigurable` mixin, and reader safety.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,7 @@
 
 ### Internal
 
-* ✅ Migrate the test suite from `pytest.mark.anyio` to `pytest-asyncio` with `asyncio_mode = "auto"`. AnyIO is no longer a dependency at all (runtime or dev).
+* ✅ Migrate the test suite from `pytest.mark.anyio` to `pytest-asyncio` with `asyncio_mode = "auto"`. AnyIO is no longer a direct dependency of grelmicro (it may still arrive transitively, for example through `fast-depends`).
 * ♻️ Adopt PEP 695 generic syntax (`class Foo[T]:`, `def f[T](...)`, `type X = ...`) across `_backends.py`, `_config.py`, `_types.py`, `health/_types.py`, `trace/_instrument.py`, and `tests/task/conftest.py`. Two files keep the older form: the recursive aliases in `_json.py` (ty cannot expand recursive PEP 695 aliases) and the decorator factory in `cache/cached.py` (PEP 695 binds the inner decorator to the outer scope's type parameters, breaking per-decoration-site inference). Issue [#65](https://github.com/grelinfo/grelmicro/issues/65).
 * 🔨 Bump `tool.ruff.target-version` to `py312` and the CI matrix to `["3.12","3.13","3.14"]`.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@
 
 ### Internal
 
+* ✅ Migrate the test suite from `pytest.mark.anyio` to `pytest-asyncio` with `asyncio_mode = "auto"`. AnyIO is no longer a dependency at all (runtime or dev).
 * ♻️ Adopt PEP 695 generic syntax (`class Foo[T]:`, `def f[T](...)`, `type X = ...`) across `_backends.py`, `_config.py`, `_types.py`, `health/_types.py`, `trace/_instrument.py`, and `tests/task/conftest.py`. Two files keep the older form: the recursive aliases in `_json.py` (ty cannot expand recursive PEP 695 aliases) and the decorator factory in `cache/cached.py` (PEP 695 binds the inner decorator to the outer scope's type parameters, breaking per-decoration-site inference). Issue [#65](https://github.com/grelinfo/grelmicro/issues/65).
 * 🔨 Bump `tool.ruff.target-version` to `py312` and the CI matrix to `["3.12","3.13","3.14"]`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
     - reference/task.md
 - Architecture:
     - architecture/index.md
+    - architecture/asyncio.md
     - architecture/backends.md
     - architecture/config.md
     - architecture/reconfigure.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ structlog = [
 
 [dependency-groups]
 dev = [
-    "anyio>=4.0.0",
+    "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "pytest>=8.0.0",
     "ruff>=0.7.4",
@@ -233,6 +233,9 @@ addopts = """
     --strict-markers
     -n auto
 """
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 markers = """
     integration: mark a test as an integration test
 """

--- a/tests/cache/test_cache_backends.py
+++ b/tests/cache/test_cache_backends.py
@@ -13,16 +13,10 @@ from grelmicro.cache.redis import RedisCacheBackend
 from grelmicro.cache.serializers import JsonSerializer
 from grelmicro.cache.ttl import TTLCache
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(30)]
+pytestmark = [pytest.mark.timeout(30)]
 
 
 # --- Fixtures (parametrized across backends) ---
-
-
-@pytest.fixture(scope="module")
-def anyio_backend() -> str:
-    """AnyIO Backend Module Scope."""
-    return "asyncio"
 
 
 @pytest.fixture(

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -12,7 +12,7 @@ from grelmicro.cache.memory import MemoryCacheBackend
 from grelmicro.cache.serializers import PickleSerializer
 from grelmicro.cache.ttl import TTLCache
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
+pytestmark = [pytest.mark.timeout(10)]
 
 EXPECTED_DOUBLE_5 = 10
 EXPECTED_CALL_COUNT_1 = 1

--- a/tests/cache/test_memory.py
+++ b/tests/cache/test_memory.py
@@ -9,7 +9,7 @@ from grelmicro.cache import use_backend
 from grelmicro.cache._backends import cache_backend_registry, get_cache_backend
 from grelmicro.cache.memory import MemoryCacheBackend
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(5)]
+pytestmark = [pytest.mark.timeout(5)]
 
 
 class TestMemoryCacheBackendGet:

--- a/tests/cache/test_redis.py
+++ b/tests/cache/test_redis.py
@@ -11,7 +11,7 @@ from grelmicro.cache._backends import cache_backend_registry, get_cache_backend
 from grelmicro.cache.errors import CacheSettingsValidationError
 from grelmicro.cache.redis import RedisCacheBackend
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(1)]
+pytestmark = [pytest.mark.timeout(1)]
 
 URL = "redis://:test_password@test_host:1234/0"
 

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -12,7 +12,7 @@ from grelmicro.cache.memory import MemoryCacheBackend
 from grelmicro.cache.serializers import JsonSerializer, PickleSerializer
 from grelmicro.cache.ttl import CacheInfo, TTLCache
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
+pytestmark = [pytest.mark.timeout(10)]
 
 EXPECTED_HITS_2 = 2
 EXPECTED_OVERWRITE_VALUE = 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,28 @@
 
 import pytest
 
+from grelmicro.cache._backends import cache_backend_registry
+from grelmicro.resilience._backends import (
+    circuit_breaker_backend_registry,
+    rate_limiter_backend_registry,
+)
+from grelmicro.sync._backends import sync_backend_registry
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend_registries() -> None:
+    """Reset every backend registry before each test.
+
+    Tests register backends ad-hoc and the order they run in is
+    randomised, so a leaked entry from one test can fail an
+    unrelated one with ``BackendAlreadyRegisteredError``. Resetting
+    up-front isolates each test from the rest.
+    """
+    sync_backend_registry.reset()
+    cache_backend_registry.reset()
+    rate_limiter_backend_registry.reset()
+    circuit_breaker_backend_registry.reset()
+
 
 @pytest.fixture(autouse=True)
 def _opt_in_env_config(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,6 @@
 import pytest
 
 
-@pytest.fixture
-def anyio_backend() -> str:
-    """AnyIO Backend."""
-    return "asyncio"
-
-
 @pytest.fixture(autouse=True)
 def _opt_in_env_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """Enable the Environmental config path for all tests by default.

--- a/tests/health/test_fastapi.py
+++ b/tests/health/test_fastapi.py
@@ -23,7 +23,7 @@ from grelmicro.health.fastapi import health_router
 
 from .conftest import healthy, healthy_with_details, unhealthy
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
+pytestmark = [pytest.mark.timeout(10)]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/health/test_registry.py
+++ b/tests/health/test_registry.py
@@ -28,7 +28,7 @@ from .conftest import (
     unhealthy_with_health_error,
 )
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
+pytestmark = [pytest.mark.timeout(10)]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -38,8 +38,6 @@ ALL_STATES = [
     CircuitBreakerState.FORCED_OPEN,
 ]
 
-pytestmark = pytest.mark.anyio
-
 
 @pytest.fixture(autouse=True)
 def _register_cb_backend() -> Iterator[MemoryCircuitBreakerBackend]:

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -31,7 +31,7 @@ async def checkpoint() -> None:
     await asyncio.sleep(0)
 
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(1)]
+pytestmark = [pytest.mark.timeout(1)]
 
 LIMIT = 5
 WINDOW = 60.0
@@ -58,7 +58,7 @@ def _sync_backend() -> MemoryRateLimiterBackend:
     """Create and register a memory backend for sync-only tests.
 
     Sync tests can't consume the async `_backend` fixture
-    (pytest-anyio doesn't bridge them).
+    (pytest-asyncio doesn't bridge them).
     """
     backend = MemoryRateLimiterBackend()
     rate_limiter_backend_registry.register(backend, "default")

--- a/tests/resilience/test_ratelimiter_backends.py
+++ b/tests/resilience/test_ratelimiter_backends.py
@@ -17,7 +17,7 @@ from grelmicro.resilience.algorithms import (
 from grelmicro.resilience.memory import MemoryRateLimiterBackend
 from grelmicro.resilience.redis import RedisRateLimiterBackend
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(30)]
+pytestmark = [pytest.mark.timeout(30)]
 
 LIMIT = 5
 WINDOW = 60.0
@@ -26,12 +26,6 @@ REFILL_RATE = 0.1  # slow enough to not refill between assertions
 
 
 # --- Fixtures (parametrized across backends + algorithms) ---
-
-
-@pytest.fixture(scope="module")
-def anyio_backend() -> str:
-    """AnyIO Backend Module Scope."""
-    return "asyncio"
 
 
 @pytest.fixture(

--- a/tests/resilience/test_ratelimiter_redis.py
+++ b/tests/resilience/test_ratelimiter_redis.py
@@ -6,7 +6,7 @@ from grelmicro.resilience._backends import rate_limiter_backend_registry
 from grelmicro.resilience.errors import ResilienceSettingsValidationError
 from grelmicro.resilience.redis import RedisRateLimiterBackend
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(1)]
+pytestmark = [pytest.mark.timeout(1)]
 
 URL = "redis://:test_password@test_host:1234/0"
 

--- a/tests/sync/test_backends.py
+++ b/tests/sync/test_backends.py
@@ -2,11 +2,11 @@
 
 import tempfile
 import time as time_module
+from asyncio import sleep
 from collections.abc import AsyncGenerator, Callable, Generator
 from uuid import uuid4
 
 import pytest
-from anyio import sleep
 from testcontainers.core.container import DockerContainer
 from testcontainers.postgres import PostgresContainer
 from testcontainers.redis import RedisContainer
@@ -21,7 +21,7 @@ from grelmicro.sync.postgres import PostgresSyncBackend
 from grelmicro.sync.redis import RedisSyncBackend
 from grelmicro.sync.sqlite import SQLiteSyncBackend
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(30)]
+pytestmark = [pytest.mark.timeout(30)]
 
 
 def _wait_for_k3s(
@@ -46,12 +46,6 @@ def _extract_kubeconfig(container: DockerContainer) -> str:
         msg = "Failed to extract kubeconfig"
         raise RuntimeError(msg)
     return output.decode()
-
-
-@pytest.fixture(scope="module")
-def anyio_backend() -> str:
-    """AnyIO Backend Module Scope."""
-    return "asyncio"
 
 
 @pytest.fixture(scope="module")

--- a/tests/sync/test_kubernetes.py
+++ b/tests/sync/test_kubernetes.py
@@ -20,7 +20,7 @@ from grelmicro.sync.kubernetes import (
     _sanitize_lease_name,
 )
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(1)]
+pytestmark = [pytest.mark.timeout(1)]
 
 TOKEN = "test-token"  # noqa: S105
 

--- a/tests/sync/test_leaderelection.py
+++ b/tests/sync/test_leaderelection.py
@@ -21,7 +21,7 @@ WORKER_1 = 0
 WORKER_2 = 1
 TEST_TIMEOUT = 1
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(TEST_TIMEOUT)]
+pytestmark = [pytest.mark.timeout(TEST_TIMEOUT)]
 
 
 @pytest.fixture

--- a/tests/sync/test_leaderelection_config.py
+++ b/tests/sync/test_leaderelection_config.py
@@ -22,7 +22,6 @@ def backend() -> SyncBackend:
     return MemorySyncBackend()
 
 
-@pytest.mark.anyio
 async def test_release_is_noop_when_backend_was_never_resolved() -> None:
     """`_release` returns silently when no backend was ever bound."""
     le = LeaderElection("svc")

--- a/tests/sync/test_lock.py
+++ b/tests/sync/test_lock.py
@@ -21,7 +21,7 @@ from grelmicro.sync.errors import (
 from grelmicro.sync.lock import Lock
 from grelmicro.sync.memory import MemorySyncBackend
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(1)]
+pytestmark = [pytest.mark.timeout(1)]
 
 WORKER_1 = 0
 WORKER_2 = 1

--- a/tests/sync/test_lock_release_ordering.py
+++ b/tests/sync/test_lock_release_ordering.py
@@ -15,7 +15,7 @@ from grelmicro.sync.errors import (
 from grelmicro.sync.lock import Lock
 from grelmicro.sync.memory import MemorySyncBackend
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(1)]
+pytestmark = [pytest.mark.timeout(1)]
 
 LOCK_NAME = "test_lock_release_ordering"
 WORKER = "worker_1"

--- a/tests/sync/test_postgres.py
+++ b/tests/sync/test_postgres.py
@@ -7,7 +7,7 @@ from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.errors import SyncSettingsValidationError
 from grelmicro.sync.postgres import PostgresSyncBackend
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(1)]
+pytestmark = [pytest.mark.timeout(1)]
 
 URL = "postgresql://test_user:test_password@test_host:1234/test_db"
 URL_DEFAULT_PORT = "postgresql://test_user:test_password@test_host:5432/test_db"

--- a/tests/sync/test_redis.py
+++ b/tests/sync/test_redis.py
@@ -5,7 +5,7 @@ import pytest
 from grelmicro.sync.errors import SyncSettingsValidationError
 from grelmicro.sync.redis import RedisSyncBackend
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(1)]
+pytestmark = [pytest.mark.timeout(1)]
 
 URL = "redis://:test_password@test_host:1234/0"
 

--- a/tests/sync/test_sqlite.py
+++ b/tests/sync/test_sqlite.py
@@ -7,7 +7,7 @@ from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.errors import SyncSettingsValidationError
 from grelmicro.sync.sqlite import SQLiteSyncBackend
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(1)]
+pytestmark = [pytest.mark.timeout(1)]
 
 
 @pytest.mark.parametrize(

--- a/tests/sync/test_tasklock.py
+++ b/tests/sync/test_tasklock.py
@@ -22,7 +22,7 @@ from grelmicro.sync.lock import Lock, LockConfig
 from grelmicro.sync.memory import MemorySyncBackend
 from grelmicro.sync.tasklock import TaskLock, TaskLockConfig
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
+pytestmark = [pytest.mark.timeout(10)]
 
 LOCK_NAME = "test_task_lock"
 BACKEND_LOCK_NAME = f"tasklock:{LOCK_NAME}"

--- a/tests/sync/test_tokens.py
+++ b/tests/sync/test_tokens.py
@@ -4,16 +4,12 @@ import asyncio
 from threading import get_ident
 from uuid import uuid1
 
-import pytest
-
 from grelmicro.sync._tokens import (
     generate_task_token,
     generate_thread_token,
     generate_token_nonce,
     generate_worker_id,
 )
-
-pytestmark = pytest.mark.anyio
 
 WORKER_ID_LENGTH = 16
 

--- a/tests/task/test_e2e_tasklock.py
+++ b/tests/task/test_e2e_tasklock.py
@@ -13,7 +13,7 @@ from tests.task import samples
 from tests.task._helpers import cancel_group, start_task
 from tests.task.conftest import TaskFactory
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
+pytestmark = [pytest.mark.timeout(10)]
 
 INTERVAL = 0.1
 

--- a/tests/task/test_interval.py
+++ b/tests/task/test_interval.py
@@ -23,7 +23,7 @@ async def sleep_forever() -> None:
     await asyncio.Event().wait()
 
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
+pytestmark = [pytest.mark.timeout(10)]
 
 SLEEP = 0.01
 

--- a/tests/task/test_manager.py
+++ b/tests/task/test_manager.py
@@ -9,7 +9,7 @@ from grelmicro.task import TaskManager
 from grelmicro.task.errors import TaskAddOperationError
 from tests.task.samples import EventTask
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
+pytestmark = [pytest.mark.timeout(10)]
 
 
 def test_task_manager_init() -> None:

--- a/tests/task/test_scheduled.py
+++ b/tests/task/test_scheduled.py
@@ -25,7 +25,7 @@ async def sleep_forever() -> None:
     await asyncio.Event().wait()
 
 
-pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
+pytestmark = [pytest.mark.timeout(10)]
 
 SECONDS = 0.1
 SLEEP = 0.01

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -38,14 +38,6 @@ from grelmicro.sync.postgres import PostgresSyncBackend
 from grelmicro.sync.redis import RedisSyncBackend
 from grelmicro.sync.sqlite import SQLiteSyncBackend
 
-pytestmark = [pytest.mark.anyio]
-
-
-@pytest.fixture
-def anyio_backend() -> str:
-    """Use asyncio for async lifecycle tests."""
-    return "asyncio"
-
 
 @pytest.fixture(autouse=True)
 def _clean_registries() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -477,7 +477,6 @@ structlog = [
 [package.dev-dependencies]
 dev = [
     { name = "aiosqlite" },
-    { name = "anyio" },
     { name = "asyncpg" },
     { name = "fastapi" },
     { name = "fastapi-cli" },
@@ -490,6 +489,7 @@ dev = [
     { name = "orjson" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
@@ -533,7 +533,6 @@ provides-extras = ["standard", "postgres", "redis", "sqlite", "kubernetes", "ope
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
-    { name = "anyio", specifier = ">=4.0.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "fastapi", specifier = ">=0.115.5" },
     { name = "fastapi-cli", specifier = ">=0.0.5" },
@@ -546,6 +545,7 @@ dev = [
     { name = "orjson", specifier = ">=3.10.11" },
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
@@ -1329,6 +1329,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `docs/architecture/asyncio.md`: short summary of why grelmicro targets `asyncio` directly, with a pointer to the from-thread bridge doc.
- Migrate the test suite from `pytest.mark.anyio` to `pytest-asyncio` with `asyncio_mode = "auto"`. Drop AnyIO from the dev group (it was already gone from the runtime deps).
- Pin `asyncio_default_fixture_loop_scope = "session"` and `asyncio_default_test_loop_scope = "session"` so module-scoped backend container fixtures keep working.

Closes #183. Supersedes #186 for the dev-side migration.

## Test plan

- [x] `uv run pytest` (unit + integration, 1437 passed)
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`
- [x] No `anyio` references remain in `grelmicro/`, `tests/`, or `pyproject.toml`