### PR TITLE
📝 Rewrite quickstart example to use Grelmicro app API

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ from grelmicro import Grelmicro
 from grelmicro.cache import JsonSerializer, TTLCache, cached
 from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.health import HealthChecks
-from grelmicro.logging import configure_logging
+from grelmicro.log import configure as configure_logging
 from grelmicro.resilience import (
     CircuitBreaker,
     RateLimitExceededError,
@@ -203,7 +203,7 @@ The key shape:
 - **One container, one lifespan.** `Grelmicro(uses=[...])` lists every Adapter and active manager. `async with micro:` opens them all in order, closes in reverse.
 - **Adapters auto-register.** `RedisSyncAdapter(...)` becomes the default sync backend, `RedisCacheAdapter(...)` becomes the default cache backend. Use `Sync(adapter, name="...")` and `Cache(adapter, name="...")` for non-default names.
 - **Patterns are declared at module load.** `Lock("cart")`, `TTLCache(ttl=60)`, `CircuitBreaker("svc")` carry no backend reference. They resolve through the active app inside `async with`. The same `Lock` works in production with Redis and in tests with `MemorySyncAdapter`, no rewiring.
-- **No magic.** Every backend is explicit. `import grelmicro` imports nothing else. Tree-shaking works.
+- **Pay only for what you import.** `import grelmicro` does not pull in `redis`, `psycopg`, or any other vendor SDK. First-party Adapters live under `grelmicro.{kind}.{vendor}` and load only when you import them.
 
 For multiple Redis instances, separate names, or test overrides, see the [docs](https://grelinfo.github.io/grelmicro/).
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 
-import grelmicro
-from grelmicro import cache, resilience, sync
+from grelmicro import Grelmicro
 from grelmicro.cache import JsonSerializer, TTLCache, cached
 from grelmicro.cache.redis import RedisCacheAdapter
+from grelmicro.health import HealthChecks
 from grelmicro.logging import configure_logging
 from grelmicro.resilience import (
     CircuitBreaker,
@@ -109,23 +109,32 @@ from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
 
-# === grelmicro ===
-task = Tasks()
-sync.register(RedisSyncAdapter("redis://localhost:6379/0"))
-cache.register(RedisCacheAdapter("redis://localhost:6379/0", prefix="myapp:"))
-resilience.register(RedisRateLimiterBackend("redis://localhost:6379/0"))
+# === grelmicro app: one container, one lifespan ===
+tasks = Tasks()
+health = HealthChecks()
+leader = LeaderElection("leader-election")
+tasks.add_task(leader)
 
-leader_election = LeaderElection("leader-election")
-task.add_task(leader_election)
+micro = Grelmicro(uses=[
+    RedisSyncAdapter("redis://localhost:6379/0"),
+    RedisCacheAdapter("redis://localhost:6379/0", prefix="myapp:"),
+    RedisRateLimiterBackend("redis://localhost:6379/0"),
+    tasks,
+    health,
+])
 
+# === Patterns declared once at module load, resolved at use time ===
 ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer())
+lock = Lock("shared-resource")
+cb = CircuitBreaker("my-service")
+api_limiter = RateLimiter.gcra("api", limit=100, window=60)
 
 
-# === FastAPI ===
+# === FastAPI lifespan ===
 @asynccontextmanager
 async def lifespan(app):
     configure_logging()
-    async with grelmicro.lifespan(task):
+    async with micro:
         yield
 
 
@@ -144,9 +153,6 @@ async def read_user(user_id: int):
 
 
 # --- Circuit Breaker: protect calls to an unreliable service ---
-cb = CircuitBreaker("my-service")
-
-
 @app.get("/")
 async def read_root():
     async with cb:
@@ -154,9 +160,6 @@ async def read_root():
 
 
 # --- Rate Limiter: protect endpoints from overload ---
-api_limiter = RateLimiter.gcra("api", limit=100, window=60)
-
-
 @app.get("/api")
 async def api_endpoint(request: Request):
     try:
@@ -171,9 +174,6 @@ async def api_endpoint(request: Request):
 
 
 # --- Distributed Lock: synchronize access to a shared resource ---
-lock = Lock("shared-resource")
-
-
 @app.get("/protected")
 async def protected():
     async with lock:
@@ -181,22 +181,31 @@ async def protected():
 
 
 # --- Interval Task: run locally on every worker ---
-@task.interval(seconds=5)
+@tasks.interval(seconds=5)
 def heartbeat():
     logger.info("heartbeat")
 
 
 # --- Distributed Task: run once per interval across all workers ---
-@task.interval(seconds=60, max_lock_seconds=300)
+@tasks.interval(seconds=60, max_lock_seconds=300)
 def cleanup():
     logger.info("cleanup")
 
 
 # --- Leader-gated Task: only the leader executes ---
-@task.interval(seconds=10, leader=leader_election)
+@tasks.interval(seconds=10, leader=leader)
 def leader_only_task():
     logger.info("leader task")
 ```
+
+The key shape:
+
+- **One container, one lifespan.** `Grelmicro(uses=[...])` lists every Adapter and active manager. `async with micro:` opens them all in order, closes in reverse.
+- **Adapters auto-register.** `RedisSyncAdapter(...)` becomes the default sync backend, `RedisCacheAdapter(...)` becomes the default cache backend. Use `Sync(adapter, name="...")` and `Cache(adapter, name="...")` for non-default names.
+- **Patterns are declared at module load.** `Lock("cart")`, `TTLCache(ttl=60)`, `CircuitBreaker("svc")` carry no backend reference. They resolve through the active app inside `async with`. The same `Lock` works in production with Redis and in tests with `MemorySyncAdapter`, no rewiring.
+- **No magic.** Every backend is explicit. `import grelmicro` imports nothing else. Tree-shaking works.
+
+For multiple Redis instances, separate names, or test overrides, see the [docs](https://grelinfo.github.io/grelmicro/).
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ from grelmicro import Grelmicro
 from grelmicro.cache import JsonSerializer, TTLCache, cached
 from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.health import HealthChecks
-from grelmicro.logging import configure_logging
+from grelmicro.log import configure as configure_logging
 from grelmicro.resilience import (
     CircuitBreaker,
     RateLimitExceededError,
@@ -203,7 +203,7 @@ The key shape:
 - **One container, one lifespan.** `Grelmicro(uses=[...])` lists every Adapter and active manager. `async with micro:` opens them all in order, closes in reverse.
 - **Adapters auto-register.** `RedisSyncAdapter(...)` becomes the default sync backend, `RedisCacheAdapter(...)` becomes the default cache backend. Use `Sync(adapter, name="...")` and `Cache(adapter, name="...")` for non-default names.
 - **Patterns are declared at module load.** `Lock("cart")`, `TTLCache(ttl=60)`, `CircuitBreaker("svc")` carry no backend reference. They resolve through the active app inside `async with`. The same `Lock` works in production with Redis and in tests with `MemorySyncAdapter`, no rewiring.
-- **No magic.** Every backend is explicit. `import grelmicro` imports nothing else. Tree-shaking works.
+- **Pay only for what you import.** `import grelmicro` does not pull in `redis`, `psycopg`, or any other vendor SDK. First-party Adapters live under `grelmicro.{kind}.{vendor}` and load only when you import them.
 
 For multiple Redis instances, separate names, or test overrides, see the [docs](https://grelinfo.github.io/grelmicro/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,10 +92,10 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 
-import grelmicro
-from grelmicro import cache, resilience, sync
+from grelmicro import Grelmicro
 from grelmicro.cache import JsonSerializer, TTLCache, cached
 from grelmicro.cache.redis import RedisCacheAdapter
+from grelmicro.health import HealthChecks
 from grelmicro.logging import configure_logging
 from grelmicro.resilience import (
     CircuitBreaker,
@@ -109,23 +109,32 @@ from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
 
-# === grelmicro ===
-task = Tasks()
-sync.register(RedisSyncAdapter("redis://localhost:6379/0"))
-cache.register(RedisCacheAdapter("redis://localhost:6379/0", prefix="myapp:"))
-resilience.register(RedisRateLimiterBackend("redis://localhost:6379/0"))
+# === grelmicro app: one container, one lifespan ===
+tasks = Tasks()
+health = HealthChecks()
+leader = LeaderElection("leader-election")
+tasks.add_task(leader)
 
-leader_election = LeaderElection("leader-election")
-task.add_task(leader_election)
+micro = Grelmicro(uses=[
+    RedisSyncAdapter("redis://localhost:6379/0"),
+    RedisCacheAdapter("redis://localhost:6379/0", prefix="myapp:"),
+    RedisRateLimiterBackend("redis://localhost:6379/0"),
+    tasks,
+    health,
+])
 
+# === Patterns declared once at module load, resolved at use time ===
 ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer())
+lock = Lock("shared-resource")
+cb = CircuitBreaker("my-service")
+api_limiter = RateLimiter.gcra("api", limit=100, window=60)
 
 
-# === FastAPI ===
+# === FastAPI lifespan ===
 @asynccontextmanager
 async def lifespan(app):
     configure_logging()
-    async with grelmicro.lifespan(task):
+    async with micro:
         yield
 
 
@@ -144,9 +153,6 @@ async def read_user(user_id: int):
 
 
 # --- Circuit Breaker: protect calls to an unreliable service ---
-cb = CircuitBreaker("my-service")
-
-
 @app.get("/")
 async def read_root():
     async with cb:
@@ -154,9 +160,6 @@ async def read_root():
 
 
 # --- Rate Limiter: protect endpoints from overload ---
-api_limiter = RateLimiter.gcra("api", limit=100, window=60)
-
-
 @app.get("/api")
 async def api_endpoint(request: Request):
     try:
@@ -171,9 +174,6 @@ async def api_endpoint(request: Request):
 
 
 # --- Distributed Lock: synchronize access to a shared resource ---
-lock = Lock("shared-resource")
-
-
 @app.get("/protected")
 async def protected():
     async with lock:
@@ -181,22 +181,31 @@ async def protected():
 
 
 # --- Interval Task: run locally on every worker ---
-@task.interval(seconds=5)
+@tasks.interval(seconds=5)
 def heartbeat():
     logger.info("heartbeat")
 
 
 # --- Distributed Task: run once per interval across all workers ---
-@task.interval(seconds=60, max_lock_seconds=300)
+@tasks.interval(seconds=60, max_lock_seconds=300)
 def cleanup():
     logger.info("cleanup")
 
 
 # --- Leader-gated Task: only the leader executes ---
-@task.interval(seconds=10, leader=leader_election)
+@tasks.interval(seconds=10, leader=leader)
 def leader_only_task():
     logger.info("leader task")
 ```
+
+The key shape:
+
+- **One container, one lifespan.** `Grelmicro(uses=[...])` lists every Adapter and active manager. `async with micro:` opens them all in order, closes in reverse.
+- **Adapters auto-register.** `RedisSyncAdapter(...)` becomes the default sync backend, `RedisCacheAdapter(...)` becomes the default cache backend. Use `Sync(adapter, name="...")` and `Cache(adapter, name="...")` for non-default names.
+- **Patterns are declared at module load.** `Lock("cart")`, `TTLCache(ttl=60)`, `CircuitBreaker("svc")` carry no backend reference. They resolve through the active app inside `async with`. The same `Lock` works in production with Redis and in tests with `MemorySyncAdapter`, no rewiring.
+- **No magic.** Every backend is explicit. `import grelmicro` imports nothing else. Tree-shaking works.
+
+For multiple Redis instances, separate names, or test overrides, see the [docs](https://grelinfo.github.io/grelmicro/).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Replace the deprecated `sync.register(...)` / `cache.register(...)` / `resilience.register(...)` style with the locked `Grelmicro(uses=[...])` shape, in both `README.md` and `docs/index.md` (the latter is auto-synced from README via the `readme-to-docs` pre-commit hook).
- Add a four-bullet "key shape" recap below the snippet: one container per app, auto-registered adapters, module-level Patterns, no magic.
- Drop the `import grelmicro` + `grelmicro.lifespan(task)` pair in favor of `async with micro:`.
- Wire `HealthChecks()` into the app for parity with `Tasks()`.

The example now matches the locked architecture (#201, #220, #222) and exercises ambient resolution: `Lock("shared-resource")`, `TTLCache(...)`, `CircuitBreaker("my-service")` declared at module load, resolved through the active `Grelmicro` at use time.

Spec for the surrounding decisions lives in the Obsidian design study (vault path `2 Areas/Software Engineering/Architecture/Grelmicro Design Study/`), updated alongside this PR with new docs `16 Market Research`, `17 Pattern Roadmap to 1.0`, `18 Env Flag Migration`, `19 Module to Component Rename`, `20 Backend Entry Points`, `21 Test Ergonomics`, `22 Strategic Positioning`, and `23 Decision Sheet` (the one-page decision sheet for review).

## Test plan

- [x] `pre-commit` (ruff, codespell, readme-to-docs, ty, pytest unit + integration, coverage) all green
- [ ] Verify rendered README on GitHub
- [ ] Verify docs site `index` page renders the new example
- [ ] Spot-check that the snippet imports cleanly under the current API (`Grelmicro`, `Tasks`, `HealthChecks`, `RedisSyncAdapter`, `RedisCacheAdapter`, `RedisRateLimiterBackend`, `Lock`, `LeaderElection`, `TTLCache`, `CircuitBreaker`, `RateLimiter`)