### PR TITLE
💄 Shrink landing wordmark to 360px and hide auto-h1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-<!-- Hide the auto-generated h1 on the docs landing page. GitHub strips <style> from rendered README, so this is a no-op there. -->
+<!-- Visually hide the auto-generated h1 on the docs landing page. The wordmark is the title; the heading stays in the a11y tree for screen readers. GitHub strips <style> from rendered READMEs, so this is a no-op there. -->
 <style>
-  .md-content .md-typeset h1 { display: none; }
+  .md-content .md-typeset > h1:first-child {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 </style>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://grelinfo.github.io/grelmicro">
-    <img alt="grelmicro" class="grel-wordmark" src="docs/img/logo/wordmark.svg" width="520">
+    <img alt="grelmicro" class="grel-wordmark" src="docs/img/logo/wordmark.svg" width="360">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!-- Hide the auto-generated h1 on the docs landing page. GitHub strips <style> from rendered README, so this is a no-op there. -->
+<style>
+  .md-content .md-typeset h1 { display: none; }
+</style>
+
 <p align="center">
   <a href="https://grelinfo.github.io/grelmicro">
     <img alt="grelmicro" class="grel-wordmark" src="docs/img/logo/wordmark.svg" width="360">

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,16 @@
-<!-- Hide the auto-generated h1 on the docs landing page. GitHub strips <style> from rendered README, so this is a no-op there. -->
+<!-- Visually hide the auto-generated h1 on the docs landing page. The wordmark is the title; the heading stays in the a11y tree for screen readers. GitHub strips <style> from rendered READMEs, so this is a no-op there. -->
 <style>
-  .md-content .md-typeset h1 { display: none; }
+  .md-content .md-typeset > h1:first-child {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 </style>
 
 <p align="center">

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://grelinfo.github.io/grelmicro">
-    <img alt="grelmicro" class="grel-wordmark" src="img/logo/wordmark.svg" width="520">
+    <img alt="grelmicro" class="grel-wordmark" src="img/logo/wordmark.svg" width="360">
   </a>
 </p>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+<!-- Hide the auto-generated h1 on the docs landing page. GitHub strips <style> from rendered README, so this is a no-op there. -->
+<style>
+  .md-content .md-typeset h1 { display: none; }
+</style>
+
 <p align="center">
   <a href="https://grelinfo.github.io/grelmicro">
     <img alt="grelmicro" class="grel-wordmark" src="img/logo/wordmark.svg" width="360">


### PR DESCRIPTION
## Summary

- Reduce the landing wordmark from 520px to 360px on both `docs/index.md` and `README.md`.
- Suppress the auto-generated "grelmicro" h1 that mkdocs-material renders from the nav title (the wordmark is the title, a duplicate text heading is visual noise).

mkdocs-material's `hide:` front matter only supports `navigation`, `toc`, `footer`, `path`. There is no `hide: title`. The standard pattern (used by FastAPI's docs) is a small page-scoped `<style>` block that sets `display: none` on `.md-content .md-typeset h1`.

The style block lives in `README.md` so the `readme-to-docs` pre-commit hook keeps both files in sync. GitHub strips `<style>` from rendered READMEs, so the block is a no-op on github.com.

## Test plan

- [x] `uv run --group docs mkdocs build --strict` clean (zero warnings)
- [x] Local `mkdocs serve` shows the smaller wordmark and no duplicate "grelmicro" heading on `/`
- [x] README still renders cleanly on GitHub (style tag invisible)