### PR TITLE
🗑️ Deprecate module-level helpers in favor of Grelmicro app

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,10 @@
 
 * 💥 Rename `TaskManager` to `Tasks`. Class still extends `TaskRouter`, mirroring FastAPI's `APIRouter` ← `FastAPI` shape. Update imports to `from grelmicro.task import Tasks`. Issue [#218](https://github.com/grelinfo/grelmicro/issues/218).
 
+### Deprecated
+
+* 🗑️ Deprecate the module-level legacy helpers in favor of the `Grelmicro` app object. `grelmicro.lifespan()`, `grelmicro.sync.{register,unregister,use,use_backend}`, `grelmicro.cache.{register,unregister,use,use_backend}`, `grelmicro.health.{register,unregister,use,use_registry}`, and `grelmicro.resilience.{register,unregister,use,use_backend,register_circuit_breaker,unregister_circuit_breaker,use_circuit_breaker_backend}` now emit `DeprecationWarning`. They will be removed in 1.0.0. Build a `Grelmicro(uses=[...])` and open it with `async with micro:` instead. Issue [#206](https://github.com/grelinfo/grelmicro/issues/206), removal tracked in [#207](https://github.com/grelinfo/grelmicro/issues/207).
+
 ## 0.21.0 - 2026-05-06
 
 ### Breaking

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,7 +15,7 @@
 
 ### Deprecated
 
-* 🗑️ Deprecate the module-level legacy helpers in favor of the `Grelmicro` app object. `grelmicro.lifespan()`, `grelmicro.sync.{register,unregister,use,use_backend}`, `grelmicro.cache.{register,unregister,use,use_backend}`, `grelmicro.health.{register,unregister,use,use_registry}`, and `grelmicro.resilience.{register,unregister,use,use_backend,register_circuit_breaker,unregister_circuit_breaker,use_circuit_breaker_backend}` now emit `DeprecationWarning`. They will be removed in 1.0.0. Build a `Grelmicro(uses=[...])` and open it with `async with micro:` instead. Issue [#206](https://github.com/grelinfo/grelmicro/issues/206), removal tracked in [#207](https://github.com/grelinfo/grelmicro/issues/207).
+* 🗑️ Deprecate every module-level legacy helper in favor of the `Grelmicro` app object. `grelmicro.lifespan()` and the `register` / `unregister` / `use` / `use_backend` / `use_registry` family across `grelmicro.{sync,cache,health,resilience}` (plus the resilience circuit-breaker variants) now emit `DeprecationWarning`. Build a `Grelmicro(uses=[...])` and open it with `async with micro:` instead. Removal lands in 1.0.0. Issue [#206](https://github.com/grelinfo/grelmicro/issues/206), removal tracked in [#207](https://github.com/grelinfo/grelmicro/issues/207).
 
 ## 0.21.0 - 2026-05-06
 

--- a/grelmicro/__init__.py
+++ b/grelmicro/__init__.py
@@ -13,15 +13,18 @@ from grelmicro._app import (
     ModuleNotRegisteredError,
     NoActiveAppError,
 )
+from grelmicro._deprecation import warn_legacy
 from grelmicro._module import Module
 
 
-@asynccontextmanager
-async def lifespan(
+def lifespan(
     *ad_hoc: AbstractAsyncContextManager[object],
     exclude: Iterable[str] = (),
-) -> AsyncIterator[None]:
+) -> AbstractAsyncContextManager[None]:
     """Open every registered backend, close them all on exit.
+
+    Deprecated since 0.23.0, removed in 1.0.0. Build a `Grelmicro` app and
+    open it with `async with micro:` instead.
 
     Walks every grelmicro backend registry that has been imported
     in the current process and enters each registered backend that
@@ -40,6 +43,18 @@ async def lifespan(
     registry. ``{"resilience.ratelimiter.analytics"}`` skips just
     the named entry inside that registry.
     """
+    warn_legacy(
+        "grelmicro.lifespan",
+        "`async with Grelmicro(uses=[...]):`",
+    )
+    return _lifespan(*ad_hoc, exclude=exclude)
+
+
+@asynccontextmanager
+async def _lifespan(
+    *ad_hoc: AbstractAsyncContextManager[object],
+    exclude: Iterable[str] = (),
+) -> AsyncIterator[None]:
     from grelmicro._backends import _ALL_REGISTRIES  # noqa: PLC0415
 
     excluded = frozenset(exclude)

--- a/grelmicro/_deprecation.py
+++ b/grelmicro/_deprecation.py
@@ -1,0 +1,20 @@
+"""Internal deprecation helpers for the 0.x to 1.0 transition."""
+
+from __future__ import annotations
+
+import warnings
+
+
+def warn_legacy(symbol: str, replacement: str) -> None:
+    """Emit a DeprecationWarning for a legacy module-level helper.
+
+    `symbol` is the dotted path of the deprecated callable.
+    `replacement` is a short snippet pointing at the `Grelmicro` app object
+    path that supersedes it.
+    """
+    warnings.warn(
+        f"`{symbol}` is deprecated and will be removed in 1.0.0. "
+        f"Use {replacement} instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )

--- a/grelmicro/cache/__init__.py
+++ b/grelmicro/cache/__init__.py
@@ -6,6 +6,7 @@ from typing import Annotated
 from typing_extensions import Doc
 
 from grelmicro._backends import DEFAULT_NAME
+from grelmicro._deprecation import warn_legacy
 from grelmicro.cache._backends import cache_backend_registry
 from grelmicro.cache._module import Cache
 from grelmicro.cache._protocol import CacheBackend
@@ -26,7 +27,15 @@ def register(
         str, Doc("Name to register the backend under.")
     ] = DEFAULT_NAME,
 ) -> None:
-    """Register ``backend`` under ``name`` (defaults to ``"default"``)."""
+    """Register ``backend`` under ``name`` (defaults to ``"default"``).
+
+    Deprecated since 0.23.0, removed in 1.0.0. Use
+    `Grelmicro(uses=[Cache(backend, name=name)])` instead.
+    """
+    warn_legacy(
+        "grelmicro.cache.register",
+        "`Grelmicro(uses=[Cache(backend, name=name)])`",
+    )
     cache_backend_registry.register(backend, name)
 
 
@@ -39,7 +48,15 @@ def unregister(
         Doc("Optional backend instance for an identity-checked removal."),
     ] = None,
 ) -> None:
-    """Remove the registered backend under ``name``."""
+    """Remove the registered backend under ``name``.
+
+    Deprecated since 0.23.0, removed in 1.0.0. Construct a fresh `Grelmicro`
+    app instead of mutating a shared registry.
+    """
+    warn_legacy(
+        "grelmicro.cache.unregister",
+        "a fresh `Grelmicro(uses=[...])`",
+    )
     cache_backend_registry.unregister(name, backend)
 
 
@@ -49,7 +66,15 @@ def use_backend(
         Doc("The cache backend to register as the default."),
     ],
 ) -> None:
-    """Register ``backend`` under the ``"default"`` name."""
+    """Register ``backend`` under the ``"default"`` name.
+
+    Deprecated since 0.23.0, removed in 1.0.0. Use
+    `Grelmicro(uses=[Cache(backend)])`.
+    """
+    warn_legacy(
+        "grelmicro.cache.use_backend",
+        "`Grelmicro(uses=[Cache(backend)])`",
+    )
     cache_backend_registry.register(backend, DEFAULT_NAME)
 
 
@@ -61,7 +86,15 @@ def use(
     /,
     **named: CacheBackend,
 ) -> AbstractContextManager[None]:
-    """Install task-scoped backend overrides."""
+    """Install task-scoped backend overrides.
+
+    Deprecated since 0.23.0, removed in 1.0.0. Use
+    `async with micro.override(Cache(backend)):` instead.
+    """
+    warn_legacy(
+        "grelmicro.cache.use",
+        "`async with micro.override(Cache(backend)):`",
+    )
     return cache_backend_registry.use(backend, **named)
 
 

--- a/grelmicro/health/__init__.py
+++ b/grelmicro/health/__init__.py
@@ -6,6 +6,7 @@ from typing import Annotated
 from typing_extensions import Doc
 
 from grelmicro._backends import DEFAULT_NAME
+from grelmicro._deprecation import warn_legacy
 from grelmicro.health._backends import get_health_registry, health_registry
 from grelmicro.health._models import (
     CheckResult,
@@ -23,7 +24,15 @@ def register(
         str, Doc("Name to register the registry under.")
     ] = DEFAULT_NAME,
 ) -> None:
-    """Register ``registry`` under ``name`` (defaults to ``"default"``)."""
+    """Register ``registry`` under ``name`` (defaults to ``"default"``).
+
+    Deprecated since 0.23.0, removed in 1.0.0. Use
+    `Grelmicro(uses=[HealthChecks(...)])` instead.
+    """
+    warn_legacy(
+        "grelmicro.health.register",
+        "`Grelmicro(uses=[HealthChecks(...)])`",
+    )
     health_registry.register(registry, name)
 
 
@@ -36,7 +45,15 @@ def unregister(
         Doc("Optional instance for an identity-checked removal."),
     ] = None,
 ) -> None:
