### PR TITLE
🐛 Fix stale grelmicro.logging.uvicorn import path in uvicorn log config snippet

### DIFF
--- a/docs/snippets/log/uvicorn_log_config.json
+++ b/docs/snippets/log/uvicorn_log_config.json
@@ -3,10 +3,10 @@
   "disable_existing_loggers": false,
   "formatters": {
     "default": {
-      "()": "grelmicro.logging.uvicorn.UvicornFormatter"
+      "()": "grelmicro.log.uvicorn.UvicornFormatter"
     },
     "access": {
-      "()": "grelmicro.logging.uvicorn.UvicornAccessFormatter"
+      "()": "grelmicro.log.uvicorn.UvicornAccessFormatter"
     }
   },
   "handlers": {


### PR DESCRIPTION
## Summary

- The Uvicorn integration snippet referenced the pre-rename module path `grelmicro.logging.uvicorn.UvicornFormatter` / `UvicornAccessFormatter`. The package was renamed to `grelmicro.log` in #135 (changelog 0.16.x), so the JSON config raises `ModuleNotFoundError` when handed to `uvicorn --log-config`.
- Fix the two `()` references to `grelmicro.log.uvicorn.*`. Verified the formatters exist at `grelmicro/log/uvicorn.py:33` (`UvicornFormatter`) and `grelmicro/log/uvicorn.py:76` (`UvicornAccessFormatter`).
- Drive-by find while reviewing PR #229 (Copilot caught the same kind of stale path in the README quickstart). Sweep `docs/` confirmed no other `grelmicro.logging` references survive outside the changelog historical entry (which correctly preserves the old name).

## Test plan

- [x] `pre-commit` (codespell, uv-lock, pytest unit + integration, coverage) green
- [ ] Verify the rendered `docs/logging.md` page (where the snippet is included via `--8<-- "log/uvicorn_log_config.json"` at line 334) picks up the corrected JSON