### PR TITLE
✨ Make Log and Trace usable via Grelmicro(uses=[...])

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* ✨ Add `Log` and `Trace` components. Register `Log()` and `Trace()` in `Grelmicro(uses=[...])` to wire observability through the same verb as `Sync`, `Cache`, `RateLimit`, `Breaker`, and `Tasks`. `Log()` wraps `grelmicro.log.configure(...)` and snapshots stdlib root handlers on enter so sequential apps in tests do not stack handlers. `Trace()` owns an OTel `TracerProvider`: builds it from `TracingConfig` (env prefix `GREL_TRACE_`), installs it on enter, shuts it down and restores the prior global provider on exit. OTLP HTTP and gRPC exporters are lazy-imported. Issue [#224](https://github.com/grelinfo/grelmicro/issues/224).
+
 ## 0.22.0 - 2026-05-16
 
 ### Features

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -10,6 +10,16 @@ Logs go to stdout. Format is selected automatically. Configuration is done via e
 --8<-- "log/configure.py"
 ```
 
+Or attach it to a `Grelmicro` app via `uses=`:
+
+```python
+--8<-- "log/component.py"
+```
+
+`Log()` accepts the same knobs as `configure()` and resolves `GREL_LOG_*`
+environment variables. On exit, the previous stdlib root handlers are
+restored.
+
 With no environment variables set, `configure()` detects your terminal:
 
 - **Terminal (TTY)**: human-readable colored text

--- a/docs/snippets/log/component.py
+++ b/docs/snippets/log/component.py
@@ -1,0 +1,15 @@
+import asyncio
+import logging
+
+from grelmicro import Grelmicro
+from grelmicro.log import Log
+
+micro = Grelmicro(uses=[Log()])
+
+
+async def main() -> None:
+    async with micro:
+        logging.getLogger(__name__).info("hello", extra={"user_id": 123})
+
+
+asyncio.run(main())

--- a/docs/snippets/trace/component.py
+++ b/docs/snippets/trace/component.py
@@ -1,0 +1,29 @@
+import asyncio
+
+from grelmicro import Grelmicro
+from grelmicro.log import Log
+from grelmicro.trace import Trace, TracingExporterType, instrument
+
+
+@instrument
+async def process(order_id: str) -> None:
+    pass
+
+
+micro = Grelmicro(
+    uses=[
+        Log(),
+        Trace(
+            service_name="orders",
+            exporter=TracingExporterType.CONSOLE,
+        ),
+    ]
+)
+
+
+async def main() -> None:
+    async with micro:
+        await process(order_id="ORD-1")
+
+
+asyncio.run(main())

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -92,6 +92,8 @@ When OpenTelemetry is installed, `@instrument` and `span()` also create OTel spa
 !!! tip "Install"
     OpenTelemetry integration needs the `opentelemetry` extra: `pip install "grelmicro[opentelemetry]"`. See the [installation guide](installation.md) for `uv` and `poetry`.
 
+### Standalone
+
 ```python
 # Logging only (no OTel dependency needed)
 configure()
@@ -100,6 +102,24 @@ configure()
 # @instrument and span() will automatically create OTel spans when opentelemetry
 # is installed and a TracerProvider is configured.
 ```
+
+### Via Grelmicro app
+
+`Trace()` owns the `TracerProvider` lifecycle when registered on a
+`Grelmicro` app. The provider is installed on enter and restored to the
+prior global on exit, so sequential apps in tests do not stack
+providers.
+
+```python
+--8<-- "trace/component.py"
+```
+
+`Trace()` reads `GREL_TRACE_*` environment variables (see `TracingConfig`
+for the full field set) or accepts the same fields as keyword arguments.
+The OTLP HTTP and gRPC exporters require their own packages
+(`opentelemetry-exporter-otlp-proto-http` or
+`opentelemetry-exporter-otlp-proto-grpc`) and are imported only when
+selected.
 
 ## Works With All Backends
 

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -20,14 +20,18 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from grelmicro.cache._component import Cache
+    from grelmicro.log._component import Log
     from grelmicro.sync._component import Sync
+    from grelmicro.trace._component import Trace
 else:
     # Runtime fallback so `typing.get_type_hints(Grelmicro)` resolves the
     # `sync` / `cache` property annotations without forcing first-party
     # submodules to load at `import grelmicro`. Real types are visible to
     # static type checkers via the `TYPE_CHECKING` branch above.
     Cache = Any
+    Log = Any
     Sync = Any
+    Trace = Any
 
 _current_micro: ContextVar[Grelmicro] = ContextVar("grelmicro_current_app")
 
@@ -277,6 +281,16 @@ class Grelmicro:
     def cache(self) -> Cache:
         """The registered `Cache` component (default-named, or sole entry of kind `cache`)."""
         return self._resolve_kind("cache")
+
+    @property
+    def log(self) -> Log:
+        """The registered `Log` component (default-named, or sole entry of kind `log`)."""
+        return self._resolve_kind("log")
+
+    @property
+    def trace(self) -> Trace:
+        """The registered `Trace` component (default-named, or sole entry of kind `trace`)."""
+        return self._resolve_kind("trace")
 
     def _resolve_kind(self, name: str) -> Any:  # noqa: ANN401
         """Shared resolution logic for typed properties and `__getattr__`."""

--- a/grelmicro/log/__init__.py
+++ b/grelmicro/log/__init__.py
@@ -5,6 +5,8 @@ from typing import Annotated
 from typing_extensions import Doc
 
 from grelmicro._config import resolve_config
+from grelmicro.log._apply import apply as _apply
+from grelmicro.log._component import Log
 from grelmicro.log._dedup import DuplicateFilter, DuplicateFilterConfig
 from grelmicro.log._ratelimit import (
     RateLimitFilter,
@@ -20,24 +22,6 @@ from grelmicro.log.config import (
 )
 from grelmicro.log.errors import LoggingError
 from grelmicro.log.types import ErrorDict, JSONRecordDict
-
-
-def _apply(config: LoggingConfig) -> None:
-    """Dispatch to the selected backend with the resolved config."""
-    if config.backend == LoggingBackendType.STRUCTLOG:
-        from grelmicro.log._structlog import (  # noqa: PLC0415
-            configure as _configure,
-        )
-    elif config.backend == LoggingBackendType.STDLIB:
-        from grelmicro.log._stdlib import (  # noqa: PLC0415
-            configure as _configure,
-        )
-    else:
-        from grelmicro.log._loguru import (  # noqa: PLC0415
-            configure as _configure,
-        )
-
-    _configure(config)
 
 
 def configure(
@@ -156,6 +140,7 @@ __all__ = [
     "DuplicateFilterConfig",
     "ErrorDict",
     "JSONRecordDict",
+    "Log",
     "LoggingConfig",
     "LoggingError",
     "RateLimitFilter",

--- a/grelmicro/log/_apply.py
+++ b/grelmicro/log/_apply.py
@@ -1,0 +1,21 @@
+"""Backend dispatcher for logging configuration."""
+
+from grelmicro.log.config import LoggingBackendType, LoggingConfig
+
+
+def apply(config: LoggingConfig) -> None:
+    """Dispatch to the selected backend with the resolved config."""
+    if config.backend == LoggingBackendType.STRUCTLOG:
+        from grelmicro.log._structlog import (  # noqa: PLC0415
+            configure as _configure,
+        )
+    elif config.backend == LoggingBackendType.STDLIB:
+        from grelmicro.log._stdlib import (  # noqa: PLC0415
+            configure as _configure,
+        )
+    else:
+        from grelmicro.log._loguru import (  # noqa: PLC0415
+            configure as _configure,
+        )
+
+    _configure(config)

--- a/grelmicro/log/_component.py
+++ b/grelmicro/log/_component.py
@@ -1,0 +1,167 @@
+"""Log component for the Grelmicro app object."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self
+
+from typing_extensions import Doc
+
+from grelmicro._config import resolve_config
+from grelmicro.log._apply import apply as _apply
+from grelmicro.log.config import (
+    LoggingBackendType,
+    LoggingConfig,
+    LoggingFormatType,
+    LoggingLevelType,
+    LoggingSerializerType,
+    LoggingTimeZoneType,
+)
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+
+class Log:
+    """Log component: installs logging on enter, restores stdlib root state on exit.
+
+    Registered as `micro.log` after `Grelmicro.use(Log(...))`. Mirrors the
+    knobs on `grelmicro.log.configure(...)`. Construction stays cheap, the
+    backend is configured when the surrounding `Grelmicro` opens.
+
+    Example:
+        ```python
+        from grelmicro import Grelmicro
+        from grelmicro.log import Log
+
+        micro = Grelmicro(uses=[Log()])
+
+        async with micro:
+            ...
+        ```
+
+    On exit, the previous stdlib root handlers and level are restored so
+    sequential `Grelmicro(...)` blocks do not pile handlers up. The
+    `loguru` and `structlog` backends keep the configuration installed on
+    enter (no restore).
+
+    Read more in the [Logging](../logging.md) docs.
+    """
+
+    kind: ClassVar[str] = "log"
+
+    def __init__(
+        self,
+        *,
+        name: Annotated[
+            str,
+            Doc(
+                """
+                Registration name. Multiple `Log` components may coexist on
+                one `Grelmicro` under different names.
+                """
+            ),
+        ] = "default",
+        config: Annotated[
+            LoggingConfig | None,
+            Doc(
+                """
+                Pre-built configuration. When provided, individual kwargs
+                must be `None`. The env path is bypassed.
+                """
+            ),
+        ] = None,
+        backend: Annotated[
+            LoggingBackendType | None,
+            Doc("Logging backend (`stdlib`, `loguru`, `structlog`)."),
+        ] = None,
+        level: Annotated[
+            LoggingLevelType | None, Doc("Log level threshold.")
+        ] = None,
+        format: Annotated[  # noqa: A002
+            LoggingFormatType | str | None, Doc("Log format.")
+        ] = None,
+        timezone: Annotated[
+            LoggingTimeZoneType | None,
+            Doc("IANA timezone for timestamps."),
+        ] = None,
+        json_serializer: Annotated[
+            LoggingSerializerType | None, Doc("JSON serializer.")
+        ] = None,
+        caller_enabled: Annotated[
+            bool | None,
+            Doc("Include caller (function and line) in log records."),
+        ] = None,
+        otel_enabled: Annotated[
+            bool | None, Doc("Extract OpenTelemetry trace context.")
+        ] = None,
+        env_load: Annotated[
+            bool | None,
+            Doc(
+                "Whether to read `GREL_LOG_*` environment variables. "
+                "When None (default), follow `GREL_ENV_LOAD`."
+            ),
+        ] = None,
+    ) -> None:
+        """Initialize the component (defer configuration until `__aenter__`)."""
+        self.name = name
+        self._explicit_config = config
+        self._kwargs = {
+            "backend": backend,
+            "level": level,
+            "format": format,
+            "timezone": timezone,
+            "json_serializer": json_serializer,
+            "caller_enabled": caller_enabled,
+            "otel_enabled": otel_enabled,
+        }
+        self._env_load = env_load
+        self._resolved: LoggingConfig | None = None
+        self._snapshot_handlers: list[logging.Handler] | None = None
+        self._snapshot_level: int | None = None
+
+    @property
+    def config(self) -> LoggingConfig:
+        """Return the resolved `LoggingConfig`.
+
+        Raises:
+            RuntimeError: If accessed before the component has been entered.
+        """
+        if self._resolved is None:
+            msg = "Log.config is only available inside `async with micro:`"
+            raise RuntimeError(msg)
+        return self._resolved
+
+    async def __aenter__(self) -> Self:
+        """Snapshot stdlib root logger state, then configure logging."""
+        root = logging.getLogger()
+        self._snapshot_handlers = list(root.handlers)
+        self._snapshot_level = root.level
+        self._resolved = resolve_config(
+            LoggingConfig,
+            explicit=self._explicit_config,
+            kwargs=self._kwargs,
+            env_prefix="GREL_LOG_",
+            env_load=self._env_load,
+        )
+        _apply(self._resolved)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        """Restore the snapshotted stdlib root handlers and level."""
+        root = logging.getLogger()
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+        if self._snapshot_handlers is not None:
+            for handler in self._snapshot_handlers:
+                root.addHandler(handler)
+        if self._snapshot_level is not None:
+            root.setLevel(self._snapshot_level)
+        self._snapshot_handlers = None
+        self._snapshot_level = None
+        return None

--- a/grelmicro/log/_component.py
+++ b/grelmicro/log/_component.py
@@ -45,6 +45,10 @@ class Log:
     `loguru` and `structlog` backends keep the configuration installed on
     enter (no restore).
 
+    A single process should not run two `Grelmicro` apps with `Log`
+    components concurrently: stdlib's root logger is a single global, so
+    overlapping lifecycles would clobber each other's snapshots.
+
     Read more in the [Logging](../logging.md) docs.
     """
 

--- a/grelmicro/trace/__init__.py
+++ b/grelmicro/trace/__init__.py
@@ -4,13 +4,25 @@ Unified instrumentation. Creates OTel spans and enriches log records
 with structured context through a single decorator.
 """
 
+from grelmicro.trace._component import Trace
 from grelmicro.trace._context import add_context, get_context
 from grelmicro.trace._instrument import instrument
 from grelmicro.trace._span import span
+from grelmicro.trace.config import (
+    TracingConfig,
+    TracingExporterType,
+    TracingProcessorType,
+    TracingSamplerType,
+)
 from grelmicro.trace.errors import TracingError
 
 __all__ = [
+    "Trace",
+    "TracingConfig",
     "TracingError",
+    "TracingExporterType",
+    "TracingProcessorType",
+    "TracingSamplerType",
     "add_context",
     "get_context",
     "instrument",

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -1,0 +1,264 @@
+"""Trace component for the Grelmicro app object."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
+
+from typing_extensions import Doc
+
+from grelmicro._config import resolve_config
+from grelmicro.errors import DependencyNotFoundError
+from grelmicro.trace.config import (
+    TracingConfig,
+    TracingExporterType,
+    TracingProcessorType,
+    TracingSamplerType,
+)
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+
+class Trace:
+    """Trace component: installs an OTel `TracerProvider` for the app's lifetime.
+
+    Registered as `micro.trace` after `Grelmicro.use(Trace(...))`. On enter,
+    builds a `TracerProvider` from the resolved config and installs it via
+    `opentelemetry.trace.set_tracer_provider`. On exit, the provider is shut
+    down and the previously-installed provider (if any) is restored.
+
+    Example:
+        ```python
+        from grelmicro import Grelmicro
+        from grelmicro.trace import Trace
+
+        micro = Grelmicro(uses=[Trace(service_name="payments-api")])
+
+        async with micro:
+            ...
+        ```
+
+    The OTLP exporters are lazy-imported when selected. Install the matching
+    exporter package: `opentelemetry-exporter-otlp-proto-http` or
+    `opentelemetry-exporter-otlp-proto-grpc`.
+
+    Read more in the [Tracing](../tracing.md) docs.
+    """
+
+    kind: ClassVar[str] = "trace"
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        name: Annotated[
+            str,
+            Doc(
+                """
+                Registration name. Multiple `Trace` components may coexist
+                on one `Grelmicro` under different names.
+                """
+            ),
+        ] = "default",
+        config: Annotated[
+            TracingConfig | None,
+            Doc(
+                """
+                Pre-built configuration. When provided, individual kwargs
+                must be `None`. The env path is bypassed.
+                """
+            ),
+        ] = None,
+        service_name: Annotated[
+            str | None, Doc("Service name resource attribute.")
+        ] = None,
+        exporter: Annotated[
+            TracingExporterType | None, Doc("Span exporter.")
+        ] = None,
+        endpoint: Annotated[str | None, Doc("Exporter endpoint.")] = None,
+        headers: Annotated[
+            dict[str, str] | None, Doc("Exporter headers.")
+        ] = None,
+        processor: Annotated[
+            TracingProcessorType | None, Doc("Span processor.")
+        ] = None,
+        sampler: Annotated[TracingSamplerType | None, Doc("Sampler.")] = None,
+        sample_ratio: Annotated[
+            float | None, Doc("Sample ratio for `traceidratio` sampler.")
+        ] = None,
+        resource_attributes: Annotated[
+            dict[str, str] | None, Doc("Extra resource attributes.")
+        ] = None,
+        env_load: Annotated[
+            bool | None,
+            Doc(
+                "Whether to read `GREL_TRACE_*` environment variables. "
+                "When None (default), follow `GREL_ENV_LOAD`."
+            ),
+        ] = None,
+    ) -> None:
+        """Initialize the component (defer provider build until `__aenter__`)."""
+        self.name = name
+        self._explicit_config = config
+        self._kwargs = {
+            "service_name": service_name,
+            "exporter": exporter,
+            "endpoint": endpoint,
+            "headers": headers,
+            "processor": processor,
+            "sampler": sampler,
+            "sample_ratio": sample_ratio,
+            "resource_attributes": resource_attributes,
+        }
+        self._env_load = env_load
+        self._resolved: TracingConfig | None = None
+        self._provider: Any = None
+        self._prior_provider: Any = None
+
+    @property
+    def config(self) -> TracingConfig:
+        """Return the resolved `TracingConfig`.
+
+        Raises:
+            RuntimeError: If accessed before the component has been entered.
+        """
+        if self._resolved is None:
+            msg = "Trace.config is only available inside `async with micro:`"
+            raise RuntimeError(msg)
+        return self._resolved
+
+    @property
+    def provider(self) -> Any:  # noqa: ANN401
+        """Return the installed OTel `TracerProvider`.
+
+        Raises:
+            RuntimeError: If accessed before the component has been entered.
+        """
+        if self._provider is None:
+            msg = "Trace.provider is only available inside `async with micro:`"
+            raise RuntimeError(msg)
+        return self._provider
+
+    async def __aenter__(self) -> Self:
+        """Build the `TracerProvider` and install it as the global provider."""
+        try:
+            from opentelemetry import trace  # noqa: PLC0415
+        except ImportError as exc:  # pragma: no cover
+            raise DependencyNotFoundError(module="opentelemetry-api") from exc
+
+        self._resolved = resolve_config(
+            TracingConfig,
+            explicit=self._explicit_config,
+            kwargs=self._kwargs,
+            env_prefix="GREL_TRACE_",
+            env_load=self._env_load,
+        )
+        self._prior_provider = getattr(trace, "_TRACER_PROVIDER", None)
+        self._provider = _build_provider(self._resolved)
+        trace._TRACER_PROVIDER = self._provider  # type: ignore[attr-defined]  # noqa: SLF001
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        """Shut down the provider and restore the prior global provider."""
+        from opentelemetry import trace  # noqa: PLC0415
+
+        try:
+            shutdown = getattr(self._provider, "shutdown", None)
+            if callable(shutdown):
+                shutdown()
+        finally:
+            trace._TRACER_PROVIDER = self._prior_provider  # type: ignore[attr-defined]  # noqa: SLF001
+            self._provider = None
+            self._prior_provider = None
+        return None
+
+
+def _build_provider(config: TracingConfig) -> Any:  # noqa: ANN401
+    """Build a `TracerProvider` from a `TracingConfig`."""
+    try:
+        from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
+        from opentelemetry.sdk.trace import TracerProvider  # noqa: PLC0415
+        from opentelemetry.sdk.trace.export import (  # noqa: PLC0415
+            BatchSpanProcessor,
+            SimpleSpanProcessor,
+        )
+        from opentelemetry.sdk.trace.sampling import (  # noqa: PLC0415
+            ALWAYS_OFF,
+            ALWAYS_ON,
+            ParentBased,
+            TraceIdRatioBased,
+        )
+    except ImportError as exc:  # pragma: no cover
+        raise DependencyNotFoundError(module="opentelemetry-sdk") from exc
+
+    resource_attrs: dict[str, Any] = dict(config.resource_attributes)
+    if config.service_name is not None:
+        resource_attrs["service.name"] = config.service_name
+    resource = Resource.create(resource_attrs) if resource_attrs else None
+
+    if config.sampler == TracingSamplerType.ALWAYS_ON:
+        sampler = ALWAYS_ON
+    elif config.sampler == TracingSamplerType.ALWAYS_OFF:
+        sampler = ALWAYS_OFF
+    elif config.sampler == TracingSamplerType.TRACEIDRATIO:
+        sampler = TraceIdRatioBased(config.sample_ratio)
+    else:
+        sampler = ParentBased(ALWAYS_ON)
+
+    provider = TracerProvider(resource=resource, sampler=sampler)
+
+    if config.exporter != TracingExporterType.NONE:
+        exporter = _build_exporter(config)
+        processor_cls = (
+            BatchSpanProcessor
+            if config.processor == TracingProcessorType.BATCH
+            else SimpleSpanProcessor
+        )
+        provider.add_span_processor(processor_cls(exporter))
+
+    return provider
+
+
+def _build_exporter(config: TracingConfig) -> Any:  # noqa: ANN401
+    """Build a span exporter for the configured exporter type."""
+    if config.exporter == TracingExporterType.CONSOLE:
+        from opentelemetry.sdk.trace.export import (  # noqa: PLC0415
+            ConsoleSpanExporter,
+        )
+
+        return ConsoleSpanExporter()
+
+    if config.exporter == TracingExporterType.OTLP_HTTP:  # pragma: no cover
+        try:
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # noqa: PLC0415  # ty: ignore[unresolved-import]
+                OTLPSpanExporter,
+            )
+        except ImportError as exc:
+            raise DependencyNotFoundError(
+                module="opentelemetry-exporter-otlp-proto-http"
+            ) from exc
+        kwargs: dict[str, Any] = {}
+        if config.endpoint is not None:
+            kwargs["endpoint"] = config.endpoint
+        if config.headers:
+            kwargs["headers"] = config.headers
+        return OTLPSpanExporter(**kwargs)
+
+    try:  # pragma: no cover
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # noqa: PLC0415  # ty: ignore[unresolved-import]
+            OTLPSpanExporter,
+        )
+    except ImportError as exc:  # pragma: no cover
+        raise DependencyNotFoundError(
+            module="opentelemetry-exporter-otlp-proto-grpc"
+        ) from exc
+    kwargs = {}  # pragma: no cover
+    if config.endpoint is not None:  # pragma: no cover
+        kwargs["endpoint"] = config.endpoint
+    if config.headers:  # pragma: no cover
+        kwargs["headers"] = config.headers
+    return OTLPSpanExporter(**kwargs)  # pragma: no cover

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -23,9 +23,15 @@ class Trace:
     """Trace component: installs an OTel `TracerProvider` for the app's lifetime.
 
     Registered as `micro.trace` after `Grelmicro.use(Trace(...))`. On enter,
-    builds a `TracerProvider` from the resolved config and installs it via
-    `opentelemetry.trace.set_tracer_provider`. On exit, the provider is shut
-    down and the previously-installed provider (if any) is restored.
+    builds a `TracerProvider` from the resolved config and installs it as the
+    process-global provider. On exit, the provider is shut down and the
+    previously-installed provider (if any) is restored.
+
+    OTel's `set_tracer_provider` refuses to override an already-installed
+    provider, so `Trace` writes the process-global directly. This means a
+    single process should not run two `Grelmicro` apps with `Trace`
+    components concurrently: their lifecycles share one OTel global.
+    Sequential apps (the common test scenario) work fine.
 
     Example:
         ```python

--- a/grelmicro/trace/config.py
+++ b/grelmicro/trace/config.py
@@ -10,7 +10,9 @@ from typing_extensions import Doc
 class _CaseInsensitiveEnum(StrEnum):
     @classmethod
     def _missing_(cls, value: object) -> Self | None:
-        value = str(value).lower()
+        if not isinstance(value, str):
+            return None
+        value = value.lower()
         for member in cls:
             if member.lower() == value:
                 return member

--- a/grelmicro/trace/config.py
+++ b/grelmicro/trace/config.py
@@ -1,0 +1,89 @@
+"""Tracing Configuration."""
+
+from enum import StrEnum
+from typing import Annotated, Self
+
+from pydantic import BaseModel, Field
+from typing_extensions import Doc
+
+
+class _CaseInsensitiveEnum(StrEnum):
+    @classmethod
+    def _missing_(cls, value: object) -> Self | None:
+        value = str(value).lower()
+        for member in cls:
+            if member.lower() == value:
+                return member
+        return None
+
+
+class TracingExporterType(_CaseInsensitiveEnum):
+    """Span exporter selection."""
+
+    OTLP_HTTP = "otlp-http"
+    OTLP_GRPC = "otlp-grpc"
+    CONSOLE = "console"
+    NONE = "none"
+
+
+class TracingProcessorType(_CaseInsensitiveEnum):
+    """Span processor selection."""
+
+    BATCH = "batch"
+    SIMPLE = "simple"
+
+
+class TracingSamplerType(_CaseInsensitiveEnum):
+    """Sampler selection."""
+
+    ALWAYS_ON = "always_on"
+    ALWAYS_OFF = "always_off"
+    PARENTBASED_ALWAYS_ON = "parentbased_always_on"
+    TRACEIDRATIO = "traceidratio"
+
+
+class TracingConfig(BaseModel, frozen=True, extra="forbid"):
+    """Tracing Config."""
+
+    service_name: Annotated[
+        str | None,
+        Doc(
+            "Service name resource attribute. Falls back to "
+            "`OTEL_SERVICE_NAME` when unset."
+        ),
+    ] = None
+    exporter: Annotated[
+        TracingExporterType,
+        Doc("Span exporter."),
+    ] = TracingExporterType.OTLP_HTTP
+    endpoint: Annotated[
+        str | None,
+        Doc(
+            "Exporter endpoint. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT` "
+            "when unset."
+        ),
+    ] = None
+    headers: Annotated[
+        dict[str, str],
+        Doc(
+            "Exporter headers. Falls back to `OTEL_EXPORTER_OTLP_HEADERS` "
+            "when empty."
+        ),
+    ] = Field(default_factory=dict)
+    processor: Annotated[
+        TracingProcessorType,
+        Doc("Span processor."),
+    ] = TracingProcessorType.BATCH
+    sampler: Annotated[
+        TracingSamplerType,
+        Doc("Sampler."),
+    ] = TracingSamplerType.PARENTBASED_ALWAYS_ON
+    sample_ratio: Annotated[
+        float,
+        Doc("Sample ratio for `traceidratio` sampler."),
+        Field(ge=0.0, le=1.0),
+    ] = 1.0
+    resource_attributes: Annotated[
+        dict[str, str],
+        Doc("Extra resource attributes."),
+    ] = Field(default_factory=dict)

--- a/tests/logging/test_component.py
+++ b/tests/logging/test_component.py
@@ -1,0 +1,78 @@
+"""Tests for the `Log` component (Grelmicro app integration)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from grelmicro import Component, Grelmicro
+from grelmicro.log import Log, LoggingConfig
+from grelmicro.log.config import LoggingLevelType
+
+
+def test_log_satisfies_component_protocol() -> None:
+    """`Log` is a runtime-checkable `Component`."""
+    assert isinstance(Log(), Component)
+
+
+def test_log_default_kind_and_name() -> None:
+    """Default kind is `log` and default name is `default`."""
+    log = Log()
+    assert log.kind == "log"
+    assert log.name == "default"
+
+
+def test_log_named_registration() -> None:
+    """A named `Log` component coexists with the default one."""
+    micro = Grelmicro(uses=[Log(), Log(name="audit")])
+    assert micro.get("log", "default").name == "default"
+    assert micro.get("log", "audit").name == "audit"
+
+
+def test_log_config_unavailable_before_enter() -> None:
+    """`Log.config` raises before the component has been entered."""
+    log = Log()
+    with pytest.raises(RuntimeError, match="only available inside"):
+        _ = log.config
+
+
+async def test_log_resolves_config_on_enter(
+    reset_stdlib: None,  # noqa: ARG001
+) -> None:
+    """Entering the app resolves the config and configures logging."""
+    micro = Grelmicro(uses=[Log(level=LoggingLevelType.DEBUG)])
+    async with micro:
+        assert micro.log.config.level == LoggingLevelType.DEBUG
+        assert logging.getLogger().level == logging.DEBUG
+
+
+async def test_log_accepts_prebuilt_config(reset_stdlib: None) -> None:  # noqa: ARG001
+    """`Log(config=...)` uses the pre-built `LoggingConfig` as-is."""
+    config = LoggingConfig(level=LoggingLevelType.WARNING)
+    micro = Grelmicro(uses=[Log(config=config)])
+    async with micro:
+        assert micro.log.config is config
+
+
+async def test_log_restores_root_handlers_on_exit(
+    reset_stdlib: None,  # noqa: ARG001
+) -> None:
+    """Exiting restores the stdlib root logger handlers and level."""
+    root = logging.getLogger()
+    sentinel = logging.NullHandler()
+    root.addHandler(sentinel)
+    before = list(root.handlers)
+    root.setLevel(logging.WARNING)
+    micro = Grelmicro(uses=[Log(level=LoggingLevelType.DEBUG)])
+    async with micro:
+        assert sentinel not in root.handlers
+    assert root.handlers == before
+    assert root.level == logging.WARNING
+
+
+async def test_log_use_via_micro_attribute(reset_stdlib: None) -> None:  # noqa: ARG001
+    """`micro.log` resolves to the registered `Log` component."""
+    micro = Grelmicro(uses=[Log()])
+    async with micro:
+        assert isinstance(micro.log, Log)

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -30,6 +30,12 @@ def test_tracing_config_rejects_unknown_enum_value() -> None:
         TracingConfig.model_validate({"exporter": "bogus"})
 
 
+def test_tracing_config_rejects_none_for_enum() -> None:
+    """`None` does not silently resolve to `TracingExporterType.NONE`."""
+    with pytest.raises(ValueError, match="exporter"):
+        TracingConfig.model_validate({"exporter": None})
+
+
 def test_trace_satisfies_component_protocol() -> None:
     """`Trace` is a runtime-checkable `Component`."""
     assert isinstance(Trace(exporter=TracingExporterType.NONE), Component)

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -1,0 +1,146 @@
+"""Tests for the `Trace` component (Grelmicro app integration)."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+
+from grelmicro import Component, Grelmicro
+from grelmicro.trace import (
+    Trace,
+    TracingConfig,
+    TracingExporterType,
+    TracingSamplerType,
+)
+
+
+def test_tracing_config_accepts_case_insensitive_enums() -> None:
+    """Enum fields accept any-case strings via `_missing_`."""
+    config = TracingConfig.model_validate(
+        {"exporter": "NONE", "sampler": "ALWAYS_OFF"}
+    )
+    assert config.exporter == TracingExporterType.NONE
+    assert config.sampler == TracingSamplerType.ALWAYS_OFF
+
+
+def test_tracing_config_rejects_unknown_enum_value() -> None:
+    """Enum fields reject values that no member matches."""
+    with pytest.raises(ValueError, match="exporter"):
+        TracingConfig.model_validate({"exporter": "bogus"})
+
+
+def test_trace_satisfies_component_protocol() -> None:
+    """`Trace` is a runtime-checkable `Component`."""
+    assert isinstance(Trace(exporter=TracingExporterType.NONE), Component)
+
+
+def test_trace_default_kind_and_name() -> None:
+    """Default kind is `trace` and default name is `default`."""
+    trace = Trace(exporter=TracingExporterType.NONE)
+    assert trace.kind == "trace"
+    assert trace.name == "default"
+
+
+def test_trace_named_registration() -> None:
+    """A named `Trace` component coexists with the default one."""
+    micro = Grelmicro(
+        uses=[
+            Trace(exporter=TracingExporterType.NONE),
+            Trace(exporter=TracingExporterType.NONE, name="audit"),
+        ]
+    )
+    assert micro.get("trace", "default").name == "default"
+    assert micro.get("trace", "audit").name == "audit"
+
+
+def test_trace_config_unavailable_before_enter() -> None:
+    """`Trace.config` raises before the component has been entered."""
+    trace = Trace(exporter=TracingExporterType.NONE)
+    with pytest.raises(RuntimeError, match="only available inside"):
+        _ = trace.config
+
+
+async def test_trace_installs_provider_on_enter() -> None:
+    """Entering the app installs a TracerProvider as the global provider."""
+    prior = otel_trace.get_tracer_provider()
+    micro = Grelmicro(
+        uses=[
+            Trace(
+                exporter=TracingExporterType.NONE,
+                service_name="test-svc",
+            )
+        ]
+    )
+    async with micro:
+        installed = otel_trace.get_tracer_provider()
+        assert isinstance(installed, TracerProvider)
+        assert micro.trace.provider is installed
+    assert otel_trace.get_tracer_provider() is prior
+
+
+async def test_trace_accepts_prebuilt_config() -> None:
+    """`Trace(config=...)` uses the pre-built `TracingConfig` as-is."""
+    config = TracingConfig(
+        exporter=TracingExporterType.NONE, service_name="payments"
+    )
+    micro = Grelmicro(uses=[Trace(config=config)])
+    async with micro:
+        assert micro.trace.config is config
+
+
+def test_trace_provider_unavailable_before_enter() -> None:
+    """`Trace.provider` raises before the component has been entered."""
+    trace = Trace(exporter=TracingExporterType.NONE)
+    with pytest.raises(RuntimeError, match="only available inside"):
+        _ = trace.provider
+
+
+async def test_trace_console_exporter() -> None:
+    """`exporter=console` builds a console exporter pipeline."""
+    micro = Grelmicro(uses=[Trace(exporter=TracingExporterType.CONSOLE)])
+    async with micro:
+        assert isinstance(micro.trace.provider, TracerProvider)
+
+
+async def test_trace_always_off_sampler() -> None:
+    """`sampler=always_off` drops all spans."""
+    micro = Grelmicro(
+        uses=[
+            Trace(
+                exporter=TracingExporterType.NONE,
+                sampler=TracingSamplerType.ALWAYS_OFF,
+            )
+        ]
+    )
+    async with micro:
+        assert micro.trace.config.sampler == TracingSamplerType.ALWAYS_OFF
+
+
+async def test_trace_always_on_sampler() -> None:
+    """`sampler=always_on` keeps all spans."""
+    micro = Grelmicro(
+        uses=[
+            Trace(
+                exporter=TracingExporterType.NONE,
+                sampler=TracingSamplerType.ALWAYS_ON,
+            )
+        ]
+    )
+    async with micro:
+        assert micro.trace.config.sampler == TracingSamplerType.ALWAYS_ON
+
+
+async def test_trace_sampler_ratio() -> None:
+    """`sampler=traceidratio` builds a TraceIdRatioBased sampler."""
+    micro = Grelmicro(
+        uses=[
+            Trace(
+                exporter=TracingExporterType.NONE,
+                sampler=TracingSamplerType.TRACEIDRATIO,
+                sample_ratio=0.25,
+            )
+        ]
+    )
+    async with micro:
+        assert micro.trace.config.sample_ratio == 0.25  # noqa: PLR2004


### PR DESCRIPTION
Closes #224.

## Summary

* `Log()` and `Trace()` register through the same `Grelmicro(uses=[...])` verb as `Sync`, `Cache`, `RateLimit`, `Breaker`, and `Tasks`. Observability is no longer the holdout.
* `Log()` wraps `grelmicro.log.configure(...)`. Snapshots stdlib root handlers and level on enter, restores on exit so sequential apps in tests do not stack handlers.
* `Trace()` owns the OTel `TracerProvider` lifecycle. New `TracingConfig` (frozen `BaseModel`, env prefix `GREL_TRACE_`) covers exporter, endpoint, headers, processor, sampler, sample ratio, and resource attributes. Default exporter is `otlp-http`. OTLP HTTP and gRPC exporters are lazy-imported.
* Typed `micro.log` and `micro.trace` properties on `Grelmicro`.

## Test plan

- [x] `uv run pytest` (1624 passed, 100% coverage)
- [x] `uv run ruff check` and `uv run ty check`
- [x] Doc snippets `docs/snippets/log/component.py` and `docs/snippets/trace/component.py` run end-to-end