### PR TITLE
✨ Add Health module wrapping HealthRegistry

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 * ✨ Add `Tasks` module. Wraps `TaskManager` and exposes `interval(...)` and `add_task(...)`. Use it via `Grelmicro(modules=[Tasks()])` and reach it on `micro.task`. Issue [#184](https://github.com/grelinfo/grelmicro/issues/184).
 * ✨ Add `Sync` module. Wraps a `SyncBackend` and exposes `lock(...)`, `task_lock(...)`, `leader_election(...)` factories. Use it via `Grelmicro(modules=[Sync(RedisSyncBackend(...))])` and reach it on `micro.sync`. Issue [#210](https://github.com/grelinfo/grelmicro/issues/210).
 * ✨ Add `Cache` module. Wraps a `CacheBackend` and exposes a `ttl(...)` factory that builds a `TTLCache` bound to the wrapped backend. Use it via `Grelmicro(modules=[Cache(RedisCacheBackend(...))])` and reach it on `micro.cache`. Issue [#212](https://github.com/grelinfo/grelmicro/issues/212).
+* ✨ Add `Health` module. Wraps a `HealthRegistry` and forwards the `check(...)` decorator and `run(...)` aggregator. Use it via `Grelmicro(modules=[Health()])` and reach it on `micro.health`. Issue [#213](https://github.com/grelinfo/grelmicro/issues/213).
 * ✨ Add `Grelmicro.current()` classmethod for ambient lookup. Inside `async with micro:` it returns the active app for the current asyncio task. Matches Tokio's `Handle::current()` shape.
 
 ## 0.21.0 - 2026-05-06

--- a/grelmicro/health/__init__.py
+++ b/grelmicro/health/__init__.py
@@ -12,6 +12,7 @@ from grelmicro.health._models import (
     HealthReport,
     HealthStatus,
 )
+from grelmicro.health._module import Health
 from grelmicro.health._registry import HealthRegistry, HealthRegistryConfig
 from grelmicro.health._types import HealthCheckFunc, HealthDetails
 from grelmicro.health.errors import HealthError
@@ -64,6 +65,7 @@ def use(
 
 __all__ = [
     "CheckResult",
+    "Health",
     "HealthCheckFunc",
     "HealthDetails",
     "HealthError",

--- a/grelmicro/health/_module.py
+++ b/grelmicro/health/_module.py
@@ -1,0 +1,109 @@
+"""Health module for the Grelmicro app object."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
+
+from typing_extensions import Doc
+
+from grelmicro.health._registry import HealthRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import TracebackType
+
+    from grelmicro.health._models import HealthReport
+    from grelmicro.health._types import HealthCheckFunc
+
+
+class Health:
+    """Health module: wraps a `HealthRegistry` for the `Grelmicro` app.
+
+    Registered as `micro.health` after `Grelmicro.use(Health())`. Forwards
+    `check(...)` to the underlying registry so the user can decorate health
+    checks directly on the module:
+
+    Example:
+        ```python
+        from grelmicro import Grelmicro
+        from grelmicro.health import Health
+
+        micro = Grelmicro(modules=[Health()])
+
+        @micro.health.check("redis")
+        async def redis_alive() -> None:
+            ...
+
+        async with micro:
+            report = await micro.health.run()
+        ```
+
+    Read more in the [Health](../health.md) docs.
+    """
+
+    kind: ClassVar[str] = "health"
+
+    def __init__(
+        self,
+        *,
+        name: Annotated[
+            str,
+            Doc(
+                """
+                Registration name. Multiple `Health` modules may coexist on
+                one `Grelmicro` under different names.
+                """,
+            ),
+        ] = "default",
+        registry: Annotated[
+            HealthRegistry | None,
+            Doc(
+                """
+                A pre-built `HealthRegistry`. When `None`, a fresh default one
+                is constructed.
+                """,
+            ),
+        ] = None,
+    ) -> None:
+        """Initialize the module with the wrapped registry."""
+        self.name = name
+        self._registry = registry or HealthRegistry()
+
+    @property
+    def registry(self) -> HealthRegistry:
+        """The underlying `HealthRegistry`."""
+        return self._registry
+
+    def check(
+        self,
+        name: str,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> Callable[[HealthCheckFunc], HealthCheckFunc]:
+        """Decorate an async function to register it as a health check.
+
+        Forwards to `HealthRegistry.check`. See the underlying method for
+        keyword arguments such as `critical=` and `timeout=`.
+        """
+        return self._registry.check(name, **kwargs)
+
+    async def run(self, **kwargs: Any) -> HealthReport:  # noqa: ANN401
+        """Run the registered checks and return the aggregate `HealthReport`.
+
+        Forwards to `HealthRegistry.run`. See the underlying method for keyword
+        arguments such as `critical_only=` and `exclude=`.
+        """
+        return await self._registry.run(**kwargs)
+
+    async def __aenter__(self) -> Self:
+        """Open the underlying registry."""
+        await self._registry.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        """Close the underlying registry."""
+        return await self._registry.__aexit__(exc_type, exc, tb)

--- a/tests/health/test_module.py
+++ b/tests/health/test_module.py
@@ -1,0 +1,110 @@
+"""Tests for the `Health` module (Grelmicro app integration)."""
+
+from __future__ import annotations
+
+import pytest
+
+from grelmicro import Grelmicro, Module
+from grelmicro.health import (
+    Health,
+    HealthRegistry,
+    HealthStatus,
+)
+
+
+def test_health_satisfies_module_protocol() -> None:
+    """`Health` is a runtime-checkable `Module`."""
+    assert isinstance(Health(), Module)
+
+
+def test_health_default_kind_and_name() -> None:
+    """Default kind is `health` and default name is `default`."""
+    health = Health()
+    assert health.kind == "health"
+    assert health.name == "default"
+
+
+def test_health_constructor_creates_default_registry() -> None:
+    """When no registry is passed, a fresh `HealthRegistry` is constructed."""
+    health = Health()
+    assert isinstance(health.registry, HealthRegistry)
+
+
+def test_health_constructor_accepts_external_registry() -> None:
+    """An existing `HealthRegistry` can be wrapped."""
+    registry = HealthRegistry()
+    health = Health(registry=registry)
+    assert health.registry is registry
+
+
+def test_health_named_registration() -> None:
+    """A named `Health` module coexists with the default one."""
+    micro = Grelmicro(modules=[Health(), Health(name="readiness")])
+    assert micro.get("health", "default").name == "default"
+    assert micro.get("health", "readiness").name == "readiness"
+
+
+async def test_health_check_decorator_via_module() -> None:
+    """`@health.check(name)` registers a check on the wrapped registry."""
+    health = Health()
+
+    @health.check("ok")
+    async def ok_check() -> None:
+        return None
+
+    async with health:
+        report = await health.run()
+        assert report["status"] == HealthStatus.OK
+        assert "ok" in report["checks"]
+
+
+async def test_health_check_via_micro_attribute() -> None:
+    """`@micro.health.check(name)` is the conventional access path."""
+    micro = Grelmicro(modules=[Health()])
+
+    @micro.health.check("ping")
+    async def ping() -> None:
+        return None
+
+    async with micro:
+        report = await micro.health.run()
+        assert report["status"] == HealthStatus.OK
+
+
+async def test_health_run_aggregates_failures() -> None:
+    """A failing check flips the aggregate status away from OK."""
+    micro = Grelmicro(modules=[Health()])
+    msg = "down"
+
+    @micro.health.check("db")
+    async def db_check() -> None:
+        raise RuntimeError(msg)
+
+    async with micro:
+        report = await micro.health.run()
+        assert report["status"] != HealthStatus.OK
+        assert "db" in report["checks"]
+
+
+async def test_micro_health_prefers_default_over_named() -> None:
+    """`micro.health` resolves to the default-named module."""
+    primary = HealthRegistry()
+    micro = Grelmicro(
+        modules=[
+            Health(registry=primary),
+            Health(name="readiness"),
+        ]
+    )
+    assert micro.health.registry is primary
+
+
+async def test_micro_health_raises_when_ambiguous() -> None:
+    """`micro.health` raises when multiple non-default modules exist."""
+    micro = Grelmicro(
+        modules=[
+            Health(name="liveness"),
+            Health(name="readiness"),
+        ]
+    )
+    with pytest.raises(AttributeError, match="multiple 'health' modules"):
+        _ = micro.health


### PR DESCRIPTION
## Summary

Implements #213 (Health module). Wraps a `HealthRegistry` and forwards the `check(...)` decorator and `run(...)` aggregator. Part of the #201 epic.

## Usage

```python
from grelmicro import Grelmicro
from grelmicro.health import Health

micro = Grelmicro(modules=[Health()])

@micro.health.check("redis")
async def redis_alive() -> None:
    ...

async with micro:
    report = await micro.health.run()
```

## Changes

- `grelmicro/health/_module.py`: `Health` class implementing `Module` (`kind="health"`)
- `grelmicro/health/__init__.py`: re-export `Health`
- `tests/health/test_module.py`: 10 tests
- `docs/changelog.md`: feature entry

## Test plan

- [x] All 10 new tests pass
- [x] Full pre-commit gate green
- [x] `micro.health` follows the locked default-vs-named resolution rule