-    """Remove the registered instance under ``name``."""
+    """Remove the registered instance under ``name``.
+
+    Deprecated since 0.23.0, removed in 1.0.0. Construct a fresh `Grelmicro`
+    app instead of mutating a shared registry.
+    """
+    warn_legacy(
+        "grelmicro.health.unregister",
+        "a fresh `Grelmicro(uses=[...])`",
+    )
     health_registry.unregister(name, registry)
 
 
@@ -46,7 +63,15 @@ def use_registry(
         Doc("The health registry to install as the global default."),
     ],
 ) -> None:
-    """Register ``registry`` under the ``"default"`` name."""
+    """Register ``registry`` under the ``"default"`` name.
+
+    Deprecated since 0.23.0, removed in 1.0.0. Use
+    `Grelmicro(uses=[HealthChecks(...)])` instead.
+    """
+    warn_legacy(
+        "grelmicro.health.use_registry",
+        "`Grelmicro(uses=[HealthChecks(...)])`",
+    )
     health_registry.register(registry, DEFAULT_NAME)
 
 
@@ -58,7 +83,15 @@ def use(
     /,
     **named: HealthRegistry,
 ) -> AbstractContextManager[None]:
-    """Install task-scoped registry overrides."""
+    """Install task-scoped registry overrides.
+
+    Deprecated since 0.23.0, removed in 1.0.0. Use
+    `async with micro.override(...)` on the active app instead.
+    """
+    warn_legacy(
+        "grelmicro.health.use",
+        "`async with micro.override(...)`",
+    )
     return health_registry.use(registry, **named)
 
 

