### PR TITLE
⚡ Defer opentelemetry import in grelmicro.trace

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,10 @@
 * 💥 Rename the env-loading flag to align the per-call kwarg and the global env var. `read_env=` becomes `env_load=` on every component, `GREL_CONFIG_FROM_ENV` becomes `GREL_ENV_LOAD`, and the `grelmicro._config.env_opt_in_enabled()` helper becomes `env_load_default()`. No deprecation shim. Issue [#232](https://github.com/grelinfo/grelmicro/issues/232).
 * 💥 `Retry` outcome filter is now `when=` accepting a `Match`. The old `on=` parameter is gone. The `Match` DSL (`Match.exception(...)`, `Match.result(...)`, `Match.exception_message(...)`, `Match.exception_cause(...)`, `Match.always()`, `Match.never()`, `Match.predicate(...)`) plus their `not_*` twins and the `|`/`&` operators cover the common retry-filter surface. Bare-class shorthand is still accepted (`when=httpx.HTTPError`). Result-based retry lands in the same change: `when=Match.result(None)` retries until the function stops returning `None`. Env var renamed `GREL_RETRY_{NAME}_ON` → `GREL_RETRY_{NAME}_WHEN`. Issue [#242](https://github.com/grelinfo/grelmicro/issues/242).
 
+### Internal
+
+* ⚡ Defer the `opentelemetry` import in `grelmicro.trace`. `import grelmicro.trace` no longer loads `opentelemetry` (was 16 modules); the package is resolved lazily on first call to `instrument`, `span`, or `add_context` and cached. Issue [#189](https://github.com/grelinfo/grelmicro/issues/189).
+
 ### Deprecated
 
 * 🗑️ Deprecate every module-level legacy helper in favor of the `Grelmicro` app object. `grelmicro.lifespan()` and the `register` / `unregister` / `use` / `use_backend` / `use_registry` family across `grelmicro.{sync,cache,health,resilience}` (plus the resilience circuit-breaker variants) now emit `DeprecationWarning`. Build a `Grelmicro(uses=[...])` and open it with `async with micro:` instead. Removal lands in 1.0.0. Issue [#206](https://github.com/grelinfo/grelmicro/issues/206), removal tracked in [#207](https://github.com/grelinfo/grelmicro/issues/207).

--- a/grelmicro/trace/_context.py
+++ b/grelmicro/trace/_context.py
@@ -7,11 +7,7 @@ from typing import Any
 from grelmicro._context import (
     context_stack as _context_stack,
 )
-
-try:
-    from opentelemetry import trace as _otel_trace
-except ImportError:  # pragma: no cover
-    _otel_trace: Any = None  # type: ignore[no-redef]
+from grelmicro.trace._otel import get as _get_otel
 
 
 def get_context() -> dict[str, Any]:
@@ -50,8 +46,9 @@ def add_context(**fields: object) -> None:
     new_frame = {**stack[-1], **fields}
     _context_stack.set((*stack[:-1], new_frame))
 
-    if _otel_trace is not None:
-        span = _otel_trace.get_current_span()
+    otel = _get_otel()
+    if otel.trace is not None:
+        span = otel.trace.get_current_span()
         if span.is_recording():
             for k, v in fields.items():
                 span.set_attribute(k, str(v))

--- a/grelmicro/trace/_instrument.py
+++ b/grelmicro/trace/_instrument.py
@@ -9,17 +9,11 @@ from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, overload
 
 from grelmicro._context import pop_context as _pop_context
 from grelmicro._context import push_context as _push_context
+from grelmicro.trace._otel import get as _get_otel
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Set as AbstractSet
-
-try:
-    from opentelemetry import trace
-    from opentelemetry.trace import StatusCode
-except ImportError:  # pragma: no cover
-    trace: Any = None  # type: ignore[no-redef]
-    StatusCode: Any = None  # type: ignore[no-redef,misc]
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -36,7 +30,8 @@ def _record_exception(otel_span: object) -> None:
     ):
         exc = sys.exc_info()[1]
         if exc is not None:
-            otel_span.set_status(StatusCode.ERROR, str(exc))  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]
+            otel = _get_otel()
+            otel_span.set_status(otel.status_code.ERROR, str(exc))  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]
             otel_span.record_exception(exc)  # ty: ignore[unresolved-attribute]
 
 
@@ -114,7 +109,12 @@ def instrument[**P, R](  # type: ignore[return-value]
         extract = _make_extract_fields(
             inspect.signature(fn), skip_set, skip_all=skip_all
         )
-        tracer = trace.get_tracer(fn.__module__) if trace is not None else None
+        otel = _get_otel()
+        tracer = (
+            otel.trace.get_tracer(fn.__module__)
+            if otel.trace is not None
+            else None
+        )
 
         if inspect.iscoroutinefunction(fn):
 

--- a/grelmicro/trace/_otel.py
+++ b/grelmicro/trace/_otel.py
@@ -1,0 +1,37 @@
+"""Lazy access to the optional `opentelemetry` package.
+
+`opentelemetry` is an extra. `import grelmicro.trace` must not pull it
+in: production apps that never configure tracing should not pay the
+import cost. The package is resolved on first call to `get` and cached
+for subsequent calls via `functools.cache`.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from typing import TYPE_CHECKING, NamedTuple, Protocol, cast
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Span, StatusCode, Tracer
+
+    class _OTelTrace(Protocol):
+        def get_tracer(self, instrumenting_module_name: str) -> Tracer: ...
+        def get_current_span(self) -> Span: ...
+
+
+class OTel(NamedTuple):
+    """Resolved opentelemetry handles, or `None` when not installed."""
+
+    trace: _OTelTrace | None
+    status_code: type[StatusCode] | None
+
+
+@cache
+def get() -> OTel:
+    """Return resolved opentelemetry handles. Cached after first call."""
+    try:
+        from opentelemetry import trace  # noqa: PLC0415
+        from opentelemetry.trace import StatusCode  # noqa: PLC0415
+    except ImportError:
+        return OTel(None, None)
+    return OTel(cast("_OTelTrace", trace), StatusCode)

--- a/grelmicro/trace/_otel.py
+++ b/grelmicro/trace/_otel.py
@@ -14,9 +14,10 @@ from typing import TYPE_CHECKING, NamedTuple, Protocol, cast
 if TYPE_CHECKING:
     from opentelemetry.trace import Span, StatusCode, Tracer
 
-    class _OTelTrace(Protocol):
-        def get_tracer(self, instrumenting_module_name: str) -> Tracer: ...
-        def get_current_span(self) -> Span: ...
+
+class _OTelTrace(Protocol):
+    def get_tracer(self, instrumenting_module_name: str) -> Tracer: ...
+    def get_current_span(self) -> Span: ...
 
 
 class OTel(NamedTuple):

--- a/grelmicro/trace/_span.py
+++ b/grelmicro/trace/_span.py
@@ -4,20 +4,14 @@ from __future__ import annotations
 
 import sys
 from contextlib import contextmanager, nullcontext
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from grelmicro._context import pop_context as _pop_context
 from grelmicro._context import push_context as _push_context
+from grelmicro.trace._otel import get as _get_otel
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-
-try:
-    from opentelemetry import trace as _otel_trace
-    from opentelemetry.trace import StatusCode as _StatusCode
-except ImportError:  # pragma: no cover
-    _otel_trace: Any = None  # type: ignore[no-redef]
-    _StatusCode: Any = None  # type: ignore[no-redef,misc]
 
 
 @contextmanager
@@ -42,12 +36,13 @@ def span(name: str, **fields: object) -> Generator[None, None, None]:
         name: Span name.
         **fields: Structured fields added to both OTel span and log context.
     """
+    otel = _get_otel()
     token = _push_context(dict(fields))
     otel_cm = (
-        _otel_trace.get_tracer(__name__).start_as_current_span(
+        otel.trace.get_tracer(__name__).start_as_current_span(
             name, attributes={k: str(v) for k, v in fields.items()}
         )
-        if _otel_trace is not None
+        if otel.trace is not None
         else nullcontext()
     )
     with otel_cm as otel_span:
@@ -61,7 +56,7 @@ def span(name: str, **fields: object) -> Generator[None, None, None]:
             ):
                 exc = sys.exc_info()[1]
                 if exc is not None:
-                    otel_span.set_status(_StatusCode.ERROR, str(exc))  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]
+                    otel_span.set_status(otel.status_code.ERROR, str(exc))  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]
                     otel_span.record_exception(exc)
             raise
         finally:

