### PR TITLE
💥 Rename TaskManager to Tasks (#218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ from grelmicro.resilience import (
 from grelmicro.resilience.redis import RedisRateLimiterBackend
 from grelmicro.sync import LeaderElection, Lock
 from grelmicro.sync.redis import RedisSyncBackend
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
 
 # === grelmicro ===
-task = TaskManager()
+task = Tasks()
 sync.register(RedisSyncBackend("redis://localhost:6379/0"))
 cache.register(RedisCacheBackend("redis://localhost:6379/0", prefix="myapp:"))
 resilience.register(RedisRateLimiterBackend("redis://localhost:6379/0"))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,7 @@
 
 ### Breaking
 
-* 💥 Rename `TaskManager` to `Tasks`. The class still extends `TaskRouter`, mirroring FastAPI's `APIRouter` ← `FastAPI` shape. `from grelmicro.task import TaskManager` keeps working but emits `DeprecationWarning` and will be removed in 1.0.0. Issue [#218](https://github.com/grelinfo/grelmicro/issues/218).
+* 💥 Rename `TaskManager` to `Tasks`. Class still extends `TaskRouter`, mirroring FastAPI's `APIRouter` ← `FastAPI` shape. Update imports to `from grelmicro.task import Tasks`. Issue [#218](https://github.com/grelinfo/grelmicro/issues/218).
 
 ## 0.21.0 - 2026-05-06
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@
 * ✨ Add `Cache` module. Wraps a `CacheBackend` and exposes a `ttl(...)` factory that builds a `TTLCache` bound to the wrapped backend. Use it via `Grelmicro(uses=[Cache(RedisCacheBackend(...))])` and reach it on `micro.cache`. Issue [#212](https://github.com/grelinfo/grelmicro/issues/212).
 * ✨ Add `Grelmicro.current()` classmethod for ambient lookup. Inside `async with micro:` it returns the active app for the current asyncio task. Matches Tokio's `Handle::current()` shape.
 
+### Breaking
+
+* 💥 Rename `TaskManager` to `Tasks`. The class still extends `TaskRouter`, mirroring FastAPI's `APIRouter` ← `FastAPI` shape. `from grelmicro.task import TaskManager` keeps working but emits `DeprecationWarning` and will be removed in 1.0.0. Issue [#218](https://github.com/grelinfo/grelmicro/issues/218).
+
 ## 0.21.0 - 2026-05-06
 
 ### Breaking

--- a/docs/health.md
+++ b/docs/health.md
@@ -32,7 +32,7 @@ The registry auto-registers as the global singleton. The router resolves it auto
 
 ### Grelmicro app integration
 
-Register the `HealthRegistry` with a `Grelmicro` app to lifecycle it alongside the rest of your modules. Same FastAPI-style explicit registration as `TaskManager`:
+Register the `HealthRegistry` with a `Grelmicro` app to lifecycle it alongside the rest of your modules. Same FastAPI-style explicit registration as `Tasks`:
 
 ```python
 from grelmicro import Grelmicro
@@ -49,7 +49,7 @@ async with micro:
     report = await health.run()
 ```
 
-Use `Grelmicro.use(item)` (or `uses=`) for entry-point components like `HealthRegistry` and `TaskManager`. The caller keeps the reference and uses it directly.
+Use `Grelmicro.use(item)` (or `uses=`) for entry-point components like `HealthRegistry` and `Tasks`. The caller keeps the reference and uses it directly.
 
 For imperative registration (without a decorator), use `registry.add(name, func)`:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,12 +105,12 @@ from grelmicro.resilience import (
 from grelmicro.resilience.redis import RedisRateLimiterBackend
 from grelmicro.sync import LeaderElection, Lock
 from grelmicro.sync.redis import RedisSyncBackend
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
 
 # === grelmicro ===
-task = TaskManager()
+task = Tasks()
 sync.register(RedisSyncBackend("redis://localhost:6379/0"))
 cache.register(RedisCacheBackend("redis://localhost:6379/0", prefix="myapp:"))
 resilience.register(RedisRateLimiterBackend("redis://localhost:6379/0"))

--- a/docs/reference/task.md
+++ b/docs/reference/task.md
@@ -5,5 +5,5 @@
       show_submodules: true
       members:
         - TaskError
-        - TaskManager
+        - Tasks
         - TaskRouter

--- a/docs/snippets/simple_fastapi_app.py
+++ b/docs/snippets/simple_fastapi_app.py
@@ -7,12 +7,12 @@ from grelmicro.log import configure
 from grelmicro.resilience import CircuitBreaker
 from grelmicro.sync import LeaderElection, Lock
 from grelmicro.sync.redis import RedisSyncBackend
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
 
 # === grelmicro ===
-task = TaskManager()
+task = Tasks()
 sync_backend = RedisSyncBackend("redis://localhost:6379/0")
 leader_election = LeaderElection("leader-election")
 task.add_task(leader_election)

--- a/docs/snippets/single_file_app.py
+++ b/docs/snippets/single_file_app.py
@@ -9,10 +9,10 @@ from fastapi import FastAPI
 
 from grelmicro.sync import LeaderElection, Lock
 from grelmicro.sync.memory import MemorySyncBackend
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
 backend = MemorySyncBackend()
-task = TaskManager()
+task = Tasks()
 
 
 @asynccontextmanager

--- a/docs/snippets/sync/leaderelection_task.py
+++ b/docs/snippets/sync/leaderelection_task.py
@@ -1,6 +1,6 @@
 from grelmicro.sync import LeaderElection
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
 leader = LeaderElection("cluster_group")
-task = TaskManager()
+task = Tasks()
 task.add_task(leader)

--- a/docs/snippets/task/fastapi.py
+++ b/docs/snippets/task/fastapi.py
@@ -2,9 +2,9 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
-task = TaskManager()
+task = Tasks()
 
 
 @asynccontextmanager

--- a/docs/snippets/task/faststream.py
+++ b/docs/snippets/task/faststream.py
@@ -3,9 +3,9 @@ from contextlib import asynccontextmanager
 from faststream import ContextRepo, FastStream
 from faststream.redis import RedisBroker
 
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
-task = TaskManager()
+task = Tasks()
 
 
 @asynccontextmanager

--- a/docs/snippets/task/interval_leader.py
+++ b/docs/snippets/task/interval_leader.py
@@ -1,8 +1,8 @@
 from grelmicro.sync import LeaderElection
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
 leader = LeaderElection("my-service")
-task = TaskManager()
+task = Tasks()
 task.add_task(leader)
 
 

--- a/docs/snippets/task/interval_lock.py
+++ b/docs/snippets/task/interval_lock.py
@@ -1,6 +1,6 @@
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
-task = TaskManager()
+task = Tasks()
 
 
 @task.interval(seconds=60, max_lock_seconds=300)

--- a/docs/snippets/task/interval_lock_custom.py
+++ b/docs/snippets/task/interval_lock_custom.py
@@ -1,6 +1,6 @@
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
-task = TaskManager()
+task = Tasks()
 
 
 @task.interval(seconds=60, max_lock_seconds=300, min_lock_seconds=30)

--- a/docs/snippets/task/interval_lock_resource.py
+++ b/docs/snippets/task/interval_lock_resource.py
@@ -1,7 +1,7 @@
 from grelmicro.sync import Lock
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
-task = TaskManager()
+task = Tasks()
 resource_lock = Lock("shared-resource")
 
 

--- a/docs/snippets/task/interval_manager.py
+++ b/docs/snippets/task/interval_manager.py
@@ -1,6 +1,6 @@
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
-task = TaskManager()
+task = Tasks()
 
 
 @task.interval(seconds=5)

--- a/docs/snippets/task/leaderelection.py
+++ b/docs/snippets/task/leaderelection.py
@@ -1,8 +1,8 @@
 from grelmicro.sync import LeaderElection
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
 leader = LeaderElection("my-service")
-task = TaskManager()
+task = Tasks()
 task.add_task(leader)
 
 

--- a/docs/snippets/task/lock.py
+++ b/docs/snippets/task/lock.py
@@ -1,7 +1,7 @@
 from grelmicro.sync import Lock
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
-task = TaskManager()
+task = Tasks()
 
 
 @task.interval(seconds=5)

--- a/docs/snippets/task/router.py
+++ b/docs/snippets/task/router.py
@@ -9,7 +9,7 @@ async def my_task():
     print("Hello, World!")
 
 
-from grelmicro.task.manager import TaskManager
+from grelmicro.task import Tasks
 
-task = TaskManager()
+task = Tasks()
 task.include_router(router)

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -10,7 +10,7 @@ The available primitives are:
 - **[Leader Election](#leader-election)**: A single worker is elected as the leader for performing tasks only once in a cluster.
 - **[Lock](#lock)**: A distributed lock that can be used to synchronize access to shared resources.
 
-The synchronization primitives can be used in combination with the `TaskManager` and `TaskRouter` to control task execution in a distributed system (see more in [Task Scheduler](task.md)).
+The synchronization primitives can be used in combination with the `Tasks` and `TaskRouter` to control task execution in a distributed system (see more in [Task Scheduler](task.md)).
 
 !!! warning "Thread Safety"
     All synchronization primitives (`Lock`, `TaskLock`, `LeaderElection`) are designed for use within a single async event loop and are **not thread-safe**. Sync access from worker threads is supported via `from_thread` adapters, which dispatch operations to the event loop. Do not share instances across multiple event loops or threads without the adapter.

--- a/docs/task.md
+++ b/docs/task.md
@@ -13,7 +13,7 @@ The key features are:
 - **Dependency injection**: use [FastDepends](https://lancetnik.github.io/FastDepends/) to inject dependencies into tasks.
 - **Error handling**: errors are caught and logged, so a failing task does not stop the scheduler.
 
-## Task Manager
+## Tasks
 
 The `Tasks` class is the main entry point to manage tasks. The recommended way to lifecycle it is to register it with a `Grelmicro` app:
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -15,16 +15,16 @@ The key features are:
 
 ## Task Manager
 
-The `TaskManager` class is the main entry point to manage tasks. The recommended way to lifecycle it is to register it with a `Grelmicro` app:
+The `Tasks` class is the main entry point to manage tasks. The recommended way to lifecycle it is to register it with a `Grelmicro` app:
 
 ```python
 from grelmicro import Grelmicro
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 
-task_manager = TaskManager()
-micro = Grelmicro(uses=[task_manager])
+tasks = Tasks()
+micro = Grelmicro(uses=[tasks])
 
-@task_manager.interval(seconds=5)
+@tasks.interval(seconds=5)
 async def cleanup() -> None:
     ...
 
@@ -56,7 +56,7 @@ Use the `interval` decorator to run a task at a fixed interval:
 !!! note
     The interval specifies the waiting time between task executions. Ensure that the task execution duration is considered to meet deadlines effectively.
 
-=== "TaskManager"
+=== "Tasks"
 
     ```python
     --8<-- "task/interval_manager.py"
@@ -133,7 +133,7 @@ For bigger applications, use the `TaskRouter` class to organize tasks across mod
 --8<-- "task/router.py:1-10"
 ```
 
-Then include the `TaskRouter` into the `TaskManager` or other routers:
+Then include the `TaskRouter` into the `Tasks` or other routers:
 
 ```python
 --8<-- "task/router.py:12"

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -45,16 +45,16 @@ class Grelmicro:
     ```python
     from grelmicro import Grelmicro
     from grelmicro.sync import Sync
-    from grelmicro.task import TaskManager
+    from grelmicro.task import Tasks
 
-    task_manager = TaskManager()
+    tasks = Tasks()
 
     micro = Grelmicro(uses=[
         Sync(RedisSyncBackend()),
-        task_manager,
+        tasks,
     ])
 
-    @task_manager.interval(seconds=5)
+    @tasks.interval(seconds=5)
     async def cleanup(): ...
 
     async with micro:
@@ -139,8 +139,8 @@ class Grelmicro:
         micro.use(Sync(RedisSyncBackend(), name="analytics"))
 
         # Plain async context manager: lifecycled only, caller holds reference
-        task_manager = TaskManager()
-        micro.use(task_manager)
+        tasks = Tasks()
+        micro.use(tasks)
         ```
 
         Returns `None`. Mirrors FastAPI's `app.include_router(router)`

--- a/grelmicro/task/__init__.py
+++ b/grelmicro/task/__init__.py
@@ -1,27 +1,7 @@
 """Task."""
 
-import warnings
-from typing import TYPE_CHECKING
-
 from grelmicro.task._tasks import Tasks
 from grelmicro.task.errors import TaskError
 from grelmicro.task.router import TaskRouter
 
 __all__ = ["TaskError", "TaskRouter", "Tasks"]
-
-if TYPE_CHECKING:
-    TaskManager = Tasks
-
-
-def __getattr__(name: str) -> object:
-    if name == "TaskManager":
-        warnings.warn(
-            "TaskManager is deprecated and will be removed in 1.0.0. "
-            "Use Tasks instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        globals()["TaskManager"] = Tasks
-        return Tasks
-    msg = f"module {__name__!r} has no attribute {name!r}"
-    raise AttributeError(msg)

--- a/grelmicro/task/__init__.py
+++ b/grelmicro/task/__init__.py
@@ -21,6 +21,7 @@ def __getattr__(name: str) -> object:
             DeprecationWarning,
             stacklevel=2,
         )
+        globals()["TaskManager"] = Tasks
         return Tasks
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)

--- a/grelmicro/task/__init__.py
+++ b/grelmicro/task/__init__.py
@@ -1,7 +1,26 @@
 """Task."""
 
+import warnings
+from typing import TYPE_CHECKING
+
+from grelmicro.task._tasks import Tasks
 from grelmicro.task.errors import TaskError
-from grelmicro.task.manager import TaskManager
 from grelmicro.task.router import TaskRouter
 
-__all__ = ["TaskError", "TaskManager", "TaskRouter"]
+__all__ = ["TaskError", "TaskRouter", "Tasks"]
+
+if TYPE_CHECKING:
+    TaskManager = Tasks
+
+
+def __getattr__(name: str) -> object:
+    if name == "TaskManager":
+        warnings.warn(
+            "TaskManager is deprecated and will be removed in 1.0.0. "
+            "Use Tasks instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Tasks
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/grelmicro/task/_interval.py
+++ b/grelmicro/task/_interval.py
@@ -24,7 +24,7 @@ logger = getLogger("grelmicro.task")
 class IntervalTask(Task):
     """Interval Task.
 
-    Use the `TaskManager.interval()` or `TaskRouter.interval()` decorator instead
+    Use the `Tasks.interval()` or `TaskRouter.interval()` decorator instead
     of creating IntervalTask objects directly.
 
     Supports three modes:

--- a/grelmicro/task/_tasks.py
+++ b/grelmicro/task/_tasks.py
@@ -1,4 +1,4 @@
-"""Task Manager."""
+"""Tasks."""
 
 import asyncio
 from contextlib import AsyncExitStack
@@ -16,10 +16,10 @@ from grelmicro.task.router import TaskRouter
 logger = getLogger("grelmicro.task")
 
 
-class TaskManager(TaskRouter):
-    """Task Manager.
+class Tasks(TaskRouter):
+    """Tasks.
 
-    `TaskManager` class, the main entrypoint to manage scheduled tasks.
+    `Tasks` class, the main entrypoint to manage scheduled tasks.
     """
 
     def __init__(
@@ -42,7 +42,7 @@ class TaskManager(TaskRouter):
             ),
         ] = None,
     ) -> None:
-        """Initialize the task manager."""
+        """Initialize Tasks."""
         TaskRouter.__init__(self, tasks=tasks)
 
         self._auto_start = auto_start

--- a/grelmicro/task/router.py
+++ b/grelmicro/task/router.py
@@ -18,7 +18,7 @@ class TaskRouter:
     """Task Router.
 
     `TaskRouter` class, used to group task schedules, for example to structure an app in
-    multiple files. It would then be included in the `TaskManager`, or in another
+    multiple files. It would then be included in the `Tasks`, or in another
     `TaskRouter`.
     """
 

--- a/tests/task/test_tasks.py
+++ b/tests/task/test_tasks.py
@@ -1,6 +1,5 @@
 """Test Tasks."""
 
-import warnings
 from asyncio import Event
 
 import pytest
@@ -163,27 +162,3 @@ async def test_tasks_out_of_context_errors() -> None:
 
     with pytest.raises(OutOfContextError):
         await app.__aexit__(None, None, None)
-
-
-def test_task_manager_alias_emits_deprecation_warning() -> None:
-    """Accessing TaskManager from grelmicro.task emits DeprecationWarning once."""
-    import grelmicro.task as task_module  # noqa: PLC0415
-
-    task_module.__dict__.pop("TaskManager", None)
-
-    with pytest.warns(DeprecationWarning, match="TaskManager is deprecated"):
-        alias = task_module.TaskManager
-
-    assert alias is Tasks
-    # Cached after first access: no further warnings.
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        assert task_module.TaskManager is Tasks
-
-
-def test_unknown_attribute_raises_attribute_error() -> None:
-    """Unknown attributes on grelmicro.task raise AttributeError."""
-    import grelmicro.task as task_module  # noqa: PLC0415
-
-    with pytest.raises(AttributeError, match="has no attribute 'DoesNotExist'"):
-        task_module.DoesNotExist  # noqa: B018

--- a/tests/task/test_tasks.py
+++ b/tests/task/test_tasks.py
@@ -1,5 +1,6 @@
 """Test Tasks."""
 
+import warnings
 from asyncio import Event
 
 import pytest
@@ -165,13 +166,19 @@ async def test_tasks_out_of_context_errors() -> None:
 
 
 def test_task_manager_alias_emits_deprecation_warning() -> None:
-    """Accessing TaskManager from grelmicro.task emits DeprecationWarning."""
+    """Accessing TaskManager from grelmicro.task emits DeprecationWarning once."""
     import grelmicro.task as task_module  # noqa: PLC0415
+
+    task_module.__dict__.pop("TaskManager", None)
 
     with pytest.warns(DeprecationWarning, match="TaskManager is deprecated"):
         alias = task_module.TaskManager
 
     assert alias is Tasks
+    # Cached after first access: no further warnings.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert task_module.TaskManager is Tasks
 
 
 def test_unknown_attribute_raises_attribute_error() -> None:

--- a/tests/task/test_tasks.py
+++ b/tests/task/test_tasks.py
@@ -1,34 +1,34 @@
-"""Test Task Manager."""
+"""Test Tasks."""
 
 from asyncio import Event
 
 import pytest
 
 from grelmicro.errors import OutOfContextError
-from grelmicro.task import TaskManager
+from grelmicro.task import Tasks
 from grelmicro.task.errors import TaskAddOperationError
 from tests.task.samples import EventTask
 
 pytestmark = [pytest.mark.timeout(10)]
 
 
-def test_task_manager_init() -> None:
-    """Test Task Manager Initialization."""
+def test_tasks_init() -> None:
+    """Test Tasks Initialization."""
     # Act
     task = EventTask()
-    app = TaskManager()
-    app_with_tasks = TaskManager(tasks=[task])
+    app = Tasks()
+    app_with_tasks = Tasks(tasks=[task])
     # Assert
     assert app.tasks == []
     assert app_with_tasks.tasks == [task]
 
 
-async def test_task_manager_context() -> None:
-    """Test Task Manager Context."""
+async def test_tasks_context() -> None:
+    """Test Tasks Context."""
     # Arrange
     event = Event()
     task = EventTask(event=event)
-    app = TaskManager(tasks=[task])
+    app = Tasks(tasks=[task])
 
     # Act
     event_before = event.is_set()
@@ -41,12 +41,12 @@ async def test_task_manager_context() -> None:
 
 
 @pytest.mark.parametrize("auto_start", [True, False])
-async def test_task_manager_auto_start_disabled(*, auto_start: bool) -> None:
-    """Test Task Manager Auto Start Disabled."""
+async def test_tasks_auto_start_disabled(*, auto_start: bool) -> None:
+    """Test Tasks Auto Start Disabled."""
     # Arrange
     event = Event()
     task = EventTask(event=event)
-    app = TaskManager(auto_start=auto_start, tasks=[task])
+    app = Tasks(auto_start=auto_start, tasks=[task])
 
     # Act
     event_before = event.is_set()
@@ -58,10 +58,10 @@ async def test_task_manager_auto_start_disabled(*, auto_start: bool) -> None:
     assert event_in_context is auto_start
 
 
-async def test_task_manager_already_started_error() -> None:
-    """Test Task Manager Already Started Warning."""
+async def test_tasks_already_started_error() -> None:
+    """Test Tasks Already Started Warning."""
     # Arrange
-    app = TaskManager()
+    app = Tasks()
 
     # Act / Assert
     async with app:
@@ -69,7 +69,7 @@ async def test_task_manager_already_started_error() -> None:
             await app.start()
 
 
-async def test_task_manager_start_surfaces_early_task_failure() -> None:
+async def test_tasks_start_surfaces_early_task_failure() -> None:
     """A task that raises before setting ``ready`` surfaces the error from start()."""
     import asyncio  # noqa: PLC0415
 
@@ -85,7 +85,7 @@ async def test_task_manager_start_surfaces_early_task_failure() -> None:
             msg = "early failure"
             raise RuntimeError(msg)
 
-    app = TaskManager(auto_start=False, tasks=[FailingTask()])
+    app = Tasks(auto_start=False, tasks=[FailingTask()])
 
     with pytest.raises(BaseExceptionGroup) as exc_info:
         async with app:
@@ -97,7 +97,7 @@ async def test_task_manager_start_surfaces_early_task_failure() -> None:
     )
 
 
-async def test_task_manager_start_surfaces_early_clean_exit() -> None:
+async def test_tasks_start_surfaces_early_clean_exit() -> None:
     """A task that returns without setting ``ready`` raises instead of deadlocking."""
     import asyncio  # noqa: PLC0415
 
@@ -111,7 +111,7 @@ async def test_task_manager_start_surfaces_early_clean_exit() -> None:
         ) -> None:
             del ready
 
-    app = TaskManager(auto_start=False, tasks=[SilentTask()])
+    app = Tasks(auto_start=False, tasks=[SilentTask()])
 
     with pytest.raises(BaseExceptionGroup) as exc_info:
         async with app:
@@ -123,7 +123,7 @@ async def test_task_manager_start_surfaces_early_clean_exit() -> None:
     )
 
 
-async def test_task_manager_cancels_running_tasks_on_exit() -> None:
+async def test_tasks_cancels_running_tasks_on_exit() -> None:
     """Long-running tasks are cancelled on context exit."""
     import asyncio  # noqa: PLC0415
 
@@ -145,16 +145,16 @@ async def test_task_manager_cancels_running_tasks_on_exit() -> None:
                 cancelled.set()
                 raise
 
-    async with TaskManager(tasks=[LongRunningTask()]):
+    async with Tasks(tasks=[LongRunningTask()]):
         pass
 
     assert cancelled.is_set()
 
 
-async def test_task_manager_out_of_context_errors() -> None:
-    """Test Task Manager Out of Context Errors."""
+async def test_tasks_out_of_context_errors() -> None:
+    """Test Tasks Out of Context Errors."""
     # Arrange
-    app = TaskManager()
+    app = Tasks()
 
     # Act / Assert
     with pytest.raises(OutOfContextError):
@@ -162,3 +162,21 @@ async def test_task_manager_out_of_context_errors() -> None:
 
     with pytest.raises(OutOfContextError):
         await app.__aexit__(None, None, None)
+
+
+def test_task_manager_alias_emits_deprecation_warning() -> None:
+    """Accessing TaskManager from grelmicro.task emits DeprecationWarning."""
+    import grelmicro.task as task_module  # noqa: PLC0415
+
+    with pytest.warns(DeprecationWarning, match="TaskManager is deprecated"):
+        alias = task_module.TaskManager
+
+    assert alias is Tasks
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    """Unknown attributes on grelmicro.task raise AttributeError."""
+    import grelmicro.task as task_module  # noqa: PLC0415
+
+    with pytest.raises(AttributeError, match="has no attribute 'DoesNotExist'"):
+        task_module.DoesNotExist  # noqa: B018

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -283,7 +283,7 @@ def test_use_plain_context_manager_returns_none() -> None:
 async def test_use_lifecycles_plain_context_manager_with_app() -> None:
     """`async with micro:` enters and exits plain async context managers."""
     log: list[str] = []
-    item = _RecordingContext(log=log, label="task_manager")
+    item = _RecordingContext(log=log, label="tasks")
     micro = Grelmicro(uses=[item])
     async with micro:
         assert item.entered == 1


### PR DESCRIPTION
## Summary

- Rename `TaskManager` to `Tasks`. Class still extends `TaskRouter`, mirroring FastAPI's `APIRouter` ← `FastAPI` shape.
- Move `grelmicro/task/manager.py` to `grelmicro/task/_tasks.py`. Move `tests/task/test_manager.py` to `tests/task/test_tasks.py`.
- Keep `from grelmicro.task import TaskManager` working via module-level `__getattr__` that emits `DeprecationWarning`. Removed in 1.0.0.
- Sweep docs, snippets, and README.

Closes #218.

## Test plan

- [x] `uv run pytest` (1494 passed)
- [x] `uv run ruff check grelmicro/ tests/`
- [x] `uv run ruff format --check`
- [x] `uv run ty check grelmicro/`
- [x] Coverage 100%
- [x] New tests cover the deprecation alias and the unknown-attribute path