--- a/grelmicro/health/__init__.py
+++ b/grelmicro/health/__init__.py
@@ -27,11 +27,12 @@ def register(
     """Register ``registry`` under ``name`` (defaults to ``"default"``).
 
     Deprecated since 0.23.0, removed in 1.0.0. Use
-    `Grelmicro(uses=[HealthChecks(...)])` instead.
+    `Grelmicro(uses=[HealthRegistry(...)])` (or `micro.use(HealthRegistry(...))`)
+    instead.
     """
     warn_legacy(
         "grelmicro.health.register",
-        "`Grelmicro(uses=[HealthChecks(...)])`",
+        "`Grelmicro(uses=[HealthRegistry(...)])`",
     )
     health_registry.register(registry, name)
 
@@ -66,11 +67,11 @@ def use_registry(
     """Register ``registry`` under the ``"default"`` name.
 
     Deprecated since 0.23.0, removed in 1.0.0. Use
-    `Grelmicro(uses=[HealthChecks(...)])` instead.
+    `Grelmicro(uses=[HealthRegistry(...)])` instead.
     """
     warn_legacy(
         "grelmicro.health.use_registry",
-        "`Grelmicro(uses=[HealthChecks(...)])`",
+        "`Grelmicro(uses=[HealthRegistry(...)])`",
     )
     health_registry.register(registry, DEFAULT_NAME)
 

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -6,6 +6,7 @@ from typing import Annotated
 from typing_extensions import Doc
 
 from grelmicro._backends import DEFAULT_NAME
+from grelmicro._deprecation import warn_legacy
 from grelmicro.resilience._backends import (
     circuit_breaker_backend_registry,
     rate_limiter_backend_registry,
@@ -44,7 +45,15 @@ def register(
         str, Doc("Name to register the backend under.")
     ] = DEFAULT_NAME,
 ) -> None:
-    """Register ``backend`` under ``name`` (defaults to ``"default"``)."""
+    """Register ``backend`` under ``name`` (defaults to ``"default"``).
+
+    Deprecated since 0.23.0, removed in 1.0.0. Pass the rate limiter backend
+    to a `Grelmicro` app instead.
+    """
+    warn_legacy(
+        "grelmicro.resilience.register",
+        "`Grelmicro(uses=[...])`",
+    )
     rate_limiter_backend_registry.register(backend, name)
 
 
@@ -57,7 +66,14 @@ def unregister(
         Doc("Optional backend instance for an identity-checked removal."),
     ] = None,
 ) -> None:
-    """Remove the registered backend under ``name``."""
+    """Remove the registered backend under ``name``.
+
+    Deprecated since 0.23.0, removed in 1.0.0.
+    """
+    warn_legacy(
+        "grelmicro.resilience.unregister",
+        "a fresh `Grelmicro(uses=[...])`",
+    )
     rate_limiter_backend_registry.unregister(name, backend)
 
 
@@ -67,7 +83,15 @@ def use_backend(
         Doc("The rate limiter backend to register as the default."),
     ],
 ) -> None:
-    """Register ``backend`` under the ``"default"`` name."""
+    """Register ``backend`` under the ``"default"`` name.
+
+    Deprecated since 0.23.0, removed in 1.0.0. Pass the backend to a
+    `Grelmicro` app instead.
+    """
+    warn_legacy(
+        "grelmicro.resilience.use_backend",
+        "`Grelmicro(uses=[...])`",
+    )
     rate_limiter_backend_registry.register(backend, DEFAULT_NAME)
 
 
@@ -79,7 +103,14 @@ def use(
     /,
     **named: RateLimiterBackend,
 ) -> AbstractContextManager[None]:
-    """Install task-scoped backend overrides."""
+    """Install task-scoped backend overrides.
+
+    Deprecated since 0.23.0, removed in 1.0.0.
+    """
+    warn_legacy(
+        "grelmicro.resilience.use",
+        "`async with micro.override(...)`",
+    )
     return rate_limiter_backend_registry.use(backend, **named)
 
 
@@ -91,7 +122,14 @@ def register_circuit_breaker(
         str, Doc("Name to register the backend under.")
     ] = DEFAULT_NAME,
 ) -> None:
-    """Register a circuit breaker ``backend`` under ``name``."""
+    """Register a circuit breaker ``backend`` under ``name``.
+
+    Deprecated since 0.23.0, removed in 1.0.0.
+    """
+    warn_legacy(
+        "grelmicro.resilience.register_circuit_breaker",
+        "`Grelmicro(uses=[...])`",
+    )
     circuit_breaker_backend_registry.register(backend, name)
 
 
@@ -104,7 +142,14 @@ def unregister_circuit_breaker(
         Doc("Optional backend instance for an identity-checked removal."),
     ] = None,
 ) -> None:
