### PR TITLE
🐛 Scope landing-page h1-hide to wordmark pages only

### DIFF
--- a/docs/css/overrides.css
+++ b/docs/css/overrides.css
@@ -97,11 +97,11 @@
   word-break: keep-all;
 }
 
-/* Visually hide the auto-generated h1 that lands before the wordmark on
-   pages that open with `<p align="center"><img class="grel-wordmark" ...>`.
-   The wordmark image stands in for the title; the h1 stays in the a11y
-   tree for screen readers. */
-.md-content .md-typeset > h1:first-child {
+/* Visually hide the auto-generated h1 only on pages that carry the
+   wordmark image (the landing page). The wordmark stands in for the
+   title. The h1 stays in the a11y tree for screen readers. Other docs
+   pages keep their visible page titles. */
+.md-content .md-typeset:has(img.grel-wordmark) > h1:first-child {
   position: absolute;
   width: 1px;
   height: 1px;


### PR DESCRIPTION
## Summary

PR #244 added a CSS rule to hide the auto-generated `h1` on the landing page, but the selector `.md-content .md-typeset > h1:first-child` matches every docs page (cache, config, comparison, ...) since they all open with a `# Title`. Result: page titles disappeared site-wide.

This scopes the rule to pages that actually carry the wordmark image via `:has(img.grel-wordmark)`, so only the landing page is affected. Verified locally with `mkdocs build`: `site/index.html` carries the wordmark, other pages do not.

Caught by Copilot review on #244.

## Test plan

- [ ] `mkdocs serve` and confirm the landing page hides its `h1` while other docs pages (cache, config, comparison) keep their visible `# Title` headings.