### PR TITLE
🎨 Move docs h1-hide CSS out of README into overrides.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,3 @@
-<!-- Visually hide the auto-generated h1 on the docs landing page. The wordmark is the title; the heading stays in the a11y tree for screen readers. GitHub strips <style> from rendered READMEs, so this is a no-op there. -->
-<style>
-  .md-content .md-typeset > h1:first-child {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-</style>
-
 <p align="center">
   <a href="https://grelinfo.github.io/grelmicro">
     <img alt="grelmicro" class="grel-wordmark" src="docs/img/logo/wordmark.svg" width="360">

--- a/docs/css/overrides.css
+++ b/docs/css/overrides.css
@@ -96,3 +96,19 @@
   white-space: nowrap;
   word-break: keep-all;
 }
+
+/* Visually hide the auto-generated h1 that lands before the wordmark on
+   pages that open with `<p align="center"><img class="grel-wordmark" ...>`.
+   The wordmark image stands in for the title; the h1 stays in the a11y
+   tree for screen readers. */
+.md-content .md-typeset > h1:first-child {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,3 @@
-<!-- Visually hide the auto-generated h1 on the docs landing page. The wordmark is the title; the heading stays in the a11y tree for screen readers. GitHub strips <style> from rendered READMEs, so this is a no-op there. -->
-<style>
-  .md-content .md-typeset > h1:first-child {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-</style>
-
 <p align="center">
   <a href="https://grelinfo.github.io/grelmicro">
     <img alt="grelmicro" class="grel-wordmark" src="img/logo/wordmark.svg" width="360">


### PR DESCRIPTION
## Summary

The `<style>` block at the top of `README.md` was meant to be a no-op on GitHub and a CSS rule on the mkdocs site. Turns out **GitHub does render it visibly** (the comment claiming GitHub strips `<style>` was wrong). Move the rule into `docs/css/overrides.css` (already loaded via `extra_css` in `mkdocs.yml`) and strip the block from the README.

## Effect

| Surface | Before | After |
|---|---|---|
| **GitHub README** | raw `<style>` block visible at the top | clean, starts with the wordmark |
| **PyPI README** | PyPI strips `<style>` for security (no-op already) | unchanged (still no-op, rule no longer present) |
| **mkdocs docs site** | rule applied via inline `<style>` | rule applied via `overrides.css` (preserved) |

## Test plan

- [x] `bash -c "sed -e 's|(docs/|(|g' -e 's|=\"docs/|=\"|g' README.md > docs/index.md"` produces a clean `docs/index.md`.
- [x] `docs/css/overrides.css` carries the rule with a clarifying comment.
- [x] Pre-commit clean.