### PR TITLE
📝 Rewrite Retry docs without external attribution

### DIFF
--- a/docs/resilience/retry.md
+++ b/docs/resilience/retry.md
@@ -42,13 +42,22 @@ polling = Retry.constant("wait_job", on=NotReady, attempts=20, delay=1.0)
 
 ### Exponential
 
-Delay before retry `N` is `min(base_delay * 2 ** (N - 1), max_delay)`, then jittered. The defaults follow the AWS recipe: `base_delay=0.1`, `max_delay=30.0`, `jitter="full"`.
+Each retry waits twice as long as the previous one, capped at `max_delay`. The wait before retry `N` is `min(base_delay * 2 ** (N - 1), max_delay)`.
 
-| Jitter | Behavior |
-|---|---|
-| `none` | Use the raw computed delay. |
-| `full` | Sample uniformly from `[0, raw]`. AWS recipe. |
-| `decorrelated` | Chain samples across attempts. Use under high contention. |
+With the defaults (`base_delay=0.1`, `max_delay=30.0`), the wait doubles: `0.1s`, `0.2s`, `0.4s`, `0.8s`, `1.6s`, ..., capped at `30.0s`.
+
+#### Jitter
+
+**Jitter** is randomness added to the wait so concurrent clients do not retry at the same instant and overwhelm the recovering server.
+
+Pick a mode by how much spread you want. Default: `full`.
+
+| Jitter | Spread | When to use |
+|---|---|---|
+| `none` | none | Single client. Never with concurrency. |
+| `full` (default) | maximum | The safe default. |
+| `equal` | half | When you need predictable timing. |
+| `decorrelated` | adaptive | High contention on a shared dependency. |
 
 ### Constant
 

--- a/docs/resilience/retry.md
+++ b/docs/resilience/retry.md
@@ -42,9 +42,9 @@ polling = Retry.constant("wait_job", on=NotReady, attempts=20, delay=1.0)
 
 ### Exponential
 
-Each retry waits twice as long as the previous one, capped at `max_delay`. The wait before retry `N` is `min(base_delay * 2 ** (N - 1), max_delay)`.
+The raw wait before retry `N` is `min(base_delay * 2 ** (N - 1), max_delay)`. It doubles each attempt until it reaches the cap. With the defaults (`base_delay=0.1`, `max_delay=30.0`), the raw wait is `0.1s`, `0.2s`, `0.4s`, `0.8s`, `1.6s`, ..., capped at `30.0s`.
 
-With the defaults (`base_delay=0.1`, `max_delay=30.0`), the wait doubles: `0.1s`, `0.2s`, `0.4s`, `0.8s`, `1.6s`, ..., capped at `30.0s`.
+Jitter then transforms each raw wait into the actual sleep (see [Jitter](#jitter) below). The actual sleep may be smaller than the raw value.
 
 #### Jitter
 

--- a/grelmicro/resilience/backoffs/exponential.py
+++ b/grelmicro/resilience/backoffs/exponential.py
@@ -10,10 +10,9 @@ from typing_extensions import Doc
 class ExponentialBackoffConfig(BaseModel, frozen=True, extra="forbid"):
     """Exponential backoff with optional jitter.
 
-    The delay before retry ``N`` is
-    ``min(base_delay * 2 ** (N - 1), max_delay)``, then jittered
-    according to ``jitter``. This is the AWS-recommended recipe
-    for HTTP and network retries.
+    Each retry waits twice as long as the previous one, capped at
+    ``max_delay``. The raw delay is then transformed by ``jitter``
+    so concurrent callers do not retry in lockstep.
 
     Example:
     ```python
@@ -47,12 +46,13 @@ class ExponentialBackoffConfig(BaseModel, frozen=True, extra="forbid"):
     jitter: Annotated[
         Literal["none", "full", "equal", "decorrelated"],
         Doc(
-            "Jitter mode. ``full`` is the AWS recipe and the safest "
-            "default for retry storms (samples from ``[0, raw]``). "
-            "``equal`` is AWS's smoother variant (``raw/2 + "
-            "random(0, raw/2)``), keeps growth predictable. "
-            "``decorrelated`` chains samples across attempts for "
-            "high-contention systems. ``none`` disables jitter."
+            "Jitter mode. ``full`` (default) samples from "
+            "``[0, raw]`` and is the safest choice against retry "
+            "storms. ``equal`` samples from ``[raw/2, raw]`` and "
+            "keeps timing more predictable. ``decorrelated`` "
+            "chains samples across attempts and is best for many "
+            "clients hitting the same recovering dependency. "
+            "``none`` disables jitter."
         ),
     ] = "full"
 

--- a/grelmicro/resilience/backoffs/exponential.py
+++ b/grelmicro/resilience/backoffs/exponential.py
@@ -10,9 +10,11 @@ from typing_extensions import Doc
 class ExponentialBackoffConfig(BaseModel, frozen=True, extra="forbid"):
     """Exponential backoff with optional jitter.
 
-    Each retry waits twice as long as the previous one, capped at
-    ``max_delay``. The raw delay is then transformed by ``jitter``
-    so concurrent callers do not retry in lockstep.
+    The raw delay before retry ``N`` is
+    ``min(base_delay * 2 ** (N - 1), max_delay)``: it doubles each
+    attempt until it reaches the cap. ``jitter`` then transforms
+    that raw delay so concurrent callers do not retry in lockstep
+    (the actual sleep may be smaller than the raw value).
 
     Example:
     ```python


### PR DESCRIPTION
## Summary

- Strip every "AWS recipe" / "AWS-recommended" attribution from `docs/resilience/retry.md` and `grelmicro/resilience/backoffs/exponential.py`.
- Rewrite the Exponential section in FastAPI style: prose first ("each retry waits twice as long as the previous one"), then the precise formula `min(base_delay * 2 ** (N - 1), max_delay)`, then a worked example with the defaults.
- Define **jitter** from scratch with the thundering-herd motivation. Reduce the jitter table to three columns (mode, spread, when to use) so it stays scannable.
- Same prose treatment in the `ExponentialBackoffConfig` docstring and the `jitter` field `Doc(...)`.

## Why

User-facing docs and docstrings should describe behavior on their own terms, not by appeal to authority. A reader who already knows the AWS recipe gains nothing from the namedrop. A reader who does not gains a shrug.

## Test plan

- [x] `grep -rn "AWS\|Polly\|Tokio" docs/ grelmicro/ | grep -v changelog.md | grep -v comparison.md` returns nothing.
- [x] `pytest tests/resilience/backoffs/test_exponential.py` (7 tests, no behavior change).
- [x] Pre-commit suite passes (lint, ty, full unit + integration tests, coverage).