### PR TITLE
📝 Fix README Redis adapter examples to use shared RedisProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ from grelmicro.cache import JsonSerializer, TTLCache, cached
 from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.health import HealthChecks
 from grelmicro.log import configure as configure_logging
+from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience import (
     CircuitBreaker,
     RateLimitExceededError,
@@ -102,10 +103,12 @@ health = HealthChecks()
 leader = LeaderElection("leader-election")
 tasks.add_task(leader)
 
+redis = RedisProvider("redis://localhost:6379/0")
+
 micro = Grelmicro(uses=[
-    RedisSyncAdapter("redis://localhost:6379/0"),
-    RedisCacheAdapter("redis://localhost:6379/0", prefix="myapp:"),
-    RedisRateLimiterAdapter("redis://localhost:6379/0"),
+    RedisSyncAdapter(provider=redis),
+    RedisCacheAdapter(provider=redis, prefix="myapp:"),
+    RedisRateLimiterAdapter(provider=redis),
     tasks,
     health,
 ])

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ tasks.add_task(leader)
 redis = RedisProvider("redis://localhost:6379/0")
 
 micro = Grelmicro(uses=[
+    redis,
     RedisSyncAdapter(provider=redis),
     RedisCacheAdapter(provider=redis, prefix="myapp:"),
     RedisRateLimiterAdapter(provider=redis),

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,7 @@ from grelmicro.cache import JsonSerializer, TTLCache, cached
 from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.health import HealthChecks
 from grelmicro.log import configure as configure_logging
+from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience import (
     CircuitBreaker,
     RateLimitExceededError,
@@ -102,10 +103,12 @@ health = HealthChecks()
 leader = LeaderElection("leader-election")
 tasks.add_task(leader)
 
+redis = RedisProvider("redis://localhost:6379/0")
+
 micro = Grelmicro(uses=[
-    RedisSyncAdapter("redis://localhost:6379/0"),
-    RedisCacheAdapter("redis://localhost:6379/0", prefix="myapp:"),
-    RedisRateLimiterAdapter("redis://localhost:6379/0"),
+    RedisSyncAdapter(provider=redis),
+    RedisCacheAdapter(provider=redis, prefix="myapp:"),
+    RedisRateLimiterAdapter(provider=redis),
     tasks,
     health,
 ])

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,6 +106,7 @@ tasks.add_task(leader)
 redis = RedisProvider("redis://localhost:6379/0")
 
 micro = Grelmicro(uses=[
+    redis,
     RedisSyncAdapter(provider=redis),
     RedisCacheAdapter(provider=redis, prefix="myapp:"),
     RedisRateLimiterAdapter(provider=redis),


### PR DESCRIPTION
## Summary

The quickstart example in `README.md` (and the synced `docs/index.md`) constructed Redis adapters with positional URL arguments (`RedisSyncAdapter("redis://...")`). The constructors have been keyword-only since #248: positional `url=` no longer exists. Copy-pasting the snippet would raise `TypeError`.

Fix: build one `RedisProvider("redis://localhost:6379/0")` and pass it via `provider=` to all three adapters. This also showcases the implicit pool-sharing pattern that #248 introduced.

Surfaced during Copilot review on #253, deferred to keep that rename PR focused.

## Test plan

- [x] `uv run python -c "..."` constructs `RedisSyncAdapter`, `RedisCacheAdapter`, `RedisRateLimiterAdapter` with the new pattern without raising.
- [x] Pre-commit `readme-to-docs` hook regenerates `docs/index.md` from `README.md`.