### PR TITLE
📝 docs: Release 0.21.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.21.0 - 2026-05-06
 
 ### Breaking
 


### PR DESCRIPTION
Cuts the 0.21.0 changelog header.