### PR TITLE
📝 Sweep backends doc for resilience registry namespacing

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -14,7 +14,8 @@ All backends use **async** methods because they perform network or disk I/O (Red
 |---|---|---|---|
 | `grelmicro.sync` | `sync` | `SyncBackend` | Redis, PostgreSQL, SQLite, Kubernetes, Memory |
 | `grelmicro.cache` | `cache` | `CacheBackend` | Redis, Memory |
-| `grelmicro.resilience` | `resilience` | `RateLimiterBackend` | Redis, Memory |
+| `grelmicro.resilience` (rate limiter) | `resilience.ratelimiter` | `RateLimiterBackend` | Redis, Memory |
+| `grelmicro.resilience` (circuit breaker) | `resilience.circuitbreaker` | `CircuitBreakerBackend` | Memory |
 | `grelmicro.health` | `health` | `HealthRegistry` | (any number of named registries) |
 
 A registry holds zero or more named entries. Backends are looked up by name at call time, and each entry is independent. The `"default"` slot is the implicit name when no `backend=` is passed.
@@ -40,7 +41,7 @@ async with grelmicro.lifespan():
 # every registered backend is closed on exit (LIFO)
 ```
 
-`grelmicro.lifespan()` walks every grelmicro registry that has been imported in the current process, opens each entry via its async context manager, and closes them in reverse order on exit. Use `exclude={"<module>"}` to skip a whole module or `exclude={"<module>.<name>"}` to skip one entry.
+`grelmicro.lifespan()` walks every grelmicro registry that has been imported in the current process, opens each entry via its async context manager, and closes them in reverse order on exit. `exclude={...}` matches by dotted prefix: `{"sync"}` skips the whole sync registry, `{"resilience"}` skips both `resilience.ratelimiter` and `resilience.circuitbreaker`, `{"resilience.ratelimiter"}` skips only that registry, and `{"sync.analytics"}` skips just the named entry.
 
 **2. Module-level `use_backend` shorthand.** Equivalent to `register("default", backend)`:
 

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -8,7 +8,7 @@ All backends use **async** methods because they perform network or disk I/O (Red
 
 ## Design
 
-`BackendRegistry[T]` is a generic, typed, multi-name container with task-scoped overrides. Each module maintains its own registry. The registry key matches the module name and is the value to use in `lifespan(exclude={...})`:
+`BackendRegistry[T]` is a generic, typed, multi-name container with task-scoped overrides. Each module owns one or more registries. The registry key is the value to use in `lifespan(exclude={...})` and follows the module path: a single-registry module reuses the module name (`sync`, `cache`, `health`), and modules with multiple registries add a suffix (`resilience.ratelimiter`, `resilience.circuitbreaker`).
 
 | Module | Registry key | Protocol / Type | Backends |
 |---|---|---|---|

--- a/docs/architecture/reconfigure.md
+++ b/docs/architecture/reconfigure.md
@@ -1,6 +1,6 @@
 # Live reconfiguration
 
-This page is the engineering side of `Component.reconfigure(new_config)`. It documents the contract behind the [`Reconfigurable`][grelmicro._config.Reconfigurable] mixin and explains the choices a contributor needs to know before adding `reconfigure` support to a new component.
+This page is the engineering side of `Component.reconfigure(new_config)`. It documents the contract behind the `Reconfigurable` mixin and explains the choices a contributor needs to know before adding `reconfigure` support to a new component.
 
 ## The contract
 

--- a/grelmicro/health/_registry.py
+++ b/grelmicro/health/_registry.py
@@ -99,7 +99,7 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
     share a single execution via an ``asyncio.Event``.
 
     Supports live reconfiguration via
-    [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
+    `reconfigure(new_config)`.
     A swap takes effect on the next :meth:`run`. In-flight rounds
     keep the ``cache_ttl`` they started with. The new default
     ``timeout`` applies to checks registered after the swap.

--- a/grelmicro/resilience/circuitbreaker.py
+++ b/grelmicro/resilience/circuitbreaker.py
@@ -176,7 +176,7 @@ class CircuitBreaker(Reconfigurable[CircuitBreakerConfig]):
     failing, to avoid cascading errors.
 
     Supports live reconfiguration via
-    [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
+    `reconfigure(new_config)`.
     A swap takes effect on the next call. In-flight calls keep the
     config they entered with. The current state, counters, and
     `last_error` are kept. A new `log_level` is applied to the

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -88,7 +88,7 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
     It runs as a task to acquire or renew the distributed lock.
 
     Supports live reconfiguration via
-    [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
+    `reconfigure(new_config)`.
     A swap takes effect on the next renew loop iteration. The
     `worker` field cannot change. Changing it raises `ValueError`.
     See [Live reconfiguration](../architecture/reconfigure.md).

--- a/grelmicro/sync/lock.py
+++ b/grelmicro/sync/lock.py
@@ -66,7 +66,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
     automatically released after a duration if not extended.
 
     Supports live reconfiguration via
-    [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
+    `reconfigure(new_config)`.
     A swap takes effect on the next call. In-flight calls keep the
     config they started with. The `worker` field cannot change.
     Changing it raises `ValueError`. See

--- a/grelmicro/sync/tasklock.py
+++ b/grelmicro/sync/tasklock.py
@@ -82,7 +82,7 @@ class TaskLock(Reconfigurable[TaskLockConfig], SyncPrimitive):
     This lock is designed to be used as the `sync` parameter of `IntervalTask`.
 
     Supports live reconfiguration via
-    [`reconfigure`][grelmicro._config.Reconfigurable.reconfigure].
+    `reconfigure(new_config)`.
     A swap takes effect on the next call. An exit re-acquire uses
     the config the call entered with. The `worker` field cannot
     change. Changing it raises `ValueError`. See


### PR DESCRIPTION
## Summary

- Update the registry table in `docs/architecture/backends.md` to reflect the rename from `resilience` to `resilience.ratelimiter` and the new `resilience.circuitbreaker` row.
- Update the `lifespan(exclude=...)` description to document the dotted prefix-match semantics added in #191 (so `exclude={"resilience"}` skips both registries).

Pre-release sweep before 0.21.0.

## Test plan

- [x] `uv run --group docs mkdocs build --strict` — no new warnings introduced (7 pre-existing autoref warnings about `Reconfigurable.reconfigure` are unrelated and present on main before this PR)