### PR TITLE
💥 Rename concrete backends to *Adapter (#201)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ It is built for any Python application that coordinates work across processes, w
 
 | Module | Summary |
 |---|---|
-| [**Cache**](docs/cache.md) | `@cached` decorator with per-key stampede protection. In-memory `TTLCache` or `RedisCacheBackend`. |
+| [**Cache**](docs/cache.md) | `@cached` decorator with per-key stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
 | [**Synchronization**](docs/sync.md) | Distributed `Lock`, `TaskLock`, `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
 | [**Task Scheduler**](docs/task.md) | Periodic task execution with optional distributed locking. Lightweight, not a Celery replacement. |
 | [**Resilience**](docs/resilience/index.md) | [Circuit Breaker](docs/resilience/circuit-breaker.md) and [Rate Limiter](docs/resilience/rate-limiter.md) with pluggable algorithms (`TokenBucketConfig`, `GCRAConfig`). |
@@ -95,7 +95,7 @@ from fastapi import FastAPI, HTTPException, Request
 import grelmicro
 from grelmicro import cache, resilience, sync
 from grelmicro.cache import JsonSerializer, TTLCache, cached
-from grelmicro.cache.redis import RedisCacheBackend
+from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.logging import configure_logging
 from grelmicro.resilience import (
     CircuitBreaker,
@@ -104,15 +104,15 @@ from grelmicro.resilience import (
 )
 from grelmicro.resilience.redis import RedisRateLimiterBackend
 from grelmicro.sync import LeaderElection, Lock
-from grelmicro.sync.redis import RedisSyncBackend
+from grelmicro.sync.redis import RedisSyncAdapter
 from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
 
 # === grelmicro ===
 task = Tasks()
-sync.register(RedisSyncBackend("redis://localhost:6379/0"))
-cache.register(RedisCacheBackend("redis://localhost:6379/0", prefix="myapp:"))
+sync.register(RedisSyncAdapter("redis://localhost:6379/0"))
+cache.register(RedisCacheAdapter("redis://localhost:6379/0", prefix="myapp:"))
 resilience.register(RedisRateLimiterBackend("redis://localhost:6379/0"))
 
 leader_election = LeaderElection("leader-election")

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -32,8 +32,8 @@ There are three ways to wire a backend:
 import grelmicro
 from grelmicro import sync, cache
 
-sync.register(RedisSyncBackend())             # implicit "default"
-cache.register(RedisCacheBackend())
+sync.register(RedisSyncAdapter())             # implicit "default"
+cache.register(RedisCacheAdapter())
 
 async with grelmicro.lifespan():
     # every registered backend is open here
@@ -48,7 +48,7 @@ async with grelmicro.lifespan():
 ```python
 from grelmicro import sync
 
-sync.use_backend(RedisSyncBackend())
+sync.use_backend(RedisSyncAdapter())
 ```
 
 Available as `grelmicro.sync.use_backend`, `grelmicro.cache.use_backend`, `grelmicro.resilience.use_backend`, and `grelmicro.health.use_registry`.
@@ -56,7 +56,7 @@ Available as `grelmicro.sync.use_backend`, `grelmicro.cache.use_backend`, `grelm
 **3. Pure construction with explicit pass-through.** Skip the registry entirely:
 
 ```python
-async with RedisSyncBackend() as backend:
+async with RedisSyncAdapter() as backend:
     lock = Lock(name="my-lock", backend=backend)
     async with lock:
         ...
@@ -69,8 +69,8 @@ async with RedisSyncBackend() as backend:
 Register multiple backends under different names and pick one at the call site:
 
 ```python
-sync.register(RedisSyncBackend())                                # → "default"
-sync.register(PostgresSyncBackend("postgres://..."), "analytics")
+sync.register(RedisSyncAdapter())                                # → "default"
+sync.register(PostgresSyncAdapter("postgres://..."), "analytics")
 
 Lock("cart")                         # → "default" (Redis)
 Lock("audit", backend="analytics")   # → "analytics" (Postgres)
@@ -92,15 +92,15 @@ Resolution order, in priority:
 ```python
 from grelmicro import sync
 
-with sync.use(MemorySyncBackend()):           # overrides "default" only
-    Lock("cart")                              # → MemorySyncBackend
+with sync.use(MemorySyncAdapter()):           # overrides "default" only
+    Lock("cart")                              # → MemorySyncAdapter
 
 with sync.use(default=mem, analytics=fake):   # overrides multiple names
     ...
 
 # Tests
 async def test_checkout():
-    with sync.use(MemorySyncBackend()):
+    with sync.use(MemorySyncAdapter()):
         await checkout()
 ```
 
@@ -119,7 +119,7 @@ Each `BackendRegistry` subscribes itself into a process-wide map *when its modul
 Backends are defined by protocols (structural typing), not base classes. Any object implementing the required methods works as a backend. This enables:
 
 - Swapping backends without changing application code
-- Writing test backends (e.g. `MemorySyncBackend`) with no external dependencies
+- Writing test backends (e.g. `MemorySyncAdapter`) with no external dependencies
 - Adding new backends without modifying existing code
 
 ## Connection Pool Isolation

--- a/docs/architecture/imports.md
+++ b/docs/architecture/imports.md
@@ -13,6 +13,6 @@ grelmicro follows the Django/SQLAlchemy pattern: **core API is re-exported from 
 
 **No unnecessary imports.** Importing a primitive does not pull in backend client libraries. Users only pay for the backend they choose.
 
-**Explicit dependencies.** A submodule import like `from grelmicro.sync.redis import RedisSyncBackend` makes the infrastructure dependency visible at the import site. Grepping for the submodule path finds every file that needs that backend.
+**Explicit dependencies.** A submodule import like `from grelmicro.sync.redis import RedisSyncAdapter` makes the infrastructure dependency visible at the import site. Grepping for the submodule path finds every file that needs that backend.
 
 **Ecosystem convention.** Django databases, SQLAlchemy dialects, and Celery brokers all follow this pattern. Backends are selected once in configuration, not scattered across business logic.

--- a/docs/architecture/kubernetes.md
+++ b/docs/architecture/kubernetes.md
@@ -44,7 +44,7 @@ The sanitization strategy replaces invalid characters with hyphens, collapses co
 When multiple applications share the same Kubernetes namespace, use the `prefix` parameter to avoid lease name collisions (similar to Redis's `prefix` parameter). For example:
 
 ```python
-backend = KubernetesSyncBackend(namespace="default", prefix="myapp-")
+backend = KubernetesSyncAdapter(namespace="default", prefix="myapp-")
 ```
 
 This prepends `myapp-` to every lease name before sanitization, ensuring different applications cannot interfere with each other's locks.

--- a/docs/architecture/sync-from-thread.md
+++ b/docs/architecture/sync-from-thread.md
@@ -22,10 +22,10 @@ Each primitive reads the loop through its bound backend (`self.backend._loop`) w
 from contextlib import asynccontextmanager
 
 from grelmicro import lifespan
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 from grelmicro.sync import Lock, use_backend
 
-use_backend(MemorySyncBackend())
+use_backend(MemorySyncAdapter())
 lock = Lock("cart")
 
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -16,16 +16,16 @@ You must load a cache backend before using `TTLCache`.
 
 === "Memory"
     ```python
-    from grelmicro.cache.memory import MemoryCacheBackend
+    from grelmicro.cache.memory import MemoryCacheAdapter
 
-    backend = MemoryCacheBackend()
+    backend = MemoryCacheAdapter()
     ```
 
 === "Redis"
     ```python
-    from grelmicro.cache.redis import RedisCacheBackend
+    from grelmicro.cache.redis import RedisCacheAdapter
 
-    backend = RedisCacheBackend("redis://localhost:6379/0", prefix="myapp:")
+    backend = RedisCacheAdapter("redis://localhost:6379/0", prefix="myapp:")
     ```
 
 Backends must be used as async context managers:
@@ -43,7 +43,7 @@ async with backend:
 ```python
 from grelmicro.cache import TTLCache
 
-# Uses the registered backend (MemoryCacheBackend or RedisCacheBackend)
+# Uses the registered backend (MemoryCacheAdapter or RedisCacheAdapter)
 cache = TTLCache(maxsize=100, ttl=300)
 
 # Or pass a backend explicitly

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,15 +4,16 @@
 
 ### Features
 
-* ✨ Add `Grelmicro` app object and `Module` protocol. The user composes everything attached to the app into one container and opens it with `async with micro:`. Single `Grelmicro.use(item)` registration verb (and `uses=` constructor kwarg) accepts `Module` instances (registered with `(kind, name)` lookup, exposed on `micro.<kind>`), first-party backends (auto-wrapped into their canonical Module: `RedisCacheBackend` → `Cache`, `RedisSyncBackend` → `Sync`), and any other async context manager (lifecycled only, caller keeps the reference). Typed accessors `micro.sync` and `micro.cache` provide IDE completion. Issue [#208](https://github.com/grelinfo/grelmicro/issues/208), epic [#201](https://github.com/grelinfo/grelmicro/issues/201), unified in [#219](https://github.com/grelinfo/grelmicro/issues/219).
-* ✨ Add `Sync` module. Wraps a `SyncBackend` and exposes `lock(...)`, `task_lock(...)`, `leader_election(...)` factories. Use it via `Grelmicro(uses=[Sync(RedisSyncBackend(...))])` and reach it on `micro.sync`. Issue [#210](https://github.com/grelinfo/grelmicro/issues/210).
-* ✨ Add `Cache` module. Wraps a `CacheBackend` and exposes a `ttl(...)` factory that builds a `TTLCache` bound to the wrapped backend. Use it via `Grelmicro(uses=[Cache(RedisCacheBackend(...))])` and reach it on `micro.cache`. Issue [#212](https://github.com/grelinfo/grelmicro/issues/212).
+* ✨ Add `Grelmicro` app object and `Module` protocol. The user composes everything attached to the app into one container and opens it with `async with micro:`. Single `Grelmicro.use(item)` registration verb (and `uses=` constructor kwarg) accepts `Module` instances (registered with `(kind, name)` lookup, exposed on `micro.<kind>`), first-party backends (auto-wrapped into their canonical Module: `RedisCacheAdapter` → `Cache`, `RedisSyncAdapter` → `Sync`), and any other async context manager (lifecycled only, caller keeps the reference). Typed accessors `micro.sync` and `micro.cache` provide IDE completion. Issue [#208](https://github.com/grelinfo/grelmicro/issues/208), epic [#201](https://github.com/grelinfo/grelmicro/issues/201), unified in [#219](https://github.com/grelinfo/grelmicro/issues/219).
+* ✨ Add `Sync` module. Wraps a `SyncBackend` and exposes `lock(...)`, `task_lock(...)`, `leader_election(...)` factories. Use it via `Grelmicro(uses=[Sync(RedisSyncAdapter(...))])` and reach it on `micro.sync`. Issue [#210](https://github.com/grelinfo/grelmicro/issues/210).
+* ✨ Add `Cache` module. Wraps a `CacheBackend` and exposes a `ttl(...)` factory that builds a `TTLCache` bound to the wrapped backend. Use it via `Grelmicro(uses=[Cache(RedisCacheAdapter(...))])` and reach it on `micro.cache`. Issue [#212](https://github.com/grelinfo/grelmicro/issues/212).
 * ✨ Add `Grelmicro.current()` classmethod for ambient lookup. Inside `async with micro:` it returns the active app for the current asyncio task. Matches Tokio's `Handle::current()` shape.
 
 ### Breaking
 
 * 💥 Rename `TaskManager` to `Tasks`. Class still extends `TaskRouter`, mirroring FastAPI's `APIRouter` ← `FastAPI` shape. Update imports to `from grelmicro.task import Tasks`. Issue [#218](https://github.com/grelinfo/grelmicro/issues/218).
 * 💥 Rename `HealthRegistry` to `HealthChecks` (and `HealthRegistryConfig` to `HealthChecksConfig`). Update imports to `from grelmicro.health import HealthChecks`. Issue [#201](https://github.com/grelinfo/grelmicro/issues/201).
+* 💥 Rename concrete backends to `*Adapter`. `MemorySyncBackend`, `RedisSyncBackend`, `PostgresSyncBackend`, `SQLiteSyncBackend`, `KubernetesSyncBackend`, `MemoryCacheBackend`, and `RedisCacheBackend` become `*Adapter`. The `SyncBackend` and `CacheBackend` Protocols stay as-is. Issue [#201](https://github.com/grelinfo/grelmicro/issues/201).
 
 ### Deprecated
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -100,7 +100,7 @@ Centralise everything under one `BaseSettings` and hand grelmicro the slices it 
 from pydantic_settings import BaseSettings
 from grelmicro.sync import Lock
 from grelmicro.sync.lock import LockConfig
-from grelmicro.cache.redis import RedisCacheBackend
+from grelmicro.cache.redis import RedisCacheAdapter
 
 class AppSettings(BaseSettings):
     cart_lock: LockConfig = LockConfig()
@@ -108,7 +108,7 @@ class AppSettings(BaseSettings):
 
 settings = AppSettings()
 cart_lock = Lock.from_config("cart", settings.cart_lock)
-cache_backend = RedisCacheBackend(settings.redis_url)
+cache_backend = RedisCacheAdapter(settings.redis_url)
 ```
 
 ## Going deeper

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ It is built for any Python application that coordinates work across processes, w
 
 | Module | Summary |
 |---|---|
-| [**Cache**](cache.md) | `@cached` decorator with per-key stampede protection. In-memory `TTLCache` or `RedisCacheBackend`. |
+| [**Cache**](cache.md) | `@cached` decorator with per-key stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
 | [**Synchronization**](sync.md) | Distributed `Lock`, `TaskLock`, `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
 | [**Task Scheduler**](task.md) | Periodic task execution with optional distributed locking. Lightweight, not a Celery replacement. |
 | [**Resilience**](resilience/index.md) | [Circuit Breaker](resilience/circuit-breaker.md) and [Rate Limiter](resilience/rate-limiter.md) with pluggable algorithms (`TokenBucketConfig`, `GCRAConfig`). |
@@ -95,7 +95,7 @@ from fastapi import FastAPI, HTTPException, Request
 import grelmicro
 from grelmicro import cache, resilience, sync
 from grelmicro.cache import JsonSerializer, TTLCache, cached
-from grelmicro.cache.redis import RedisCacheBackend
+from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.logging import configure_logging
 from grelmicro.resilience import (
     CircuitBreaker,
@@ -104,15 +104,15 @@ from grelmicro.resilience import (
 )
 from grelmicro.resilience.redis import RedisRateLimiterBackend
 from grelmicro.sync import LeaderElection, Lock
-from grelmicro.sync.redis import RedisSyncBackend
+from grelmicro.sync.redis import RedisSyncAdapter
 from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
 
 # === grelmicro ===
 task = Tasks()
-sync.register(RedisSyncBackend("redis://localhost:6379/0"))
-cache.register(RedisCacheBackend("redis://localhost:6379/0", prefix="myapp:"))
+sync.register(RedisSyncAdapter("redis://localhost:6379/0"))
+cache.register(RedisCacheAdapter("redis://localhost:6379/0", prefix="myapp:"))
 resilience.register(RedisRateLimiterBackend("redis://localhost:6379/0"))
 
 leader_election = LeaderElection("leader-election")

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -18,9 +18,9 @@
 ::: grelmicro.cache.memory
     options:
       members:
-        - MemoryCacheBackend
+        - MemoryCacheAdapter
 
 ::: grelmicro.cache.redis
     options:
       members:
-        - RedisCacheBackend
+        - RedisCacheAdapter

--- a/docs/snippets/cache/redis_basic.py
+++ b/docs/snippets/cache/redis_basic.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 from grelmicro.cache import PydanticSerializer, TTLCache, cached
-from grelmicro.cache.redis import RedisCacheBackend
+from grelmicro.cache.redis import RedisCacheAdapter
 
 
 class User(BaseModel):
@@ -9,7 +9,7 @@ class User(BaseModel):
     name: str
 
 
-backend = RedisCacheBackend(prefix="myapp:")
+backend = RedisCacheAdapter(prefix="myapp:")
 
 cache = TTLCache[User](ttl=300, serializer=PydanticSerializer(User))
 

--- a/docs/snippets/json/cache_integration.py
+++ b/docs/snippets/json/cache_integration.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 from grelmicro.cache import PydanticSerializer, TTLCache
-from grelmicro.cache.memory import MemoryCacheBackend
+from grelmicro.cache.memory import MemoryCacheAdapter
 
 
 class User(BaseModel):
@@ -9,7 +9,7 @@ class User(BaseModel):
     name: str
 
 
-backend = MemoryCacheBackend()
+backend = MemoryCacheAdapter()
 
 cache = TTLCache[User](ttl=300, serializer=PydanticSerializer(User))
 

--- a/docs/snippets/simple_fastapi_app.py
+++ b/docs/snippets/simple_fastapi_app.py
@@ -6,14 +6,14 @@ from fastapi import FastAPI
 from grelmicro.log import configure
 from grelmicro.resilience import CircuitBreaker
 from grelmicro.sync import LeaderElection, Lock
-from grelmicro.sync.redis import RedisSyncBackend
+from grelmicro.sync.redis import RedisSyncAdapter
 from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
 
 # === grelmicro ===
 task = Tasks()
-sync_backend = RedisSyncBackend("redis://localhost:6379/0")
+sync_backend = RedisSyncAdapter("redis://localhost:6379/0")
 leader_election = LeaderElection("leader-election")
 task.add_task(leader_election)
 

--- a/docs/snippets/single_file_app.py
+++ b/docs/snippets/single_file_app.py
@@ -8,10 +8,10 @@ from fast_depends import Depends
 from fastapi import FastAPI
 
 from grelmicro.sync import LeaderElection, Lock
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 from grelmicro.task import Tasks
 
-backend = MemorySyncBackend()
+backend = MemorySyncAdapter()
 task = Tasks()
 
 

--- a/docs/snippets/sync/kubernetes.py
+++ b/docs/snippets/sync/kubernetes.py
@@ -1,3 +1,3 @@
-from grelmicro.sync.kubernetes import KubernetesSyncBackend
+from grelmicro.sync.kubernetes import KubernetesSyncAdapter
 
-backend = KubernetesSyncBackend(namespace="default")
+backend = KubernetesSyncAdapter(namespace="default")

--- a/docs/snippets/sync/memory.py
+++ b/docs/snippets/sync/memory.py
@@ -1,3 +1,3 @@
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 
-backend = MemorySyncBackend()
+backend = MemorySyncAdapter()

--- a/docs/snippets/sync/postgres.py
+++ b/docs/snippets/sync/postgres.py
@@ -1,3 +1,3 @@
-from grelmicro.sync.postgres import PostgresSyncBackend
+from grelmicro.sync.postgres import PostgresSyncAdapter
 
-backend = PostgresSyncBackend("postgresql://user:password@localhost:5432/db")
+backend = PostgresSyncAdapter("postgresql://user:password@localhost:5432/db")

--- a/docs/snippets/sync/redis.py
+++ b/docs/snippets/sync/redis.py
@@ -1,3 +1,3 @@
-from grelmicro.sync.redis import RedisSyncBackend
+from grelmicro.sync.redis import RedisSyncAdapter
 
-backend = RedisSyncBackend("redis://localhost:6379/0")
+backend = RedisSyncAdapter("redis://localhost:6379/0")

--- a/docs/snippets/sync/sqlite.py
+++ b/docs/snippets/sync/sqlite.py
@@ -1,3 +1,3 @@
-from grelmicro.sync.sqlite import SQLiteSyncBackend
+from grelmicro.sync.sqlite import SQLiteSyncAdapter
 
-backend = SQLiteSyncBackend("locks.db")
+backend = SQLiteSyncAdapter("locks.db")

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -50,7 +50,7 @@ class Grelmicro:
     tasks = Tasks()
 
     micro = Grelmicro(uses=[
-        Sync(RedisSyncBackend()),
+        Sync(RedisSyncAdapter()),
         tasks,
     ])
 
@@ -124,7 +124,7 @@ class Grelmicro:
 
         1. A `Module` instance: registered with `(kind, name)` lookup and
            exposed on `micro.<kind>`.
-        2. A first-party backend (e.g. `RedisSyncBackend`): auto-wrapped
+        2. A first-party backend (e.g. `RedisSyncAdapter`): auto-wrapped
            into its canonical `Module` (`Sync` for sync backends, `Cache`
            for cache backends) before registration.
         3. Any other async context manager: just lifecycled with the app,
@@ -132,11 +132,11 @@ class Grelmicro:
 
         ```python
         # Auto-wrapped first-party backend
-        micro.use(RedisSyncBackend())          # registered as (sync, default)
-        micro.use(RedisCacheBackend())         # registered as (cache, default)
+        micro.use(RedisSyncAdapter())          # registered as (sync, default)
+        micro.use(RedisCacheAdapter())         # registered as (cache, default)
 
         # Explicit Module when a non-default name is needed
-        micro.use(Sync(RedisSyncBackend(), name="analytics"))
+        micro.use(Sync(RedisSyncAdapter(), name="analytics"))
 
         # Plain async context manager: lifecycled only, caller holds reference
         tasks = Tasks()
@@ -362,7 +362,7 @@ def _maybe_wrap_first_party_backend(item: object) -> Module | None:
     """Wrap a first-party backend in its canonical Module, or return None.
 
     Imports are lazy so unused modules stay out of `import grelmicro`.
-    The user importing `RedisCacheBackend` already loads `grelmicro.cache`,
+    The user importing `RedisCacheAdapter` already loads `grelmicro.cache`,
     so the lazy import here is a cache hit.
     """
     from grelmicro.cache._module import Cache  # noqa: PLC0415

--- a/grelmicro/_redis.py
+++ b/grelmicro/_redis.py
@@ -1,6 +1,6 @@
 """Internal shared Redis URL resolution and client factory.
 
-Used by both the sync (RedisSyncBackend) and cache (RedisCacheBackend)
+Used by both the sync (RedisSyncAdapter) and cache (RedisCacheAdapter)
 domains to avoid duplicating environment-variable handling. Not part of
 the public API.
 """

--- a/grelmicro/cache/_module.py
+++ b/grelmicro/cache/_module.py
@@ -27,9 +27,9 @@ class Cache:
         ```python
         from grelmicro import Grelmicro
         from grelmicro.cache import Cache, JsonSerializer
-        from grelmicro.cache.redis import RedisCacheBackend
+        from grelmicro.cache.redis import RedisCacheAdapter
 
-        micro = Grelmicro(uses=[Cache(RedisCacheBackend("redis://localhost"))])
+        micro = Grelmicro(uses=[Cache(RedisCacheAdapter("redis://localhost"))])
         user_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
 
         @micro.cache.cached(user_cache)

--- a/grelmicro/cache/memory.py
+++ b/grelmicro/cache/memory.py
@@ -1,4 +1,4 @@
-"""Memory Cache Backend."""
+"""Memory Cache Adapter."""
 
 import asyncio
 from time import monotonic

--- a/grelmicro/cache/memory.py
+++ b/grelmicro/cache/memory.py
@@ -6,7 +6,7 @@ from types import TracebackType
 from typing import Self
 
 
-class MemoryCacheBackend:
+class MemoryCacheAdapter:
     """In-memory cache backend.
 
     Stores entries in a Python dict with lazy TTL expiry.

--- a/grelmicro/cache/redis.py
+++ b/grelmicro/cache/redis.py
@@ -1,4 +1,4 @@
-"""Redis Cache Backend."""
+"""Redis Cache Adapter."""
 
 import asyncio
 from types import TracebackType

--- a/grelmicro/cache/redis.py
+++ b/grelmicro/cache/redis.py
@@ -13,7 +13,7 @@ from grelmicro.cache.errors import CacheSettingsValidationError
 _CLEAR_BATCH_SIZE = 1000
 
 
-class RedisCacheBackend:
+class RedisCacheAdapter:
     """Redis cache storage backend.
 
     Pure key-value storage with per-entry TTL handled natively

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -47,7 +47,7 @@ class TTLCache(Generic[T]):
     and statistics on top of the backend.
 
     When no backend is provided, the registered default is used
-    (see ``MemoryCacheBackend`` or ``RedisCacheBackend``).
+    (see ``MemoryCacheAdapter`` or ``RedisCacheAdapter``).
 
     The type parameter ``T`` represents the cached value type.
     Defaults to ``Any`` when unspecified (``TTLCache()``).

--- a/grelmicro/sync/_module.py
+++ b/grelmicro/sync/_module.py
@@ -27,9 +27,9 @@ class Sync:
         ```python
         from grelmicro import Grelmicro
         from grelmicro.sync import Sync
-        from grelmicro.sync.redis import RedisSyncBackend
+        from grelmicro.sync.redis import RedisSyncAdapter
 
-        micro = Grelmicro(uses=[Sync(RedisSyncBackend("redis://localhost"))])
+        micro = Grelmicro(uses=[Sync(RedisSyncAdapter("redis://localhost"))])
 
         async with micro:
             async with micro.sync.lock("cart"):

--- a/grelmicro/sync/kubernetes.py
+++ b/grelmicro/sync/kubernetes.py
@@ -70,7 +70,7 @@ def _sanitize_lease_name(name: str) -> str:
     return sanitized
 
 
-class KubernetesSyncBackend(SyncBackend):
+class KubernetesSyncAdapter(SyncBackend):
     """Kubernetes Synchronization Backend."""
 
     def __init__(

--- a/grelmicro/sync/kubernetes.py
+++ b/grelmicro/sync/kubernetes.py
@@ -1,4 +1,4 @@
-"""Kubernetes Synchronization Backend."""
+"""Kubernetes Synchronization Adapter."""
 
 import asyncio
 import re
@@ -71,7 +71,7 @@ def _sanitize_lease_name(name: str) -> str:
 
 
 class KubernetesSyncAdapter(SyncBackend):
-    """Kubernetes Synchronization Backend."""
+    """Kubernetes Synchronization Adapter."""
 
     def __init__(
         self,

--- a/grelmicro/sync/memory.py
+++ b/grelmicro/sync/memory.py
@@ -8,7 +8,7 @@ from typing import Self
 from grelmicro.sync.abc import SyncBackend
 
 
-class MemorySyncBackend(SyncBackend):
+class MemorySyncAdapter(SyncBackend):
     """Memory Synchronization Backend.
 
     This is not a backend with a real distributed lock. It is a local lock that can be used for

--- a/grelmicro/sync/memory.py
+++ b/grelmicro/sync/memory.py
@@ -1,4 +1,4 @@
-"""Memory Synchronization Backend."""
+"""Memory Synchronization Adapter."""
 
 import asyncio
 from time import monotonic
@@ -9,7 +9,7 @@ from grelmicro.sync.abc import SyncBackend
 
 
 class MemorySyncAdapter(SyncBackend):
-    """Memory Synchronization Backend.
+    """Memory Synchronization Adapter.
 
     This is not a backend with a real distributed lock. It is a local lock that can be used for
     testing purposes or for locking operations that are executed in the same asyncio event loop.

--- a/grelmicro/sync/postgres.py
+++ b/grelmicro/sync/postgres.py
@@ -1,4 +1,4 @@
-"""PostgreSQL Synchronization Backend."""
+"""PostgreSQL Synchronization Adapter."""
 
 import asyncio
 import re
@@ -67,7 +67,7 @@ def _get_postgres_url() -> str:
 
 
 class PostgresSyncAdapter(SyncBackend):
-    """PostgreSQL Synchronization Backend."""
+    """PostgreSQL Synchronization Adapter."""
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """
                 CREATE TABLE IF NOT EXISTS {table_name} (

--- a/grelmicro/sync/postgres.py
+++ b/grelmicro/sync/postgres.py
@@ -66,7 +66,7 @@ def _get_postgres_url() -> str:
     raise SyncSettingsValidationError(msg)
 
 
-class PostgresSyncBackend(SyncBackend):
+class PostgresSyncAdapter(SyncBackend):
     """PostgreSQL Synchronization Backend."""
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """

--- a/grelmicro/sync/redis.py
+++ b/grelmicro/sync/redis.py
@@ -1,4 +1,4 @@
-"""Redis Synchronization Backend."""
+"""Redis Synchronization Adapter."""
 
 import asyncio
 from types import TracebackType
@@ -13,7 +13,7 @@ from grelmicro.sync.errors import SyncSettingsValidationError
 
 
 class RedisSyncAdapter(SyncBackend):
-    """Redis Synchronization Backend."""
+    """Redis Synchronization Adapter."""
 
     _LUA_ACQUIRE_OR_EXTEND = """
         local token = redis.call('get', KEYS[1])

--- a/grelmicro/sync/redis.py
+++ b/grelmicro/sync/redis.py
@@ -12,7 +12,7 @@ from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.errors import SyncSettingsValidationError
 
 
-class RedisSyncBackend(SyncBackend):
+class RedisSyncAdapter(SyncBackend):
     """Redis Synchronization Backend."""
 
     _LUA_ACQUIRE_OR_EXTEND = """

--- a/grelmicro/sync/sqlite.py
+++ b/grelmicro/sync/sqlite.py
@@ -1,4 +1,4 @@
-"""SQLite Synchronization Backend."""
+"""SQLite Synchronization Adapter."""
 
 import asyncio
 import re
@@ -38,7 +38,7 @@ def _get_sqlite_path() -> str:
 
 
 class SQLiteSyncAdapter(SyncBackend):
-    """SQLite Synchronization Backend."""
+    """SQLite Synchronization Adapter."""
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """
                 CREATE TABLE IF NOT EXISTS {table_name} (

--- a/grelmicro/sync/sqlite.py
+++ b/grelmicro/sync/sqlite.py
@@ -37,7 +37,7 @@ def _get_sqlite_path() -> str:
     raise SyncSettingsValidationError(msg)
 
 
-class SQLiteSyncBackend(SyncBackend):
+class SQLiteSyncAdapter(SyncBackend):
     """SQLite Synchronization Backend."""
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """

--- a/tests/cache/test_cache_backends.py
+++ b/tests/cache/test_cache_backends.py
@@ -8,8 +8,8 @@ from testcontainers.redis import RedisContainer
 
 from grelmicro.cache._protocol import CacheBackend
 from grelmicro.cache.cached import cached
-from grelmicro.cache.memory import MemoryCacheBackend
-from grelmicro.cache.redis import RedisCacheBackend
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.cache.serializers import JsonSerializer
 from grelmicro.cache.ttl import TTLCache
 
@@ -50,13 +50,13 @@ async def backend(
     """Cache backend instance."""
     if backend_name == "redis" and container:
         port = container.get_exposed_port(6379)
-        async with RedisCacheBackend(
+        async with RedisCacheAdapter(
             f"redis://localhost:{port}/0",
             prefix="test:",
         ) as redis_backend:
             yield redis_backend
     elif backend_name == "memory":
-        async with MemoryCacheBackend() as memory_backend:
+        async with MemoryCacheAdapter() as memory_backend:
             yield memory_backend
 
 
@@ -136,8 +136,8 @@ async def test_redis_prefix_isolation() -> None:
         port = container.get_exposed_port(6379)
         url = f"redis://localhost:{port}/0"
         async with (
-            RedisCacheBackend(url, prefix="alpha:") as alpha,
-            RedisCacheBackend(url, prefix="beta:") as beta,
+            RedisCacheAdapter(url, prefix="alpha:") as alpha,
+            RedisCacheAdapter(url, prefix="beta:") as beta,
         ):
             await alpha.set(key="k", value=b"alpha", ttl=60)
             await beta.set(key="k", value=b"beta", ttl=60)
@@ -157,7 +157,7 @@ async def test_cached_end_to_end_with_redis() -> None:
     with RedisContainer() as container:
         port = container.get_exposed_port(6379)
         url = f"redis://localhost:{port}/0"
-        async with RedisCacheBackend(url, prefix="e2e:") as redis_backend:
+        async with RedisCacheAdapter(url, prefix="e2e:") as redis_backend:
             cache = TTLCache(
                 ttl=60,
                 backend=redis_backend,
@@ -180,8 +180,8 @@ async def test_cached_end_to_end_with_redis() -> None:
 
 
 async def test_cached_end_to_end_with_memory() -> None:
-    """Test @cached with TTLCache backed by MemoryCacheBackend."""
-    async with MemoryCacheBackend() as memory_backend:
+    """Test @cached with TTLCache backed by MemoryCacheAdapter."""
+    async with MemoryCacheAdapter() as memory_backend:
         cache = TTLCache(
             ttl=60,
             backend=memory_backend,

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 import pytest
 
 from grelmicro.cache.cached import cached
-from grelmicro.cache.memory import MemoryCacheBackend
+from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.serializers import PickleSerializer
 from grelmicro.cache.ttl import TTLCache
 
@@ -31,7 +31,7 @@ def _make_cache(maxsize: int = 10, ttl: float = 60) -> TTLCache:
     ``async with backend:`` setup. Production code goes through
     ``grelmicro.lifespan()`` which does this for free.
     """
-    backend = MemoryCacheBackend()
+    backend = MemoryCacheAdapter()
     with suppress(RuntimeError):
         backend._loop = asyncio.get_running_loop()
     return TTLCache(

--- a/tests/cache/test_memory.py
+++ b/tests/cache/test_memory.py
@@ -1,4 +1,4 @@
-"""Tests for MemoryCacheBackend."""
+"""Tests for MemoryCacheAdapter."""
 
 from asyncio import sleep
 
@@ -7,17 +7,17 @@ import pytest
 from grelmicro._backends import BackendNotLoadedError
 from grelmicro.cache import use_backend
 from grelmicro.cache._backends import cache_backend_registry, get_cache_backend
-from grelmicro.cache.memory import MemoryCacheBackend
+from grelmicro.cache.memory import MemoryCacheAdapter
 
 pytestmark = [pytest.mark.timeout(5)]
 
 
-class TestMemoryCacheBackendGet:
-    """Tests for MemoryCacheBackend.get."""
+class TestMemoryCacheAdapterGet:
+    """Tests for MemoryCacheAdapter.get."""
 
     async def test_get_returns_stored_bytes(self) -> None:
         """Test that get returns the bytes stored by set."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="k", value=b"hello", ttl=60)
 
         result = await backend.get(key="k")
@@ -26,7 +26,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_miss_returns_none(self) -> None:
         """Test that get returns None for a key that was never written."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
 
         result = await backend.get(key="nonexistent")
 
@@ -34,7 +34,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_expired_returns_none(self) -> None:
         """Test that get returns None after the entry's TTL has elapsed."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="exp", value=b"data", ttl=0.05)
 
         await sleep(0.1)
@@ -44,7 +44,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_removes_expired_entry_lazily(self) -> None:
         """Test that expired entries are removed from internal storage on access."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="lazy", value=b"val", ttl=0.05)
 
         await sleep(0.1)
@@ -55,7 +55,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_not_yet_expired_returns_value(self) -> None:
         """Test that get returns the value when the TTL has not yet elapsed."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="fresh", value=b"still here", ttl=60)
 
         result = await backend.get(key="fresh")
@@ -64,7 +64,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_empty_bytes_value(self) -> None:
         """Test that get correctly returns an empty bytes value."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="empty", value=b"", ttl=60)
 
         result = await backend.get(key="empty")
@@ -73,7 +73,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_large_value(self) -> None:
         """Test that get returns large byte payloads without truncation."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         large = b"x" * 100_000
         await backend.set(key="big", value=large, ttl=60)
 
@@ -83,7 +83,7 @@ class TestMemoryCacheBackendGet:
 
     async def test_get_unicode_key(self) -> None:
         """Test that get works with Unicode (non-ASCII) key strings."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="unicode-key", value=b"unicode-value", ttl=60)
 
         result = await backend.get(key="unicode-key")
@@ -91,12 +91,12 @@ class TestMemoryCacheBackendGet:
         assert result == b"unicode-value"
 
 
-class TestMemoryCacheBackendSet:
-    """Tests for MemoryCacheBackend.set."""
+class TestMemoryCacheAdapterSet:
+    """Tests for MemoryCacheAdapter.set."""
 
     async def test_set_overwrites_existing_key(self) -> None:
         """Test that a second set replaces the previous value for the same key."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="k", value=b"first", ttl=60)
         await backend.set(key="k", value=b"second", ttl=60)
 
@@ -106,7 +106,7 @@ class TestMemoryCacheBackendSet:
 
     async def test_set_updates_ttl_on_overwrite(self) -> None:
         """Test that overwriting a key resets its expiry to the new TTL."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         # Write with a very short TTL.
         await backend.set(key="k", value=b"v", ttl=0.05)
         # Immediately overwrite with a long TTL.
@@ -121,7 +121,7 @@ class TestMemoryCacheBackendSet:
 
     async def test_set_multiple_keys_independently(self) -> None:
         """Test that multiple keys do not interfere with each other."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="a", value=b"aaa", ttl=60)
         await backend.set(key="b", value=b"bbb", ttl=60)
 
@@ -129,12 +129,12 @@ class TestMemoryCacheBackendSet:
         assert await backend.get(key="b") == b"bbb"
 
 
-class TestMemoryCacheBackendDelete:
-    """Tests for MemoryCacheBackend.delete."""
+class TestMemoryCacheAdapterDelete:
+    """Tests for MemoryCacheAdapter.delete."""
 
     async def test_delete_removes_key(self) -> None:
         """Test that delete makes the key unavailable."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="del", value=b"bye", ttl=60)
 
         await backend.delete(key="del")
@@ -143,14 +143,14 @@ class TestMemoryCacheBackendDelete:
 
     async def test_delete_missing_key_is_no_op(self) -> None:
         """Test that deleting a key that does not exist does not raise."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
 
         # Should not raise.
         await backend.delete(key="ghost")
 
     async def test_delete_does_not_affect_other_keys(self) -> None:
         """Test that deleting one key leaves other keys intact."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="keep", value=b"safe", ttl=60)
         await backend.set(key="remove", value=b"gone", ttl=60)
 
@@ -160,12 +160,12 @@ class TestMemoryCacheBackendDelete:
         assert await backend.get(key="remove") is None
 
 
-class TestMemoryCacheBackendClear:
-    """Tests for MemoryCacheBackend.clear."""
+class TestMemoryCacheAdapterClear:
+    """Tests for MemoryCacheAdapter.clear."""
 
     async def test_clear_removes_all_entries(self) -> None:
         """Test that clear empties the store completely."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="one", value=b"1", ttl=60)
         await backend.set(key="two", value=b"2", ttl=60)
 
@@ -176,7 +176,7 @@ class TestMemoryCacheBackendClear:
 
     async def test_clear_on_empty_store_is_no_op(self) -> None:
         """Test that clearing an already-empty store does not raise."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
 
         await backend.clear()
 
@@ -184,7 +184,7 @@ class TestMemoryCacheBackendClear:
 
     async def test_can_set_after_clear(self) -> None:
         """Test that the backend remains usable after a clear."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="before", value=b"old", ttl=60)
         await backend.clear()
 
@@ -194,19 +194,19 @@ class TestMemoryCacheBackendClear:
         assert result == b"new"
 
 
-class TestMemoryCacheBackendContextManager:
-    """Tests for MemoryCacheBackend async context manager."""
+class TestMemoryCacheAdapterContextManager:
+    """Tests for MemoryCacheAdapter async context manager."""
 
     async def test_context_manager_returns_self(self) -> None:
         """Test that __aenter__ returns the backend instance."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
 
         async with backend as entered:
             assert entered is backend
 
     async def test_context_manager_clears_data_on_exit(self) -> None:
         """Test that __aexit__ clears the internal store."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="k", value=b"v", ttl=60)
 
         async with backend:
@@ -217,7 +217,7 @@ class TestMemoryCacheBackendContextManager:
 
     async def test_context_manager_clears_even_on_exception(self) -> None:
         """Test that __aexit__ clears the store even when the body raises."""
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
         await backend.set(key="k", value=b"v", ttl=60)
 
         with pytest.raises(RuntimeError, match="test error"):  # noqa: PT012
@@ -228,21 +228,21 @@ class TestMemoryCacheBackendContextManager:
         assert await backend.get(key="k") is None
 
 
-class TestMemoryCacheBackendRegistration:
-    """Tests for explicit registration of MemoryCacheBackend."""
+class TestMemoryCacheAdapterRegistration:
+    """Tests for explicit registration of MemoryCacheAdapter."""
 
     def test_constructor_does_not_register(self) -> None:
         """Constructing the backend performs no registry writes."""
         cache_backend_registry.reset()
 
-        MemoryCacheBackend()
+        MemoryCacheAdapter()
 
         assert not cache_backend_registry.is_loaded
 
     def test_use_backend_registers(self) -> None:
         """`cache.use_backend` registers the backend as default."""
         cache_backend_registry.reset()
-        backend = MemoryCacheBackend()
+        backend = MemoryCacheAdapter()
 
         with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
             use_backend(backend)

--- a/tests/cache/test_module.py
+++ b/tests/cache/test_module.py
@@ -6,17 +6,17 @@ import pytest
 
 from grelmicro import Grelmicro, Module
 from grelmicro.cache import Cache, JsonSerializer, TTLCache
-from grelmicro.cache.memory import MemoryCacheBackend
+from grelmicro.cache.memory import MemoryCacheAdapter
 
 
 def test_cache_satisfies_module_protocol() -> None:
     """`Cache` is a runtime-checkable `Module`."""
-    assert isinstance(Cache(MemoryCacheBackend()), Module)
+    assert isinstance(Cache(MemoryCacheAdapter()), Module)
 
 
 def test_cache_default_kind_and_name() -> None:
     """Default kind is `cache` and default name is `default`."""
-    cache = Cache(MemoryCacheBackend())
+    cache = Cache(MemoryCacheAdapter())
     assert cache.kind == "cache"
     assert cache.name == "default"
 
@@ -25,8 +25,8 @@ def test_cache_named_registration() -> None:
     """A named `Cache` module coexists with the default one."""
     micro = Grelmicro(
         uses=[
-            Cache(MemoryCacheBackend()),
-            Cache(MemoryCacheBackend(), name="responses"),
+            Cache(MemoryCacheAdapter()),
+            Cache(MemoryCacheAdapter(), name="responses"),
         ]
     )
     assert micro.get("cache", "default").name == "default"
@@ -35,14 +35,14 @@ def test_cache_named_registration() -> None:
 
 def test_cache_backend_property() -> None:
     """`cache.backend` returns the wrapped backend."""
-    backend = MemoryCacheBackend()
+    backend = MemoryCacheAdapter()
     cache = Cache(backend)
     assert cache.backend is backend
 
 
 async def test_cache_ttl_factory_binds_backend() -> None:
     """`cache.ttl(...)` creates a `TTLCache` whose writes round-trip via the same backend."""
-    backend = MemoryCacheBackend()
+    backend = MemoryCacheAdapter()
     cache_a = Cache(backend)
     cache_b = Cache(backend)  # second wrapper over the SAME backend
     ttl_a = cache_a.ttl(ttl=300)
@@ -56,7 +56,7 @@ async def test_cache_ttl_factory_binds_backend() -> None:
 
 async def test_cache_ttl_factory_passes_serializer() -> None:
     """`cache.ttl(serializer=...)` round-trips a non-bytes value through the serializer."""
-    cache = Cache(MemoryCacheBackend())
+    cache = Cache(MemoryCacheAdapter())
     ttl_cache = cache.ttl(ttl=60, serializer=JsonSerializer())
     async with cache:
         await ttl_cache.set("payload", {"id": 1, "tags": ["a", "b"]})
@@ -65,7 +65,7 @@ async def test_cache_ttl_factory_passes_serializer() -> None:
 
 async def test_cache_cached_decorator_works_via_micro_attribute() -> None:
     """`@micro.cache.cached(ttl_cache)` decorates and caches results."""
-    micro = Grelmicro(uses=[Cache(MemoryCacheBackend())])
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
     calls = 0
     async with micro:
         ttl_cache = micro.cache.ttl(ttl=60, serializer=JsonSerializer())
@@ -85,7 +85,7 @@ async def test_cache_cached_decorator_works_via_micro_attribute() -> None:
 
 async def test_cache_opens_and_closes_backend_with_app() -> None:
     """`async with micro:` opens and closes the underlying backend."""
-    backend = MemoryCacheBackend()
+    backend = MemoryCacheAdapter()
     cache = Cache(backend)
     micro = Grelmicro(uses=[cache])
     async with micro:
@@ -96,7 +96,7 @@ async def test_cache_opens_and_closes_backend_with_app() -> None:
 
 async def test_micro_cache_via_attribute() -> None:
     """`micro.cache.ttl(...)` is the conventional access path."""
-    micro = Grelmicro(uses=[Cache(MemoryCacheBackend())])
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
     async with micro:
         ttl_cache = micro.cache.ttl(ttl=60, serializer=JsonSerializer())
         await ttl_cache.set("alice", {"id": 1})
@@ -104,8 +104,8 @@ async def test_micro_cache_via_attribute() -> None:
 
 
 async def test_use_auto_wraps_raw_cache_backend() -> None:
-    """`micro.use(MemoryCacheBackend())` auto-wraps the backend in `Cache`."""
-    backend = MemoryCacheBackend()
+    """`micro.use(MemoryCacheAdapter())` auto-wraps the backend in `Cache`."""
+    backend = MemoryCacheAdapter()
     micro = Grelmicro(uses=[backend])
     assert isinstance(micro.cache, Cache)
     assert micro.cache.backend is backend
@@ -113,7 +113,7 @@ async def test_use_auto_wraps_raw_cache_backend() -> None:
 
 async def test_use_auto_wrap_cache_lifecycles_backend() -> None:
     """Auto-wrapped cache backend opens and closes with the app."""
-    backend = MemoryCacheBackend()
+    backend = MemoryCacheAdapter()
     micro = Grelmicro(uses=[backend])
     async with micro:
         ttl_cache = micro.cache.ttl(ttl=60)
@@ -123,11 +123,11 @@ async def test_use_auto_wrap_cache_lifecycles_backend() -> None:
 
 async def test_micro_cache_prefers_default_over_named() -> None:
     """`micro.cache` resolves to `(cache, default)` even when named modules exist."""
-    primary = MemoryCacheBackend()
+    primary = MemoryCacheAdapter()
     micro = Grelmicro(
         uses=[
             Cache(primary),
-            Cache(MemoryCacheBackend(), name="responses"),
+            Cache(MemoryCacheAdapter(), name="responses"),
         ]
     )
     assert micro.cache.backend is primary
@@ -137,8 +137,8 @@ async def test_micro_cache_raises_when_ambiguous() -> None:
     """`micro.cache` raises when multiple non-default modules exist."""
     micro = Grelmicro(
         uses=[
-            Cache(MemoryCacheBackend(), name="a"),
-            Cache(MemoryCacheBackend(), name="b"),
+            Cache(MemoryCacheAdapter(), name="a"),
+            Cache(MemoryCacheAdapter(), name="b"),
         ]
     )
     with pytest.raises(AttributeError, match="multiple 'cache' modules"):

--- a/tests/cache/test_redis.py
+++ b/tests/cache/test_redis.py
@@ -1,4 +1,4 @@
-"""Tests for RedisCacheBackend."""
+"""Tests for RedisCacheAdapter."""
 
 from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
@@ -9,15 +9,15 @@ from grelmicro._backends import BackendNotLoadedError
 from grelmicro.cache import use_backend
 from grelmicro.cache._backends import cache_backend_registry, get_cache_backend
 from grelmicro.cache.errors import CacheSettingsValidationError
-from grelmicro.cache.redis import RedisCacheBackend
+from grelmicro.cache.redis import RedisCacheAdapter
 
 pytestmark = [pytest.mark.timeout(1)]
 
 URL = "redis://:test_password@test_host:1234/0"
 
 
-class TestRedisCacheBackendEnvVarSettings:
-    """Tests for RedisCacheBackend settings resolved from environment variables."""
+class TestRedisCacheAdapterEnvVarSettings:
+    """Tests for RedisCacheAdapter settings resolved from environment variables."""
 
     @pytest.mark.parametrize(
         ("environs", "expected_url"),
@@ -53,14 +53,14 @@ class TestRedisCacheBackendEnvVarSettings:
             monkeypatch.setenv(key, value)
 
         # Act
-        backend = RedisCacheBackend()
+        backend = RedisCacheAdapter()
 
         # Assert
         assert backend._url == expected_url
 
 
-class TestRedisCacheBackendEnvVarValidationError:
-    """Tests for RedisCacheBackend settings validation errors."""
+class TestRedisCacheAdapterEnvVarValidationError:
+    """Tests for RedisCacheAdapter settings validation errors."""
 
     @pytest.mark.parametrize(
         "environs",
@@ -85,11 +85,11 @@ class TestRedisCacheBackendEnvVarValidationError:
             CacheSettingsValidationError,
             match=r"Could not validate environment variables settings:\n",
         ):
-            RedisCacheBackend()
+            RedisCacheAdapter()
 
 
-class TestRedisCacheBackendConstructor:
-    """Tests for RedisCacheBackend constructor with explicit arguments."""
+class TestRedisCacheAdapterConstructor:
+    """Tests for RedisCacheAdapter constructor with explicit arguments."""
 
     def test_explicit_url_bypasses_env_vars(
         self, monkeypatch: pytest.MonkeyPatch
@@ -100,7 +100,7 @@ class TestRedisCacheBackendConstructor:
         monkeypatch.delenv("REDIS_HOST", raising=False)
 
         # Act
-        backend = RedisCacheBackend(URL)
+        backend = RedisCacheAdapter(URL)
 
         # Assert
         assert backend._url == URL
@@ -112,20 +112,20 @@ class TestRedisCacheBackendConstructor:
         monkeypatch.delenv("REDIS_URL", raising=False)
         monkeypatch.delenv("REDIS_HOST", raising=False)
 
-        backend = RedisCacheBackend(url=URL)
+        backend = RedisCacheAdapter(url=URL)
 
         assert backend._url == URL
 
     def test_prefix_stored(self) -> None:
         """Test that the prefix argument is stored on the backend."""
-        backend = RedisCacheBackend(URL, prefix="myns:")
+        backend = RedisCacheAdapter(URL, prefix="myns:")
 
         assert backend._prefix == "myns:"
 
     def test_no_ttl_in_constructor(self) -> None:
-        """Test that RedisCacheBackend has no ttl constructor parameter."""
+        """Test that RedisCacheAdapter has no ttl constructor parameter."""
         # TTL is now per-call; constructing without ttl must not raise.
-        backend = RedisCacheBackend(URL)
+        backend = RedisCacheAdapter(URL)
 
         # The backend protocol exposes no ttl attribute.
         assert not hasattr(backend, "ttl")
@@ -136,17 +136,17 @@ class TestCacheBackendRegistry:
     """Tests for cache backend registry integration."""
 
     def test_constructor_does_not_register(self) -> None:
-        """Constructing RedisCacheBackend performs no registry writes."""
+        """Constructing RedisCacheAdapter performs no registry writes."""
         cache_backend_registry.reset()
 
-        RedisCacheBackend(URL)
+        RedisCacheAdapter(URL)
 
         assert not cache_backend_registry.is_loaded
 
     def test_use_backend_registers(self) -> None:
         """`cache.use_backend` registers the backend as default."""
         cache_backend_registry.reset()
-        backend = RedisCacheBackend(URL)
+        backend = RedisCacheAdapter(URL)
 
         with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
             use_backend(backend)
@@ -163,12 +163,12 @@ class TestCacheBackendRegistry:
             get_cache_backend()
 
 
-class TestRedisCacheBackendAsyncMethods:
-    """Tests for RedisCacheBackend async methods using a mocked Redis client."""
+class TestRedisCacheAdapterAsyncMethods:
+    """Tests for RedisCacheAdapter async methods using a mocked Redis client."""
 
     async def test_get_hit(self) -> None:
         """Test that get returns the stored bytes when the key exists."""
-        backend = RedisCacheBackend(URL)
+        backend = RedisCacheAdapter(URL)
         backend._redis = MagicMock()
         backend._redis.get = AsyncMock(return_value=b"value")
 
@@ -179,7 +179,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_get_miss_returns_none(self) -> None:
         """Test that get returns None when the key does not exist."""
-        backend = RedisCacheBackend(URL)
+        backend = RedisCacheAdapter(URL)
         backend._redis = MagicMock()
         backend._redis.get = AsyncMock(return_value=None)
 
@@ -189,7 +189,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_get_with_prefix(self) -> None:
         """Test that get prepends the configured prefix to the Redis key."""
-        backend = RedisCacheBackend(URL, prefix="ns:")
+        backend = RedisCacheAdapter(URL, prefix="ns:")
         backend._redis = MagicMock()
         backend._redis.get = AsyncMock(return_value=b"v")
 
@@ -199,7 +199,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_set_passes_key_value_ttl(self) -> None:
         """Test that set calls redis.set with the prefixed key, value, and TTL."""
-        backend = RedisCacheBackend(URL, prefix="p:")
+        backend = RedisCacheAdapter(URL, prefix="p:")
         backend._redis = MagicMock()
         backend._redis.set = AsyncMock()
 
@@ -209,7 +209,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_set_without_prefix(self) -> None:
         """Test that set uses the bare key when no prefix is configured."""
-        backend = RedisCacheBackend(URL)
+        backend = RedisCacheAdapter(URL)
         backend._redis = MagicMock()
         backend._redis.set = AsyncMock()
 
@@ -219,7 +219,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_set_float_ttl(self) -> None:
         """Test that set passes fractional TTL values through to Redis."""
-        backend = RedisCacheBackend(URL)
+        backend = RedisCacheAdapter(URL)
         backend._redis = MagicMock()
         backend._redis.set = AsyncMock()
 
@@ -229,7 +229,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_delete(self) -> None:
         """Test that delete calls redis.delete with the prefixed key."""
-        backend = RedisCacheBackend(URL, prefix="p:")
+        backend = RedisCacheAdapter(URL, prefix="p:")
         backend._redis = MagicMock()
         backend._redis.delete = AsyncMock()
 
@@ -239,7 +239,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_delete_missing_key_is_no_op(self) -> None:
         """Test that delete on a missing key does not raise."""
-        backend = RedisCacheBackend(URL)
+        backend = RedisCacheAdapter(URL)
         backend._redis = MagicMock()
         backend._redis.delete = AsyncMock(return_value=0)
 
@@ -250,7 +250,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_clear(self) -> None:
         """Test that clear scans and deletes all keys matching the prefix."""
-        backend = RedisCacheBackend(URL, prefix="p:")
+        backend = RedisCacheAdapter(URL, prefix="p:")
         mock_redis = MagicMock()
         mock_redis.delete = AsyncMock()
 
@@ -267,7 +267,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_clear_large_batch(self) -> None:
         """Test that clear deletes in batches when the key count exceeds batch size."""
-        backend = RedisCacheBackend(URL, prefix="p:")
+        backend = RedisCacheAdapter(URL, prefix="p:")
         mock_redis = MagicMock()
         mock_redis.delete = AsyncMock()
 
@@ -288,7 +288,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_clear_empty_store(self) -> None:
         """Test that clear on an empty store issues no delete calls."""
-        backend = RedisCacheBackend(URL, prefix="p:")
+        backend = RedisCacheAdapter(URL, prefix="p:")
         mock_redis = MagicMock()
         mock_redis.delete = AsyncMock()
 
@@ -305,7 +305,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_context_manager_closes_redis(self) -> None:
         """Test that the async context manager calls aclose on exit."""
-        backend = RedisCacheBackend(URL)
+        backend = RedisCacheAdapter(URL)
         backend._redis = MagicMock()
         backend._redis.aclose = AsyncMock()
 
@@ -316,7 +316,7 @@ class TestRedisCacheBackendAsyncMethods:
 
     async def test_context_manager_returns_self(self) -> None:
         """Test that __aenter__ returns the backend instance itself."""
-        backend = RedisCacheBackend(URL)
+        backend = RedisCacheAdapter(URL)
         backend._redis = MagicMock()
         backend._redis.aclose = AsyncMock()
 

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from grelmicro.cache._backends import cache_backend_registry
-from grelmicro.cache.memory import MemoryCacheBackend
+from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.serializers import JsonSerializer, PickleSerializer
 from grelmicro.cache.ttl import CacheInfo, TTLCache
 
@@ -20,9 +20,9 @@ EXPECTED_UNLIMITED_COUNT = 1000
 
 
 @pytest.fixture
-def backend() -> MemoryCacheBackend:
+def backend() -> MemoryCacheAdapter:
     """Provide an isolated in-memory cache backend (not registered globally)."""
-    return MemoryCacheBackend()
+    return MemoryCacheAdapter()
 
 
 # ---------------------------------------------------------------------------
@@ -33,7 +33,7 @@ def backend() -> MemoryCacheBackend:
 class TestInit:
     """Test TTLCache initialization and constructor validation."""
 
-    def test_valid_params(self, backend: MemoryCacheBackend) -> None:
+    def test_valid_params(self, backend: MemoryCacheAdapter) -> None:
         """Test creating a cache with valid parameters."""
         # Act
         cache = TTLCache(maxsize=100, ttl=60, backend=backend)
@@ -44,7 +44,7 @@ class TestInit:
         expected_maxsize = 100
         assert info.maxsize == expected_maxsize
 
-    def test_unlimited_maxsize(self, backend: MemoryCacheBackend) -> None:
+    def test_unlimited_maxsize(self, backend: MemoryCacheAdapter) -> None:
         """Test creating a cache with unlimited maxsize (maxsize=0)."""
         # Act
         cache = TTLCache(maxsize=0, ttl=60, backend=backend)
@@ -54,19 +54,19 @@ class TestInit:
         assert info.maxsize == 0
         assert info.currsize == 0
 
-    def test_negative_maxsize_raises(self, backend: MemoryCacheBackend) -> None:
+    def test_negative_maxsize_raises(self, backend: MemoryCacheAdapter) -> None:
         """Test that negative maxsize raises ValueError."""
         # Act / Assert
         with pytest.raises(ValueError, match="maxsize must be non-negative"):
             TTLCache(maxsize=-1, ttl=60, backend=backend)
 
-    def test_zero_ttl_raises(self, backend: MemoryCacheBackend) -> None:
+    def test_zero_ttl_raises(self, backend: MemoryCacheAdapter) -> None:
         """Test that zero ttl raises ValueError."""
         # Act / Assert
         with pytest.raises(ValueError, match="ttl must be positive"):
             TTLCache(maxsize=10, ttl=0, backend=backend)
 
-    def test_negative_ttl_raises(self, backend: MemoryCacheBackend) -> None:
+    def test_negative_ttl_raises(self, backend: MemoryCacheAdapter) -> None:
         """Test that negative ttl raises ValueError."""
         # Act / Assert
         with pytest.raises(ValueError, match="ttl must be positive"):
@@ -82,7 +82,7 @@ class TestInit:
         assert info.hits == 0
 
     async def test_default_backend_from_registry(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that TTLCache uses the registered backend when none is provided."""
         # Arrange: register the backend
@@ -108,7 +108,7 @@ class TestInit:
 class TestGetSet:
     """Test TTLCache get and set operations."""
 
-    async def test_set_and_get_bytes(self, backend: MemoryCacheBackend) -> None:
+    async def test_set_and_get_bytes(self, backend: MemoryCacheAdapter) -> None:
         """Test setting and getting raw bytes without a serializer."""
         # Arrange
         cache = TTLCache(maxsize=10, ttl=60, backend=backend)
@@ -121,7 +121,7 @@ class TestGetSet:
         assert result == b"hello"
 
     async def test_set_and_get_with_serializer(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test get/set round-trip using json serializer/deserializer."""
         # Arrange
@@ -140,7 +140,7 @@ class TestGetSet:
         assert result == {"x": 1}
 
     async def test_get_missing_key_returns_none(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test getting a missing key returns None by default."""
         # Arrange
@@ -153,7 +153,7 @@ class TestGetSet:
         assert result is None
 
     async def test_get_missing_key_with_default(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test getting a missing key returns the supplied default."""
         # Arrange
@@ -166,7 +166,7 @@ class TestGetSet:
         assert result == "fallback"
 
     async def test_set_overwrites_existing(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that setting an existing key overwrites the value."""
         # Arrange
@@ -182,7 +182,7 @@ class TestGetSet:
         assert cache.cache_info().currsize == 1
 
     async def test_set_non_bytes_without_serializer_raises(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that setting a non-bytes value without a serializer raises TypeError."""
         # Arrange
@@ -195,7 +195,7 @@ class TestGetSet:
             await cache.set("key", "not-bytes")
 
     async def test_set_invalid_per_entry_ttl_zero_raises(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that per-entry ttl=0 raises ValueError."""
         # Arrange
@@ -206,7 +206,7 @@ class TestGetSet:
             await cache.set("key", b"v", ttl=0)
 
     async def test_set_invalid_per_entry_ttl_negative_raises(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that negative per-entry ttl raises ValueError."""
         # Arrange
@@ -226,7 +226,7 @@ class TestExpiry:
     """Test TTLCache TTL expiry behavior."""
 
     async def test_entry_expires_at_ttl_boundary(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that an entry is gone once the TTL has elapsed."""
         # Arrange
@@ -245,7 +245,7 @@ class TestExpiry:
             assert await cache.get("key") is None
 
     async def test_per_entry_ttl_override(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that a per-entry TTL overrides the cache-level default."""
         # Arrange
@@ -264,7 +264,7 @@ class TestExpiry:
             assert await cache.get("key") is None
 
     async def test_expired_entry_counts_as_miss(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that a get on an expired entry increments misses, not hits."""
         # Arrange
@@ -297,7 +297,7 @@ class TestEviction:
     """Test TTLCache LRU eviction and maxsize enforcement."""
 
     async def test_lru_eviction_when_full(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that the least recently used entry is evicted when cache is full."""
         # Arrange
@@ -314,7 +314,7 @@ class TestEviction:
         assert await cache.get("c") == b"3"
 
     async def test_get_promotes_to_mru(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that get() promotes an entry to most-recently-used position."""
         # Arrange: a=LRU, b, c=MRU
@@ -334,7 +334,7 @@ class TestEviction:
         assert await cache.get("d") is not None
 
     async def test_overwrite_promotes_to_mru(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that overwriting an existing key promotes it to MRU."""
         # Arrange: a=LRU, b, c=MRU
@@ -354,7 +354,7 @@ class TestEviction:
         assert await cache.get("d") is not None
 
     async def test_unlimited_maxsize_no_eviction(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that maxsize=0 allows unlimited entries without eviction."""
         # Arrange
@@ -371,7 +371,7 @@ class TestEviction:
         assert info.currsize == 0
 
     async def test_evictions_tracked_in_cache_info(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that eviction count increments correctly in cache_info."""
         # Arrange
@@ -395,7 +395,7 @@ class TestDeleteClear:
     """Test TTLCache delete and clear operations."""
 
     async def test_delete_existing_key(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that deleting an existing key removes it from the cache."""
         # Arrange
@@ -410,7 +410,7 @@ class TestDeleteClear:
         assert cache.cache_info().currsize == 0
 
     async def test_delete_missing_key_is_noop(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that deleting a non-existent key does not raise."""
         # Arrange
@@ -420,7 +420,7 @@ class TestDeleteClear:
         await cache.delete("missing")
 
     async def test_delete_removes_from_lru_tracker(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that delete removes the key from the LRU tracking list."""
         # Arrange
@@ -435,7 +435,7 @@ class TestDeleteClear:
         assert cache.cache_info().currsize == 1
 
     async def test_clear_removes_all_entries(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that clear() removes all entries and resets LRU tracking."""
         # Arrange
@@ -460,7 +460,7 @@ class TestDeleteClear:
 class TestCacheInfo:
     """Test TTLCache cache_info statistics and CacheInfo immutability."""
 
-    def test_initial_stats(self, backend: MemoryCacheBackend) -> None:
+    def test_initial_stats(self, backend: MemoryCacheAdapter) -> None:
         """Test that a freshly created cache has zero stats."""
         # Arrange
         cache = TTLCache(maxsize=10, ttl=60, backend=backend)
@@ -474,7 +474,7 @@ class TestCacheInfo:
         )
 
     async def test_hits_and_misses_tracked(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that hits and misses accumulate correctly."""
         # Arrange
@@ -492,7 +492,7 @@ class TestCacheInfo:
         assert info.misses == 1
         assert info.currsize == 1
 
-    def test_cache_info_is_immutable(self, backend: MemoryCacheBackend) -> None:
+    def test_cache_info_is_immutable(self, backend: MemoryCacheAdapter) -> None:
         """Test that CacheInfo instances are frozen dataclasses."""
         # Arrange
         cache = TTLCache(maxsize=10, ttl=60, backend=backend)
@@ -503,7 +503,7 @@ class TestCacheInfo:
             info.hits = 99  # type: ignore[misc]  # ty: ignore[invalid-assignment]
 
     async def test_currsize_reflects_lru_tracker(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that currsize in cache_info reflects the LRU key list length."""
         # Arrange
@@ -518,7 +518,7 @@ class TestCacheInfo:
         assert cache.cache_info().currsize == expected_size
 
     async def test_currsize_zero_for_unlimited(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that currsize is 0 for unlimited caches (no LRU tracking)."""
         # Arrange
@@ -539,7 +539,7 @@ class TestCacheInfo:
 class TestSerializer:
     """Test TTLCache serializer and deserializer integration."""
 
-    async def test_json_round_trip(self, backend: MemoryCacheBackend) -> None:
+    async def test_json_round_trip(self, backend: MemoryCacheAdapter) -> None:
         """Test a full JSON serializer/deserializer round-trip."""
         # Arrange
         cache = TTLCache(
@@ -556,7 +556,7 @@ class TestSerializer:
         # Assert
         assert result == {"id": 42, "name": "alice"}
 
-    async def test_pickle_serializer(self, backend: MemoryCacheBackend) -> None:
+    async def test_pickle_serializer(self, backend: MemoryCacheAdapter) -> None:
         """Test serializing with PickleSerializer."""
         # Arrange
         cache = TTLCache(
@@ -575,7 +575,7 @@ class TestSerializer:
         assert result == expected
 
     async def test_no_serializer_bytes_pass_through(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that raw bytes are stored and returned unchanged without a serializer."""
         # Arrange
@@ -590,7 +590,7 @@ class TestSerializer:
         assert result == payload
 
     async def test_type_error_for_non_bytes_without_serializer(
-        self, backend: MemoryCacheBackend
+        self, backend: MemoryCacheAdapter
     ) -> None:
         """Test that storing a list without a serializer raises TypeError."""
         # Arrange

--- a/tests/sync/test_backends.py
+++ b/tests/sync/test_backends.py
@@ -15,11 +15,11 @@ from grelmicro.sync import use_backend
 from grelmicro.sync._backends import get_sync_backend, sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.errors import BackendNotLoadedError
-from grelmicro.sync.kubernetes import KubernetesSyncBackend
-from grelmicro.sync.memory import MemorySyncBackend
-from grelmicro.sync.postgres import PostgresSyncBackend
-from grelmicro.sync.redis import RedisSyncBackend
-from grelmicro.sync.sqlite import SQLiteSyncBackend
+from grelmicro.sync.kubernetes import KubernetesSyncAdapter
+from grelmicro.sync.memory import MemorySyncAdapter
+from grelmicro.sync.postgres import PostgresSyncAdapter
+from grelmicro.sync.redis import RedisSyncAdapter
+from grelmicro.sync.sqlite import SQLiteSyncAdapter
 
 pytestmark = [pytest.mark.timeout(30)]
 
@@ -157,22 +157,22 @@ async def backend(
     """Test Container for each Backend."""
     if backend_name == "redis" and container:
         port = container.get_exposed_port(6379)
-        async with RedisSyncBackend(f"redis://localhost:{port}/0") as backend:
+        async with RedisSyncAdapter(f"redis://localhost:{port}/0") as backend:
             yield backend
     elif backend_name == "postgres" and container:
         port = container.get_exposed_port(5432)
-        async with PostgresSyncBackend(
+        async with PostgresSyncAdapter(
             f"postgresql://test:test@localhost:{port}/test"
         ) as backend:
             yield backend
     elif backend_name == "memory":
-        async with MemorySyncBackend() as backend:
+        async with MemorySyncAdapter() as backend:
             yield backend
     elif backend_name == "sqlite":
-        async with SQLiteSyncBackend(":memory:") as backend:
+        async with SQLiteSyncAdapter(":memory:") as backend:
             yield backend
     elif backend_name == "kubernetes" and container:
-        async with KubernetesSyncBackend(namespace="default") as backend:
+        async with KubernetesSyncAdapter(namespace="default") as backend:
             yield backend
 
 
@@ -412,13 +412,13 @@ async def test_owned_another(backend: SyncBackend) -> None:
 @pytest.mark.parametrize(
     "backend_factory",
     [
-        MemorySyncBackend,
-        lambda: RedisSyncBackend("redis://localhost:6379/0"),
-        lambda: PostgresSyncBackend(
+        MemorySyncAdapter,
+        lambda: RedisSyncAdapter("redis://localhost:6379/0"),
+        lambda: PostgresSyncAdapter(
             "postgresql://user:password@localhost:5432/db"
         ),
-        lambda: SQLiteSyncBackend(":memory:"),
-        lambda: KubernetesSyncBackend(namespace="default"),
+        lambda: SQLiteSyncAdapter(":memory:"),
+        lambda: KubernetesSyncAdapter(namespace="default"),
     ],
 )
 @pytest.mark.usefixtures("clean_registry")
@@ -444,13 +444,13 @@ def test_get_sync_backend_not_loaded() -> None:
 @pytest.mark.parametrize(
     "backend_factory",
     [
-        MemorySyncBackend,
-        lambda: RedisSyncBackend("redis://localhost:6379/0"),
-        lambda: PostgresSyncBackend(
+        MemorySyncAdapter,
+        lambda: RedisSyncAdapter("redis://localhost:6379/0"),
+        lambda: PostgresSyncAdapter(
             "postgresql://user:password@localhost:5432/db"
         ),
-        lambda: SQLiteSyncBackend(":memory:"),
-        lambda: KubernetesSyncBackend(namespace="default"),
+        lambda: SQLiteSyncAdapter(":memory:"),
+        lambda: KubernetesSyncAdapter(namespace="default"),
     ],
 )
 @pytest.mark.usefixtures("clean_registry")

--- a/tests/sync/test_kubernetes.py
+++ b/tests/sync/test_kubernetes.py
@@ -15,7 +15,7 @@ from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.errors import SyncSettingsValidationError
 from grelmicro.sync.kubernetes import (
     _MAX_NAME_LENGTH,
-    KubernetesSyncBackend,
+    KubernetesSyncAdapter,
     _get_expire_at,
     _sanitize_lease_name,
 )
@@ -62,9 +62,9 @@ def _make_lease(
 
 def _make_mocked_backend(
     **client_overrides: AsyncMock,
-) -> KubernetesSyncBackend:
-    """Create a KubernetesSyncBackend with a mocked client."""
-    backend = KubernetesSyncBackend(namespace="default")
+) -> KubernetesSyncAdapter:
+    """Create a KubernetesSyncAdapter with a mocked client."""
+    backend = KubernetesSyncAdapter(namespace="default")
     mock_client = AsyncMock()
     for attr, mock in client_overrides.items():
         setattr(mock_client, attr, mock)
@@ -84,7 +84,7 @@ async def _async_iter(items: list) -> AsyncIterator:
 async def test_sync_backend_out_of_context_errors() -> None:
     """Test Synchronization Backend Out Of Context Errors."""
     # Arrange
-    backend = KubernetesSyncBackend(namespace="default")
+    backend = KubernetesSyncAdapter(namespace="default")
     name = "lock"
     key = "token"
 
@@ -110,7 +110,7 @@ def test_kubernetes_env_var_settings(
     monkeypatch.setenv("KUBE_NAMESPACE", "my-namespace")
 
     # Act
-    backend = KubernetesSyncBackend()
+    backend = KubernetesSyncAdapter()
 
     # Assert
     assert backend._namespace == "my-namespace"
@@ -123,7 +123,7 @@ def test_kubernetes_env_var_settings_validation_error() -> None:
         SyncSettingsValidationError,
         match=(r"Could not validate environment variables settings:\n"),
     ):
-        KubernetesSyncBackend()
+        KubernetesSyncAdapter()
 
 
 # --- Registration ---
@@ -133,7 +133,7 @@ def test_sync_backend_constructor_does_not_register() -> None:
     """Constructing the backend performs no registry writes."""
     sync_backend_registry.reset()
 
-    KubernetesSyncBackend(namespace="default")
+    KubernetesSyncAdapter(namespace="default")
 
     assert not sync_backend_registry.is_loaded
 
@@ -141,7 +141,7 @@ def test_sync_backend_constructor_does_not_register() -> None:
 def test_sync_backend_prefix() -> None:
     """Test Synchronization Backend Prefix."""
     # Act
-    backend = KubernetesSyncBackend(namespace="default", prefix="myapp-")
+    backend = KubernetesSyncAdapter(namespace="default", prefix="myapp-")
 
     # Assert
     assert backend._prefix == "myapp-"
@@ -227,7 +227,7 @@ def test_get_expire_at_computes_correctly() -> None:
 async def test_aenter_sets_client(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test __aenter__ creates an AsyncClient."""
     # Arrange
-    backend = KubernetesSyncBackend(namespace="default")
+    backend = KubernetesSyncAdapter(namespace="default")
     monkeypatch.setattr(
         "grelmicro.sync.kubernetes.AsyncClient",
         lambda **_kwargs: AsyncMock(),
@@ -416,7 +416,7 @@ async def test_owned_wrong_token() -> None:
     ids=["acquire", "release", "locked", "owned"],
 )
 async def test_raises_on_non_404_get_error(
-    method_caller: Callable[[KubernetesSyncBackend], Awaitable[bool]],
+    method_caller: Callable[[KubernetesSyncAdapter], Awaitable[bool]],
 ) -> None:
     """Test all methods re-raise non-404 API errors on GET."""
     # Arrange
@@ -531,7 +531,7 @@ async def test_aexit_cleanup_delete_errors(
 ) -> None:
     """Test __aexit__ error handling during cleanup delete."""
     # Arrange
-    backend = KubernetesSyncBackend(namespace="default")
+    backend = KubernetesSyncAdapter(namespace="default")
     expired_lease = _make_lease(expired=True)
     mock_client = AsyncMock()
     mock_client.list = MagicMock(return_value=_async_iter([expired_lease]))

--- a/tests/sync/test_leaderelection.py
+++ b/tests/sync/test_leaderelection.py
@@ -11,7 +11,7 @@ from pytest_mock import MockerFixture
 from grelmicro.errors import WouldBlockError as WouldBlock
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.leaderelection import LeaderElection, LeaderElectionConfig
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 from tests.task._helpers import cancel_group, start_task
 
 LEADER_NAME = "test_leader_election"
@@ -27,7 +27,7 @@ pytestmark = [pytest.mark.timeout(TEST_TIMEOUT)]
 @pytest.fixture
 def backend() -> SyncBackend:
     """Return Memory Synchronization Backend."""
-    return MemorySyncBackend()
+    return MemorySyncAdapter()
 
 
 @pytest.fixture

--- a/tests/sync/test_leaderelection_config.py
+++ b/tests/sync/test_leaderelection_config.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.leaderelection import LeaderElection, LeaderElectionConfig
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 
 LEASE_KWARG = 12.0
 RETRY_KWARG = 1.0
@@ -19,7 +19,7 @@ DEFAULT_RETRY = 2.0
 @pytest.fixture
 def backend() -> SyncBackend:
     """Return a memory backend usable without a running event loop."""
-    return MemorySyncBackend()
+    return MemorySyncAdapter()
 
 
 async def test_release_is_noop_when_backend_was_never_resolved() -> None:
@@ -39,7 +39,7 @@ def test_backend_property_resolves_on_every_call(
     mocker: MockerFixture,
 ) -> None:
     """`le.backend` consults the registry on each read so `sync.use(...)` overrides apply."""
-    backend_instance = MemorySyncBackend()
+    backend_instance = MemorySyncAdapter()
     spy = mocker.patch(
         "grelmicro.sync.leaderelection.get_sync_backend",
         return_value=backend_instance,

--- a/tests/sync/test_lock.py
+++ b/tests/sync/test_lock.py
@@ -19,7 +19,7 @@ from grelmicro.sync.errors import (
     LockReleaseError,
 )
 from grelmicro.sync.lock import Lock
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 
 pytestmark = [pytest.mark.timeout(1)]
 
@@ -34,7 +34,7 @@ BACKEND_LOCK_NAME = f"lock:{LOCK_NAME}"
 @pytest.fixture
 async def backend() -> AsyncGenerator[SyncBackend]:
     """Return Memory Synchronization Backend."""
-    async with MemorySyncBackend() as backend:
+    async with MemorySyncAdapter() as backend:
         yield backend
 
 

--- a/tests/sync/test_lock_config.py
+++ b/tests/sync/test_lock_config.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.lock import Lock, LockConfig
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 
 LEASE_KWARG = 30.0
 LEASE_ENV = 120.0
@@ -18,7 +18,7 @@ DEFAULT_RETRY = 0.1
 @pytest.fixture
 def backend() -> SyncBackend:
     """Return a memory backend usable without a running event loop."""
-    return MemorySyncBackend()
+    return MemorySyncAdapter()
 
 
 def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
@@ -32,7 +32,7 @@ def test_backend_property_resolves_on_every_call(
     mocker: MockerFixture,
 ) -> None:
     """`lock.backend` consults the registry on each read so `sync.use(...)` overrides apply."""
-    backend_instance = MemorySyncBackend()
+    backend_instance = MemorySyncAdapter()
     spy = mocker.patch(
         "grelmicro.sync.lock.get_sync_backend", return_value=backend_instance
     )

--- a/tests/sync/test_lock_release_ordering.py
+++ b/tests/sync/test_lock_release_ordering.py
@@ -13,7 +13,7 @@ from grelmicro.sync.errors import (
     LockReleaseError,
 )
 from grelmicro.sync.lock import Lock
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 
 pytestmark = [pytest.mark.timeout(1)]
 
@@ -24,7 +24,7 @@ WORKER = "worker_1"
 @pytest.fixture
 async def backend() -> AsyncGenerator[SyncBackend]:
     """Return a Memory sync backend."""
-    async with MemorySyncBackend() as backend:
+    async with MemorySyncAdapter() as backend:
         yield backend
 
 

--- a/tests/sync/test_module.py
+++ b/tests/sync/test_module.py
@@ -6,17 +6,17 @@ import pytest
 
 from grelmicro import Grelmicro, Module
 from grelmicro.sync import LeaderElection, Lock, Sync, TaskLock
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 
 
 def test_sync_satisfies_module_protocol() -> None:
     """`Sync` is a runtime-checkable `Module`."""
-    assert isinstance(Sync(MemorySyncBackend()), Module)
+    assert isinstance(Sync(MemorySyncAdapter()), Module)
 
 
 def test_sync_default_kind_and_name() -> None:
     """Default kind is `sync` and default name is `default`."""
-    sync = Sync(MemorySyncBackend())
+    sync = Sync(MemorySyncAdapter())
     assert sync.kind == "sync"
     assert sync.name == "default"
 
@@ -25,8 +25,8 @@ def test_sync_named_registration() -> None:
     """A named `Sync` module coexists with the default one."""
     micro = Grelmicro(
         uses=[
-            Sync(MemorySyncBackend()),
-            Sync(MemorySyncBackend(), name="analytics"),
+            Sync(MemorySyncAdapter()),
+            Sync(MemorySyncAdapter(), name="analytics"),
         ]
     )
     assert micro.get("sync", "default").name == "default"
@@ -35,7 +35,7 @@ def test_sync_named_registration() -> None:
 
 def test_sync_lock_factory_binds_backend() -> None:
     """`sync.lock(name)` creates a `Lock` bound to the wrapped backend."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     sync = Sync(backend)
     lock = sync.lock("cart")
     assert isinstance(lock, Lock)
@@ -44,7 +44,7 @@ def test_sync_lock_factory_binds_backend() -> None:
 
 def test_sync_task_lock_factory_binds_backend() -> None:
     """`sync.task_lock(name)` creates a `TaskLock` bound to the wrapped backend."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     sync = Sync(backend)
     task_lock = sync.task_lock("cleanup")
     assert isinstance(task_lock, TaskLock)
@@ -53,7 +53,7 @@ def test_sync_task_lock_factory_binds_backend() -> None:
 
 def test_sync_leader_election_factory_binds_backend() -> None:
     """`sync.leader_election(name)` creates a `LeaderElection` bound to the backend."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     sync = Sync(backend)
     election = sync.leader_election("primary")
     assert isinstance(election, LeaderElection)
@@ -62,14 +62,14 @@ def test_sync_leader_election_factory_binds_backend() -> None:
 
 def test_sync_backend_property() -> None:
     """`sync.backend` returns the wrapped backend."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     sync = Sync(backend)
     assert sync.backend is backend
 
 
 async def test_sync_opens_and_closes_backend_with_app() -> None:
     """`async with micro:` opens and closes the underlying backend."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     sync = Sync(backend)
     micro = Grelmicro(uses=[sync])
     async with micro, sync.lock("k"):
@@ -79,14 +79,14 @@ async def test_sync_opens_and_closes_backend_with_app() -> None:
 
 async def test_sync_lock_via_micro_attribute() -> None:
     """`micro.sync.lock(...)` is the conventional access path."""
-    micro = Grelmicro(uses=[Sync(MemorySyncBackend())])
+    micro = Grelmicro(uses=[Sync(MemorySyncAdapter())])
     async with micro, micro.sync.lock("cart"):
         pass
 
 
 async def test_use_auto_wraps_raw_sync_backend() -> None:
-    """`micro.use(MemorySyncBackend())` auto-wraps the backend in `Sync`."""
-    backend = MemorySyncBackend()
+    """`micro.use(MemorySyncAdapter())` auto-wraps the backend in `Sync`."""
+    backend = MemorySyncAdapter()
     micro = Grelmicro(uses=[backend])
     assert isinstance(micro.sync, Sync)
     assert micro.sync.backend is backend
@@ -94,7 +94,7 @@ async def test_use_auto_wraps_raw_sync_backend() -> None:
 
 async def test_use_auto_wrap_lifecycles_backend() -> None:
     """Auto-wrapped backend opens and closes with the app."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     micro = Grelmicro(uses=[backend])
     async with micro, micro.sync.lock("k"):
         pass
@@ -102,8 +102,8 @@ async def test_use_auto_wrap_lifecycles_backend() -> None:
 
 async def test_micro_sync_prefers_default_when_named_also_registered() -> None:
     """`micro.sync` resolves to the `(sync, default)` module even after named registrations."""
-    primary = MemorySyncBackend()
-    analytics = MemorySyncBackend()
+    primary = MemorySyncAdapter()
+    analytics = MemorySyncAdapter()
     micro = Grelmicro(
         uses=[
             Sync(primary),
@@ -115,7 +115,7 @@ async def test_micro_sync_prefers_default_when_named_also_registered() -> None:
 
 async def test_micro_sync_returns_sole_entry_when_no_default() -> None:
     """`micro.sync` returns the only registered Sync when no default exists."""
-    only = MemorySyncBackend()
+    only = MemorySyncAdapter()
     micro = Grelmicro(uses=[Sync(only, name="primary")])
     assert micro.sync.backend is only
 
@@ -124,8 +124,8 @@ async def test_micro_sync_raises_when_ambiguous() -> None:
     """`micro.sync` raises when multiple non-default modules exist with no default."""
     micro = Grelmicro(
         uses=[
-            Sync(MemorySyncBackend(), name="primary"),
-            Sync(MemorySyncBackend(), name="analytics"),
+            Sync(MemorySyncAdapter(), name="primary"),
+            Sync(MemorySyncAdapter(), name="analytics"),
         ]
     )
     with pytest.raises(AttributeError, match="multiple 'sync' modules"):
@@ -134,8 +134,8 @@ async def test_micro_sync_raises_when_ambiguous() -> None:
 
 async def test_sync_multi_backend_named_lookup() -> None:
     """Named `Sync` modules are reachable via `micro.get('sync', name)`."""
-    primary = MemorySyncBackend()
-    analytics = MemorySyncBackend()
+    primary = MemorySyncAdapter()
+    analytics = MemorySyncAdapter()
     micro = Grelmicro(
         uses=[
             Sync(primary),

--- a/tests/sync/test_postgres.py
+++ b/tests/sync/test_postgres.py
@@ -5,7 +5,7 @@ import pytest
 from grelmicro.errors import OutOfContextError
 from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.errors import SyncSettingsValidationError
-from grelmicro.sync.postgres import PostgresSyncBackend
+from grelmicro.sync.postgres import PostgresSyncAdapter
 
 pytestmark = [pytest.mark.timeout(1)]
 
@@ -29,13 +29,13 @@ def test_sync_backend_table_name_invalid(table_name: str) -> None:
     with pytest.raises(
         ValueError, match=r"Table name '.*' is not a valid SQL identifier"
     ):
-        PostgresSyncBackend(url=URL, table_name=table_name)
+        PostgresSyncAdapter(url=URL, table_name=table_name)
 
 
 async def test_sync_backend_out_of_context_errors() -> None:
     """Test Synchronization Backend Out Of Context Errors."""
     # Arrange
-    backend = PostgresSyncBackend(url=URL)
+    backend = PostgresSyncAdapter(url=URL)
     name = "lock"
     key = "token"
 
@@ -72,7 +72,7 @@ def test_postgres_env_var_settings(
         monkeypatch.setenv(key, value)
 
     # Act
-    backend = PostgresSyncBackend()
+    backend = PostgresSyncAdapter()
 
     # Assert
     assert backend._url == URL
@@ -108,14 +108,14 @@ def test_postgres_env_var_settings_validation_error(
         SyncSettingsValidationError,
         match=(r"Could not validate environment variables settings:\n"),
     ):
-        PostgresSyncBackend()
+        PostgresSyncAdapter()
 
 
 def test_sync_backend_constructor_does_not_register() -> None:
     """Constructing the backend performs no registry writes."""
     sync_backend_registry.reset()
 
-    PostgresSyncBackend(url=URL)
+    PostgresSyncAdapter(url=URL)
 
     assert not sync_backend_registry.is_loaded
 
@@ -123,7 +123,7 @@ def test_sync_backend_constructor_does_not_register() -> None:
 def test_sync_backend_custom_table_name() -> None:
     """Test Synchronization Backend Custom Table Name."""
     # Act
-    backend = PostgresSyncBackend(url=URL, table_name="my_locks")
+    backend = PostgresSyncAdapter(url=URL, table_name="my_locks")
 
     # Assert
     assert backend._table_name == "my_locks"
@@ -140,7 +140,7 @@ def test_postgres_env_var_settings_default_port(
     monkeypatch.setenv("POSTGRES_DB", "test_db")
 
     # Act
-    backend = PostgresSyncBackend()
+    backend = PostgresSyncAdapter()
 
     # Assert
     assert backend._url == URL_DEFAULT_PORT

--- a/tests/sync/test_redis.py
+++ b/tests/sync/test_redis.py
@@ -3,7 +3,7 @@
 import pytest
 
 from grelmicro.sync.errors import SyncSettingsValidationError
-from grelmicro.sync.redis import RedisSyncBackend
+from grelmicro.sync.redis import RedisSyncAdapter
 
 pytestmark = [pytest.mark.timeout(1)]
 
@@ -31,7 +31,7 @@ def test_redis_env_var_settings(
         monkeypatch.setenv(key, value)
 
     # Act
-    backend = RedisSyncBackend()
+    backend = RedisSyncAdapter()
 
     # Assert
     assert backend._url == URL
@@ -66,4 +66,4 @@ def test_redis_env_var_settings_validation_error(
         SyncSettingsValidationError,
         match=(r"Could not validate environment variables settings:\n"),
     ):
-        RedisSyncBackend()
+        RedisSyncAdapter()

--- a/tests/sync/test_sqlite.py
+++ b/tests/sync/test_sqlite.py
@@ -5,7 +5,7 @@ import pytest
 from grelmicro.errors import OutOfContextError
 from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.errors import SyncSettingsValidationError
-from grelmicro.sync.sqlite import SQLiteSyncBackend
+from grelmicro.sync.sqlite import SQLiteSyncAdapter
 
 pytestmark = [pytest.mark.timeout(1)]
 
@@ -26,13 +26,13 @@ def test_sync_backend_table_name_invalid(table_name: str) -> None:
     with pytest.raises(
         ValueError, match=r"Table name '.*' is not a valid SQL identifier"
     ):
-        SQLiteSyncBackend(path=":memory:", table_name=table_name)
+        SQLiteSyncAdapter(path=":memory:", table_name=table_name)
 
 
 async def test_sync_backend_out_of_context_errors() -> None:
     """Test Synchronization Backend Out Of Context Errors."""
     # Arrange
-    backend = SQLiteSyncBackend(path=":memory:")
+    backend = SQLiteSyncAdapter(path=":memory:")
     name = "lock"
     key = "token"
 
@@ -55,7 +55,7 @@ def test_sqlite_env_var_settings(
     monkeypatch.setenv("SQLITE_PATH", "locks.db")
 
     # Act
-    backend = SQLiteSyncBackend()
+    backend = SQLiteSyncAdapter()
 
     # Assert
     assert backend._path == "locks.db"
@@ -68,14 +68,14 @@ def test_sqlite_env_var_settings_validation_error() -> None:
         SyncSettingsValidationError,
         match=(r"Could not validate environment variables settings:\n"),
     ):
-        SQLiteSyncBackend()
+        SQLiteSyncAdapter()
 
 
 def test_sync_backend_constructor_does_not_register() -> None:
     """Constructing the backend performs no registry writes."""
     sync_backend_registry.reset()
 
-    SQLiteSyncBackend(path=":memory:")
+    SQLiteSyncAdapter(path=":memory:")
 
     assert not sync_backend_registry.is_loaded
 
@@ -83,7 +83,7 @@ def test_sync_backend_constructor_does_not_register() -> None:
 def test_sync_backend_custom_table_name() -> None:
     """Test Synchronization Backend Custom Table Name."""
     # Act
-    backend = SQLiteSyncBackend(path=":memory:", table_name="my_locks")
+    backend = SQLiteSyncAdapter(path=":memory:", table_name="my_locks")
 
     # Assert
     assert backend._table_name == "my_locks"

--- a/tests/sync/test_tasklock.py
+++ b/tests/sync/test_tasklock.py
@@ -19,7 +19,7 @@ from grelmicro.sync.errors import (
     LockReleaseError,
 )
 from grelmicro.sync.lock import Lock, LockConfig
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 from grelmicro.sync.tasklock import TaskLock, TaskLockConfig
 
 pytestmark = [pytest.mark.timeout(10)]
@@ -35,7 +35,7 @@ WORKER_2 = "worker_2"
 @pytest.fixture
 async def backend() -> AsyncGenerator[SyncBackend]:
     """Return Memory Synchronization Backend."""
-    async with MemorySyncBackend() as backend:
+    async with MemorySyncAdapter() as backend:
         yield backend
 
 

--- a/tests/sync/test_tasklock_config.py
+++ b/tests/sync/test_tasklock_config.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture
 
 from grelmicro.sync._backends import sync_backend_registry
 from grelmicro.sync.abc import SyncBackend
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 from grelmicro.sync.tasklock import TaskLock, TaskLockConfig
 
 MIN_KWARG = 5.0
@@ -19,7 +19,7 @@ DEFAULT_MAX = 60.0
 @pytest.fixture
 def backend() -> SyncBackend:
     """Return a memory backend usable without a running event loop."""
-    return MemorySyncBackend()
+    return MemorySyncAdapter()
 
 
 def test_construction_does_not_touch_registry(mocker: MockerFixture) -> None:
@@ -33,7 +33,7 @@ def test_backend_property_resolves_on_every_call(
     mocker: MockerFixture,
 ) -> None:
     """`task_lock.backend` consults the registry on each read so `sync.use(...)` overrides apply."""
-    backend_instance = MemorySyncBackend()
+    backend_instance = MemorySyncAdapter()
     spy = mocker.patch(
         "grelmicro.sync.tasklock.get_sync_backend",
         return_value=backend_instance,

--- a/tests/task/conftest.py
+++ b/tests/task/conftest.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator, Callable
 import pytest
 
 from grelmicro.sync.abc import SyncBackend
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 from grelmicro.sync.tasklock import TaskLock
 from grelmicro.task._interval import IntervalTask
 from tests.task import samples
@@ -78,7 +78,7 @@ def task_factory(request: pytest.FixtureRequest) -> TaskFactory:
 @pytest.fixture
 async def backend() -> AsyncGenerator[SyncBackend]:
     """Return Memory Synchronization Backend."""
-    async with MemorySyncBackend() as backend:
+    async with MemorySyncAdapter() as backend:
         yield backend
 
 

--- a/tests/task/test_router.py
+++ b/tests/task/test_router.py
@@ -6,7 +6,7 @@ from functools import partial
 import pytest
 
 from grelmicro.sync.lock import Lock
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 from grelmicro.task import TaskRouter
 from grelmicro.task._interval import IntervalTask
 from grelmicro.task.errors import FunctionTypeError, TaskAddOperationError
@@ -65,7 +65,7 @@ def test_router_interval() -> None:
     task_count = 4
     custom_task = EventTask()
     router = TaskRouter(tasks=[custom_task])
-    sync = Lock(backend=MemorySyncBackend(), name="testlock")
+    sync = Lock(backend=MemorySyncAdapter(), name="testlock")
 
     # Act
     router.interval(name="test1", seconds=10, sync=sync)(test1)
@@ -134,7 +134,7 @@ def test_router_interval_name_generation_error() -> None:
 def test_router_interval_with_lock() -> None:
     """Test Task Router add interval task with distributed lock."""
     # Arrange
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     router = TaskRouter()
 
     # Act
@@ -149,7 +149,7 @@ def test_router_interval_with_lock() -> None:
 def test_router_interval_with_lock_and_custom_least() -> None:
     """Test Task Router add interval task with custom min_lock_seconds."""
     # Arrange
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     router = TaskRouter()
 
     # Act

--- a/tests/task/test_scheduled.py
+++ b/tests/task/test_scheduled.py
@@ -9,7 +9,7 @@ from pytest_mock import MockFixture
 from grelmicro.sync.abc import SyncBackend
 from grelmicro.sync.leaderelection import LeaderElection
 from grelmicro.sync.lock import Lock
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 from grelmicro.task._interval import IntervalTask
 from tests.task import samples
 from tests.task._helpers import cancel_group, start_task
@@ -34,7 +34,7 @@ SLEEP = 0.01
 def test_interval_task_with_lock_init() -> None:
     """Test IntervalTask with lock initialization."""
     # Arrange
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     # Act
     task = IntervalTask(
         seconds=1, function=test1, max_lock_seconds=5, backend=backend
@@ -46,7 +46,7 @@ def test_interval_task_with_lock_init() -> None:
 def test_interval_task_with_lock_init_with_name() -> None:
     """Test IntervalTask with lock initialization with name."""
     # Arrange
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     # Act
     task = IntervalTask(
         seconds=1,
@@ -62,7 +62,7 @@ def test_interval_task_with_lock_init_with_name() -> None:
 def test_interval_task_with_lock_init_invalid_seconds() -> None:
     """Test IntervalTask with lock initialization with invalid seconds."""
     # Arrange
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     # Act / Assert
     with pytest.raises(ValueError, match="seconds must be greater than 0"):
         IntervalTask(
@@ -73,7 +73,7 @@ def test_interval_task_with_lock_init_invalid_seconds() -> None:
 def test_interval_task_with_lock_default_max_lock_seconds() -> None:
     """Test IntervalTask with leader uses default max_lock_seconds."""
     # Arrange
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     leader = LeaderElection("test-leader", backend=backend)
     # Act - leader implies lock, max_lock_seconds defaults to interval * 5
     task = IntervalTask(
@@ -86,7 +86,7 @@ def test_interval_task_with_lock_default_max_lock_seconds() -> None:
 def test_interval_task_with_lock_custom_max_lock_seconds() -> None:
     """Test IntervalTask with custom max_lock_seconds."""
     # Arrange
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     # Act
     task = IntervalTask(
         seconds=10, function=test1, max_lock_seconds=100, backend=backend
@@ -98,7 +98,7 @@ def test_interval_task_with_lock_custom_max_lock_seconds() -> None:
 def test_interval_task_with_max_lock_seconds_validation() -> None:
     """Test IntervalTask max_lock_seconds validation."""
     # Arrange
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     # Act / Assert
     with pytest.raises(
         ValueError,
@@ -120,7 +120,7 @@ def test_interval_task_min_lock_seconds_without_lock() -> None:
 
 def test_interval_task_min_lock_seconds_validation() -> None:
     """Test min_lock_seconds must be <= max_lock_seconds."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     with pytest.raises(
         ValueError,
         match="min_lock_seconds must be less than or equal to max_lock_seconds",
@@ -155,7 +155,7 @@ async def test_interval_task_with_lock_and_resource_lock(
 
 def test_interval_task_custom_min_lock_seconds() -> None:
     """Test IntervalTask with custom min_lock_seconds."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     # Act - should not raise
     task = IntervalTask(
         seconds=10,

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -17,8 +17,8 @@ from grelmicro._backends import (
     BackendNotLoadedError,
 )
 from grelmicro.cache._backends import cache_backend_registry
-from grelmicro.cache.memory import MemoryCacheBackend
-from grelmicro.cache.redis import RedisCacheBackend
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.health._backends import health_checks
 from grelmicro.health._checks import HealthChecks
 from grelmicro.resilience._backends import (
@@ -32,11 +32,11 @@ from grelmicro.resilience.memory import (
 from grelmicro.resilience.redis import RedisRateLimiterBackend
 from grelmicro.sync import Lock
 from grelmicro.sync._backends import sync_backend_registry
-from grelmicro.sync.kubernetes import KubernetesSyncBackend
-from grelmicro.sync.memory import MemorySyncBackend
-from grelmicro.sync.postgres import PostgresSyncBackend
-from grelmicro.sync.redis import RedisSyncBackend
-from grelmicro.sync.sqlite import SQLiteSyncBackend
+from grelmicro.sync.kubernetes import KubernetesSyncAdapter
+from grelmicro.sync.memory import MemorySyncAdapter
+from grelmicro.sync.postgres import PostgresSyncAdapter
+from grelmicro.sync.redis import RedisSyncAdapter
+from grelmicro.sync.sqlite import SQLiteSyncAdapter
 
 
 @pytest.fixture(autouse=True)
@@ -74,13 +74,13 @@ def mock_redis(mocker: MockerFixture) -> MagicMock:
 
 def test_sync_constructor_does_not_register() -> None:
     """Sync constructor does not register."""
-    MemorySyncBackend()
+    MemorySyncAdapter()
     assert not sync_backend_registry.is_loaded
 
 
 def test_cache_constructor_does_not_register() -> None:
     """Cache constructor does not register."""
-    MemoryCacheBackend()
+    MemoryCacheAdapter()
     assert not cache_backend_registry.is_loaded
 
 
@@ -95,13 +95,13 @@ def test_rate_limiter_constructor_does_not_register() -> None:
 
 async def test_sync_memory_async_with_does_not_register() -> None:
     """Sync memory async with does not register."""
-    async with MemorySyncBackend():
+    async with MemorySyncAdapter():
         assert not sync_backend_registry.is_loaded
 
 
 async def test_cache_memory_async_with_does_not_register() -> None:
     """Cache memory async with does not register."""
-    async with MemoryCacheBackend():
+    async with MemoryCacheAdapter():
         assert not cache_backend_registry.is_loaded
 
 
@@ -110,15 +110,15 @@ async def test_cache_memory_async_with_does_not_register() -> None:
 
 def test_register_and_get() -> None:
     """Register and get."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     sync_backend_registry.register(backend, "default")
     assert sync_backend_registry.get() is backend
 
 
 def test_register_named_and_get_by_name() -> None:
     """Register named and get by name."""
-    primary = MemorySyncBackend()
-    analytics = MemorySyncBackend()
+    primary = MemorySyncAdapter()
+    analytics = MemorySyncAdapter()
     sync_backend_registry.register(primary, "primary")
     sync_backend_registry.register(analytics, "analytics")
     assert sync_backend_registry.get("primary") is primary
@@ -127,22 +127,22 @@ def test_register_named_and_get_by_name() -> None:
 
 def test_get_default_falls_back_to_sole_entry() -> None:
     """Get default falls back to sole entry."""
-    only = MemorySyncBackend()
+    only = MemorySyncAdapter()
     sync_backend_registry.register(only, "primary")
     assert sync_backend_registry.get() is only
 
 
 def test_get_default_raises_when_multiple_no_default() -> None:
     """Get default raises when multiple no default."""
-    sync_backend_registry.register(MemorySyncBackend(), "primary")
-    sync_backend_registry.register(MemorySyncBackend(), "analytics")
+    sync_backend_registry.register(MemorySyncAdapter(), "primary")
+    sync_backend_registry.register(MemorySyncAdapter(), "analytics")
     with pytest.raises(BackendNotLoadedError, match="multiple"):
         sync_backend_registry.get()
 
 
 def test_register_same_instance_is_noop() -> None:
     """Register same instance is noop."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     sync_backend_registry.register(backend, "default")
     with warnings.catch_warnings():
         warnings.simplefilter("error")
@@ -152,15 +152,15 @@ def test_register_same_instance_is_noop() -> None:
 
 def test_register_different_instance_raises() -> None:
     """Register different instance raises BackendAlreadyRegisteredError."""
-    sync_backend_registry.register(MemorySyncBackend(), "default")
+    sync_backend_registry.register(MemorySyncAdapter(), "default")
     with pytest.raises(BackendAlreadyRegisteredError):
-        sync_backend_registry.register(MemorySyncBackend(), "default")
+        sync_backend_registry.register(MemorySyncAdapter(), "default")
 
 
 def test_unregister_with_identity_check() -> None:
     """Unregister with identity check."""
-    a = MemorySyncBackend()
-    b = MemorySyncBackend()
+    a = MemorySyncAdapter()
+    b = MemorySyncAdapter()
     sync_backend_registry.register(a, "default")
     sync_backend_registry.unregister("default", b)  # wrong instance: no-op
     assert sync_backend_registry.get() is a
@@ -179,8 +179,8 @@ def test_unregister_unknown_name_is_noop() -> None:
 
 def test_use_overrides_default() -> None:
     """Use overrides default."""
-    registered = MemorySyncBackend()
-    override = MemorySyncBackend()
+    registered = MemorySyncAdapter()
+    override = MemorySyncAdapter()
     sync_backend_registry.register(registered, "default")
     with sync_backend_registry.use(override):
         assert sync_backend_registry.get() is override
@@ -189,18 +189,18 @@ def test_use_overrides_default() -> None:
 
 def test_use_overrides_named() -> None:
     """Use overrides named."""
-    sync_backend_registry.register(MemorySyncBackend(), "primary")
-    sync_backend_registry.register(MemorySyncBackend(), "analytics")
-    fake_analytics = MemorySyncBackend()
+    sync_backend_registry.register(MemorySyncAdapter(), "primary")
+    sync_backend_registry.register(MemorySyncAdapter(), "analytics")
+    fake_analytics = MemorySyncAdapter()
     with sync_backend_registry.use(analytics=fake_analytics):
         assert sync_backend_registry.get("analytics") is fake_analytics
 
 
 def test_use_stacks_lifo() -> None:
     """Use stacks lifo."""
-    inner = MemorySyncBackend()
-    outer = MemorySyncBackend()
-    sync_backend_registry.register(MemorySyncBackend(), "default")
+    inner = MemorySyncAdapter()
+    outer = MemorySyncAdapter()
+    sync_backend_registry.register(MemorySyncAdapter(), "default")
     with sync_backend_registry.use(outer):
         with sync_backend_registry.use(inner):
             assert sync_backend_registry.get() is inner
@@ -212,8 +212,8 @@ def test_use_stacks_lifo() -> None:
 
 async def test_lifespan_opens_registered_backends() -> None:
     """Lifespan opens registered backends."""
-    sync_b = MemorySyncBackend()
-    cache_b = MemoryCacheBackend()
+    sync_b = MemorySyncAdapter()
+    cache_b = MemoryCacheAdapter()
     rl_b = MemoryRateLimiterBackend()
     sync_backend_registry.register(sync_b, "default")
     cache_backend_registry.register(cache_b, "default")
@@ -230,8 +230,8 @@ async def test_lifespan_opens_registered_backends() -> None:
 
 async def test_lifespan_excludes_module() -> None:
     """Lifespan excludes module."""
-    sync_backend_registry.register(MemorySyncBackend(), "default")
-    cache_backend_registry.register(MemoryCacheBackend(), "default")
+    sync_backend_registry.register(MemorySyncAdapter(), "default")
+    cache_backend_registry.register(MemoryCacheAdapter(), "default")
     with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
         cm = grelmicro.lifespan(exclude={"cache"})
     async with cm:
@@ -243,8 +243,8 @@ async def test_lifespan_excludes_module() -> None:
 
 async def test_lifespan_excludes_named_entry() -> None:
     """Lifespan excludes named entry."""
-    primary = MemorySyncBackend()
-    analytics = MemorySyncBackend()
+    primary = MemorySyncAdapter()
+    analytics = MemorySyncAdapter()
     sync_backend_registry.register(primary, "primary")
     sync_backend_registry.register(analytics, "analytics")
     with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
@@ -272,7 +272,7 @@ async def test_lifespan_excludes_resilience_module_key() -> None:
     cb = MemoryCircuitBreakerBackend()
     rate_limiter_backend_registry.register(rl, "default")
     circuit_breaker_backend_registry.register(cb, "default")
-    sync_backend_registry.register(MemorySyncBackend(), "default")
+    sync_backend_registry.register(MemorySyncAdapter(), "default")
     with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
         cm = grelmicro.lifespan(exclude={"resilience"})
     async with cm:
@@ -298,8 +298,8 @@ async def test_lifespan_excludes_specific_resilience_registry() -> None:
 
 def test_lock_resolves_named_backend_from_registry() -> None:
     """``Lock(backend="analytics")`` resolves the named entry on each call."""
-    primary = MemorySyncBackend()
-    analytics = MemorySyncBackend()
+    primary = MemorySyncAdapter()
+    analytics = MemorySyncAdapter()
     sync_backend_registry.register(primary, "primary")
     sync_backend_registry.register(analytics, "analytics")
 
@@ -309,8 +309,8 @@ def test_lock_resolves_named_backend_from_registry() -> None:
 
 def test_lock_named_backend_honors_use_override() -> None:
     """``sync.use(...)`` overrides a named backend selection per task."""
-    real_analytics = MemorySyncBackend()
-    fake_analytics = MemorySyncBackend()
+    real_analytics = MemorySyncAdapter()
+    fake_analytics = MemorySyncAdapter()
     sync_backend_registry.register(real_analytics, "analytics")
 
     lock = Lock("audit", backend="analytics")
@@ -324,7 +324,7 @@ def test_lock_named_backend_honors_use_override() -> None:
 
 async def test_lifespan_with_ad_hoc_backend() -> None:
     """Lifespan with ad hoc backend."""
-    ad_hoc = MemorySyncBackend()
+    ad_hoc = MemorySyncAdapter()
     with pytest.warns(DeprecationWarning, match="grelmicro.lifespan"):
         cm = grelmicro.lifespan(ad_hoc)
     async with cm:
@@ -339,7 +339,7 @@ async def test_sync_redis_async_with_round_trip(
     mock_redis: MagicMock,  # noqa: ARG001
 ) -> None:
     """Sync redis async with round trip."""
-    async with RedisSyncBackend("redis://localhost"):
+    async with RedisSyncAdapter("redis://localhost"):
         pass
 
 
@@ -354,13 +354,13 @@ async def test_sync_postgres_async_with_round_trip(
         "grelmicro.sync.postgres.create_pool",
         AsyncMock(return_value=mock_pool),
     )
-    async with PostgresSyncBackend("postgresql://localhost/db"):
+    async with PostgresSyncAdapter("postgresql://localhost/db"):
         pass
 
 
 async def test_sync_sqlite_async_with_round_trip(tmp_path) -> None:  # noqa: ANN001
     """Sync sqlite async with round trip."""
-    async with SQLiteSyncBackend(tmp_path / "lock.db"):
+    async with SQLiteSyncAdapter(tmp_path / "lock.db"):
         pass
 
 
@@ -380,7 +380,7 @@ async def test_sync_kubernetes_async_with_round_trip(
         "grelmicro.sync.kubernetes.AsyncClient",
         return_value=mock_client,
     )
-    async with KubernetesSyncBackend(namespace="default"):
+    async with KubernetesSyncAdapter(namespace="default"):
         pass
 
 
@@ -388,7 +388,7 @@ async def test_cache_redis_async_with_round_trip(
     mock_redis: MagicMock,  # noqa: ARG001
 ) -> None:
     """Cache redis async with round trip."""
-    async with RedisCacheBackend("redis://localhost"):
+    async with RedisCacheAdapter("redis://localhost"):
         pass
 
 
@@ -405,7 +405,7 @@ async def test_rate_limiter_redis_async_with_round_trip(
 
 def test_sync_use_backend_registers_default() -> None:
     """Sync use backend registers default."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     with pytest.warns(DeprecationWarning, match="grelmicro.sync"):
         sync_mod.use_backend(backend)
     assert sync_backend_registry.get() is backend
@@ -413,7 +413,7 @@ def test_sync_use_backend_registers_default() -> None:
 
 def test_cache_use_backend_registers_default() -> None:
     """Cache use backend registers default."""
-    backend = MemoryCacheBackend()
+    backend = MemoryCacheAdapter()
     with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
         cache_mod.use_backend(backend)
     assert cache_backend_registry.get() is backend
@@ -429,7 +429,7 @@ def test_resilience_use_backend_registers_default() -> None:
 
 def test_sync_register_and_unregister_module_helpers() -> None:
     """Sync register and unregister module helpers."""
-    backend = MemorySyncBackend()
+    backend = MemorySyncAdapter()
     with pytest.warns(DeprecationWarning, match="grelmicro.sync"):
         sync_mod.register(backend, "primary")
     assert sync_backend_registry.get("primary") is backend
@@ -440,8 +440,8 @@ def test_sync_register_and_unregister_module_helpers() -> None:
 
 def test_sync_use_module_helper() -> None:
     """Sync use module helper."""
-    sync_backend_registry.register(MemorySyncBackend(), "default")
-    override = MemorySyncBackend()
+    sync_backend_registry.register(MemorySyncAdapter(), "default")
+    override = MemorySyncAdapter()
     with pytest.warns(DeprecationWarning, match="grelmicro.sync"):
         cm = sync_mod.use(override)
     with cm:
@@ -450,11 +450,11 @@ def test_sync_use_module_helper() -> None:
 
 def test_cache_register_unregister_use_module_helpers() -> None:
     """Cache register, unregister, and use module helpers."""
-    backend = MemoryCacheBackend()
+    backend = MemoryCacheAdapter()
     with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
         cache_mod.register(backend, "primary")
     assert cache_backend_registry.get("primary") is backend
-    override = MemoryCacheBackend()
+    override = MemoryCacheAdapter()
     with pytest.warns(DeprecationWarning, match="grelmicro.cache"):
         cm = cache_mod.use(override)
     with cm:

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -8,7 +8,7 @@ from grelmicro import health as health_mod
 from grelmicro import resilience as resilience_mod
 from grelmicro import sync as sync_mod
 from grelmicro.cache._backends import cache_backend_registry
-from grelmicro.cache.memory import MemoryCacheBackend
+from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.health._backends import health_checks
 from grelmicro.health._checks import HealthChecks
 from grelmicro.resilience._backends import (
@@ -20,7 +20,7 @@ from grelmicro.resilience.memory import (
     MemoryRateLimiterBackend,
 )
 from grelmicro.sync._backends import sync_backend_registry
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 
 
 @pytest.fixture(autouse=True)
@@ -36,18 +36,18 @@ def _clean_registries() -> None:
 def test_sync_use_backend_warns() -> None:
     """`grelmicro.sync.use_backend` warns and points at `Grelmicro`."""
     with pytest.warns(DeprecationWarning, match="grelmicro.sync.use_backend"):
-        sync_mod.use_backend(MemorySyncBackend())
+        sync_mod.use_backend(MemorySyncAdapter())
 
 
 def test_sync_register_warns() -> None:
     """`grelmicro.sync.register` warns."""
     with pytest.warns(DeprecationWarning, match="grelmicro.sync.register"):
-        sync_mod.register(MemorySyncBackend(), "primary")
+        sync_mod.register(MemorySyncAdapter(), "primary")
 
 
 def test_sync_unregister_warns() -> None:
     """`grelmicro.sync.unregister` warns."""
-    sync_backend_registry.register(MemorySyncBackend(), "primary")
+    sync_backend_registry.register(MemorySyncAdapter(), "primary")
     with pytest.warns(DeprecationWarning, match="grelmicro.sync.unregister"):
         sync_mod.unregister("primary")
 
@@ -55,7 +55,7 @@ def test_sync_unregister_warns() -> None:
 def test_sync_use_warns() -> None:
     """`grelmicro.sync.use` warns."""
     with pytest.warns(DeprecationWarning, match="grelmicro.sync.use"):
-        cm = sync_mod.use(MemorySyncBackend())
+        cm = sync_mod.use(MemorySyncAdapter())
     with cm:
         pass
 
@@ -63,18 +63,18 @@ def test_sync_use_warns() -> None:
 def test_cache_use_backend_warns() -> None:
     """`grelmicro.cache.use_backend` warns."""
     with pytest.warns(DeprecationWarning, match="grelmicro.cache.use_backend"):
-        cache_mod.use_backend(MemoryCacheBackend())
+        cache_mod.use_backend(MemoryCacheAdapter())
 
 
 def test_cache_register_warns() -> None:
     """`grelmicro.cache.register` warns."""
     with pytest.warns(DeprecationWarning, match="grelmicro.cache.register"):
-        cache_mod.register(MemoryCacheBackend(), "primary")
+        cache_mod.register(MemoryCacheAdapter(), "primary")
 
 
 def test_cache_unregister_warns() -> None:
     """`grelmicro.cache.unregister` warns."""
-    cache_backend_registry.register(MemoryCacheBackend(), "primary")
+    cache_backend_registry.register(MemoryCacheAdapter(), "primary")
     with pytest.warns(DeprecationWarning, match="grelmicro.cache.unregister"):
         cache_mod.unregister("primary")
 
@@ -82,7 +82,7 @@ def test_cache_unregister_warns() -> None:
 def test_cache_use_warns() -> None:
     """`grelmicro.cache.use` warns."""
     with pytest.warns(DeprecationWarning, match="grelmicro.cache.use"):
-        cm = cache_mod.use(MemoryCacheBackend())
+        cm = cache_mod.use(MemoryCacheAdapter())
     with cm:
         pass
 

--- a/tests/test_env_opt_in.py
+++ b/tests/test_env_opt_in.py
@@ -4,7 +4,7 @@ import pytest
 
 from grelmicro._config import env_opt_in_enabled, resolve_config
 from grelmicro.sync.lock import Lock, LockConfig
-from grelmicro.sync.memory import MemorySyncBackend
+from grelmicro.sync.memory import MemorySyncAdapter
 
 LEASE_OVERRIDE = 999.0
 LEASE_FROM_ENV = 42.0
@@ -12,9 +12,9 @@ DEFAULT_LEASE = LockConfig.model_fields["lease_duration"].default
 
 
 @pytest.fixture
-def backend() -> MemorySyncBackend:
+def backend() -> MemorySyncAdapter:
     """Memory backend usable without an event loop."""
-    return MemorySyncBackend()
+    return MemorySyncAdapter()
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def test_env_opt_in_falsy_values(
 
 @pytest.mark.usefixtures("_no_env_opt_in")
 def test_env_ignored_when_flag_off(
-    backend: MemorySyncBackend,
+    backend: MemorySyncAdapter,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Without the global flag, env vars are not read."""
@@ -56,7 +56,7 @@ def test_env_ignored_when_flag_off(
 
 @pytest.mark.usefixtures("_no_env_opt_in")
 def test_per_call_read_env_true_overrides_flag_off(
-    backend: MemorySyncBackend,
+    backend: MemorySyncAdapter,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """`read_env=True` reads env even when the global flag is off."""
@@ -68,7 +68,7 @@ def test_per_call_read_env_true_overrides_flag_off(
 
 
 def test_per_call_read_env_false_overrides_flag_on(
-    backend: MemorySyncBackend,
+    backend: MemorySyncAdapter,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """`read_env=False` ignores env even when the global flag is on."""


### PR DESCRIPTION
## Summary

- Rename concrete backend implementations to `*Adapter`. Next item in the naming sweep tracked by #201.
- `MemorySyncBackend`, `RedisSyncBackend`, `PostgresSyncBackend`, `SQLiteSyncBackend`, `KubernetesSyncBackend` → `*SyncAdapter`.
- `MemoryCacheBackend`, `RedisCacheBackend` → `*CacheAdapter`.
- `SyncBackend` and `CacheBackend` Protocols stay as-is (Backend layer is Protocol-only per #201's locked vocabulary).
- No deprecation aliases (matching #221/#225, "iterating fast pre-1.0").
- Filenames unchanged. Env prefixes unchanged.
- Sweep across `grelmicro/`, `tests/`, `docs/`.

Part of #201.

## Test plan

- [x] `uv run pytest -m "not integration"` (1444 passed)
- [x] `uv run ruff check grelmicro/ tests/`
- [x] `uv run ruff format --check`
- [x] `uv run ty check grelmicro/`