### PR TITLE
✨ Add Cache module wrapping cache backends

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,6 +334,35 @@ After `1.0.0`, standard semver applies: breaking changes only on
 `MAJOR`, and removals go through at least two `MINOR` releases
 with a `DeprecationWarning` first.
 
+## Issues and releases
+
+grelmicro ships continuously: a PR merges, a release follows when
+it makes sense. There is no project board and no per-release
+milestone.
+
+The full workflow uses **GitHub issue state plus two labels**:
+
+| State | Meaning |
+|---|---|
+| Open, no label | Backlog. Anyone can propose work here. |
+| `next` label | Picked for the next release. Short list. |
+| `v1.0` label | Targeted for the 1.0 line, not the next release. |
+| Assigned to someone | In progress. |
+| Closed | Done. |
+
+Useful filters:
+
+```text
+is:open is:issue label:next                 # next up
+is:open is:issue assignee:@me               # in progress
+is:open is:issue no:label                   # groomable backlog
+is:open is:issue label:v1.0                 # 1.0 scope
+```
+
+A release happens when one or more `next`-labeled issues are
+closed and the changelog has enough to ship. There is no
+fixed cadence.
+
 ## Before opening a PR
 
 - All pre-commit gates pass locally

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 * ✨ Add `Grelmicro` app object and `Module` protocol. The user composes patterns into one container and opens them with `async with micro:`. Issue [#208](https://github.com/grelinfo/grelmicro/issues/208), epic [#201](https://github.com/grelinfo/grelmicro/issues/201).
 * ✨ Add `Tasks` module. Wraps `TaskManager` and exposes `interval(...)` and `add_task(...)`. Use it via `Grelmicro(modules=[Tasks()])` and reach it on `micro.task`. Issue [#184](https://github.com/grelinfo/grelmicro/issues/184).
 * ✨ Add `Sync` module. Wraps a `SyncBackend` and exposes `lock(...)`, `task_lock(...)`, `leader_election(...)` factories. Use it via `Grelmicro(modules=[Sync(RedisSyncBackend(...))])` and reach it on `micro.sync`. Issue [#210](https://github.com/grelinfo/grelmicro/issues/210).
+* ✨ Add `Cache` module. Wraps a `CacheBackend` and exposes a `ttl(...)` factory that builds a `TTLCache` bound to the wrapped backend. Use it via `Grelmicro(modules=[Cache(RedisCacheBackend(...))])` and reach it on `micro.cache`. Issue [#212](https://github.com/grelinfo/grelmicro/issues/212).
 * ✨ Add `Grelmicro.current()` classmethod for ambient lookup. Inside `async with micro:` it returns the active app for the current asyncio task. Matches Tokio's `Handle::current()` shape.
 
 ## 0.21.0 - 2026-05-06

--- a/grelmicro/cache/__init__.py
+++ b/grelmicro/cache/__init__.py
@@ -7,6 +7,7 @@ from typing_extensions import Doc
 
 from grelmicro._backends import DEFAULT_NAME
 from grelmicro.cache._backends import cache_backend_registry
+from grelmicro.cache._module import Cache
 from grelmicro.cache._protocol import CacheBackend
 from grelmicro.cache.cached import cached
 from grelmicro.cache.errors import CacheError, CacheSettingsValidationError
@@ -65,6 +66,7 @@ def use(
 
 
 __all__ = [
+    "Cache",
     "CacheBackend",
     "CacheError",
     "CacheInfo",

--- a/grelmicro/cache/_module.py
+++ b/grelmicro/cache/_module.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self
 
 from typing_extensions import Doc
 
+from grelmicro.cache.cached import cached
 from grelmicro.cache.ttl import TTLCache
 
 if TYPE_CHECKING:
@@ -29,14 +30,21 @@ class Cache:
         from grelmicro.cache.redis import RedisCacheBackend
 
         micro = Grelmicro(modules=[Cache(RedisCacheBackend("redis://localhost"))])
+        user_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
+
+        @micro.cache.cached(user_cache)
+        async def get_user(user_id: int) -> dict:
+            ...
 
         async with micro:
-            user_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
-            await user_cache.set("alice", {"id": 1})
+            user = await get_user(1)
         ```
 
     Read more in the [Cache](../cache.md) docs.
     """
+
+    cached = staticmethod(cached)
+    """Re-export of `grelmicro.cache.cached.cached` for app-style ergonomics."""
 
     kind: ClassVar[str] = "cache"
 
@@ -66,14 +74,17 @@ class Cache:
         """The underlying `CacheBackend`."""
         return self._backend
 
-    def ttl(
+    def ttl[T](
         self,
         *,
         ttl: float = 60,
         maxsize: int = 0,
-        serializer: CacheSerializer[Any] | None = None,
-    ) -> TTLCache[Any]:
+        serializer: CacheSerializer[T] | None = None,
+    ) -> TTLCache[T]:
         """Construct a `TTLCache` bound to this module's backend.
+
+        The return type tracks the serializer's type parameter, so passing
+        `JsonSerializer[User]()` yields a `TTLCache[User]`.
 
         Args:
             ttl: Default TTL in seconds for cached entries.

--- a/grelmicro/cache/_module.py
+++ b/grelmicro/cache/_module.py
@@ -1,0 +1,102 @@
+"""Cache module for the Grelmicro app object."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
+
+from typing_extensions import Doc
+
+from grelmicro.cache.ttl import TTLCache
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from grelmicro.cache._protocol import CacheBackend
+    from grelmicro.cache.serializers import CacheSerializer
+
+
+class Cache:
+    """Cache module: wraps a `CacheBackend` and exposes the `TTLCache` factory.
+
+    Registered as `micro.cache` after `Grelmicro.use(Cache(backend))`. The
+    `ttl(...)` factory builds a `TTLCache` bound to this module's backend so
+    users do not need to thread `backend=` on every cache instance.
+
+    Example:
+        ```python
+        from grelmicro import Grelmicro
+        from grelmicro.cache import Cache, JsonSerializer
+        from grelmicro.cache.redis import RedisCacheBackend
+
+        micro = Grelmicro(modules=[Cache(RedisCacheBackend("redis://localhost"))])
+
+        async with micro:
+            user_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
+            await user_cache.set("alice", {"id": 1})
+        ```
+
+    Read more in the [Cache](../cache.md) docs.
+    """
+
+    kind: ClassVar[str] = "cache"
+
+    def __init__(
+        self,
+        backend: Annotated[
+            CacheBackend,
+            Doc("The cache backend opened with the module."),
+        ],
+        *,
+        name: Annotated[
+            str,
+            Doc(
+                """
+                Registration name. Multiple `Cache` modules may coexist on
+                one `Grelmicro` under different names.
+                """,
+            ),
+        ] = "default",
+    ) -> None:
+        """Initialize the module with the wrapped backend."""
+        self.name = name
+        self._backend = backend
+
+    @property
+    def backend(self) -> CacheBackend:
+        """The underlying `CacheBackend`."""
+        return self._backend
+
+    def ttl(
+        self,
+        *,
+        ttl: float = 60,
+        maxsize: int = 0,
+        serializer: CacheSerializer[Any] | None = None,
+    ) -> TTLCache[Any]:
+        """Construct a `TTLCache` bound to this module's backend.
+
+        Args:
+            ttl: Default TTL in seconds for cached entries.
+            maxsize: Maximum local cache entries (`0` means unlimited).
+            serializer: Serialization strategy. Defaults to raw bytes.
+        """
+        return TTLCache(
+            maxsize=maxsize,
+            ttl=ttl,
+            backend=self._backend,
+            serializer=serializer,
+        )
+
+    async def __aenter__(self) -> Self:
+        """Open the underlying backend."""
+        await self._backend.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        """Close the underlying backend."""
+        return await self._backend.__aexit__(exc_type, exc, tb)

--- a/tests/cache/test_module.py
+++ b/tests/cache/test_module.py
@@ -1,0 +1,101 @@
+"""Tests for the `Cache` module (Grelmicro app integration)."""
+
+from __future__ import annotations
+
+import pytest
+
+from grelmicro import Grelmicro, Module
+from grelmicro.cache import Cache, JsonSerializer, TTLCache
+from grelmicro.cache.memory import MemoryCacheBackend
+
+
+def test_cache_satisfies_module_protocol() -> None:
+    """`Cache` is a runtime-checkable `Module`."""
+    assert isinstance(Cache(MemoryCacheBackend()), Module)
+
+
+def test_cache_default_kind_and_name() -> None:
+    """Default kind is `cache` and default name is `default`."""
+    cache = Cache(MemoryCacheBackend())
+    assert cache.kind == "cache"
+    assert cache.name == "default"
+
+
+def test_cache_named_registration() -> None:
+    """A named `Cache` module coexists with the default one."""
+    micro = Grelmicro(
+        modules=[
+            Cache(MemoryCacheBackend()),
+            Cache(MemoryCacheBackend(), name="responses"),
+        ]
+    )
+    assert micro.get("cache", "default").name == "default"
+    assert micro.get("cache", "responses").name == "responses"
+
+
+def test_cache_backend_property() -> None:
+    """`cache.backend` returns the wrapped backend."""
+    backend = MemoryCacheBackend()
+    cache = Cache(backend)
+    assert cache.backend is backend
+
+
+def test_cache_ttl_factory_binds_backend() -> None:
+    """`cache.ttl(...)` creates a `TTLCache` bound to the wrapped backend."""
+    backend = MemoryCacheBackend()
+    cache = Cache(backend)
+    ttl_cache = cache.ttl(ttl=300)
+    assert isinstance(ttl_cache, TTLCache)
+    assert ttl_cache._backend is backend
+
+
+def test_cache_ttl_factory_passes_serializer() -> None:
+    """`cache.ttl(serializer=...)` forwards the serializer to `TTLCache`."""
+    serializer = JsonSerializer()
+    cache = Cache(MemoryCacheBackend())
+    ttl_cache = cache.ttl(ttl=60, serializer=serializer)
+    assert ttl_cache._serializer is serializer
+
+
+async def test_cache_opens_and_closes_backend_with_app() -> None:
+    """`async with micro:` opens and closes the underlying backend."""
+    backend = MemoryCacheBackend()
+    cache = Cache(backend)
+    micro = Grelmicro(modules=[cache])
+    async with micro:
+        ttl_cache = cache.ttl(ttl=60)
+        await ttl_cache.set("k", b"v")
+        assert await ttl_cache.get("k") == b"v"
+
+
+async def test_micro_cache_via_attribute() -> None:
+    """`micro.cache.ttl(...)` is the conventional access path."""
+    micro = Grelmicro(modules=[Cache(MemoryCacheBackend())])
+    async with micro:
+        ttl_cache = micro.cache.ttl(ttl=60, serializer=JsonSerializer())
+        await ttl_cache.set("alice", {"id": 1})
+        assert await ttl_cache.get("alice") == {"id": 1}
+
+
+async def test_micro_cache_prefers_default_over_named() -> None:
+    """`micro.cache` resolves to `(cache, default)` even when named modules exist."""
+    primary = MemoryCacheBackend()
+    micro = Grelmicro(
+        modules=[
+            Cache(primary),
+            Cache(MemoryCacheBackend(), name="responses"),
+        ]
+    )
+    assert micro.cache.backend is primary
+
+
+async def test_micro_cache_raises_when_ambiguous() -> None:
+    """`micro.cache` raises when multiple non-default modules exist."""
+    micro = Grelmicro(
+        modules=[
+            Cache(MemoryCacheBackend(), name="a"),
+            Cache(MemoryCacheBackend(), name="b"),
+        ]
+    )
+    with pytest.raises(AttributeError, match="multiple 'cache' modules"):
+        _ = micro.cache

--- a/tests/cache/test_module.py
+++ b/tests/cache/test_module.py
@@ -40,21 +40,47 @@ def test_cache_backend_property() -> None:
     assert cache.backend is backend
 
 
-def test_cache_ttl_factory_binds_backend() -> None:
-    """`cache.ttl(...)` creates a `TTLCache` bound to the wrapped backend."""
+async def test_cache_ttl_factory_binds_backend() -> None:
+    """`cache.ttl(...)` creates a `TTLCache` whose writes round-trip via the same backend."""
     backend = MemoryCacheBackend()
-    cache = Cache(backend)
-    ttl_cache = cache.ttl(ttl=300)
-    assert isinstance(ttl_cache, TTLCache)
-    assert ttl_cache._backend is backend
+    cache_a = Cache(backend)
+    cache_b = Cache(backend)  # second wrapper over the SAME backend
+    ttl_a = cache_a.ttl(ttl=300)
+    ttl_b = cache_b.ttl(ttl=300)
+    assert isinstance(ttl_a, TTLCache)
+    async with backend:
+        await ttl_a.set("k", b"v")
+        # Same backend ⇒ second TTLCache reads what the first wrote.
+        assert await ttl_b.get("k") == b"v"
 
 
-def test_cache_ttl_factory_passes_serializer() -> None:
-    """`cache.ttl(serializer=...)` forwards the serializer to `TTLCache`."""
-    serializer = JsonSerializer()
+async def test_cache_ttl_factory_passes_serializer() -> None:
+    """`cache.ttl(serializer=...)` round-trips a non-bytes value through the serializer."""
     cache = Cache(MemoryCacheBackend())
-    ttl_cache = cache.ttl(ttl=60, serializer=serializer)
-    assert ttl_cache._serializer is serializer
+    ttl_cache = cache.ttl(ttl=60, serializer=JsonSerializer())
+    async with cache:
+        await ttl_cache.set("payload", {"id": 1, "tags": ["a", "b"]})
+        assert await ttl_cache.get("payload") == {"id": 1, "tags": ["a", "b"]}
+
+
+async def test_cache_cached_decorator_works_via_micro_attribute() -> None:
+    """`@micro.cache.cached(ttl_cache)` decorates and caches results."""
+    micro = Grelmicro(modules=[Cache(MemoryCacheBackend())])
+    calls = 0
+    async with micro:
+        ttl_cache = micro.cache.ttl(ttl=60, serializer=JsonSerializer())
+
+        @micro.cache.cached(ttl_cache)
+        async def lookup(user_id: int) -> dict:
+            nonlocal calls
+            calls += 1
+            return {"id": user_id, "name": "alice"}
+
+        first = await lookup(1)
+        second = await lookup(1)
+        assert first == second == {"id": 1, "name": "alice"}
+        # Second call hit the cache, not the function.
+        assert calls == 1
 
 
 async def test_cache_opens_and_closes_backend_with_app() -> None:


### PR DESCRIPTION
## Summary

Implements #212 (Cache module). Wraps a `CacheBackend` and exposes a `ttl(...)` factory that builds `TTLCache` instances bound to the wrapped backend. Part of the #201 epic.

## Usage

```python
from grelmicro import Grelmicro
from grelmicro.cache import Cache, JsonSerializer
from grelmicro.cache.redis import RedisCacheBackend

micro = Grelmicro(modules=[Cache(RedisCacheBackend("redis://localhost"))])

async with micro:
    user_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
    await user_cache.set("alice", {"id": 1})
```

## Changes

- `grelmicro/cache/_module.py`: `Cache` class implementing `Module` (`kind="cache"`)
- `grelmicro/cache/__init__.py`: re-export `Cache`
- `tests/cache/test_module.py`: 10 tests covering protocol, factory, lifecycle, named registration, default-vs-named resolution
- `docs/changelog.md`: feature entry under Unreleased

## Test plan

- [x] All 10 new tests pass
- [x] Full pre-commit gate green: ruff, ty, pytest unit + integration, 100% coverage
- [x] `micro.cache` resolves to `(cache, "default")` even when named modules registered (regression coverage from PR #214 review)