### PR TITLE
💥 Rename HealthRegistry to HealthChecks (#201)

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -16,7 +16,7 @@ All backends use **async** methods because they perform network or disk I/O (Red
 | `grelmicro.cache` | `cache` | `CacheBackend` | Redis, Memory |
 | `grelmicro.resilience` (rate limiter) | `resilience.ratelimiter` | `RateLimiterBackend` | Redis, Memory |
 | `grelmicro.resilience` (circuit breaker) | `resilience.circuitbreaker` | `CircuitBreakerBackend` | Memory |
-| `grelmicro.health` | `health` | `HealthRegistry` | (any number of named registries) |
+| `grelmicro.health` | `health` | `HealthChecks` | (any number of named instances) |
 
 A registry holds zero or more named entries. Backends are looked up by name at call time, and each entry is independent. The `"default"` slot is the implicit name when no `backend=` is passed.
 

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -13,7 +13,7 @@ Components fall in two categories.
 | `__init__(name, **kwargs)` | Positional name + optional fields | Programmatic and environmental construction |
 | `from_config(name, config)` | Positional name + frozen config | Declarative construction from a settings tree |
 
-**Single-instance components** (`HealthRegistry`, `RateLimitFilter`, `DuplicateFilter`, `log.configure`) drop the positional name because the application typically holds one:
+**Single-instance components** (`HealthChecks`, `RateLimitFilter`, `DuplicateFilter`, `log.configure`) drop the positional name because the application typically holds one:
 
 | Surface | Form | Intent |
 |---|---|---|
@@ -104,7 +104,7 @@ We keep `self._config` as the single source of truth. If a future profile shows 
 | `RateLimiterConfig` (discriminated union) | `grelmicro.resilience.algorithms` |
 | `RateLimitFilterConfig` | `grelmicro.log` |
 | `DuplicateFilterConfig` | `grelmicro.log` |
-| `HealthRegistryConfig` | `grelmicro.health` |
+| `HealthChecksConfig` | `grelmicro.health` |
 | `LoggingConfig` | `grelmicro.log` |
 
 Each is a `BaseModel, frozen=True, extra="forbid"`. Field docs live in `Annotated[T, Doc("...")]` blocks and surface in IDEs and the API reference.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 ### Breaking
 
 * 💥 Rename `TaskManager` to `Tasks`. Class still extends `TaskRouter`, mirroring FastAPI's `APIRouter` ← `FastAPI` shape. Update imports to `from grelmicro.task import Tasks`. Issue [#218](https://github.com/grelinfo/grelmicro/issues/218).
+* 💥 Rename `HealthRegistry` to `HealthChecks` (and `HealthRegistryConfig` to `HealthChecksConfig`). Update imports to `from grelmicro.health import HealthChecks`. Issue [#201](https://github.com/grelinfo/grelmicro/issues/201).
 
 ### Deprecated
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -53,7 +53,7 @@ The instance name (`"cart"`) becomes the namespace inside the prefix. Names with
 | `LeaderElection("svc")` | `GREL_LEADER_ELECTION_SVC_` |
 | `RateLimitFilter()` | `GREL_RATE_LIMIT_FILTER_` |
 | `DuplicateFilter()` | `GREL_DUPLICATE_FILTER_` |
-| `HealthRegistry()` | `GREL_HEALTH_` |
+| `HealthChecks()` | `GREL_HEALTH_` |
 | `log.configure()` | `GREL_LOG_` |
 
 ## Declarative

--- a/docs/health.md
+++ b/docs/health.md
@@ -28,7 +28,7 @@ Create a `HealthChecks` and register checks with the `@health.check(name)` decor
 --8<-- "health/basic.py"
 ```
 
-The instance auto-registers as the global singleton. The router resolves it automatically.
+Register the instance with a `Grelmicro` app (see below) so the router can resolve it, or pass it explicitly via `health_router(registry=health)`.
 
 ### Grelmicro app integration
 

--- a/docs/health.md
+++ b/docs/health.md
@@ -1,8 +1,8 @@
 # Health Checks
 
-The `health` module provides a health check registry with concurrent execution and FastAPI integration for liveness, readiness, and aggregate health endpoints.
+The `health` module provides a health checks manager with concurrent execution and FastAPI integration for liveness, readiness, and aggregate health endpoints.
 
-- **[HealthRegistry](#registry)**: Register check functions with a FastAPI-style decorator, run them concurrently with per-check timeouts and caching.
+- **[HealthChecks](#health-checks)**: Register check functions with a FastAPI-style decorator, run them concurrently with per-check timeouts and caching.
 - **[health_router](#fastapi-integration)**: FastAPI router with `/livez`, `/readyz`, and `/healthz` endpoints.
 
 ## Health Check
@@ -20,25 +20,25 @@ A health check is a function returning `None` (healthy) or a `HealthDetails` dic
 
 `HealthDetails` is a type alias for `dict[str, JSONEncodable]`. Both sync and async check functions are supported. Sync functions run in a worker thread via `asyncio.to_thread` so they never block the event loop.
 
-## Registry
+## Health Checks
 
-Create a `HealthRegistry` and register checks with the `@registry.check(name)` decorator:
+Create a `HealthChecks` and register checks with the `@health.check(name)` decorator:
 
 ```python
 --8<-- "health/basic.py"
 ```
 
-The registry auto-registers as the global singleton. The router resolves it automatically.
+The instance auto-registers as the global singleton. The router resolves it automatically.
 
 ### Grelmicro app integration
 
-Register the `HealthRegistry` with a `Grelmicro` app to lifecycle it alongside the rest of your modules. Same FastAPI-style explicit registration as `Tasks`:
+Register the `HealthChecks` with a `Grelmicro` app to lifecycle it alongside the rest of your modules. Same FastAPI-style explicit registration as `Tasks`:
 
 ```python
 from grelmicro import Grelmicro
-from grelmicro.health import HealthRegistry
+from grelmicro.health import HealthChecks
 
-health = HealthRegistry()
+health = HealthChecks()
 micro = Grelmicro(uses=[health])
 
 @health.check("redis")
@@ -49,9 +49,9 @@ async with micro:
     report = await health.run()
 ```
 
-Use `Grelmicro.use(item)` (or `uses=`) for entry-point components like `HealthRegistry` and `Tasks`. The caller keeps the reference and uses it directly.
+Use `Grelmicro.use(item)` (or `uses=`) for entry-point components like `HealthChecks` and `Tasks`. The caller keeps the reference and uses it directly.
 
-For imperative registration (without a decorator), use `registry.add(name, func)`:
+For imperative registration (without a decorator), use `health.add(name, func)`:
 
 ```python
 --8<-- "health/add.py"
@@ -81,7 +81,7 @@ Checks that exceed their timeout are reported as failed:
 --8<-- "health/timeout.py"
 ```
 
-The registry has a global default `timeout` (5.0 seconds). Per-check overrides are set on registration:
+`HealthChecks` has a global default `timeout` (5.0 seconds). Per-check overrides are set on registration:
 
 ```python
 --8<-- "health/per_check_timeout.py"
@@ -89,11 +89,11 @@ The registry has a global default `timeout` (5.0 seconds). Per-check overrides a
 
 A slow non-critical check hits the timeout and is reported with `status: "error"` in the response body, but the aggregate stays `ok` and `/readyz` stays `200`.
 
-Timeout detection uses `asyncio.timeout`. The wrapper distinguishes the registry-imposed timeout from a `TimeoutError` raised inside the check itself (for example a socket timeout).
+Timeout detection uses `asyncio.timeout`. The wrapper distinguishes the configured timeout from a `TimeoutError` raised inside the check itself (for example a socket timeout).
 
 ### Caching
 
-The registry caches each check's result for `cache_ttl` seconds (default `1.0`) and coalesces concurrent calls via single-flight per check. A given check runs at most once per TTL regardless of how many endpoints or concurrent requests are in flight. This prevents probe traffic from amplifying onto your database.
+`HealthChecks` caches each check's result for `cache_ttl` seconds (default `1.0`) and coalesces concurrent calls via single-flight per check. A given check runs at most once per TTL regardless of how many endpoints or concurrent requests are in flight. This prevents probe traffic from amplifying onto your database.
 
 ```python
 --8<-- "health/caching.py"
@@ -260,4 +260,4 @@ This mirrors FastAPI's own `@app.get("/path")` routing style and keeps grelmicro
 
 ### Concurrent Execution
 
-All selected checks run in parallel via an `asyncio.TaskGroup`. A slow check does not block other checks. Each check runs with its own timeout (falling back to the registry default).
+All selected checks run in parallel via an `asyncio.TaskGroup`. A slow check does not block other checks. Each check runs with its own timeout (falling back to the default).

--- a/docs/reference/health.md
+++ b/docs/reference/health.md
@@ -8,11 +8,11 @@
         - HealthCheckFunc
         - HealthDetails
         - HealthError
-        - HealthRegistry
-        - HealthRegistryConfig
+        - HealthChecks
+        - HealthChecksConfig
         - HealthReport
         - HealthStatus
-        - get_health_registry
+        - get_health_checks
 
 ::: grelmicro.health.fastapi
     options:

--- a/docs/snippets/health/add.py
+++ b/docs/snippets/health/add.py
@@ -1,6 +1,6 @@
-from grelmicro.health import HealthDetails, HealthRegistry
+from grelmicro.health import HealthChecks, HealthDetails
 
-health = HealthRegistry()
+health = HealthChecks()
 
 
 async def check_kafka() -> HealthDetails | None:

--- a/docs/snippets/health/basic.py
+++ b/docs/snippets/health/basic.py
@@ -1,6 +1,7 @@
 from grelmicro.health import HealthChecks, HealthDetails
 
-# Create the health (auto-registers as the global singleton)
+# Create the HealthChecks instance and register it with the Grelmicro
+# app via `Grelmicro(uses=[health])` so the router can resolve it.
 health = HealthChecks()
 
 

--- a/docs/snippets/health/basic.py
+++ b/docs/snippets/health/basic.py
@@ -1,7 +1,7 @@
-from grelmicro.health import HealthDetails, HealthRegistry
+from grelmicro.health import HealthChecks, HealthDetails
 
 # Create the health (auto-registers as the global singleton)
-health = HealthRegistry()
+health = HealthChecks()
 
 
 # Register checks with the @health.check(name) decorator

--- a/docs/snippets/health/caching.py
+++ b/docs/snippets/health/caching.py
@@ -1,7 +1,7 @@
-from grelmicro.health import HealthRegistry
+from grelmicro.health import HealthChecks
 
 # Default: 1-second TTL with single-flight per check
-HealthRegistry(timeout=5.0, cache_ttl=1.0)
+HealthChecks(timeout=5.0, cache_ttl=1.0)
 
 # Disable caching entirely
-HealthRegistry(cache_ttl=0)
+HealthChecks(cache_ttl=0)

--- a/docs/snippets/health/checker.py
+++ b/docs/snippets/health/checker.py
@@ -1,7 +1,7 @@
-from grelmicro.health import HealthDetails, HealthRegistry
+from grelmicro.health import HealthChecks, HealthDetails
 from grelmicro.health.errors import HealthError
 
-health = HealthRegistry()
+health = HealthChecks()
 
 
 # Decorator form: register an async function under a name

--- a/docs/snippets/health/error_details.py
+++ b/docs/snippets/health/error_details.py
@@ -1,7 +1,7 @@
-from grelmicro.health import HealthDetails, HealthRegistry
+from grelmicro.health import HealthChecks, HealthDetails
 from grelmicro.health.errors import HealthError
 
-health = HealthRegistry()
+health = HealthChecks()
 
 
 @health.check("database")

--- a/docs/snippets/health/fastapi.py
+++ b/docs/snippets/health/fastapi.py
@@ -3,10 +3,10 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from grelmicro.health import HealthDetails, HealthRegistry
+from grelmicro.health import HealthChecks, HealthDetails
 from grelmicro.health.fastapi import health_router
 
-health = HealthRegistry()
+health = HealthChecks()
 
 
 @health.check("database")

--- a/docs/snippets/health/non_critical.py
+++ b/docs/snippets/health/non_critical.py
@@ -1,6 +1,6 @@
-from grelmicro.health import HealthDetails, HealthRegistry
+from grelmicro.health import HealthChecks, HealthDetails
 
-health = HealthRegistry()
+health = HealthChecks()
 
 
 @health.check("external-api", critical=False)

--- a/docs/snippets/health/per_check_timeout.py
+++ b/docs/snippets/health/per_check_timeout.py
@@ -1,6 +1,6 @@
-from grelmicro.health import HealthDetails, HealthRegistry
+from grelmicro.health import HealthChecks, HealthDetails
 
-health = HealthRegistry()
+health = HealthChecks()
 
 
 @health.check("slow-api", critical=False, timeout=0.5)

--- a/docs/snippets/health/timeout.py
+++ b/docs/snippets/health/timeout.py
@@ -1,7 +1,7 @@
-from grelmicro.health import HealthDetails, HealthRegistry
+from grelmicro.health import HealthChecks, HealthDetails
 
 # Registry default: 2s per check (default is 5s)
-health = HealthRegistry(timeout=2.0)
+health = HealthChecks(timeout=2.0)
 
 
 # Per-check override: tight timeout for a flaky optional dep

--- a/grelmicro/health/__init__.py
+++ b/grelmicro/health/__init__.py
@@ -1,4 +1,4 @@
-"""Health Check Registry."""
+"""Health Checks."""
 
 from contextlib import AbstractContextManager
 from typing import Annotated
@@ -7,34 +7,34 @@ from typing_extensions import Doc
 
 from grelmicro._backends import DEFAULT_NAME
 from grelmicro._deprecation import warn_legacy
-from grelmicro.health._backends import get_health_registry, health_registry
+from grelmicro.health._backends import get_health_checks, health_checks
+from grelmicro.health._checks import HealthChecks, HealthChecksConfig
 from grelmicro.health._models import (
     CheckResult,
     HealthReport,
     HealthStatus,
 )
-from grelmicro.health._registry import HealthRegistry, HealthRegistryConfig
 from grelmicro.health._types import HealthCheckFunc, HealthDetails
 from grelmicro.health.errors import HealthError
 
 
 def register(
-    registry: Annotated[HealthRegistry, Doc("The health registry instance.")],
+    registry: Annotated[HealthChecks, Doc("The health checks instance.")],
     name: Annotated[
-        str, Doc("Name to register the registry under.")
+        str, Doc("Name to register the instance under.")
     ] = DEFAULT_NAME,
 ) -> None:
     """Register ``registry`` under ``name`` (defaults to ``"default"``).
 
     Deprecated since 0.23.0, removed in 1.0.0. Use
-    `Grelmicro(uses=[HealthRegistry(...)])` (or `micro.use(HealthRegistry(...))`)
+    `Grelmicro(uses=[HealthChecks(...)])` (or `micro.use(HealthChecks(...))`)
     instead.
     """
     warn_legacy(
         "grelmicro.health.register",
-        "`Grelmicro(uses=[HealthRegistry(...)])`",
+        "`Grelmicro(uses=[HealthChecks(...)])`",
     )
-    health_registry.register(registry, name)
+    health_checks.register(registry, name)
 
 
 def unregister(
@@ -42,49 +42,49 @@ def unregister(
         str, Doc("Name of the registered instance to remove.")
     ] = DEFAULT_NAME,
     registry: Annotated[
-        HealthRegistry | None,
+        HealthChecks | None,
         Doc("Optional instance for an identity-checked removal."),
     ] = None,
 ) -> None:
     """Remove the registered instance under ``name``.
 
     Deprecated since 0.23.0, removed in 1.0.0. Construct a fresh `Grelmicro`
-    app instead of mutating a shared registry.
+    app instead of mutating a shared instance.
     """
     warn_legacy(
         "grelmicro.health.unregister",
         "a fresh `Grelmicro(uses=[...])`",
     )
-    health_registry.unregister(name, registry)
+    health_checks.unregister(name, registry)
 
 
 def use_registry(
     registry: Annotated[
-        HealthRegistry,
-        Doc("The health registry to install as the global default."),
+        HealthChecks,
+        Doc("The health checks to install as the global default."),
     ],
 ) -> None:
     """Register ``registry`` under the ``"default"`` name.
 
     Deprecated since 0.23.0, removed in 1.0.0. Use
-    `Grelmicro(uses=[HealthRegistry(...)])` instead.
+    `Grelmicro(uses=[HealthChecks(...)])` instead.
     """
     warn_legacy(
         "grelmicro.health.use_registry",
-        "`Grelmicro(uses=[HealthRegistry(...)])`",
+        "`Grelmicro(uses=[HealthChecks(...)])`",
     )
-    health_registry.register(registry, DEFAULT_NAME)
+    health_checks.register(registry, DEFAULT_NAME)
 
 
 def use(
     registry: Annotated[
-        HealthRegistry | None,
+        HealthChecks | None,
         Doc('Override the ``"default"`` slot for the duration of the block.'),
     ] = None,
     /,
-    **named: HealthRegistry,
+    **named: HealthChecks,
 ) -> AbstractContextManager[None]:
-    """Install task-scoped registry overrides.
+    """Install task-scoped overrides.
 
     Deprecated since 0.23.0, removed in 1.0.0. Use
     `async with micro.override(...)` on the active app instead.
@@ -93,19 +93,19 @@ def use(
         "grelmicro.health.use",
         "`async with micro.override(...)`",
     )
-    return health_registry.use(registry, **named)
+    return health_checks.use(registry, **named)
 
 
 __all__ = [
     "CheckResult",
     "HealthCheckFunc",
+    "HealthChecks",
+    "HealthChecksConfig",
     "HealthDetails",
     "HealthError",
-    "HealthRegistry",
-    "HealthRegistryConfig",
     "HealthReport",
     "HealthStatus",
-    "get_health_registry",
+    "get_health_checks",
     "register",
     "unregister",
     "use",

--- a/grelmicro/health/_backends.py
+++ b/grelmicro/health/_backends.py
@@ -1,4 +1,4 @@
-"""Health Registry Backend."""
+"""Health Checks Backend."""
 
 from __future__ import annotations
 
@@ -7,17 +7,15 @@ from typing import TYPE_CHECKING
 from grelmicro._backends import DEFAULT_NAME, BackendRegistry
 
 if TYPE_CHECKING:
-    from grelmicro.health._registry import HealthRegistry
+    from grelmicro.health._checks import HealthChecks
 
-health_registry: BackendRegistry[HealthRegistry] = BackendRegistry(
-    name="health"
-)
+health_checks: BackendRegistry[HealthChecks] = BackendRegistry(name="health")
 
 
-def get_health_registry(name: str = DEFAULT_NAME) -> HealthRegistry:
-    """Resolve a health registry by ``name``.
+def get_health_checks(name: str = DEFAULT_NAME) -> HealthChecks:
+    """Resolve health checks by ``name``.
 
     Raises:
-        BackendNotLoadedError: If no registry resolves.
+        BackendNotLoadedError: If no instance resolves.
     """
-    return health_registry.get(name)
+    return health_checks.get(name)

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -1,4 +1,4 @@
-"""Health Check Registry."""
+"""Health Checks."""
 
 import asyncio
 import re
@@ -37,8 +37,8 @@ _NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9:_-]*$")
 _NAME_MAX_LEN = 64
 
 
-class HealthRegistryConfig(BaseModel, frozen=True, extra="forbid"):
-    """Health Registry Config."""
+class HealthChecksConfig(BaseModel, frozen=True, extra="forbid"):
+    """Health Checks Config."""
 
     timeout: Annotated[
         PositiveFloat,
@@ -88,13 +88,13 @@ def _normalize(func: HealthCheckFunc) -> AsyncHealthCheckFunc:
     return _async_wrapper
 
 
-class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
-    """Registry that manages health checks and runs them concurrently.
+class HealthChecks(Reconfigurable[HealthChecksConfig]):
+    """Manages health checks and runs them concurrently.
 
     Checks are plain async functions. Register them with the
     :meth:`check` decorator or the :meth:`add` method. All registered
     checks are executed in parallel via an ``asyncio.TaskGroup``. Each
-    check has its own timeout (falling back to the registry default)
+    check has its own timeout (falling back to the default)
     and its own cached result. Concurrent requests for the same check
     share a single execution via an ``asyncio.Event``.
 
@@ -122,7 +122,7 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
                 ``GREL_CONFIG_FROM_ENV``), resolves from the
                 environment variable ``GREL_HEALTH_TIMEOUT`` if
                 present, otherwise falls back to the
-                ``HealthRegistryConfig`` default.
+                ``HealthChecksConfig`` default.
                 """
             ),
         ] = None,
@@ -136,7 +136,7 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
                 ``GREL_CONFIG_FROM_ENV``), resolves from the
                 environment variable ``GREL_HEALTH_CACHE_TTL`` if
                 present, otherwise falls back to the
-                ``HealthRegistryConfig`` default.
+                ``HealthChecksConfig`` default.
                 """
             ),
         ] = None,
@@ -163,9 +163,9 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
             ),
         ] = None,
     ) -> None:
-        """Initialize the health registry."""
+        """Initialize the health checks."""
         config = resolve_config(
-            HealthRegistryConfig,
+            HealthChecksConfig,
             explicit=None,
             kwargs={"timeout": timeout, "cache_ttl": cache_ttl},
             env_prefix=env_prefix or "GREL_HEALTH_",
@@ -177,10 +177,10 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
     def from_config(
         cls,
         config: Annotated[
-            HealthRegistryConfig,
+            HealthChecksConfig,
             Doc(
                 """
-                The pre-built health registry configuration.
+                The pre-built health checks configuration.
 
                 Use this path when the configuration is assembled at
                 startup from a settings tree (for example YAML, Vault,
@@ -191,19 +191,19 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
             ),
         ],
     ) -> Self:
-        """Construct a `HealthRegistry` from a pre-built `HealthRegistryConfig`."""
+        """Construct a `HealthChecks` from a pre-built `HealthChecksConfig`."""
         instance = cls.__new__(cls)
         instance._setup(config)  # noqa: SLF001
         return instance
 
-    def _setup(self, config: HealthRegistryConfig) -> None:
+    def _setup(self, config: HealthChecksConfig) -> None:
         """Wire the validated config and runtime deps onto the instance."""
         self._config = config
         self._reconfigure_lock = asyncio.Lock()
         self._entries: dict[str, _Entry] = {}
 
     async def __aenter__(self) -> Self:
-        """Open the health registry."""
+        """Open the health checks."""
         return self
 
     async def __aexit__(
@@ -212,7 +212,7 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the health registry."""
+        """Close the health checks."""
 
     def add(
         self,
@@ -240,7 +240,7 @@ class HealthRegistry(Reconfigurable[HealthRegistryConfig]):
             PositiveFloat | None,
             Doc(
                 "Per-check timeout override. Falls back to the "
-                "registry default when omitted."
+                "default when omitted."
             ),
         ] = None,
     ) -> None:
@@ -420,7 +420,7 @@ async def _run_check(entry: _Entry) -> CheckResult:
                 result: HealthDetails | None = await entry.func()
         except TimeoutError:
             if not cm.expired():
-                # User code raised TimeoutError, not the registry timeout.
+                # User code raised TimeoutError, not the configured timeout.
                 raise
             logger.warning(
                 "Health check '%s' timed out after %gs",

--- a/grelmicro/health/fastapi.py
+++ b/grelmicro/health/fastapi.py
@@ -48,9 +48,9 @@ def health_router(
         HealthChecks | None,
         Doc(
             "Health checks instance whose checks the router runs. When "
-            "omitted, the router resolves the global instance "
-            "(the instance installed via ``health.use_registry`` "
-            "or entered as an async context manager)."
+            "omitted, the router resolves the instance registered as "
+            "the default (via ``Grelmicro(uses=[HealthChecks(...)])`` "
+            "or the legacy ``health.use_registry`` helper)."
         ),
     ] = None,
     *,

--- a/grelmicro/health/fastapi.py
+++ b/grelmicro/health/fastapi.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel
 from typing_extensions import Doc
 
 from grelmicro._json import json_dumps_bytes
+from grelmicro.health._checks import HealthChecks
 from grelmicro.health._models import HealthStatus
-from grelmicro.health._registry import HealthRegistry
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -45,11 +45,11 @@ class HealthzResponse(BaseModel):
 
 def health_router(
     registry: Annotated[
-        HealthRegistry | None,
+        HealthChecks | None,
         Doc(
-            "Health registry whose checks the router runs. When "
-            "omitted, the router resolves the global registry "
-            "(the registry installed via ``health.use_registry`` "
+            "Health checks instance whose checks the router runs. When "
+            "omitted, the router resolves the global instance "
+            "(the instance installed via ``health.use_registry`` "
             "or entered as an async context manager)."
         ),
     ] = None,
@@ -120,7 +120,7 @@ def health_router(
         raise DependencyNotFoundError(module="fastapi")  # noqa: B904
 
     from grelmicro.health._backends import (  # noqa: PLC0415
-        get_health_registry,
+        get_health_checks,
     )
 
     show_details_dep = _resolve_show_details_dep(show_details)
@@ -155,7 +155,7 @@ def health_router(
         ] = None,
     ) -> Response:
         """Readiness probe. Runs critical checkers only."""
-        report = await (registry or get_health_registry()).run(
+        report = await (registry or get_health_checks()).run(
             critical_only=True,
             exclude=_parse_exclude(exclude),
         )
@@ -188,7 +188,7 @@ def health_router(
         ] = None,
     ) -> Response:
         """Aggregate JSON report of all checker results."""
-        report = await (registry or get_health_registry()).run(
+        report = await (registry or get_health_checks()).run(
             critical_only=False,
             exclude=_parse_exclude(exclude),
         )

--- a/tests/health/test_checks.py
+++ b/tests/health/test_checks.py
@@ -13,9 +13,9 @@ from grelmicro._backends import (
     BackendNotLoadedError,
 )
 from grelmicro.health import use_registry
-from grelmicro.health._backends import get_health_registry, health_registry
+from grelmicro.health._backends import get_health_checks, health_checks
+from grelmicro.health._checks import HealthChecks
 from grelmicro.health._models import HealthStatus
-from grelmicro.health._registry import HealthRegistry
 from grelmicro.health._types import HealthDetails
 
 from .conftest import (
@@ -34,16 +34,16 @@ pytestmark = [pytest.mark.timeout(10)]
 @pytest.fixture(autouse=True)
 def _clean_registry() -> Generator[None]:
     """Reset global health registry before and after each test."""
-    health_registry.reset()
+    health_checks.reset()
     yield
-    health_registry.reset()
+    health_checks.reset()
 
 
 async def test_user_timeout_error_is_not_classified_as_registry_timeout() -> (
     None
 ):
     """A TimeoutError raised by the check itself stays a generic failure."""
-    registry = HealthRegistry(timeout=10)
+    registry = HealthChecks(timeout=10)
 
     async def check_raises_timeout() -> HealthDetails | None:
         msg = "downstream call timed out"
@@ -60,7 +60,7 @@ async def test_user_timeout_error_is_not_classified_as_registry_timeout() -> (
 
 async def test_empty_registry_is_ok() -> None:
     """An empty registry reports ok."""
-    registry = HealthRegistry()
+    registry = HealthChecks()
 
     report = await registry.run()
 
@@ -70,7 +70,7 @@ async def test_empty_registry_is_ok() -> None:
 
 async def test_add_and_run_single_healthy() -> None:
     """registry.add() + run() reports ok for a healthy check."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("db", healthy())
 
     report = await registry.run()
@@ -86,7 +86,7 @@ async def test_add_and_run_single_healthy() -> None:
 
 async def test_decorator_registers_check() -> None:
     """@registry.check(name) registers the decorated function."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
 
     @registry.check("database")
     async def _check_db() -> HealthDetails | None:
@@ -100,7 +100,7 @@ async def test_decorator_registers_check() -> None:
 
 async def test_sync_check_runs_in_thread() -> None:
     """A sync check function is executed via ``asyncio.to_thread``."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
 
     def sync_check() -> HealthDetails | None:
         return {"ran": "sync"}
@@ -115,7 +115,7 @@ async def test_sync_check_runs_in_thread() -> None:
 
 async def test_decorator_returns_function_unchanged() -> None:
     """The decorator returns the wrapped function as-is."""
-    registry = HealthRegistry()
+    registry = HealthChecks()
 
     async def _fn() -> HealthDetails | None:
         return {"ok": True}
@@ -127,7 +127,7 @@ async def test_decorator_returns_function_unchanged() -> None:
 
 async def test_decorator_with_options() -> None:
     """Decorator accepts critical and timeout kwargs."""
-    registry = HealthRegistry(cache_ttl=0, timeout=5.0)
+    registry = HealthChecks(cache_ttl=0, timeout=5.0)
 
     @registry.check("analytics", critical=False, timeout=0.1)
     async def _check() -> HealthDetails | None:
@@ -146,7 +146,7 @@ async def test_decorator_with_options() -> None:
 
 async def test_critical_failure_produces_error() -> None:
     """Critical failure produces aggregate error."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("redis", unhealthy())
 
     report = await registry.run()
@@ -160,7 +160,7 @@ async def test_critical_failure_produces_error() -> None:
 
 async def test_non_critical_failure_keeps_aggregate_ok() -> None:
     """Non-critical failures do not flip the aggregate."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("db", healthy())
     registry.add("external-api", unhealthy(), critical=False)
 
@@ -174,7 +174,7 @@ async def test_non_critical_failure_keeps_aggregate_ok() -> None:
 
 async def test_critical_failure_trumps_non_critical() -> None:
     """Any critical failure produces aggregate error."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("db", unhealthy(), critical=True)
     registry.add("analytics", unhealthy(), critical=False)
 
@@ -185,7 +185,7 @@ async def test_critical_failure_trumps_non_critical() -> None:
 
 async def test_all_non_critical_fail_aggregate_ok() -> None:
     """All non-critical failures keep the aggregate ok."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("a", unhealthy(), critical=False)
     registry.add("b", unhealthy(), critical=False)
 
@@ -196,7 +196,7 @@ async def test_all_non_critical_fail_aggregate_ok() -> None:
 
 async def test_check_with_details() -> None:
     """Checker details are captured in the result."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     report = await registry.run()
@@ -206,7 +206,7 @@ async def test_check_with_details() -> None:
 
 async def test_checks_sorted_by_name() -> None:
     """Checks are returned in alphabetical order."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("zeta", healthy())
     registry.add("alpha", healthy())
     registry.add("mu", healthy())
@@ -218,7 +218,7 @@ async def test_checks_sorted_by_name() -> None:
 
 async def test_critical_only_filter() -> None:
     """critical_only=True skips non-critical checks entirely."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("db", healthy())
     registry.add("analytics", unhealthy(), critical=False)
 
@@ -230,7 +230,7 @@ async def test_critical_only_filter() -> None:
 
 async def test_exclude_filter() -> None:
     """Exclude skips the named checks."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("db", healthy())
     registry.add("redis", unhealthy())
 
@@ -242,7 +242,7 @@ async def test_exclude_filter() -> None:
 
 async def test_global_timeout_applies() -> None:
     """Global timeout applies when no per-check timeout is set."""
-    registry = HealthRegistry(timeout=0.1, cache_ttl=0)
+    registry = HealthChecks(timeout=0.1, cache_ttl=0)
     registry.add("slow", slow(delay=1.0))
 
     report = await registry.run()
@@ -258,7 +258,7 @@ async def test_global_timeout_applies() -> None:
 
 async def test_per_check_timeout_override_via_add() -> None:
     """Per-check timeout overrides the registry default via add()."""
-    registry = HealthRegistry(timeout=5.0, cache_ttl=0)
+    registry = HealthChecks(timeout=5.0, cache_ttl=0)
     registry.add("slow", slow(delay=1.0), timeout=0.1, critical=False)
 
     started = time.monotonic()
@@ -274,7 +274,7 @@ async def test_concurrent_execution() -> None:
     """Checks run in parallel, not sequentially."""
     count = 3
     delay = 0.1
-    registry = HealthRegistry(timeout=2.0, cache_ttl=0)
+    registry = HealthChecks(timeout=2.0, cache_ttl=0)
     for i in range(count):
         registry.add(f"c{i}", slow(delay=delay))
 
@@ -288,7 +288,7 @@ async def test_concurrent_execution() -> None:
 
 async def test_cache_hit_returns_same_result() -> None:
     """Within TTL, repeated calls return the cached result."""
-    registry = HealthRegistry(cache_ttl=10.0)
+    registry = HealthChecks(cache_ttl=10.0)
     check = Counting()
     registry.add("db", check)
 
@@ -301,7 +301,7 @@ async def test_cache_hit_returns_same_result() -> None:
 
 async def test_cache_expires() -> None:
     """After TTL expires, the check runs again."""
-    registry = HealthRegistry(cache_ttl=0.05)
+    registry = HealthChecks(cache_ttl=0.05)
     check = Counting()
     registry.add("db", check)
 
@@ -315,7 +315,7 @@ async def test_cache_expires() -> None:
 
 async def test_cache_disabled_with_zero_ttl() -> None:
     """cache_ttl=0 disables the cache entirely."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     check = Counting()
     registry.add("db", check)
 
@@ -328,7 +328,7 @@ async def test_cache_disabled_with_zero_ttl() -> None:
 
 async def test_single_flight_coalesces_concurrent_calls() -> None:
     """Concurrent cache-fill requests share a single execution."""
-    registry = HealthRegistry(cache_ttl=1.0)
+    registry = HealthChecks(cache_ttl=1.0)
     check = SlowCounting(delay=0.1)
     registry.add("db", check)
 
@@ -341,7 +341,7 @@ async def test_single_flight_coalesces_concurrent_calls() -> None:
 
 async def test_shared_cache_between_readyz_and_healthz_paths() -> None:
     """critical_only=True and full run share per-check cache."""
-    registry = HealthRegistry(cache_ttl=10.0)
+    registry = HealthChecks(cache_ttl=10.0)
     critical = Counting()
     non_critical = Counting()
     registry.add("db", critical)
@@ -369,14 +369,14 @@ async def test_shared_cache_between_readyz_and_healthz_paths() -> None:
 )
 async def test_invalid_name_rejected(name: str) -> None:
     """Names must match ^[a-z0-9][a-z0-9:_-]*$."""
-    registry = HealthRegistry()
+    registry = HealthChecks()
     with pytest.raises(ValueError, match="Invalid health check name"):
         registry.add(name, healthy())
 
 
 async def test_namespaced_name_accepted() -> None:
     """Colon-separated names are allowed for namespacing."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("weather:circuitbreaker", healthy())
     report = await registry.run()
     assert "weather:circuitbreaker" in report["checks"]
@@ -384,21 +384,21 @@ async def test_namespaced_name_accepted() -> None:
 
 async def test_digit_leading_name_accepted() -> None:
     """Digits are valid as the leading character."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("0-primary", healthy())
     assert "0-primary" in (await registry.run())["checks"]
 
 
 async def test_name_too_long_rejected() -> None:
     """Names longer than 64 chars are rejected."""
-    registry = HealthRegistry()
+    registry = HealthChecks()
     with pytest.raises(ValueError, match="Invalid health check name"):
         registry.add("a" * 65, healthy())
 
 
 async def test_name_at_max_len_accepted() -> None:
     """A name of exactly 64 chars is accepted."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("a" * 64, healthy())
     report = await registry.run()
     assert "a" * 64 in report["checks"]
@@ -406,7 +406,7 @@ async def test_name_at_max_len_accepted() -> None:
 
 async def test_duplicate_name_raises_for_add() -> None:
     """Registering two checks with the same name via add() raises."""
-    registry = HealthRegistry()
+    registry = HealthChecks()
     registry.add("db", healthy())
 
     with pytest.raises(ValueError, match="already registered"):
@@ -415,7 +415,7 @@ async def test_duplicate_name_raises_for_add() -> None:
 
 async def test_duplicate_name_raises_for_decorator() -> None:
     """The decorator form also rejects duplicates."""
-    registry = HealthRegistry()
+    registry = HealthChecks()
 
     @registry.check("db")
     async def _first() -> HealthDetails | None:
@@ -430,7 +430,7 @@ async def test_duplicate_name_raises_for_decorator() -> None:
 
 async def test_health_error_exposes_message() -> None:
     """HealthError subclasses expose their message in the error field."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("db", unhealthy_with_health_error())
 
     report = await registry.run()
@@ -442,7 +442,7 @@ async def test_health_error_exposes_message() -> None:
 
 async def test_generic_exception_hides_message() -> None:
     """Non-HealthError exceptions get a generic message."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("redis", unhealthy())
 
     report = await registry.run()
@@ -454,7 +454,7 @@ async def test_health_error_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """HealthError failures log at WARNING with exc_info."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("db", unhealthy_with_health_error())
 
     with caplog.at_level(logging.WARNING, logger="grelmicro.health"):
@@ -472,7 +472,7 @@ async def test_generic_exception_logs_error(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Unexpected exceptions log at ERROR with a traceback."""
-    registry = HealthRegistry(cache_ttl=0)
+    registry = HealthChecks(cache_ttl=0)
     registry.add("redis", unhealthy())
 
     with caplog.at_level(logging.WARNING, logger="grelmicro.health"):
@@ -487,7 +487,7 @@ async def test_timeout_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Timed-out checks log at WARNING with the per-check timeout."""
-    registry = HealthRegistry(timeout=0.05, cache_ttl=0)
+    registry = HealthChecks(timeout=0.05, cache_ttl=0)
     registry.add("slow", slow(delay=1.0))
 
     with caplog.at_level(logging.WARNING, logger="grelmicro.health"):
@@ -504,77 +504,77 @@ async def test_timeout_logs_warning(
 def test_timeout_zero_raises() -> None:
     """timeout=0 is rejected."""
     with pytest.raises(ValidationError, match="greater than 0"):
-        HealthRegistry(timeout=0)
+        HealthChecks(timeout=0)
 
 
 def test_timeout_negative_raises() -> None:
     """Negative timeout is rejected."""
     with pytest.raises(ValidationError, match="greater than 0"):
-        HealthRegistry(timeout=-1.0)
+        HealthChecks(timeout=-1.0)
 
 
 def test_cache_ttl_negative_raises() -> None:
     """Negative cache_ttl is rejected."""
     with pytest.raises(ValidationError):
-        HealthRegistry(cache_ttl=-1.0)
+        HealthChecks(cache_ttl=-1.0)
 
 
 async def test_async_context_manager_does_not_register() -> None:
-    """``async with HealthRegistry()`` opens but does not register."""
-    async with HealthRegistry():
+    """``async with HealthChecks()`` opens but does not register."""
+    async with HealthChecks():
         with pytest.raises(BackendNotLoadedError):
-            get_health_registry()
+            get_health_checks()
 
 
 def test_constructor_does_not_register() -> None:
-    """Constructing a HealthRegistry performs no registry writes."""
-    HealthRegistry()
+    """Constructing a HealthChecks performs no registry writes."""
+    HealthChecks()
 
     with pytest.raises(BackendNotLoadedError):
-        get_health_registry()
+        get_health_checks()
 
 
 def test_use_registry_installs_singleton() -> None:
     """`health.use_registry` installs the registry as the global default."""
-    registry = HealthRegistry()
+    registry = HealthChecks()
     with pytest.warns(DeprecationWarning, match="grelmicro.health"):
         use_registry(registry)
 
-    assert get_health_registry() is registry
+    assert get_health_checks() is registry
 
 
-def test_get_health_registry_raises_when_not_loaded() -> None:
-    """get_health_registry raises before a registry is registered."""
+def test_get_health_checks_raises_when_not_loaded() -> None:
+    """get_health_checks raises before a registry is registered."""
     with pytest.raises(BackendNotLoadedError):
-        get_health_registry()
+        get_health_checks()
 
 
 def test_overwrite_raises() -> None:
     """Registering a different registry over an existing one raises."""
-    health_registry.register(HealthRegistry(), "default")
+    health_checks.register(HealthChecks(), "default")
 
     with pytest.raises(BackendAlreadyRegisteredError):
-        health_registry.register(HealthRegistry(), "default")
+        health_checks.register(HealthChecks(), "default")
 
 
-def test_register_health_registry() -> None:
-    """health_registry.register installs the singleton."""
-    registry = HealthRegistry()
+def test_register_health_checks() -> None:
+    """health_checks.register installs the singleton."""
+    registry = HealthChecks()
 
-    health_registry.register(registry, "default")
+    health_checks.register(registry, "default")
 
-    assert get_health_registry() is registry
+    assert get_health_checks() is registry
 
 
-def test_reset_health_registry() -> None:
-    """health_registry.reset removes the singleton."""
-    registry = HealthRegistry()
-    health_registry.register(registry, "default")
+def test_reset_health_checks() -> None:
+    """health_checks.reset removes the singleton."""
+    registry = HealthChecks()
+    health_checks.register(registry, "default")
 
-    health_registry.reset()
+    health_checks.reset()
 
     with pytest.raises(BackendNotLoadedError):
-        get_health_registry()
+        get_health_checks()
 
 
 # --- reconfigure ---
@@ -582,7 +582,7 @@ def test_reset_health_registry() -> None:
 
 async def test_reconfigure_swaps_config() -> None:
     """Reconfigure publishes the new config."""
-    registry = HealthRegistry(timeout=1.0, cache_ttl=1.0)
+    registry = HealthChecks(timeout=1.0, cache_ttl=1.0)
     new_config = registry.config.model_copy(update={"cache_ttl": 5.0})
 
     await registry.reconfigure(new_config)
@@ -592,7 +592,7 @@ async def test_reconfigure_swaps_config() -> None:
 
 async def test_reconfigure_same_config_is_noop() -> None:
     """Equal configs short-circuit."""
-    registry = HealthRegistry(timeout=1.0, cache_ttl=1.0)
+    registry = HealthChecks(timeout=1.0, cache_ttl=1.0)
     same = registry.config.model_copy()
 
     await registry.reconfigure(same)
@@ -606,8 +606,8 @@ async def test_reconfigure_rejects_different_config_type() -> None:
     class Other(BaseModel):
         pass
 
-    registry = HealthRegistry()
-    with pytest.raises(TypeError, match="HealthRegistryConfig"):
+    registry = HealthChecks()
+    with pytest.raises(TypeError, match="HealthChecksConfig"):
         await registry.reconfigure(Other())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
 
@@ -619,7 +619,7 @@ async def test_reconfigure_changes_cache_ttl_for_next_run() -> None:
         nonlocal call_count
         call_count += 1
 
-    registry = HealthRegistry(cache_ttl=60.0)
+    registry = HealthChecks(cache_ttl=60.0)
     registry.add("c", check)
 
     await registry.run()
@@ -660,7 +660,7 @@ async def test_reconfigure_during_inflight_run_uses_admission_snapshot() -> (
         in_check.set()
         await can_finish.wait()
 
-    registry = HealthRegistry(cache_ttl=60.0)
+    registry = HealthChecks(cache_ttl=60.0)
     registry.add("c", slow_check)
 
     async with asyncio.TaskGroup() as tg:
@@ -701,7 +701,7 @@ async def test_reconfigure_round_is_consistent_across_checks() -> None:
         slow_started.set()
         await slow_can_finish.wait()
 
-    registry = HealthRegistry(cache_ttl=60.0)
+    registry = HealthChecks(cache_ttl=60.0)
     registry.add("fast", fast_check)
     registry.add("slow", slow_check)
 

--- a/tests/health/test_checks_config.py
+++ b/tests/health/test_checks_config.py
@@ -1,9 +1,9 @@
-"""Tests for the three-paths HealthRegistry construction."""
+"""Tests for the three-paths HealthChecks construction."""
 
 import pytest
 
-from grelmicro.health._backends import health_registry
-from grelmicro.health._registry import HealthRegistry, HealthRegistryConfig
+from grelmicro.health._backends import health_checks
+from grelmicro.health._checks import HealthChecks, HealthChecksConfig
 
 TIMEOUT_KWARG = 2.5
 CACHE_TTL_KWARG = 0.5
@@ -16,28 +16,28 @@ DEFAULT_CACHE_TTL = 1.0
 @pytest.fixture(autouse=True)
 def _reset_registry() -> None:
     """Reset the global health registry between tests."""
-    health_registry.reset()
+    health_checks.reset()
 
 
 def test_programmatic_path_uses_kwargs() -> None:
     """Plain kwargs build a config, falling back to defaults."""
-    registry = HealthRegistry(timeout=TIMEOUT_KWARG, cache_ttl=CACHE_TTL_KWARG)
+    registry = HealthChecks(timeout=TIMEOUT_KWARG, cache_ttl=CACHE_TTL_KWARG)
     assert registry._config.timeout == TIMEOUT_KWARG
     assert registry._config.cache_ttl == CACHE_TTL_KWARG
 
 
 def test_declarative_path_uses_from_config() -> None:
-    """`HealthRegistry.from_config()` constructs from a pre-built config."""
-    cfg = HealthRegistryConfig(timeout=TIMEOUT_KWARG, cache_ttl=CACHE_TTL_KWARG)
-    registry = HealthRegistry.from_config(cfg)
+    """`HealthChecks.from_config()` constructs from a pre-built config."""
+    cfg = HealthChecksConfig(timeout=TIMEOUT_KWARG, cache_ttl=CACHE_TTL_KWARG)
+    registry = HealthChecks.from_config(cfg)
     assert registry._config is cfg
 
 
 def test_from_config_bypasses_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`HealthRegistry.from_config()` ignores env even when set."""
+    """`HealthChecks.from_config()` ignores env even when set."""
     monkeypatch.setenv("GREL_HEALTH_TIMEOUT", str(TIMEOUT_ENV))
-    cfg = HealthRegistryConfig(timeout=TIMEOUT_KWARG, cache_ttl=CACHE_TTL_KWARG)
-    registry = HealthRegistry.from_config(cfg)
+    cfg = HealthChecksConfig(timeout=TIMEOUT_KWARG, cache_ttl=CACHE_TTL_KWARG)
+    registry = HealthChecks.from_config(cfg)
     assert registry._config.timeout == TIMEOUT_KWARG
 
 
@@ -47,7 +47,7 @@ def test_environmental_path_reads_grel_prefixed_env(
     """Env vars under ``GREL_HEALTH_*`` populate unset fields."""
     monkeypatch.setenv("GREL_HEALTH_TIMEOUT", str(TIMEOUT_ENV))
     monkeypatch.setenv("GREL_HEALTH_CACHE_TTL", str(CACHE_TTL_ENV))
-    registry = HealthRegistry()
+    registry = HealthChecks()
     assert registry._config.timeout == TIMEOUT_ENV
     assert registry._config.cache_ttl == CACHE_TTL_ENV
 
@@ -55,14 +55,14 @@ def test_environmental_path_reads_grel_prefixed_env(
 def test_kwargs_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Caller kwargs win over env vars."""
     monkeypatch.setenv("GREL_HEALTH_TIMEOUT", str(TIMEOUT_ENV))
-    registry = HealthRegistry(timeout=TIMEOUT_KWARG)
+    registry = HealthChecks(timeout=TIMEOUT_KWARG)
     assert registry._config.timeout == TIMEOUT_KWARG
 
 
 def test_env_prefix_override(monkeypatch: pytest.MonkeyPatch) -> None:
     """``env_prefix=`` replaces the auto-derived ``GREL_HEALTH_``."""
     monkeypatch.setenv("MYAPP_HEALTH_TIMEOUT", str(TIMEOUT_ENV))
-    registry = HealthRegistry(env_prefix="MYAPP_HEALTH_")
+    registry = HealthChecks(env_prefix="MYAPP_HEALTH_")
     assert registry._config.timeout == TIMEOUT_ENV
 
 
@@ -71,23 +71,23 @@ def test_read_env_false_ignores_env(
 ) -> None:
     """``read_env=False`` skips env reads entirely."""
     monkeypatch.setenv("GREL_HEALTH_TIMEOUT", str(TIMEOUT_ENV))
-    registry = HealthRegistry(read_env=False)
+    registry = HealthChecks(read_env=False)
     assert registry._config.timeout == DEFAULT_TIMEOUT
 
 
 def test_zero_config_uses_health_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Without env or kwargs, HealthRegistryConfig defaults take over."""
+    """Without env or kwargs, HealthChecksConfig defaults take over."""
     monkeypatch.delenv("GREL_HEALTH_TIMEOUT", raising=False)
     monkeypatch.delenv("GREL_HEALTH_CACHE_TTL", raising=False)
-    registry = HealthRegistry()
+    registry = HealthChecks()
     assert registry._config.timeout == DEFAULT_TIMEOUT
     assert registry._config.cache_ttl == DEFAULT_CACHE_TTL
 
 
 def test_from_config_does_not_register() -> None:
     """`from_config(...)` is a pure constructor and does not register."""
-    cfg = HealthRegistryConfig()
-    HealthRegistry.from_config(cfg)
-    assert health_registry.is_loaded is False
+    cfg = HealthChecksConfig()
+    HealthChecks.from_config(cfg)
+    assert health_checks.is_loaded is False

--- a/tests/health/test_fastapi.py
+++ b/tests/health/test_fastapi.py
@@ -17,8 +17,8 @@ from starlette.status import (
 )
 
 from grelmicro.errors import DependencyNotFoundError
-from grelmicro.health._backends import health_registry
-from grelmicro.health._registry import HealthRegistry
+from grelmicro.health._backends import health_checks
+from grelmicro.health._checks import HealthChecks
 from grelmicro.health.fastapi import health_router
 
 from .conftest import healthy, healthy_with_details, unhealthy
@@ -29,16 +29,16 @@ pytestmark = [pytest.mark.timeout(10)]
 @pytest.fixture(autouse=True)
 def _clean_registry() -> Generator[None]:
     """Reset global health registry before and after each test."""
-    health_registry.reset()
+    health_checks.reset()
     yield
-    health_registry.reset()
+    health_checks.reset()
 
 
 @pytest.fixture
-def registry() -> HealthRegistry:
+def registry() -> HealthChecks:
     """Health registry with caching disabled, registered as the default."""
-    instance = HealthRegistry(cache_ttl=0)
-    health_registry.register(instance, "default")
+    instance = HealthChecks(cache_ttl=0)
+    health_checks.register(instance, "default")
     return instance
 
 
@@ -78,8 +78,8 @@ def test_livez_head_method(client: TestClient) -> None:
 
 def test_livez_never_runs_checkers() -> None:
     """A failing registered checker does not affect /livez."""
-    registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry, "default")
+    registry = HealthChecks(cache_ttl=0)
+    health_checks.register(registry, "default")
     registry.add("db", unhealthy())
     app = FastAPI()
     app.include_router(health_router())
@@ -105,7 +105,7 @@ def test_readyz_ok_when_no_checkers(client: TestClient) -> None:
 
 
 def test_readyz_ok_with_healthy_critical(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """Readyz returns 200 when critical checkers pass."""
     registry.add("db", healthy())
@@ -117,7 +117,7 @@ def test_readyz_ok_with_healthy_critical(
 
 
 def test_readyz_503_on_critical_failure(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """Readyz returns 503 when any critical check fails."""
     registry.add("db", unhealthy())
@@ -129,7 +129,7 @@ def test_readyz_503_on_critical_failure(
 
 
 def test_readyz_ignores_non_critical(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """Readyz skips non-critical checkers entirely."""
     registry.add("db", healthy())
@@ -141,7 +141,7 @@ def test_readyz_ignores_non_critical(
 
 
 def test_readyz_exclude_critical_checker(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """Excluding the failing critical checker makes /readyz pass."""
     registry.add("db", unhealthy())
@@ -153,7 +153,7 @@ def test_readyz_exclude_critical_checker(
 
 
 def test_readyz_exclude_multiple_comma_separated(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """The ?exclude param accepts a comma-separated list."""
     registry.add("db", unhealthy())
@@ -164,9 +164,7 @@ def test_readyz_exclude_multiple_comma_separated(
     assert response.status_code == HTTP_200_OK
 
 
-def test_readyz_head_method(
-    registry: HealthRegistry, client: TestClient
-) -> None:
+def test_readyz_head_method(registry: HealthChecks, client: TestClient) -> None:
     """Readyz accepts HEAD."""
     registry.add("db", unhealthy())
 
@@ -189,7 +187,7 @@ def test_healthz_empty_ok(client: TestClient) -> None:
 
 
 def test_healthz_includes_all_checkers(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """Healthz includes critical and non-critical in the checks dict."""
     registry.add("db", healthy())
@@ -208,7 +206,7 @@ def test_healthz_includes_all_checkers(
 
 
 def test_healthz_503_on_critical_failure(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """Healthz returns 503 when any critical check fails."""
     registry.add("db", unhealthy())
@@ -220,7 +218,7 @@ def test_healthz_503_on_critical_failure(
 
 
 def test_healthz_details_hidden_by_default(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """Details are stripped from /healthz by default."""
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
@@ -232,8 +230,8 @@ def test_healthz_details_hidden_by_default(
 
 def test_healthz_details_true_always_shown() -> None:
     """show_details=True always includes details."""
-    registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry, "default")
+    registry = HealthChecks(cache_ttl=0)
+    health_checks.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
     app = FastAPI()
     app.include_router(health_router(show_details=True))
@@ -246,8 +244,8 @@ def test_healthz_details_true_always_shown() -> None:
 
 def test_healthz_details_dep_returns_false_strips() -> None:
     """A dep returning False strips details, endpoint returns 200."""
-    registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry, "default")
+    registry = HealthChecks(cache_ttl=0)
+    health_checks.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow() -> bool:
@@ -265,8 +263,8 @@ def test_healthz_details_dep_returns_false_strips() -> None:
 
 def test_healthz_details_dep_returns_true_shows() -> None:
     """A dep returning True includes details."""
-    registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry, "default")
+    registry = HealthChecks(cache_ttl=0)
+    health_checks.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow() -> bool:
@@ -283,8 +281,8 @@ def test_healthz_details_dep_returns_true_shows() -> None:
 
 def test_healthz_details_async_dep_shows() -> None:
     """An async dep is awaited by FastAPI's DI."""
-    registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry, "default")
+    registry = HealthChecks(cache_ttl=0)
+    health_checks.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     async def allow_async() -> bool:
@@ -301,8 +299,8 @@ def test_healthz_details_async_dep_shows() -> None:
 
 def test_healthz_details_dep_with_request() -> None:
     """A Request-annotated dep receives the request via FastAPI DI."""
-    registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry, "default")
+    registry = HealthChecks(cache_ttl=0)
+    health_checks.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def allow_if_admin(request: _Request) -> bool:
@@ -319,8 +317,8 @@ def test_healthz_details_dep_with_request() -> None:
 
 def test_healthz_details_dep_with_sub_dependency() -> None:
     """FastAPI sub-dependencies resolve through ``Depends`` chains."""
-    registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry, "default")
+    registry = HealthChecks(cache_ttl=0)
+    health_checks.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def current_role(request: _Request) -> str:
@@ -340,8 +338,8 @@ def test_healthz_details_dep_with_sub_dependency() -> None:
 
 def test_healthz_details_dep_http_exception_blocks_endpoint() -> None:
     """Raising HTTPException in the dep blocks the endpoint (documented)."""
-    registry = HealthRegistry(cache_ttl=0)
-    health_registry.register(registry, "default")
+    registry = HealthChecks(cache_ttl=0)
+    health_checks.register(registry, "default")
     registry.add("redis", healthy_with_details({"latency_ms": 1.5}))
 
     def deny() -> bool:
@@ -369,7 +367,7 @@ def test_healthz_details_invalid_type_rejected() -> None:
 
 
 def test_healthz_exclude_checker(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """?exclude removes the named checker from the response."""
     registry.add("db", healthy())
@@ -385,7 +383,7 @@ def test_healthz_exclude_checker(
 
 def test_healthz_dependencies_block_endpoint() -> None:
     """healthz_dependencies block the entire endpoint on failure."""
-    HealthRegistry(cache_ttl=0)
+    HealthChecks(cache_ttl=0)
 
     def deny() -> None:
         raise HTTPException(status_code=HTTP_401_UNAUTHORIZED)
@@ -400,7 +398,7 @@ def test_healthz_dependencies_block_endpoint() -> None:
 
 
 def test_healthz_head_method(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """Healthz accepts HEAD."""
     registry.add("db", healthy())
@@ -456,7 +454,7 @@ def test_router_prefix() -> None:
 
 
 def test_registry_unhealthy_produces_503_on_both_endpoints(
-    registry: HealthRegistry, client: TestClient
+    registry: HealthChecks, client: TestClient
 ) -> None:
     """Critical failure flips both /readyz and /healthz to 503."""
     registry.add("db", unhealthy())

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -19,8 +19,8 @@ from grelmicro._backends import (
 from grelmicro.cache._backends import cache_backend_registry
 from grelmicro.cache.memory import MemoryCacheBackend
 from grelmicro.cache.redis import RedisCacheBackend
-from grelmicro.health._backends import health_registry
-from grelmicro.health._registry import HealthRegistry
+from grelmicro.health._backends import health_checks
+from grelmicro.health._checks import HealthChecks
 from grelmicro.resilience._backends import (
     circuit_breaker_backend_registry,
     rate_limiter_backend_registry,
@@ -482,19 +482,19 @@ def test_resilience_register_unregister_use_module_helpers() -> None:
 
 def test_health_register_unregister_use_module_helpers() -> None:
     """Health register, unregister, use, and use_registry helpers."""
-    health_registry.reset()
-    registry = HealthRegistry()
+    health_checks.reset()
+    registry = HealthChecks()
     with pytest.warns(DeprecationWarning, match="grelmicro.health"):
         health_mod.register(registry, "primary")
-    assert health_registry.get("primary") is registry
-    override = HealthRegistry()
+    assert health_checks.get("primary") is registry
+    override = HealthChecks()
     with pytest.warns(DeprecationWarning, match="grelmicro.health"):
         cm = health_mod.use(override)
     with cm:
-        assert health_registry.get() is override
+        assert health_checks.get() is override
     with pytest.warns(DeprecationWarning, match="grelmicro.health"):
         health_mod.use_registry(registry)
-    assert health_registry.get() is registry
+    assert health_checks.get() is registry
     with pytest.warns(DeprecationWarning, match="grelmicro.health"):
         health_mod.unregister("primary", registry)
-    health_registry.reset()
+    health_checks.reset()

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -9,8 +9,8 @@ from grelmicro import resilience as resilience_mod
 from grelmicro import sync as sync_mod
 from grelmicro.cache._backends import cache_backend_registry
 from grelmicro.cache.memory import MemoryCacheBackend
-from grelmicro.health._backends import health_registry
-from grelmicro.health._registry import HealthRegistry
+from grelmicro.health._backends import health_checks
+from grelmicro.health._checks import HealthChecks
 from grelmicro.resilience._backends import (
     circuit_breaker_backend_registry,
     rate_limiter_backend_registry,
@@ -30,7 +30,7 @@ def _clean_registries() -> None:
     cache_backend_registry.reset()
     rate_limiter_backend_registry.reset()
     circuit_breaker_backend_registry.reset()
-    health_registry.reset()
+    health_checks.reset()
 
 
 def test_sync_use_backend_warns() -> None:
@@ -92,18 +92,18 @@ def test_health_use_registry_warns() -> None:
     with pytest.warns(
         DeprecationWarning, match="grelmicro.health.use_registry"
     ):
-        health_mod.use_registry(HealthRegistry())
+        health_mod.use_registry(HealthChecks())
 
 
 def test_health_register_warns() -> None:
     """`grelmicro.health.register` warns."""
     with pytest.warns(DeprecationWarning, match="grelmicro.health.register"):
-        health_mod.register(HealthRegistry(), "primary")
+        health_mod.register(HealthChecks(), "primary")
 
 
 def test_health_unregister_warns() -> None:
     """`grelmicro.health.unregister` warns."""
-    health_registry.register(HealthRegistry(), "primary")
+    health_checks.register(HealthChecks(), "primary")
     with pytest.warns(DeprecationWarning, match="grelmicro.health.unregister"):
         health_mod.unregister("primary")
 
@@ -111,7 +111,7 @@ def test_health_unregister_warns() -> None:
 def test_health_use_warns() -> None:
     """`grelmicro.health.use` warns."""
     with pytest.warns(DeprecationWarning, match="grelmicro.health.use"):
-        cm = health_mod.use(HealthRegistry())
+        cm = health_mod.use(HealthChecks())
     with cm:
         pass
 


### PR DESCRIPTION
## Summary

- Rename `HealthRegistry` to `HealthChecks` and `HealthRegistryConfig` to `HealthChecksConfig`. Sister rename to `TaskManager` → `Tasks` (PR #221), per the locked vocabulary in #201.
- Move `grelmicro/health/_registry.py` to `grelmicro/health/_checks.py`. Rename the matching tests.
- Internal `health_registry` / `get_health_registry` renamed to `health_checks` / `get_health_checks`.
- No deprecation alias (matching #221's "iterating fast pre-1.0" decision).
- `GREL_HEALTH_` env prefix unchanged (component-level, not class-level).
- Sweep docs, snippets, and changelog.

Part of #201.

## Test plan

- [x] `uv run pytest` (1513 passed)
- [x] `uv run ruff check grelmicro/ tests/`
- [x] `uv run ruff format --check`
- [x] `uv run ty check grelmicro/`