--- a/tests/tracing/test_context.py
+++ b/tests/tracing/test_context.py
@@ -1,6 +1,7 @@
 """Unit tests for tracing context internals."""
 
 import asyncio
+import builtins
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,6 +21,7 @@ from grelmicro.trace._context import (
     get_context,
 )
 from grelmicro.trace._instrument import _record_exception, instrument
+from grelmicro.trace._otel import OTel
 from grelmicro.trace._span import span as tracing_span
 
 
@@ -119,9 +121,11 @@ class TestAddContext:
         mock_span = MagicMock()
         mock_span.is_recording.return_value = True
 
+        mock_trace = MagicMock()
+        mock_trace.get_current_span.return_value = mock_span
         mocker.patch(
-            "grelmicro.trace._context._otel_trace.get_current_span",
-            return_value=mock_span,
+            "grelmicro.trace._context._get_otel",
+            return_value=OTel(mock_trace, None),
         )
 
         token = _push_context({"a": 1})
@@ -140,9 +144,11 @@ class TestAddContext:
         mock_span = MagicMock()
         mock_span.is_recording.return_value = False
 
+        mock_trace = MagicMock()
+        mock_trace.get_current_span.return_value = mock_span
         mocker.patch(
-            "grelmicro.trace._context._otel_trace.get_current_span",
-            return_value=mock_span,
+            "grelmicro.trace._context._get_otel",
+            return_value=OTel(mock_trace, None),
         )
 
         token = _push_context({"a": 1})