-    """Remove the registered circuit breaker backend under ``name``."""
+    """Remove the registered circuit breaker backend under ``name``.
+
+    Deprecated since 0.23.0, removed in 1.0.0.
+    """
+    warn_legacy(
+        "grelmicro.resilience.unregister_circuit_breaker",
+        "a fresh `Grelmicro(uses=[...])`",
+    )
     circuit_breaker_backend_registry.unregister(name, backend)
 
 
@@ -114,10 +159,15 @@ def use_circuit_breaker_backend(
         Doc("The circuit breaker backend to register as the default."),
     ],
 ) -> None:
-    """Register a circuit breaker ``backend`` under the ``"default"`` name."""
-    circuit_breaker_backend_registry.register(
-        backend, DEFAULT_NAME
-    )  # pragma: no cover
+    """Register a circuit breaker ``backend`` under the ``"default"`` name.
+
+    Deprecated since 0.23.0, removed in 1.0.0.
+    """
+    warn_legacy(
+        "grelmicro.resilience.use_circuit_breaker_backend",
+        "`Grelmicro(uses=[...])`",
+    )
+    circuit_breaker_backend_registry.register(backend, DEFAULT_NAME)
 
 
 __all__ = [

--- a/grelmicro/sync/__init__.py
+++ b/grelmicro/sync/__init__.py
@@ -6,6 +6,7 @@ from typing import Annotated
 from typing_extensions import Doc
 
 from grelmicro._backends import DEFAULT_NAME
+from grelmicro._deprecation import warn_legacy
 from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync._module import Sync
 from grelmicro.sync.abc import SyncBackend, SyncPrimitive
@@ -21,7 +22,15 @@ def register(
         str, Doc("Name to register the backend under.")
     ] = DEFAULT_NAME,
 ) -> None:
-    """Register ``backend`` under ``name`` (defaults to ``"default"``)."""
+    """Register ``backend`` under ``name`` (defaults to ``"default"``).
+
+    Deprecated since 0.23.0, removed in 1.0.0. Use
+    `Grelmicro(uses=[Sync(backend, name=name)])` instead.
+    """
+    warn_legacy(
+        "grelmicro.sync.register",
+        "`Grelmicro(uses=[Sync(backend, name=name)])`",
+    )
     sync_backend_registry.register(backend, name)
 
 
@@ -34,7 +43,15 @@ def unregister(
         Doc("Optional backend instance for an identity-checked removal."),
     ] = None,
 ) -> None:
-    """Remove the registered backend under ``name``."""
+    """Remove the registered backend under ``name``.
+
+    Deprecated since 0.23.0, removed in 1.0.0. Construct a fresh `Grelmicro`
+    app instead of mutating a shared registry.
+    """
+    warn_legacy(
+        "grelmicro.sync.unregister",
+        "a fresh `Grelmicro(uses=[...])`",
+    )
     sync_backend_registry.unregister(name, backend)
 
 
@@ -44,7 +61,16 @@ def use_backend(
         Doc("The synchronization backend to register as the default."),
     ],
 ) -> None:
-    """Register ``backend`` under the ``"default"`` name."""
+    """Register ``backend`` under the ``"default"`` name.
+
+    Deprecated since 0.23.0, removed in 1.0.0. Use
+    `Grelmicro(uses=[Sync(backend)])` (or pass the backend directly,
+    `Grelmicro(uses=[backend])` for first-party backends).
+    """
+    warn_legacy(
+        "grelmicro.sync.use_backend",
+        "`Grelmicro(uses=[Sync(backend)])`",
+    )
     sync_backend_registry.register(backend, DEFAULT_NAME)
 
 
@@ -58,11 +84,13 @@ def use(
 ) -> AbstractContextManager[None]:
     """Install task-scoped backend overrides.
 
-    Use as a context manager:
-
-        with sync.use(MemorySyncBackend()):
-            ...
+    Deprecated since 0.23.0, removed in 1.0.0. Use
+    `async with micro.override(Sync(backend)):` instead.
     """
+    warn_legacy(
+        "grelmicro.sync.use",
+        "`async with micro.override(Sync(backend)):`",
+    )
     return sync_backend_registry.use(backend, **named)
 
 

--- a/tests/cache/test_memory.py
+++ b/tests/cache/test_memory.py
@@ -244,7 +244,8 @@ class TestMemoryCacheBackendRegistration:
         cache_backend_registry.reset()
         backend = MemoryCacheBackend()
 
-        use_backend(backend)
+        with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
+            use_backend(backend)
 
         assert get_cache_backend() is backend
 

--- a/tests/cache/test_redis.py
+++ b/tests/cache/test_redis.py
@@ -148,7 +148,8 @@ class TestCacheBackendRegistry:
         cache_backend_registry.reset()
         backend = RedisCacheBackend(URL)
 
-        use_backend(backend)
+        with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
+            use_backend(backend)
 
         assert get_cache_backend() is backend
 

--- a/tests/health/test_registry.py
+++ b/tests/health/test_registry.py
@@ -537,7 +537,8 @@ def test_constructor_does_not_register() -> None:
 def test_use_registry_installs_singleton() -> None:
     """`health.use_registry` installs the registry as the global default."""
     registry = HealthRegistry()
