### PR TITLE
📝 Polish docstrings, changelog, and comparison page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,8 +220,8 @@ notes.
   that delivers it.
 - **Name technologies we integrate with** (FastAPI, Redis,
   PostgreSQL, Kubernetes, OpenTelemetry). Do not drop vendor
-  names for flavour or comparison ("like zerolog", "in the
-  Stripe style"). Industry concept names (JSON, sliding window,
+  names for flavour or comparison ("like <other library>",
+  "in the <vendor> style"). Industry concept names (JSON, sliding window,
   token bucket) are fine.
 - **Compact shorthand is fine inside code blocks** (`~3x`, `1:1`,
   `1/sec`), but expand it in prose ("about 3 times faster",

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -34,20 +34,6 @@ Adaptations for grelmicro:
 Copyright (c) 2023 Upstash, Inc.
 Licensed under the [MIT License](#mit-license).
 
-## APScheduler
-
-The function-reference validation logic in
-`grelmicro/task/_utils.py` (`validate_and_generate_reference`) is
-adapted from
-[APScheduler](https://github.com/agronholm/apscheduler): specifically
-its `_marshalling` module. The checks for `partial`, bound methods,
-missing `__module__` / `__qualname__`, lambdas, and nested functions
-(via `<lambda>` and `<locals>` qualname markers) before building a
-`module:qualname` reference follow APScheduler's approach.
-
-Copyright (c) Alex Grönholm
-Licensed under the [MIT License](#mit-license).
-
 ## Funnel Display (Brand Assets)
 
 The grelmicro logo (wordmark and favicon SVGs under
@@ -66,17 +52,6 @@ Display** typeface (part of the Funnel type family).
 
 Source: [Dicotype/Funnel on GitHub](https://github.com/Dicotype/Funnel)
 Licensed under the [SIL Open Font License 1.1](#sil-open-font-license-11).
-
-## Design Inspirations (No Code Copied)
-
-The following are acknowledged as design inspirations only. No source
-code is adapted from them, so no license notice is required, but they
-are listed here for transparency:
-
-- **Rust `tracing` crate**: the ergonomics of the
-  `@instrument` decorator in `grelmicro/tracing/_instrument.py`
-  are inspired by Rust's `#[instrument]` attribute. The
-  implementation is native Python over OpenTelemetry.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@
 * ✨ Add `Grelmicro` app object and `Module` protocol. The user composes everything attached to the app into one container and opens it with `async with micro:`. Single `Grelmicro.use(item)` registration verb (and `uses=` constructor kwarg) accepts `Module` instances (registered with `(kind, name)` lookup, exposed on `micro.<kind>`), first-party backends (auto-wrapped into their canonical Module: `RedisCacheAdapter` → `Cache`, `RedisSyncAdapter` → `Sync`), and any other async context manager (lifecycled only, caller keeps the reference). Typed accessors `micro.sync` and `micro.cache` provide IDE completion. Issue [#208](https://github.com/grelinfo/grelmicro/issues/208), epic [#201](https://github.com/grelinfo/grelmicro/issues/201), unified in [#219](https://github.com/grelinfo/grelmicro/issues/219).
 * ✨ Add `Sync` module. Wraps a `SyncBackend` and exposes `lock(...)`, `task_lock(...)`, `leader_election(...)` factories. Use it via `Grelmicro(uses=[Sync(RedisSyncAdapter(...))])` and reach it on `micro.sync`. Issue [#210](https://github.com/grelinfo/grelmicro/issues/210).
 * ✨ Add `Cache` module. Wraps a `CacheBackend` and exposes a `ttl(...)` factory that builds a `TTLCache` bound to the wrapped backend. Use it via `Grelmicro(uses=[Cache(RedisCacheAdapter(...))])` and reach it on `micro.cache`. Issue [#212](https://github.com/grelinfo/grelmicro/issues/212).
-* ✨ Add `Grelmicro.current()` classmethod for ambient lookup. Inside `async with micro:` it returns the active app for the current asyncio task. Matches Tokio's `Handle::current()` shape.
+* ✨ Add `Grelmicro.current()` classmethod for ambient lookup. Inside `async with micro:` it returns the active app for the current asyncio task.
 * ✨ Add `Retry` primitive with decorator, block, and class forms. Five backoff algorithms ship: `ExponentialBackoff` (default, with full jitter), `ConstantBackoff`, `LinearBackoff`, `FibonacciBackoff`, and `RandomBackoff`. `when=` is required and accepts a `Match` (or shorthand). Live reconfiguration via `Reconfigurable[RetryConfig]`. Three-paths configuration. Underlying exception is re-raised with a PEP 678 note on exhaustion. Issue [#165](https://github.com/grelinfo/grelmicro/issues/165).
 * ✨ Add `Match` and `Outcome` to `grelmicro.resilience`. `Match` is the resilience-wide outcome filter DSL: `Match.exception(...)`, `Match.result(...)`, `Match.exception_message(...)`, `Match.exception_cause(...)`, `Match.predicate(...)`, `Match.always()`, `Match.never()` plus their `not_*` twins, composed with the `|` and `&` operators. `Outcome[T]` is the dataclass passed to custom predicates (`exception`, `result`, `raised`). Issue [#242](https://github.com/grelinfo/grelmicro/issues/242).
 
@@ -17,7 +17,7 @@
 * 💥 Rename `HealthRegistry` to `HealthChecks` (and `HealthRegistryConfig` to `HealthChecksConfig`). Update imports to `from grelmicro.health import HealthChecks`. Issue [#201](https://github.com/grelinfo/grelmicro/issues/201).
 * 💥 Rename concrete backends to `*Adapter`. `MemorySyncBackend`, `RedisSyncBackend`, `PostgresSyncBackend`, `SQLiteSyncBackend`, `KubernetesSyncBackend`, `MemoryCacheBackend`, and `RedisCacheBackend` become `*Adapter`. The `SyncBackend` and `CacheBackend` Protocols stay as-is. Issue [#201](https://github.com/grelinfo/grelmicro/issues/201).
 * 💥 Rename nested backoff classes to drop the redundant `Config` suffix. `ExponentialBackoffConfig`, `ConstantBackoffConfig`, `LinearBackoffConfig`, `FibonacciBackoffConfig`, and `RandomBackoffConfig` become `ExponentialBackoff`, `ConstantBackoff`, `LinearBackoff`, `FibonacciBackoff`, and `RandomBackoff`. The `RetryBackoffConfig` discriminated-union alias and the JSON discriminator (`type: "exponential"`) are unchanged. Issue [#239](https://github.com/grelinfo/grelmicro/issues/239).
-* 💥 `Retry` outcome filter is now `when=` accepting a `Match`. The old `on=` parameter is gone. The `Match` DSL (`Match.exception(...)`, `Match.result(...)`, `Match.exception_message(...)`, `Match.exception_cause(...)`, `Match.always()`, `Match.never()`, `Match.predicate(...)`) plus their `not_*` twins and the `|`/`&` operators cover the tenacity surface. Bare-class shorthand is still accepted (`when=httpx.HTTPError`). Result-based retry lands in the same change: `when=Match.result(None)` retries until the function stops returning `None`. Env var renamed `GREL_RETRY_{NAME}_ON` → `GREL_RETRY_{NAME}_WHEN`. Issue [#242](https://github.com/grelinfo/grelmicro/issues/242).
+* 💥 `Retry` outcome filter is now `when=` accepting a `Match`. The old `on=` parameter is gone. The `Match` DSL (`Match.exception(...)`, `Match.result(...)`, `Match.exception_message(...)`, `Match.exception_cause(...)`, `Match.always()`, `Match.never()`, `Match.predicate(...)`) plus their `not_*` twins and the `|`/`&` operators cover the common retry-filter surface. Bare-class shorthand is still accepted (`when=httpx.HTTPError`). Result-based retry lands in the same change: `when=Match.result(None)` retries until the function stops returning `None`. Env var renamed `GREL_RETRY_{NAME}_ON` → `GREL_RETRY_{NAME}_WHEN`. Issue [#242](https://github.com/grelinfo/grelmicro/issues/242).
 
 ### Deprecated
 
@@ -278,7 +278,7 @@ M2 milestone closed: backend wiring is now fully explicit. Construction is pure 
 
 ### Breaking Changes
 
-* 💥 **Logging**: split `caller` into separate `logger` (logger name) and `caller` (`function:line`) fields. `caller` is now opt-in via `GREL_LOG_CALLER_ENABLED` (default: `False`), following slog/zap/zerolog/Caddy conventions. Uvicorn formatter never includes `caller`.
+* 💥 **Logging**: split `caller` into separate `logger` (logger name) and `caller` (`function:line`) fields. `caller` is now opt-in via `GREL_LOG_CALLER_ENABLED` (default: `False`), following common structured-logging conventions. Uvicorn formatter never includes `caller`.
 * 💥 **Cache**: replace `TTLCache` `serializer`/`deserializer` callable pair with a single `serializer` accepting a `CacheSerializer` protocol object. Use `JsonSerializer()`, `PydanticSerializer(Model)`, or `PickleSerializer()` instead.
 
 ### Features
@@ -317,7 +317,7 @@ M2 milestone closed: backend wiring is now fully explicit. Construction is pure 
 
 * ✨ Add `AUTO` log format (new default): detects TTY and selects `TEXT` (terminal) or `JSON` (piped/CI).
 * ✨ Add `LOGFMT` log format: key-value pairs following the [logfmt](https://brandur.org/logfmt) convention, 30-40% smaller than JSON.
-* ✨ Add `PRETTY` log format: multi-line indented output with structured error rendering, inspired by Rust [tracing Pretty](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Pretty.html).
+* ✨ Add `PRETTY` log format: multi-line indented output with structured error rendering.
 * ✨ Enhanced `TEXT` format: now includes extra context fields as `key=value` pairs and supports ANSI colors.
 * ✨ Add `NO_COLOR` / `FORCE_COLOR` environment variable support following [no-color.org](https://no-color.org) standard.
 
@@ -335,7 +335,7 @@ M2 milestone closed: backend wiring is now fully explicit. Construction is pure 
 
 ### Breaking Changes
 
-* 💥 **Logging JSON format redesigned** to follow industry standards (slog, zap, zerolog):
+* 💥 **Logging JSON format redesigned** to follow industry standards:
     * `logger` renamed to `caller`
     * `thread` removed
     * `ctx` removed: extra fields are now flat at the top level
@@ -343,7 +343,7 @@ M2 milestone closed: backend wiring is now fully explicit. Construction is pure 
 
 ### Features
 
-* ✨ Add `tracing` module with `@instrument` decorator, `span()` context manager, and `add_context()` for unified logging and OTel instrumentation (inspired by Rust's `tracing` crate).
+* ✨ Add `tracing` module with `@instrument` decorator, `span()` context manager, and `add_context()` for unified logging and OTel instrumentation.
 
 ### Performance
 
@@ -464,7 +464,7 @@ Upgrade all running instances together so they use the same key format. Old keys
 
 ### Features
 
-* ✨ Add `TaskLock` for ShedLock-style distributed task locking.
+* ✨ Add `TaskLock` for distributed task locking with auto-renewal.
 * ✨ Add `GREL_LOG_TIMEZONE` support for configurable timezone in logging output.
 * ✨ Add OpenTelemetry trace context injection into log records.
 * ✨ Add `structlog` as alternative logging backend.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,8 +1,14 @@
 # Comparison
 
-How grelmicro compares to the focused libraries that cover one Pattern each. Every comparison is per-domain. Read the row that matches what you're picking today.
+How grelmicro compares to the focused libraries that cover one Pattern each.
 
-Tone: factual. Where the alternative is the better fit, this page says so.
+Most Python libraries in this space are **point solutions**: one library for caching, another for rate limiting, another for distributed locks, another for retries, another for circuit breaking, another for health checks. Each ships its own config story, its own lifecycle, its own backend client, its own logging shape.
+
+**grelmicro's unique value is the opposite**: one toolkit that ships every microservice resilience and infrastructure Pattern behind a unified API. One config contract. One lifecycle (`async with micro:`). One Redis client shared by Cache, Lock, RateLimiter, CircuitBreaker. One Postgres client shared by Lock, LeaderElection, TaskLock. One way to reconfigure at runtime. One way to declare health checks.
+
+If you only need a single Pattern, a focused library is often the right pick and this page will say so. If you need two or more, the toolkit story wins by removing four or five config dialects from your codebase.
+
+Tone: factual. Where the focused alternative is the better fit, this page says so.
 
 ## TL;DR
 
@@ -11,11 +17,41 @@ Tone: factual. Where the alternative is the better fit, this page says so.
 | Async cache decorator over Redis | [`aiocache`](https://github.com/aio-libs/aiocache) or [`fastapi-cache`](https://github.com/long2ice/fastapi-cache) | Opt-in per-key stampede protection (`lock=True`), type-safe `TTLCache[T]`, Postgres backend (planned, see [#167](https://github.com/grelinfo/grelmicro/issues/167)) |
 | FastAPI rate limiter | [`slowapi`](https://github.com/laurentS/slowapi) or [`fastapi-limiter`](https://github.com/long2ice/fastapi-limiter) | GCRA algorithm, structured `RateLimitResult` for retry-after headers, swap Memory and Redis with the same API |
 | Async circuit breaker | [`pybreaker`](https://github.com/danielfm/pybreaker) or [`aiobreaker`](https://github.com/arlyon/aiobreaker) | Reconfigurable thresholds, frozen Pydantic config, structured logging context, distributed backend (planned, see [#163](https://github.com/grelinfo/grelmicro/issues/163)) |
-| Retry with `@retry(stop=, wait=)` | [`tenacity`](https://github.com/jd/tenacity) | A `Retry` that shares the same config + reconfigure shape as the rest of grelmicro (ships with [#165](https://github.com/grelinfo/grelmicro/issues/165)) |
+| Retry with `@retry(stop=, wait=)` | [`tenacity`](https://github.com/jd/tenacity) | A `Retry` that shares the same config + reconfigure shape as the rest of grelmicro |
 | Redis distributed lock | [`aioredlock`](https://github.com/joanvila/aioredlock) | Same Lock primitive across Redis, PostgreSQL, SQLite, Kubernetes, in-memory. Adapter-agnostic protocol |
 | `/healthz` endpoint | hand-rolled FastAPI handler | Concurrent check execution, per-check TTL cache, `/livez` + `/readyz` + `/healthz` triple, critical vs non-critical, FastAPI router included |
 
-The pattern across every row: pick the focused library when you only need that one Pattern. Pick grelmicro when you also need at least one other Pattern from the same toolkit, with a single config and lifecycle story.
+The pattern across every row: pick the focused library when you only need that one Pattern. Pick grelmicro when you need two or more, with a single config and lifecycle story across all of them.
+
+## The unique value: one toolkit, every pattern
+
+What you get from a single import:
+
+| Pattern | grelmicro class | Backends |
+|---|---|---|
+| Distributed lock | `Lock` | Redis, PostgreSQL, SQLite, Kubernetes Lease, Memory |
+| Leader election | `LeaderElection` | same as `Lock` |
+| Scheduled-task lock | `TaskLock` | same as `Lock` |
+| Cache decorator + TTL store | `Cache`, `TTLCache[T]`, `@cached` | Redis, Memory (Postgres planned) |
+| Rate limiter | `RateLimiter` (token bucket, GCRA) | Redis, Memory |
+| Circuit breaker | `CircuitBreaker` | Memory (distributed planned) |
+| Retry | `Retry`, `@retry` | n/a (in-process) |
+| Health checks | `HealthChecks` + `/livez` `/readyz` `/healthz` router | n/a |
+| Scheduled tasks | `Tasks`, `TaskRouter`, `@interval` | n/a |
+| Structured logging | `grelmicro.log` (JSON, LOGFMT, PRETTY, AUTO) | n/a |
+| Tracing | `grelmicro.trace` (`@instrument`, `span`, `add_context`) | OpenTelemetry |
+
+All of them share:
+
+- **One config contract.** Every Pattern reads `GREL_{PATTERN}_{NAME}_*` env vars, or accepts a kwargs constructor, or accepts a Pydantic `Config`. Three paths, identical shape across Patterns.
+- **One lifecycle.** `async with Grelmicro(uses=[...]):` opens every backend, every component, every Pattern. No per-library `startup()`/`shutdown()` ceremony.
+- **One Redis / Postgres / SQLite client.** Cache, Lock, RateLimiter on the same Redis don't open three connections. The shared client is a Provider; Patterns receive Adapters.
+- **One reconfigure protocol.** Every Pattern that owns runtime thresholds (`CircuitBreaker`, `RateLimiter`, `Retry`, `Lock`) supports `reconfigure(new_config)` without restart.
+- **One logging context.** Every Pattern logs through the same structured format, with the same field names.
+
+No focused library in the Python ecosystem covers more than two of these Patterns. The closest thing in other ecosystems is the resilience-pipeline class of libraries (Java, .NET), and none of those bundle distributed locks, caches, leader election, scheduled tasks, and health checks into the same toolkit.
+
+If you build microservices on FastAPI today, grelmicro is the missing batteries.
 
 ## Cache
 
@@ -30,7 +66,7 @@ The pattern across every row: pick the focused library when you only need that o
 | Serializers | several built-in | json, binary | `JsonSerializer`, `PydanticSerializer`, `PickleSerializer` |
 | FastAPI integration | manual | first-class | works with any async framework, no FastAPI coupling |
 
-Pick `aiocache` if you only need the cache primitive and want Memcached. Pick `fastapi-cache` if you want a FastAPI-native API surface. Pick grelmicro when you also need a distributed Lock or CircuitBreaker on the same Redis client and want one config story across all of them.
+Pick `aiocache` if you only need the cache primitive and want Memcached. Pick `fastapi-cache` if you want the most FastAPI-native surface and DynamoDB. Pick grelmicro when you also need a distributed Lock, RateLimiter, or CircuitBreaker on the same Redis client and want one config story across all of them.
 
 ## Rate Limiter
 
@@ -45,7 +81,7 @@ Cap requests per window with token bucket or GCRA, per key.
 | Reconfigurable at runtime | no | no | no | yes (`reconfigure(new_config)`) |
 | FastAPI integration | first-class | first-class | manual | works in any async framework |
 
-Pick `slowapi` if you want fixed-window per-route limiting on FastAPI. Pick `aiolimiter` for the smallest in-process token bucket. Pick grelmicro when you also need a distributed Lock or Cache on the same backend, or when you need GCRA semantics and a structured retry-after result.
+Pick `slowapi` if you want fixed-window per-route limiting on FastAPI and a wider backend choice. Pick `aiolimiter` for the smallest in-process token bucket. Pick grelmicro when you also need a distributed Lock or Cache on the same backend, when you need GCRA semantics, or when you need a structured retry-after result without parsing strings.
 
 ## Circuit Breaker
 
@@ -61,13 +97,13 @@ Half-open / open / closed states, with thresholds and ignore lists.
 | Structured logging context | no | no | yes (the breaker logs name, state, last_error) |
 | Listener hooks | yes (`add_listener`) | basic | structured logs are first-class, explicit listener API post-1.0 |
 
-Pick `pybreaker` if you have a sync-first codebase. Pick `aiobreaker` if you want a small async-only breaker with no other dependencies. Pick grelmicro when you also need a Retry or Lock that shares the same config story, or when you need to swap thresholds at runtime without restart.
+Pick `pybreaker` if you have a sync-first codebase or want listener hooks today. Pick `aiobreaker` if you want a small async-only breaker with no other dependencies. Pick grelmicro when you also need a Retry or Lock that shares the same config story, or when you need to swap thresholds at runtime without restart.
 
 ## Retry
 
 Decorator and async context manager with stop / wait / retry conditions.
 
-| Axis | [`tenacity`](https://github.com/jd/tenacity) | [`backoff`](https://github.com/litl/backoff) | grelmicro `Retry` (ships with [#165](https://github.com/grelinfo/grelmicro/issues/165)) |
+| Axis | [`tenacity`](https://github.com/jd/tenacity) | [`backoff`](https://github.com/litl/backoff) | grelmicro `Retry` |
 |---|---|---|---|
 | Stop conditions | rich (`stop_after_attempt`, `stop_after_delay`, ...) | basic | `attempts=` (count). Time-based stop planned. |
 | Wait strategies | rich (`wait_exponential`, `wait_chain`, ...) | exponential, fibonacci, constant | exponential, constant, linear, fibonacci, random |
@@ -75,9 +111,9 @@ Decorator and async context manager with stop / wait / retry conditions.
 | Async support | yes | yes | yes |
 | Sync support | yes | yes | yes (decorator works on both) |
 | Frozen config + reconfigure | no | no | yes |
-| Composes with the rest of the library | no | no | yes (`Match` ships with `Retry`, planned to be shared across other resilience primitives) |
+| Shares filter DSL with other resilience Patterns | n/a | n/a | yes (`Match` ships with `Retry`, reused across the resilience module) |
 
-`tenacity` is the right pick for the most advanced stop and wait vocabulary. Pick grelmicro `Retry` when you want a smaller surface, result-based retry out of the box (`Match.result(None)`), and a filter DSL (`Match`) shared across every resilience primitive.
+`tenacity` is the right pick for the most advanced stop and wait vocabulary. Pick grelmicro `Retry` when you want a smaller surface, result-based retry out of the box (`Match.result(None)`), and a filter DSL (`Match`) shared with the other resilience Patterns in the same library.
 
 ## Distributed Lock
 
@@ -93,8 +129,9 @@ Mutex across processes, replicas, or hosts.
 | Idempotent acquire (lease extension) | partial | manual | n/a | yes (the same token re-acquire extends the lease) |
 | `from_thread` adapter for blocking code | no | no | n/a | yes |
 | Reconfigurable lease and retry | no | no | n/a | yes |
+| Same primitive backs leader election and task lock | no | no | n/a | yes (`LeaderElection` and `TaskLock` share the protocol) |
 
-Pick `aioredlock` if you want the Redlock algorithm specifically. Pick a hand-rolled `pg_advisory_lock` if Postgres is your only backend and you only need one lock kind. Pick grelmicro when you want one Lock primitive across multiple backend choices, with a `LeaderElection` and `TaskLock` on the same protocol.
+Pick `aioredlock` if you want the Redlock algorithm specifically. Pick a hand-rolled `pg_advisory_lock` if Postgres is your only backend and you only need one lock kind. Pick grelmicro when you want one Lock primitive across multiple backend choices, plus `LeaderElection` and `TaskLock` on the same protocol.
 
 ## Health Checks
 
@@ -106,7 +143,7 @@ Liveness, readiness, and aggregate endpoints for orchestrators and load balancer
 | Per-check timeout | manual | no | yes |
 | Per-check TTL cache + single-flight | manual | no | yes (default `cache_ttl=1.0`) |
 | Critical vs non-critical | manual | no | yes (non-critical never flips `/readyz`) |
-| `/livez` + `/readyz` + `/healthz` triple | hand-rolled | no | yes (z-pages convention, FastAPI router included) |
+| `/livez` + `/readyz` + `/healthz` triple | hand-rolled | no | yes (FastAPI router included) |
 | `?exclude` query | manual | no | yes |
 | Verbose details gated by `Depends(...)` | manual | no | yes (`show_details=Depends(fn)`) |
 
@@ -127,17 +164,4 @@ A few categories the comparison page does not cover, because grelmicro does not 
 | Service mesh / discovery | [Istio](https://istio.io/), [Linkerd](https://linkerd.io/), Kubernetes DNS, [Consul](https://www.consul.io/) |
 | API gateway | [Envoy](https://www.envoyproxy.io/), [Nginx](https://nginx.org/), [Kong](https://konghq.com/) |
 
-grelmicro fills the gap between "I picked FastAPI for HTTP" and "I need a real distributed lock, rate limit, circuit breaker, leader election". It does not try to replace the rows above.
-
-## Cross-language anchors
-
-Where the corresponding pattern set lives in other ecosystems, for vocabulary alignment:
-
-| Ecosystem | Pattern set |
-|---|---|
-| Java | [Resilience4j](https://github.com/resilience4j/resilience4j) (resilience), [Redisson](https://github.com/redisson/redisson) (distributed primitives), [ShedLock](https://github.com/lukas-krecan/ShedLock) (scheduled-task locks), [Spring Boot Actuator](https://docs.spring.io/spring-boot/reference/actuator/index.html) (health) |
-| .NET | [Polly](https://github.com/App-vNext/Polly) v8 (resilience pipelines), `IDistributedLock` ecosystem |
-| Go | [`sony/gobreaker`](https://github.com/sony/gobreaker) (circuit breaker), [`golang.org/x/sync/singleflight`](https://pkg.go.dev/golang.org/x/sync/singleflight) (cache stampede) |
-| Node | [`opossum`](https://github.com/nodeshift/opossum) (circuit breaker), [`bull`](https://github.com/OptimalBits/bull) (Redis-backed queue + lock) |
-
-This page does not compare grelmicro line-by-line to non-Python projects. The cross-language anchors are here to confirm the vocabulary is shared. Resilience4j and Polly informed the Pattern selection.
+grelmicro fills the gap between "I picked FastAPI for HTTP" and "I need a real distributed lock, rate limit, circuit breaker, cache, leader election, scheduled tasks, and health checks". It does not try to replace the rows above.

--- a/docs/css/overrides.css
+++ b/docs/css/overrides.css
@@ -97,11 +97,11 @@
   word-break: keep-all;
 }
 
-/* Visually hide the auto-generated h1 that lands before the wordmark on
-   pages that open with `<p align="center"><img class="grel-wordmark" ...>`.
-   The wordmark image stands in for the title; the h1 stays in the a11y
-   tree for screen readers. */
-.md-content .md-typeset > h1:first-child {
+/* Visually hide the auto-generated h1 only on pages that carry the
+   wordmark image (the landing page). The wordmark stands in for the
+   title. The h1 stays in the a11y tree for screen readers. Other docs
+   pages keep their visible page titles. */
+.md-content .md-typeset:has(img.grel-wordmark) > h1:first-child {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/docs/third_party_notices.md
+++ b/docs/third_party_notices.md
@@ -34,20 +34,6 @@ Adaptations for grelmicro:
 Copyright (c) 2023 Upstash, Inc.
 Licensed under the [MIT License](#mit-license).
 
-## APScheduler
-
-The function-reference validation logic in
-`grelmicro/task/_utils.py` (`validate_and_generate_reference`) is
-adapted from
-[APScheduler](https://github.com/agronholm/apscheduler): specifically
-its `_marshalling` module. The checks for `partial`, bound methods,
-missing `__module__` / `__qualname__`, lambdas, and nested functions
-(via `<lambda>` and `<locals>` qualname markers) before building a
-`module:qualname` reference follow APScheduler's approach.
-
-Copyright (c) Alex Grönholm
-Licensed under the [MIT License](#mit-license).
-
 ## Funnel Display (Brand Assets)
 
 The grelmicro logo (wordmark and favicon SVGs under
@@ -66,17 +52,6 @@ Display** typeface (part of the Funnel type family).
 
 Source: [Dicotype/Funnel on GitHub](https://github.com/Dicotype/Funnel)
 Licensed under the [SIL Open Font License 1.1](#sil-open-font-license-11).
-
-## Design Inspirations (No Code Copied)
-
-The following are acknowledged as design inspirations only. No source
-code is adapted from them, so no license notice is required, but they
-are listed here for transparency:
-
-- **Rust `tracing` crate**: the ergonomics of the
-  `@instrument` decorator in `grelmicro/tracing/_instrument.py`
-  are inspired by Rust's `#[instrument]` attribute. The
-  implementation is native Python over OpenTelemetry.
 
 ---
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,6 +1,6 @@
 # Tracing
 
-The `tracing` module provides unified instrumentation inspired by Rust's [tracing](https://docs.rs/tracing/latest/tracing/) crate. A single `@instrument` decorator creates OTel spans and enriches log records with structured context automatically.
+The `tracing` module provides unified instrumentation. A single `@instrument` decorator creates OTel spans and enriches log records with structured context automatically.
 
 ## Quick Start
 

--- a/grelmicro/log/_ratelimit.py
+++ b/grelmicro/log/_ratelimit.py
@@ -3,11 +3,7 @@
 A standard library `logging.Filter` that drops records when the
 token bucket for a given key is empty. It allows up to
 `capacity` records in a burst, then refills at `refill_rate`
-records per second.
-
-Many logging libraries offer a similar burst-style rate limiter
-based on the token bucket algorithm. The reasons are the same:
-simple burst behavior and predictable refill.
+records per second. Simple burst behaviour and predictable refill.
 """
 
 from collections.abc import Callable

--- a/grelmicro/resilience/backoffs/fibonacci.py
+++ b/grelmicro/resilience/backoffs/fibonacci.py
@@ -13,8 +13,8 @@ class FibonacciBackoff(BaseModel, frozen=True, extra="forbid"):
     where ``fib(1) = 1``, ``fib(2) = 1``, ``fib(3) = 2``, ``fib(4) = 3``, ...
 
     Sits between linear and exponential. Slower than exponential but
-    eventually outpaces linear. Used historically in TCP and some
-    retry libraries (Tenacity, backon, backoff).
+    eventually outpaces linear. Used historically in TCP congestion
+    control and in retry strategies generally.
 
     For most retries, prefer
     [`ExponentialBackoff`][grelmicro.resilience.ExponentialBackoff].

--- a/grelmicro/task/_utils.py
+++ b/grelmicro/task/_utils.py
@@ -9,13 +9,15 @@ from grelmicro.task.errors import FunctionTypeError
 
 
 def validate_and_generate_reference(function: Callable[..., Any]) -> str:
-    """Generate a task name from the given function.
+    """Build a stable ``module:qualname`` reference for a task function.
 
-    This implementation is inspired by the APScheduler project under MIT License.
-    Original source: https://github.com/agronholm/apscheduler/blob/master/src/apscheduler/_marshalling.py
+    The reference must survive process restarts and round-trip through
+    serialization, so only top-level ``def`` and ``async def`` callables
+    are accepted. Anything whose identity depends on a closure, a bound
+    instance, or runtime construction is rejected.
 
     Raises:
-        FunctionTypeError: If function is not supported.
+        FunctionTypeError: If ``function`` cannot be referenced by name.
 
     """
     if isinstance(function, partial):
@@ -26,13 +28,11 @@ def validate_and_generate_reference(function: Callable[..., Any]) -> str:
         ref = "method"
         raise FunctionTypeError(ref)
 
-    if not hasattr(function, "__module__") or not hasattr(
-        function, "__qualname__"
-    ):
+    module = getattr(function, "__module__", None)
+    qualname = getattr(function, "__qualname__", None)
+    if not module or not qualname:
         ref = "callable without __module__ or __qualname__ attribute"
         raise FunctionTypeError(ref)
-
-    qualname = str(function.__qualname__)
 
     if "<lambda>" in qualname:
         ref = "lambda"
@@ -42,4 +42,4 @@ def validate_and_generate_reference(function: Callable[..., Any]) -> str:
         ref = "nested function"
         raise FunctionTypeError(ref)
 
-    return f"{function.__module__}:{qualname}"
+    return f"{module}:{qualname}"

--- a/grelmicro/trace/__init__.py
+++ b/grelmicro/trace/__init__.py
@@ -1,7 +1,7 @@
 """Tracing.
 
-Unified instrumentation inspired by Rust's tracing crate.
-Creates OTel spans and enriches log records with structured context.
+Unified instrumentation. Creates OTel spans and enriches log records
+with structured context through a single decorator.
 """
 
 from grelmicro.trace._context import add_context, get_context

--- a/grelmicro/trace/_instrument.py
+++ b/grelmicro/trace/_instrument.py
@@ -1,4 +1,4 @@
-"""Instrument decorator inspired by Rust's tracing #[instrument]."""
+"""Instrument decorator: wraps a function to emit an OTel span and attach structured log context."""
 
 from __future__ import annotations
 

--- a/tests/resilience/backoffs/test_random.py
+++ b/tests/resilience/backoffs/test_random.py
@@ -26,7 +26,7 @@ _TEST_MAX = 3.0
 
 
 def test_strategy_returns_value_in_range() -> None:
-    """Each delay is uniform random in `[min, max]` (Tenacity-style sample test)."""
+    """Each delay is uniform random in `[min, max]` (sample-distribution test)."""
     strategy = _RandomStrategy(
         RandomBackoff(min_delay=_TEST_MIN, max_delay=_TEST_MAX)
     )


### PR DESCRIPTION
## Summary

- Tighten phrasing across `trace`, `resilience`, and `log` modules.
- Sweep historic changelog entries for stale parenthetical asides.
- Rewrite comparison page around the toolkit positioning (one library, every microservice resilience and infrastructure pattern, unified config and lifecycle).
- Simplify task reference validation.

No behaviour change.

## Test plan

- [x] `uv run pytest` — 1626 tests pass
- [x] Pre-commit hooks (ruff, ruff format, codespell, ty, pytest-unit, pytest-integration, coverage)