### PR TITLE
📝 Restore APScheduler MIT attribution in third-party notices

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -34,6 +34,20 @@ Adaptations for grelmicro:
 Copyright (c) 2023 Upstash, Inc.
 Licensed under the [MIT License](#mit-license).
 
+## APScheduler
+
+The function-reference validation logic in
+`grelmicro/task/_utils.py` (`validate_and_generate_reference`) is
+adapted from
+[APScheduler](https://github.com/agronholm/apscheduler): specifically
+its `_marshalling` module. The checks for `partial`, bound methods,
+missing `__module__` / `__qualname__`, lambdas, and nested functions
+(via `<lambda>` and `<locals>` qualname markers) before building a
+`module:qualname` reference follow APScheduler's approach.
+
+Copyright (c) Alex Grönholm
+Licensed under the [MIT License](#mit-license).
+
 ## Funnel Display (Brand Assets)
 
 The grelmicro logo (wordmark and favicon SVGs under

--- a/docs/third_party_notices.md
+++ b/docs/third_party_notices.md
@@ -34,6 +34,20 @@ Adaptations for grelmicro:
 Copyright (c) 2023 Upstash, Inc.
 Licensed under the [MIT License](#mit-license).
 
+## APScheduler
+
+The function-reference validation logic in
+`grelmicro/task/_utils.py` (`validate_and_generate_reference`) is
+adapted from
+[APScheduler](https://github.com/agronholm/apscheduler): specifically
+its `_marshalling` module. The checks for `partial`, bound methods,
+missing `__module__` / `__qualname__`, lambdas, and nested functions
+(via `<lambda>` and `<locals>` qualname markers) before building a
+`module:qualname` reference follow APScheduler's approach.
+
+Copyright (c) Alex Grönholm
+Licensed under the [MIT License](#mit-license).
+
 ## Funnel Display (Brand Assets)
 
 The grelmicro logo (wordmark and favicon SVGs under


### PR DESCRIPTION
## Summary

- PR #246 removed the APScheduler MIT notice, but `grelmicro/task/_utils.py::validate_and_generate_reference` is still adapted from APScheduler's `_marshalling` module (the partial / bound-method / `__module__` / `__qualname__` / `<lambda>` / `<locals>` checks). Keeping the code without the notice would have been license-noncompliant.
- Restores the attribution block in both `THIRD_PARTY_NOTICES.md` and `docs/third_party_notices.md`. Caught by Copilot review on #246.

## Test plan

- [x] `notices-to-docs` pre-commit hook passes (root and docs copies stay in sync)