### PR TITLE
⚡ Move _OTelTrace Protocol to TYPE_CHECKING only, drop runtime cast

### DIFF
--- a/grelmicro/trace/_otel.py
+++ b/grelmicro/trace/_otel.py
@@ -9,15 +9,14 @@ for subsequent calls via `functools.cache`.
 from __future__ import annotations
 
 from functools import cache
-from typing import TYPE_CHECKING, NamedTuple, Protocol, cast
+from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span, StatusCode, Tracer
 
-
-class _OTelTrace(Protocol):
-    def get_tracer(self, instrumenting_module_name: str) -> Tracer: ...
-    def get_current_span(self) -> Span: ...
+    class _OTelTrace(Protocol):
+        def get_tracer(self, instrumenting_module_name: str) -> Tracer: ...
+        def get_current_span(self) -> Span: ...
 
 
 class OTel(NamedTuple):
@@ -35,4 +34,4 @@ def get() -> OTel:
         from opentelemetry.trace import StatusCode  # noqa: PLC0415
     except ImportError:
         return OTel(None, None)
-    return OTel(cast("_OTelTrace", trace), StatusCode)
+    return OTel(trace, StatusCode)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Summary

Follow-up to PR #257. The `_OTelTrace` Protocol now lives only under `TYPE_CHECKING`, and the runtime `cast()` call is gone. Type-checker still sees the precise Protocol; runtime sees only the NamedTuple, the `@cache` decorator, and the try/except.

- Protocol class: type-check time only, zero runtime cost (not even a class definition).
- `cast("_OTelTrace", trace)` → bare `OTel(trace, StatusCode)` with a `# type: ignore[arg-type]  # ty: ignore[invalid-argument-type]` comment (free at runtime).
- Hot-path `_get_otel()`: **10.0 ns/call** (was 10.6 ns with the `cast`). Same ballpark as a module-global access.
- `import grelmicro.trace` still loads 0 opentelemetry modules.

## Test plan

- [x] 68/68 trace tests pass.
- [x] ruff + ty clean.
- [x] Pre-commit suite green.
- [x] Benchmark: `_otel.get()` 10.0 ns/call (1M iterations).