### PR TITLE
✨ Add Sync module wrapping sync backends

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 * ✨ Add `Grelmicro` app object and `Module` protocol. The user composes patterns into one container and opens them with `async with micro:`. Issue [#208](https://github.com/grelinfo/grelmicro/issues/208), epic [#201](https://github.com/grelinfo/grelmicro/issues/201).
 * ✨ Add `Tasks` module. Wraps `TaskManager` and exposes `interval(...)` and `add_task(...)`. Use it via `Grelmicro(modules=[Tasks()])` and reach it on `micro.task`. Issue [#184](https://github.com/grelinfo/grelmicro/issues/184).
+* ✨ Add `Sync` module. Wraps a `SyncBackend` and exposes `lock(...)`, `task_lock(...)`, `leader_election(...)` factories. Use it via `Grelmicro(modules=[Sync(RedisSyncBackend(...))])` and reach it on `micro.sync`. Issue [#210](https://github.com/grelinfo/grelmicro/issues/210).
 * ✨ Add `Grelmicro.current()` classmethod for ambient lookup. Inside `async with micro:` it returns the active app for the current asyncio task. Matches Tokio's `Handle::current()` shape.
 
 ## 0.21.0 - 2026-05-06

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -127,10 +127,12 @@ class Grelmicro:
             raise ModuleAlreadyRegisteredError(msg)
         self._by_key[key] = module
         self._modules.append(module)
-        # Last-write-wins for `micro.<kind>` resolved through `__getattr__`,
-        # mirroring the registry's default-name fallback when only one entry
-        # exists per kind.
-        self._by_kind[module.kind] = module
+        # `micro.<kind>` prefers the entry named `"default"`. Only update the
+        # kind-default index when this registration is the default one.
+        # `__getattr__` falls back to the sole entry per kind when no default
+        # is registered.
+        if module.name == "default":
+            self._by_kind[module.kind] = module
         return module
 
     def get(self, kind: str, name: str = "default") -> Any:  # noqa: ANN401
@@ -192,7 +194,8 @@ class Grelmicro:
                 self._by_key[key] = module
                 if module not in self._modules:
                     self._modules.append(module)
-                self._by_kind[module.kind] = module
+                if module.name == "default":
+                    self._by_kind[module.kind] = module
                 await stack.enter_async_context(module)
             try:
                 yield
@@ -202,19 +205,37 @@ class Grelmicro:
                 self._by_kind = snapshot_by_kind
 
     def __getattr__(self, name: str) -> Any:  # noqa: ANN401
-        """Resolve `micro.<kind>` to the most recently registered module of that kind.
+        """Resolve `micro.<kind>` to the registered module of that kind.
+
+        Resolution order, matching the legacy `BackendRegistry.get()` semantics:
+
+        1. The module registered as `(kind, "default")` if present.
+        2. The sole entry of that kind if exactly one is registered.
+        3. Otherwise raises `AttributeError`.
 
         Returns `Any` so callers can invoke module-specific methods
-        (`micro.task.interval(...)`, `micro.cache.get(...)`) without per-call
+        (`micro.task.interval(...)`, `micro.cache.ttl(...)`) without per-call
         casts. The actual concrete type depends on the registered module.
+
+        Use `micro.get(kind, name)` for explicit name-based resolution.
         """
-        try:
-            return self.__dict__["_by_kind"][name]
-        except KeyError:
+        by_kind = self.__dict__.get("_by_kind", {})
+        if name in by_kind:
+            return by_kind[name]
+        by_key = self.__dict__.get("_by_key", {})
+        matches = [v for (k, _), v in by_key.items() if k == name]
+        if len(matches) == 1:
+            return matches[0]
+        cls = type(self).__name__
+        if matches:
+            names = sorted(n for (k, n), _ in by_key.items() if k == name)
             msg = (
-                f"{type(self).__name__!r} object has no module of kind {name!r}"
+                f"{cls!r} has multiple {name!r} modules ({names}), "
+                f"none named 'default'. Use micro.get({name!r}, <name>)."
             )
-            raise AttributeError(msg) from None
+            raise AttributeError(msg)
+        msg = f"{cls!r} object has no module of kind {name!r}"
+        raise AttributeError(msg)
 
     async def __aenter__(self) -> Self:
         """Open every registered module in registration order."""

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -133,8 +133,12 @@ class Grelmicro:
         self._by_kind[module.kind] = module
         return module
 
-    def get(self, kind: str, name: str = "default") -> Module:
+    def get(self, kind: str, name: str = "default") -> Any:  # noqa: ANN401
         """Resolve a registered module by `(kind, name)`.
+
+        Returns `Any` for the same reason `micro.<kind>` does: the dynamic
+        registration can't be statically typed without a global registry.
+        Callers know the concrete type they registered.
 
         Raises:
             ModuleNotRegisteredError: If no module matches.

--- a/grelmicro/sync/__init__.py
+++ b/grelmicro/sync/__init__.py
@@ -7,6 +7,7 @@ from typing_extensions import Doc
 
 from grelmicro._backends import DEFAULT_NAME
 from grelmicro.sync._backends import sync_backend_registry
+from grelmicro.sync._module import Sync
 from grelmicro.sync.abc import SyncBackend, SyncPrimitive
 from grelmicro.sync.errors import SyncError, SyncSettingsValidationError
 from grelmicro.sync.leaderelection import LeaderElection
@@ -68,6 +69,7 @@ def use(
 __all__ = [
     "LeaderElection",
     "Lock",
+    "Sync",
     "SyncError",
     "SyncPrimitive",
     "SyncSettingsValidationError",

--- a/grelmicro/sync/_module.py
+++ b/grelmicro/sync/_module.py
@@ -1,0 +1,98 @@
+"""Sync module for the Grelmicro app object."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
+
+from typing_extensions import Doc
+
+from grelmicro.sync.leaderelection import LeaderElection
+from grelmicro.sync.lock import Lock
+from grelmicro.sync.tasklock import TaskLock
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from grelmicro.sync.abc import SyncBackend
+
+
+class Sync:
+    """Sync module: wraps a `SyncBackend` and exposes lock primitives.
+
+    Registered as `micro.sync` after `Grelmicro.use(Sync(backend))`. Exposes
+    `lock(...)`, `task_lock(...)`, and `leader_election(...)` factories so
+    users do not need to pass `backend=` on every primitive.
+
+    Example:
+        ```python
+        from grelmicro import Grelmicro
+        from grelmicro.sync import Sync
+        from grelmicro.sync.redis import RedisSyncBackend
+
+        micro = Grelmicro(modules=[Sync(RedisSyncBackend("redis://localhost"))])
+
+        async with micro:
+            async with micro.sync.lock("cart"):
+                ...
+        ```
+
+    Read more in the [Synchronization](../sync.md) docs.
+    """
+
+    kind: ClassVar[str] = "sync"
+
+    def __init__(
+        self,
+        backend: Annotated[
+            SyncBackend,
+            Doc("The synchronization backend opened with the module."),
+        ],
+        *,
+        name: Annotated[
+            str,
+            Doc(
+                """
+                Registration name. Multiple `Sync` modules may coexist on one
+                `Grelmicro` under different names.
+                """,
+            ),
+        ] = "default",
+    ) -> None:
+        """Initialize the module with the wrapped backend."""
+        self.name = name
+        self._backend = backend
+
+    @property
+    def backend(self) -> SyncBackend:
+        """The underlying `SyncBackend`."""
+        return self._backend
+
+    def lock(self, name: str, **kwargs: Any) -> Lock:  # noqa: ANN401
+        """Construct a `Lock` bound to this module's backend."""
+        return Lock(name, backend=self._backend, **kwargs)
+
+    def task_lock(self, name: str, **kwargs: Any) -> TaskLock:  # noqa: ANN401
+        """Construct a `TaskLock` bound to this module's backend."""
+        return TaskLock(name, backend=self._backend, **kwargs)
+
+    def leader_election(
+        self,
+        name: str,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> LeaderElection:
+        """Construct a `LeaderElection` bound to this module's backend."""
+        return LeaderElection(name, backend=self._backend, **kwargs)
+
+    async def __aenter__(self) -> Self:
+        """Open the underlying backend."""
+        await self._backend.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        """Close the underlying backend."""
+        return await self._backend.__aexit__(exc_type, exc, tb)

--- a/tests/sync/test_module.py
+++ b/tests/sync/test_module.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from grelmicro import Grelmicro, Module
 from grelmicro.sync import LeaderElection, Lock, Sync, TaskLock
 from grelmicro.sync.memory import MemorySyncBackend
@@ -80,6 +82,38 @@ async def test_sync_lock_via_micro_attribute() -> None:
     micro = Grelmicro(modules=[Sync(MemorySyncBackend())])
     async with micro, micro.sync.lock("cart"):
         pass
+
+
+async def test_micro_sync_prefers_default_when_named_also_registered() -> None:
+    """`micro.sync` resolves to the `(sync, default)` module even after named registrations."""
+    primary = MemorySyncBackend()
+    analytics = MemorySyncBackend()
+    micro = Grelmicro(
+        modules=[
+            Sync(primary),
+            Sync(analytics, name="analytics"),
+        ]
+    )
+    assert micro.sync.backend is primary
+
+
+async def test_micro_sync_returns_sole_entry_when_no_default() -> None:
+    """`micro.sync` returns the only registered Sync when no default exists."""
+    only = MemorySyncBackend()
+    micro = Grelmicro(modules=[Sync(only, name="primary")])
+    assert micro.sync.backend is only
+
+
+async def test_micro_sync_raises_when_ambiguous() -> None:
+    """`micro.sync` raises when multiple non-default modules exist with no default."""
+    micro = Grelmicro(
+        modules=[
+            Sync(MemorySyncBackend(), name="primary"),
+            Sync(MemorySyncBackend(), name="analytics"),
+        ]
+    )
+    with pytest.raises(AttributeError, match="multiple 'sync' modules"):
+        _ = micro.sync
 
 
 async def test_sync_multi_backend_named_lookup() -> None:

--- a/tests/sync/test_module.py
+++ b/tests/sync/test_module.py
@@ -1,0 +1,99 @@
+"""Tests for the `Sync` module (Grelmicro app integration)."""
+
+from __future__ import annotations
+
+from grelmicro import Grelmicro, Module
+from grelmicro.sync import LeaderElection, Lock, Sync, TaskLock
+from grelmicro.sync.memory import MemorySyncBackend
+
+
+def test_sync_satisfies_module_protocol() -> None:
+    """`Sync` is a runtime-checkable `Module`."""
+    assert isinstance(Sync(MemorySyncBackend()), Module)
+
+
+def test_sync_default_kind_and_name() -> None:
+    """Default kind is `sync` and default name is `default`."""
+    sync = Sync(MemorySyncBackend())
+    assert sync.kind == "sync"
+    assert sync.name == "default"
+
+
+def test_sync_named_registration() -> None:
+    """A named `Sync` module coexists with the default one."""
+    micro = Grelmicro(
+        modules=[
+            Sync(MemorySyncBackend()),
+            Sync(MemorySyncBackend(), name="analytics"),
+        ]
+    )
+    assert micro.get("sync", "default").name == "default"
+    assert micro.get("sync", "analytics").name == "analytics"
+
+
+def test_sync_lock_factory_binds_backend() -> None:
+    """`sync.lock(name)` creates a `Lock` bound to the wrapped backend."""
+    backend = MemorySyncBackend()
+    sync = Sync(backend)
+    lock = sync.lock("cart")
+    assert isinstance(lock, Lock)
+    assert lock.backend is backend
+
+
+def test_sync_task_lock_factory_binds_backend() -> None:
+    """`sync.task_lock(name)` creates a `TaskLock` bound to the wrapped backend."""
+    backend = MemorySyncBackend()
+    sync = Sync(backend)
+    task_lock = sync.task_lock("cleanup")
+    assert isinstance(task_lock, TaskLock)
+    assert task_lock.backend is backend
+
+
+def test_sync_leader_election_factory_binds_backend() -> None:
+    """`sync.leader_election(name)` creates a `LeaderElection` bound to the backend."""
+    backend = MemorySyncBackend()
+    sync = Sync(backend)
+    election = sync.leader_election("primary")
+    assert isinstance(election, LeaderElection)
+    assert election.backend is backend
+
+
+def test_sync_backend_property() -> None:
+    """`sync.backend` returns the wrapped backend."""
+    backend = MemorySyncBackend()
+    sync = Sync(backend)
+    assert sync.backend is backend
+
+
+async def test_sync_opens_and_closes_backend_with_app() -> None:
+    """`async with micro:` opens and closes the underlying backend."""
+    backend = MemorySyncBackend()
+    sync = Sync(backend)
+    micro = Grelmicro(modules=[sync])
+    async with micro, sync.lock("k"):
+        # Backend is open: a Lock can be acquired.
+        pass
+
+
+async def test_sync_lock_via_micro_attribute() -> None:
+    """`micro.sync.lock(...)` is the conventional access path."""
+    micro = Grelmicro(modules=[Sync(MemorySyncBackend())])
+    async with micro, micro.sync.lock("cart"):
+        pass
+
+
+async def test_sync_multi_backend_named_lookup() -> None:
+    """Named `Sync` modules are reachable via `micro.get('sync', name)`."""
+    primary = MemorySyncBackend()
+    analytics = MemorySyncBackend()
+    micro = Grelmicro(
+        modules=[
+            Sync(primary),
+            Sync(analytics, name="analytics"),
+        ]
+    )
+    async with micro:
+        async with micro.get("sync", "analytics").lock("event"):
+            pass
+        assert micro.get("sync", "analytics").backend is analytics
+        assert micro.get("sync", "default").backend is primary


### PR DESCRIPTION
## Summary

Implements #210 (Sync module). Wraps a `SyncBackend` and exposes `lock`, `task_lock`, `leader_election` factories so users do not need to thread `backend=` on every primitive. Part of the #201 epic.

## Usage

```python
from grelmicro import Grelmicro
from grelmicro.sync import Sync
from grelmicro.sync.redis import RedisSyncBackend

micro = Grelmicro(modules=[
    Sync(RedisSyncBackend("redis://primary")),
    Sync(RedisSyncBackend("redis://analytics"), name="analytics"),
])

async with micro:
    async with micro.sync.lock("cart"):
        ...
```

## Changes

- `grelmicro/sync/_module.py`: `Sync` class implementing `Module` (`kind="sync"`)
- `grelmicro/sync/__init__.py`: re-export `Sync`
- `grelmicro/_app.py`: `Grelmicro.get(...)` now returns `Any` (matches `__getattr__` rationale)
- `tests/sync/test_module.py`: 10 tests
- `docs/changelog.md`: feature entry under Unreleased

## Test plan

- [x] All 10 new tests pass
- [x] Full pre-commit gate green: ruff, ty, pytest unit + integration, 100% coverage