@@ -264,9 +270,12 @@ class TestSpanExceptionRecording:
             return_value=False
         )
 
+        mock_trace = MagicMock()
+        mock_trace.get_tracer.return_value = mock_tracer
+        mock_status = MagicMock()
         mocker.patch(
-            "grelmicro.trace._span._otel_trace.get_tracer",
-            return_value=mock_tracer,
+            "grelmicro.trace._span._get_otel",
+            return_value=OTel(mock_trace, mock_status),  # ty: ignore[invalid-argument-type]
         )
 
         def _raise_in_span() -> None:
@@ -289,7 +298,10 @@ class TestInstrumentNoOtel:
         mocker: pytest_mock.MockerFixture,
     ) -> None:
         """Test sync @instrument works when tracer is None."""
-        mocker.patch("grelmicro.trace._instrument.trace", None)
+        mocker.patch(
+            "grelmicro.trace._instrument._get_otel",
+            return_value=OTel(None, None),
+        )
 
         @instrument
         def process(order_id: str) -> str:  # noqa: ARG001
@@ -302,10 +314,40 @@ class TestInstrumentNoOtel:
         mocker: pytest_mock.MockerFixture,
     ) -> None:
         """Test async @instrument works when tracer is None."""
-        mocker.patch("grelmicro.trace._instrument.trace", None)
+        mocker.patch(
+            "grelmicro.trace._instrument._get_otel",
+            return_value=OTel(None, None),
+        )
 
         @instrument
         async def async_process(order_id: str) -> str:  # noqa: ARG001
             return "done"
 
         assert asyncio.run(async_process("ORD-1")) == "done"
+
+
+class TestOTelResolver:
+    """Test `_otel.get` lazy resolution."""
+
+    def test_returns_none_when_opentelemetry_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`get()` returns `OTel(None, None)` when opentelemetry import fails."""
+        from grelmicro.trace import _otel  # noqa: PLC0415
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN002, ANN003, ANN202
+            if name.startswith("opentelemetry"):
+                raise ImportError(name)
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        _otel.get.cache_clear()
+        try:
+            result = _otel.get()
+        finally:
+            _otel.get.cache_clear()
+
+        assert result == OTel(None, None)


### PR DESCRIPTION
## Summary

Pre-1.0 import-cost audit (#189). `import grelmicro.trace` no longer loads `opentelemetry` (16 modules avoided). The package is resolved lazily on first call to `instrument`, `span`, or `add_context`, then cached via `functools.cache`.

- New `grelmicro/trace/_otel.py` (37 lines): `@cache`-memoized `get()` returning `OTel(trace, status_code)` NamedTuple. `Protocol` `_OTelTrace` (under `TYPE_CHECKING`) types the trace module without a runtime import. No `global` state.
- `_context.py`, `_instrument.py`, `_span.py`: top-level `try: from opentelemetry…` blocks replaced with a single `_get_otel()` call inside each user-facing function.
- Tests: 5 reworked to patch `_get_otel` at the consumer site, plus a new `TestOTelResolver` that exercises the `ImportError` branch (100% coverage).

Closes #189 (tracing portion). The remaining `__all__` audit and the borderline 19 ms `import grelmicro` cost stay open for follow-ups.

## Test plan

- [x] `import grelmicro.trace` — 0 opentelemetry modules in `sys.modules` (was 16).
- [x] First `@instrument` decoration loads 16 opentelemetry modules — lazy load fires where expected.
- [x] 68/68 tracing tests pass.
- [x] Full pre-commit suite green (ruff, ty, unit, integration, 100% coverage).