-    use_registry(registry)
+    with pytest.warns(DeprecationWarning, match="grelmicro.health"):
+        use_registry(registry)
 
     assert get_health_registry() is registry
 

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -42,15 +42,14 @@ ALL_STATES = [
 @pytest.fixture(autouse=True)
 def _register_cb_backend() -> Iterator[MemoryCircuitBreakerBackend]:
     """Register an in-memory circuit breaker backend for every test."""
-    from grelmicro.resilience import (  # noqa: PLC0415
-        register_circuit_breaker,
-        unregister_circuit_breaker,
+    from grelmicro.resilience._backends import (  # noqa: PLC0415
+        circuit_breaker_backend_registry,
     )
 
     backend = MemoryCircuitBreakerBackend()
-    register_circuit_breaker(backend)
+    circuit_breaker_backend_registry.register(backend)
     yield backend
-    unregister_circuit_breaker()
+    circuit_breaker_backend_registry.unregister()
 
 
 @pytest.fixture(autouse=True)
@@ -170,14 +169,13 @@ async def test_circuit_from_thread_init() -> None:
 async def test_circuit_from_thread_unopened_backend_raises() -> None:
     """Worker-thread entry on a closed backend raises a clear error."""
     # Arrange: register a fresh backend that we never open.
-    from grelmicro.resilience import (  # noqa: PLC0415
-        register_circuit_breaker,
-        unregister_circuit_breaker,
+    from grelmicro.resilience._backends import (  # noqa: PLC0415
+        circuit_breaker_backend_registry,
     )
 
-    unregister_circuit_breaker()
+    circuit_breaker_backend_registry.unregister()
     closed_backend = MemoryCircuitBreakerBackend()
-    register_circuit_breaker(closed_backend)
+    circuit_breaker_backend_registry.register(closed_backend)
     cb = CircuitBreaker("test")
 
     def enter() -> None:

--- a/tests/sync/test_backends.py
+++ b/tests/sync/test_backends.py
@@ -425,7 +425,8 @@ async def test_owned_another(backend: SyncBackend) -> None:
 def test_get_sync_backend(backend_factory: Callable[[], SyncBackend]) -> None:
     """`use_backend` registers the constructed backend as the default."""
     expected_backend = backend_factory()
-    use_backend(expected_backend)
+    with pytest.warns(DeprecationWarning, match="grelmicro.sync"):
+        use_backend(expected_backend)
 
     backend = get_sync_backend()
 

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -219,7 +219,9 @@ async def test_lifespan_opens_registered_backends() -> None:
     cache_backend_registry.register(cache_b, "default")
     rate_limiter_backend_registry.register(rl_b, "default")
 
-    async with grelmicro.lifespan():
+    with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
+        cm = grelmicro.lifespan()
+    async with cm:
         # backends remain registered while open
         assert sync_backend_registry.get() is sync_b
         assert cache_backend_registry.get() is cache_b
@@ -230,7 +232,9 @@ async def test_lifespan_excludes_module() -> None:
     """Lifespan excludes module."""
     sync_backend_registry.register(MemorySyncBackend(), "default")
     cache_backend_registry.register(MemoryCacheBackend(), "default")
-    async with grelmicro.lifespan(exclude={"cache"}):
+    with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
+        cm = grelmicro.lifespan(exclude={"cache"})
+    async with cm:
         # cache backend was not entered (we cannot easily detect this
         # for memory backends; the contract is that entries in
         # ``exclude`` are skipped — verified at unit level in registry)
@@ -243,7 +247,9 @@ async def test_lifespan_excludes_named_entry() -> None:
     analytics = MemorySyncBackend()
     sync_backend_registry.register(primary, "primary")
     sync_backend_registry.register(analytics, "analytics")
-    async with grelmicro.lifespan(exclude={"sync.analytics"}):
+    with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
+        cm = grelmicro.lifespan(exclude={"sync.analytics"})
+    async with cm:
         assert sync_backend_registry.get("primary") is primary
 
 
@@ -267,7 +273,9 @@ async def test_lifespan_excludes_resilience_module_key() -> None:
     rate_limiter_backend_registry.register(rl, "default")
     circuit_breaker_backend_registry.register(cb, "default")
     sync_backend_registry.register(MemorySyncBackend(), "default")
-    async with grelmicro.lifespan(exclude={"resilience"}):
+    with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
+        cm = grelmicro.lifespan(exclude={"resilience"})
+    async with cm:
         assert sync_backend_registry.is_loaded
         # Neither resilience backend was entered.
         assert rl.entered == 0
@@ -280,7 +288,9 @@ async def test_lifespan_excludes_specific_resilience_registry() -> None:
     cb = MemoryCircuitBreakerBackend()
     rate_limiter_backend_registry.register(rl, "default")
     circuit_breaker_backend_registry.register(cb, "default")
-    async with grelmicro.lifespan(exclude={"resilience.ratelimiter"}):
+    with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
+        cm = grelmicro.lifespan(exclude={"resilience.ratelimiter"})
+    async with cm:
         # Rate limiter was skipped, CB was opened.
         assert rl.entered == 0
         assert cb._loop is not None
@@ -305,7 +315,9 @@ def test_lock_named_backend_honors_use_override() -> None:
 
     lock = Lock("audit", backend="analytics")
     assert lock.backend is real_analytics
-    with sync_mod.use(analytics=fake_analytics):
+    with pytest.warns(DeprecationWarning, match="grelmicro.sync"):
+        cm = sync_mod.use(analytics=fake_analytics)
+    with cm:
         assert lock.backend is fake_analytics
     assert lock.backend is real_analytics
 
@@ -313,7 +325,9 @@ def test_lock_named_backend_honors_use_override() -> None:
 async def test_lifespan_with_ad_hoc_backend() -> None:
     """Lifespan with ad hoc backend."""
     ad_hoc = MemorySyncBackend()
-    async with grelmicro.lifespan(ad_hoc):
+    with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
+        cm = grelmicro.lifespan(ad_hoc)
+    async with cm:
         # ad-hoc enters the async ctx but is not registered
         assert not sync_backend_registry.is_loaded
 
@@ -392,30 +406,35 @@ async def test_rate_limiter_redis_async_with_round_trip(
 def test_sync_use_backend_registers_default() -> None:
     """Sync use backend registers default."""
     backend = MemorySyncBackend()
-    sync_mod.use_backend(backend)
+    with pytest.warns(DeprecationWarning, match="grelmicro.sync"):
+        sync_mod.use_backend(backend)
     assert sync_backend_registry.get() is backend
 
 
 def test_cache_use_backend_registers_default() -> None:
     """Cache use backend registers default."""
     backend = MemoryCacheBackend()
-    cache_mod.use_backend(backend)
+    with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
+        cache_mod.use_backend(backend)
     assert cache_backend_registry.get() is backend
 
 
 def test_resilience_use_backend_registers_default() -> None:
     """Resilience use backend registers default."""
     backend = MemoryRateLimiterBackend()
-    resilience_mod.use_backend(backend)
+    with pytest.warns(DeprecationWarning, match="grelmicro.resilience"):
+        resilience_mod.use_backend(backend)
     assert rate_limiter_backend_registry.get() is backend
 
 
 def test_sync_register_and_unregister_module_helpers() -> None:
     """Sync register and unregister module helpers."""
     backend = MemorySyncBackend()
-    sync_mod.register(backend, "primary")
+    with pytest.warns(DeprecationWarning, match="grelmicro.sync"):
+        sync_mod.register(backend, "primary")
     assert sync_backend_registry.get("primary") is backend
-    sync_mod.unregister("primary", backend)
+    with pytest.warns(DeprecationWarning, match="grelmicro.sync"):
+        sync_mod.unregister("primary", backend)
     assert not sync_backend_registry.is_loaded
 
 
@@ -423,31 +442,41 @@ def test_sync_use_module_helper() -> None:
     """Sync use module helper."""
     sync_backend_registry.register(MemorySyncBackend(), "default")
     override = MemorySyncBackend()
-    with sync_mod.use(override):
+    with pytest.warns(DeprecationWarning, match="grelmicro.sync"):
+        cm = sync_mod.use(override)
+    with cm:
         assert sync_backend_registry.get() is override
 
 
 def test_cache_register_unregister_use_module_helpers() -> None:
     """Cache register, unregister, and use module helpers."""
     backend = MemoryCacheBackend()
-    cache_mod.register(backend, "primary")
+    with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
+        cache_mod.register(backend, "primary")
     assert cache_backend_registry.get("primary") is backend
     override = MemoryCacheBackend()
-    with cache_mod.use(override):
+    with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
+        cm = cache_mod.use(override)
+    with cm:
         assert cache_backend_registry.get() is override
-    cache_mod.unregister("primary", backend)
+    with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
+        cache_mod.unregister("primary", backend)
     assert not cache_backend_registry.is_loaded
 
 
 def test_resilience_register_unregister_use_module_helpers() -> None:
     """Resilience register, unregister, and use module helpers."""
     backend = MemoryRateLimiterBackend()
-    resilience_mod.register(backend, "primary")
+    with pytest.warns(DeprecationWarning, match="grelmicro.resilience"):
+        resilience_mod.register(backend, "primary")
     assert rate_limiter_backend_registry.get("primary") is backend
     override = MemoryRateLimiterBackend()
-    with resilience_mod.use(override):
+    with pytest.warns(DeprecationWarning, match="grelmicro.resilience"):
+        cm = resilience_mod.use(override)
+    with cm:
         assert rate_limiter_backend_registry.get() is override
-    resilience_mod.unregister("primary", backend)
+    with pytest.warns(DeprecationWarning, match="grelmicro.resilience"):
+        resilience_mod.unregister("primary", backend)
     assert not rate_limiter_backend_registry.is_loaded
 
 
@@ -455,12 +484,17 @@ def test_health_register_unregister_use_module_helpers() -> None:
     """Health register, unregister, use, and use_registry helpers."""
     health_registry.reset()
     registry = HealthRegistry()
-    health_mod.register(registry, "primary")
+    with pytest.warns(DeprecationWarning, match="grelmicro.health"):
+        health_mod.register(registry, "primary")
     assert health_registry.get("primary") is registry
     override = HealthRegistry()
-    with health_mod.use(override):
+    with pytest.warns(DeprecationWarning, match="grelmicro.health"):
+        cm = health_mod.use(override)
+    with cm:
         assert health_registry.get() is override
-    health_mod.use_registry(registry)
+    with pytest.warns(DeprecationWarning, match="grelmicro.health"):
+        health_mod.use_registry(registry)
     assert health_registry.get() is registry
-    health_mod.unregister("primary", registry)
+    with pytest.warns(DeprecationWarning, match="grelmicro.health"):
+        health_mod.unregister("primary", registry)
     health_registry.reset()

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,196 @@
+"""DeprecationWarning coverage for legacy module-level helpers (issue #206)."""
+
+import pytest
+
+import grelmicro
+from grelmicro import cache as cache_mod
+from grelmicro import health as health_mod
+from grelmicro import resilience as resilience_mod
+from grelmicro import sync as sync_mod
+from grelmicro.cache._backends import cache_backend_registry
+from grelmicro.cache.memory import MemoryCacheBackend
+from grelmicro.health._backends import health_registry
+from grelmicro.health._registry import HealthRegistry
+from grelmicro.resilience._backends import (
+    circuit_breaker_backend_registry,
+    rate_limiter_backend_registry,
+)
+from grelmicro.resilience.memory import (
+    MemoryCircuitBreakerBackend,
+    MemoryRateLimiterBackend,
+)
+from grelmicro.sync._backends import sync_backend_registry
+from grelmicro.sync.memory import MemorySyncBackend
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries() -> None:
+    """Reset every backend registry between tests."""
+    sync_backend_registry.reset()
+    cache_backend_registry.reset()
+    rate_limiter_backend_registry.reset()
+    circuit_breaker_backend_registry.reset()
+    health_registry.reset()
+
+
+def test_sync_use_backend_warns() -> None:
+    """`grelmicro.sync.use_backend` warns and points at `Grelmicro`."""
+    with pytest.warns(DeprecationWarning, match="grelmicro.sync.use_backend"):
+        sync_mod.use_backend(MemorySyncBackend())
+
+
+def test_sync_register_warns() -> None:
+    """`grelmicro.sync.register` warns."""
+    with pytest.warns(DeprecationWarning, match="grelmicro.sync.register"):
+        sync_mod.register(MemorySyncBackend(), "primary")
+
+
+def test_sync_unregister_warns() -> None:
+    """`grelmicro.sync.unregister` warns."""
+    sync_backend_registry.register(MemorySyncBackend(), "primary")
+    with pytest.warns(DeprecationWarning, match="grelmicro.sync.unregister"):
+        sync_mod.unregister("primary")
+
+
+def test_sync_use_warns() -> None:
+    """`grelmicro.sync.use` warns."""
+    with (
+        pytest.warns(DeprecationWarning, match="grelmicro.sync.use"),
+        sync_mod.use(MemorySyncBackend()),
+    ):
+        pass
+
+
+def test_cache_use_backend_warns() -> None:
+    """`grelmicro.cache.use_backend` warns."""
+    with pytest.warns(DeprecationWarning, match="grelmicro.cache.use_backend"):
+        cache_mod.use_backend(MemoryCacheBackend())
+
+
+def test_cache_register_warns() -> None:
+    """`grelmicro.cache.register` warns."""
+    with pytest.warns(DeprecationWarning, match="grelmicro.cache.register"):
+        cache_mod.register(MemoryCacheBackend(), "primary")
+
+
+def test_cache_unregister_warns() -> None:
+    """`grelmicro.cache.unregister` warns."""
+    cache_backend_registry.register(MemoryCacheBackend(), "primary")
+    with pytest.warns(DeprecationWarning, match="grelmicro.cache.unregister"):
+        cache_mod.unregister("primary")
+
+
+def test_cache_use_warns() -> None:
+    """`grelmicro.cache.use` warns."""
+    with (
+        pytest.warns(DeprecationWarning, match="grelmicro.cache.use"),
+        cache_mod.use(MemoryCacheBackend()),
+    ):
+        pass
+
+
+def test_health_use_registry_warns() -> None:
+    """`grelmicro.health.use_registry` warns."""
+    with pytest.warns(
+        DeprecationWarning, match="grelmicro.health.use_registry"
+    ):
+        health_mod.use_registry(HealthRegistry())
+
+
+def test_health_register_warns() -> None:
+    """`grelmicro.health.register` warns."""
+    with pytest.warns(DeprecationWarning, match="grelmicro.health.register"):
+        health_mod.register(HealthRegistry(), "primary")
+
+
+def test_health_unregister_warns() -> None:
+    """`grelmicro.health.unregister` warns."""
+    health_registry.register(HealthRegistry(), "primary")
+    with pytest.warns(DeprecationWarning, match="grelmicro.health.unregister"):
+        health_mod.unregister("primary")
+
+
+def test_health_use_warns() -> None:
+    """`grelmicro.health.use` warns."""
+    with (
+        pytest.warns(DeprecationWarning, match="grelmicro.health.use"),
+        health_mod.use(HealthRegistry()),
+    ):
+        pass
+
+
+def test_resilience_use_backend_warns() -> None:
+    """`grelmicro.resilience.use_backend` warns."""
+    with pytest.warns(
+        DeprecationWarning, match="grelmicro.resilience.use_backend"
+    ):
+        resilience_mod.use_backend(MemoryRateLimiterBackend())
+
+
+def test_resilience_register_warns() -> None:
+    """`grelmicro.resilience.register` warns."""
+    with pytest.warns(
+        DeprecationWarning, match="grelmicro.resilience.register"
+    ):
+        resilience_mod.register(MemoryRateLimiterBackend(), "primary")
+
+
+def test_resilience_unregister_warns() -> None:
+    """`grelmicro.resilience.unregister` warns."""
+    rate_limiter_backend_registry.register(
+        MemoryRateLimiterBackend(), "primary"
+    )
+    with pytest.warns(
+        DeprecationWarning, match="grelmicro.resilience.unregister"
+    ):
+        resilience_mod.unregister("primary")
+
+
+def test_resilience_use_warns() -> None:
+    """`grelmicro.resilience.use` warns."""
+    with (
+        pytest.warns(DeprecationWarning, match="grelmicro.resilience.use"),
+        resilience_mod.use(MemoryRateLimiterBackend()),
+    ):
+        pass
+
+
+def test_resilience_register_circuit_breaker_warns() -> None:
+    """`grelmicro.resilience.register_circuit_breaker` warns."""
+    with pytest.warns(
+        DeprecationWarning,
+        match="grelmicro.resilience.register_circuit_breaker",
+    ):
+        resilience_mod.register_circuit_breaker(
+            MemoryCircuitBreakerBackend(), "primary"
+        )
+
+
+def test_resilience_use_circuit_breaker_backend_warns() -> None:
+    """`grelmicro.resilience.use_circuit_breaker_backend` warns."""
+    with pytest.warns(
+        DeprecationWarning,
+        match="grelmicro.resilience.use_circuit_breaker_backend",
+    ):
+        resilience_mod.use_circuit_breaker_backend(
+            MemoryCircuitBreakerBackend()
+        )
+
+
+def test_resilience_unregister_circuit_breaker_warns() -> None:
+    """`grelmicro.resilience.unregister_circuit_breaker` warns."""
+    circuit_breaker_backend_registry.register(
+        MemoryCircuitBreakerBackend(), "primary"
+    )
+    with pytest.warns(
+        DeprecationWarning,
+        match="grelmicro.resilience.unregister_circuit_breaker",
+    ):
+        resilience_mod.unregister_circuit_breaker("primary")
+
+
+async def test_lifespan_warns() -> None:
+    """The free `grelmicro.lifespan()` warns."""
+    with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
+        async with grelmicro.lifespan():
+            pass

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -54,10 +54,9 @@ def test_sync_unregister_warns() -> None:
 
 def test_sync_use_warns() -> None:
     """`grelmicro.sync.use` warns."""
-    with (
-        pytest.warns(DeprecationWarning, match="grelmicro.sync.use"),
-        sync_mod.use(MemorySyncBackend()),
-    ):
+    with pytest.warns(DeprecationWarning, match="grelmicro.sync.use"):
+        cm = sync_mod.use(MemorySyncBackend())
+    with cm:
         pass
 
 
@@ -82,10 +81,9 @@ def test_cache_unregister_warns() -> None:
 
 def test_cache_use_warns() -> None:
     """`grelmicro.cache.use` warns."""
-    with (
-        pytest.warns(DeprecationWarning, match="grelmicro.cache.use"),
-        cache_mod.use(MemoryCacheBackend()),
-    ):
+    with pytest.warns(DeprecationWarning, match="grelmicro.cache.use"):
+        cm = cache_mod.use(MemoryCacheBackend())
+    with cm:
         pass
 
 
@@ -112,10 +110,9 @@ def test_health_unregister_warns() -> None:
 
 def test_health_use_warns() -> None:
     """`grelmicro.health.use` warns."""
-    with (
-        pytest.warns(DeprecationWarning, match="grelmicro.health.use"),
-        health_mod.use(HealthRegistry()),
-    ):
+    with pytest.warns(DeprecationWarning, match="grelmicro.health.use"):
+        cm = health_mod.use(HealthRegistry())
+    with cm:
         pass
 
 
@@ -148,10 +145,9 @@ def test_resilience_unregister_warns() -> None:
 
 def test_resilience_use_warns() -> None:
     """`grelmicro.resilience.use` warns."""
-    with (
-        pytest.warns(DeprecationWarning, match="grelmicro.resilience.use"),
-        resilience_mod.use(MemoryRateLimiterBackend()),
-    ):
+    with pytest.warns(DeprecationWarning, match="grelmicro.resilience.use"):
+        cm = resilience_mod.use(MemoryRateLimiterBackend())
+    with cm:
         pass
 
 


### PR DESCRIPTION
## Summary

- Step 1 of the two-step deprecation toward 1.0 (closes #206, removal tracked in #207).
- Every legacy module-level helper now emits `DeprecationWarning` pointing at the `Grelmicro` app object: `grelmicro.lifespan()`, and the `register` / `unregister` / `use` / `use_backend` / `use_registry` family across `grelmicro.{sync,cache,health,resilience}` (plus the resilience circuit-breaker variants).
- `lifespan()` is refactored so the warning fires at call time, not on `__aenter__`, so users see it during construction.

## Test plan

- [x] `tests/test_deprecations.py` asserts each helper warns with a matching dotted path.
- [x] Existing tests that exercise legacy paths now wrap them in `pytest.warns(DeprecationWarning, match=...)`.
- [x] `uv run pytest` (1513 passed, 100% coverage), `uv run ruff check`, `uv run ty check`.