### PR TITLE
✨ Wire TaskManager into grelmicro.lifespan()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* ✨ Add `grelmicro.task.use_manager(manager)`. `grelmicro.lifespan()` now starts and stops the registered `TaskManager` alongside every other component. The full helper set (`register`, `unregister`, `use_manager`, `use`) mirrors `grelmicro.sync.*`. Issue [#184](https://github.com/grelinfo/grelmicro/issues/184).
+
 ## 0.21.0 - 2026-05-06
 
 ### Breaking

--- a/docs/snippets/task/fastapi.py
+++ b/docs/snippets/task/fastapi.py
@@ -2,14 +2,16 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from grelmicro.task import TaskManager
+import grelmicro
+import grelmicro.task
 
-task = TaskManager()
+manager = grelmicro.task.TaskManager()
+grelmicro.task.use_manager(manager)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    async with task:
+    async with grelmicro.lifespan():
         yield
 
 

--- a/docs/snippets/task/faststream.py
+++ b/docs/snippets/task/faststream.py
@@ -3,14 +3,16 @@ from contextlib import asynccontextmanager
 from faststream import ContextRepo, FastStream
 from faststream.redis import RedisBroker
 
-from grelmicro.task import TaskManager
+import grelmicro
+import grelmicro.task
 
-task = TaskManager()
+manager = grelmicro.task.TaskManager()
+grelmicro.task.use_manager(manager)
 
 
 @asynccontextmanager
 async def lifespan(context: ContextRepo):
-    async with task:
+    async with grelmicro.lifespan():
         yield
 
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -15,7 +15,7 @@ The key features are:
 
 ## Task Manager
 
-The `TaskManager` class is the main entry point to manage tasks. Start it using the application lifespan:
+The `TaskManager` class is the main entry point to manage tasks. Register it with `grelmicro.task.use_manager()` and let `grelmicro.lifespan()` start and stop it with every other grelmicro component.
 
 === "FastAPI"
 
@@ -26,7 +26,6 @@ The `TaskManager` class is the main entry point to manage tasks. Start it using 
 === "FastStream"
 
     ```python
-
     --8<-- "task/faststream.py"
     ```
 

--- a/grelmicro/task/__init__.py
+++ b/grelmicro/task/__init__.py
@@ -1,7 +1,69 @@
 """Task."""
 
+from contextlib import AbstractContextManager
+from typing import Annotated
+
+from typing_extensions import Doc
+
+from grelmicro._backends import DEFAULT_NAME
+from grelmicro.task._backends import get_task_manager, task_manager_registry
 from grelmicro.task.errors import TaskError
 from grelmicro.task.manager import TaskManager
 from grelmicro.task.router import TaskRouter
 
-__all__ = ["TaskError", "TaskManager", "TaskRouter"]
+
+def register(
+    manager: Annotated[TaskManager, Doc("The task manager instance.")],
+    name: Annotated[
+        str, Doc("Name to register the manager under.")
+    ] = DEFAULT_NAME,
+) -> None:
+    """Register ``manager`` under ``name`` (defaults to ``"default"``)."""
+    task_manager_registry.register(manager, name)
+
+
+def unregister(
+    name: Annotated[
+        str, Doc("Name of the registered manager to remove.")
+    ] = DEFAULT_NAME,
+    manager: Annotated[
+        TaskManager | None,
+        Doc("Optional manager instance for an identity-checked removal."),
+    ] = None,
+) -> None:
+    """Remove the registered manager under ``name``."""
+    task_manager_registry.unregister(name, manager)
+
+
+def use_manager(
+    manager: Annotated[
+        TaskManager,
+        Doc("The task manager to install as the global default."),
+    ],
+) -> None:
+    """Register ``manager`` under the ``"default"`` name."""
+    task_manager_registry.register(manager, DEFAULT_NAME)
+
+
+def use(
+    manager: Annotated[
+        TaskManager | None,
+        Doc('Override the ``"default"`` slot for the duration of the block.'),
+    ] = None,
+    /,
+    **named: TaskManager,
+) -> AbstractContextManager[None]:
+    """Install task-scoped manager overrides."""
+    return task_manager_registry.use(manager, **named)
+
+
+__all__ = [
+    "TaskError",
+    "TaskManager",
+    "TaskRouter",
+    "get_task_manager",
+    "register",
+    "unregister",
+    "use",
+    "use_manager",
+]

--- a/grelmicro/task/_backends.py
+++ b/grelmicro/task/_backends.py
@@ -1,0 +1,23 @@
+"""Task Manager Registry."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from grelmicro._backends import DEFAULT_NAME, BackendRegistry
+
+if TYPE_CHECKING:
+    from grelmicro.task.manager import TaskManager
+
+task_manager_registry: BackendRegistry[TaskManager] = BackendRegistry(
+    name="task"
+)
+
+
+def get_task_manager(name: str = DEFAULT_NAME) -> TaskManager:
+    """Resolve a task manager by ``name``.
+
+    Raises:
+        BackendNotLoadedError: If no manager resolves.
+    """
+    return task_manager_registry.get(name)

--- a/tests/task/test_backends.py
+++ b/tests/task/test_backends.py
@@ -1,0 +1,110 @@
+"""Task Manager registry, scoped overrides, and lifespan wiring."""
+
+from collections.abc import Generator
+
+import pytest
+
+import grelmicro
+from grelmicro import task as task_mod
+from grelmicro._backends import (
+    BackendAlreadyRegisteredError,
+    BackendNotLoadedError,
+)
+from grelmicro.task import TaskManager
+from grelmicro.task._backends import get_task_manager, task_manager_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Generator[None, None, None]:
+    """Reset the task manager registry between tests."""
+    task_manager_registry.reset()
+    yield
+    task_manager_registry.reset()
+
+
+def test_constructor_does_not_register() -> None:
+    """Constructing a TaskManager performs no registry writes."""
+    TaskManager()
+    assert not task_manager_registry.is_loaded
+
+
+def test_get_not_loaded() -> None:
+    """`get_task_manager` raises when no manager has been registered."""
+    with pytest.raises(BackendNotLoadedError):
+        get_task_manager()
+
+
+def test_register_and_get() -> None:
+    """Register and resolve."""
+    manager = TaskManager()
+    task_mod.register(manager)
+    assert get_task_manager() is manager
+
+
+def test_use_manager_registers_default() -> None:
+    """`use_manager` registers under the default name."""
+    manager = TaskManager()
+    task_mod.use_manager(manager)
+    assert get_task_manager() is manager
+
+
+def test_register_same_instance_is_noop() -> None:
+    """Re-registering the same instance under the same name is a no-op."""
+    manager = TaskManager()
+    task_mod.register(manager)
+    task_mod.register(manager)
+    assert get_task_manager() is manager
+
+
+def test_register_different_instance_raises() -> None:
+    """Registering a different instance under the same name raises."""
+    task_mod.register(TaskManager())
+    with pytest.raises(BackendAlreadyRegisteredError):
+        task_mod.register(TaskManager())
+
+
+def test_unregister_with_identity_check() -> None:
+    """`unregister` clears only when the identity matches."""
+    a = TaskManager()
+    b = TaskManager()
+    task_mod.register(a)
+    task_mod.unregister(manager=b)  # wrong instance: no-op
+    assert get_task_manager() is a
+    task_mod.unregister(manager=a)
+    assert not task_manager_registry.is_loaded
+
+
+def test_use_overrides_default() -> None:
+    """`use` overrides the default slot for the block."""
+    registered = TaskManager()
+    override = TaskManager()
+    task_mod.register(registered)
+    with task_mod.use(override):
+        assert get_task_manager() is override
+    assert get_task_manager() is registered
+
+
+def test_use_overrides_named() -> None:
+    """`use` overrides a named entry for the block."""
+    primary = TaskManager()
+    fake = TaskManager()
+    task_mod.register(primary, "primary")
+    with task_mod.use(primary=fake):
+        assert get_task_manager("primary") is fake
+    assert get_task_manager("primary") is primary
+
+
+async def test_lifespan_starts_and_stops_registered_manager() -> None:
+    """`grelmicro.lifespan()` enters the registered manager."""
+    manager = TaskManager()
+    task_mod.use_manager(manager)
+    async with grelmicro.lifespan():
+        assert manager._task_group is not None
+
+
+async def test_lifespan_excludes_task_module() -> None:
+    """`exclude={"task"}` skips the task registry."""
+    manager = TaskManager()
+    task_mod.use_manager(manager)
+    async with grelmicro.lifespan(exclude={"task"}):
+        assert manager._task_group is None

--- a/tests/task/test_backends.py
+++ b/tests/task/test_backends.py
@@ -98,8 +98,9 @@ async def test_lifespan_starts_and_stops_registered_manager() -> None:
     """`grelmicro.lifespan()` enters the registered manager."""
     manager = TaskManager()
     task_mod.use_manager(manager)
+    assert not manager.started()
     async with grelmicro.lifespan():
-        assert manager._task_group is not None
+        assert manager.started()
 
 
 async def test_lifespan_excludes_task_module() -> None:
@@ -107,4 +108,4 @@ async def test_lifespan_excludes_task_module() -> None:
     manager = TaskManager()
     task_mod.use_manager(manager)
     async with grelmicro.lifespan(exclude={"task"}):
-        assert manager._task_group is None
+        assert not manager.started()


### PR DESCRIPTION
## Summary

- New `grelmicro.task.register / unregister / use_manager / use` helpers mirror `grelmicro.sync.*`.
- `grelmicro.lifespan()` now starts and stops the registered `TaskManager` with every other component.
- Snippets and `docs/task.md` lead with `use_manager` + `grelmicro.lifespan()` as the canonical setup.

Closes #184.

## Test plan

- [x] 11 new tests in `tests/task/test_backends.py` cover register, unregister, identity check, `use(...)` overrides, lifespan entry, and `exclude={"task"}`.
- [x] 100% coverage on the task module.
- [x] Full non-integration test suite passes (1379 tests).
- [x] ruff + ty + format clean.