### PR TITLE
💥 Rename discriminator field type to kind on tagged unions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 Rename the discriminator field from `type` to `kind` on every tagged union. Affects `RateLimiterConfig` (`TokenBucketConfig`, `SlidingWindowConfig`) and `RetryBackoffConfig` (`ExponentialBackoff`, `ConstantBackoff`, `LinearBackoff`, `FibonacciBackoff`, `RandomBackoff`). Serialized YAML and JSON configs must replace `type:` with `kind:` (for example `GREL_RETRY_FOO_BACKOFF={"kind":"exponential",...}`). Frees the Python `type` builtin from being shadowed on every config object. Issue [#268](https://github.com/grelinfo/grelmicro/issues/268).
 * 💥 Rename `GCRAConfig` to `SlidingWindowConfig` and `RateLimiter.gcra(...)` to `RateLimiter.sliding_window(...)`. The discriminator value also moves from `"gcra"` to `"sliding_window"`. Module `grelmicro.resilience.algorithms.gcra` becomes `grelmicro.resilience.algorithms.sliding_window`. Internal strategy classes (`_RedisGCRA`, `_MemoryGCRA`) keep their names since they describe the underlying algorithm. Issue [#259](https://github.com/grelinfo/grelmicro/issues/259).
 
 ### Features

--- a/docs/resilience/retry.md
+++ b/docs/resilience/retry.md
@@ -145,11 +145,11 @@ Prefix: `GREL_RETRY_{NAME_UPPER}_`
 |---|---|---|---|
 | `GREL_RETRY_{NAME_UPPER}_ATTEMPTS` | `attempts` | `int` (>= 1) | `3` |
 | `GREL_RETRY_{NAME_UPPER}_WHEN` | `when` | CSV or JSON list of FQN strings (e.g. `httpx.HTTPError`). Coerced to `Match.exception(...)`. Predicate forms cannot come from env. | required |
-| `GREL_RETRY_{NAME_UPPER}_BACKOFF` | `backoff` | JSON object with a `type` field (see below) | `{"type":"exponential"}` |
+| `GREL_RETRY_{NAME_UPPER}_BACKOFF` | `backoff` | JSON object with a `kind` field (see below) | `{"kind":"exponential"}` |
 
 The full backoff config is a discriminated Pydantic union, so the env value is parsed as one JSON object. Each algorithm accepts the same fields it takes in code:
 
-| `type` | Fields |
+| `kind` | Fields |
 |---|---|
 | `exponential` | `base_delay`, `max_delay`, `jitter` (`none` / `full` / `equal` / `decorrelated`) |
 | `constant` | `delay` |

--- a/docs/snippets/resilience/retry_environmental.py
+++ b/docs/snippets/resilience/retry_environmental.py
@@ -7,5 +7,5 @@ from grelmicro.resilience import Retry
 #
 # - GREL_RETRY_PAYMENTS_ATTEMPTS=5
 # - GREL_RETRY_PAYMENTS_WHEN=httpx.HTTPError
-# - GREL_RETRY_PAYMENTS_BACKOFF={"type":"exponential","base_delay":0.2}
+# - GREL_RETRY_PAYMENTS_BACKOFF={"kind":"exponential","base_delay":0.2}
 policy = Retry("payments", when=httpx.HTTPError)

--- a/grelmicro/resilience/algorithms/__init__.py
+++ b/grelmicro/resilience/algorithms/__init__.py
@@ -17,7 +17,7 @@ from grelmicro.resilience.algorithms.tokenbucket import TokenBucketConfig
 
 RateLimiterConfig = Annotated[
     TokenBucketConfig | SlidingWindowConfig,
-    Discriminator("type"),
+    Discriminator("kind"),
 ]
 """Discriminated union of supported rate-limiter algorithm configurations."""
 

--- a/grelmicro/resilience/algorithms/sliding_window.py
+++ b/grelmicro/resilience/algorithms/sliding_window.py
@@ -31,7 +31,7 @@ class SlidingWindowConfig(_BaseRateLimiterConfig, frozen=True, extra="forbid"):
     Read more in the [Rate Limiter](../resilience/rate-limiter.md) docs.
     """
 
-    type: Annotated[
+    kind: Annotated[
         Literal["sliding_window"],
         Doc("Discriminator for the algorithm Pydantic union."),
     ] = "sliding_window"

--- a/grelmicro/resilience/algorithms/tokenbucket.py
+++ b/grelmicro/resilience/algorithms/tokenbucket.py
@@ -31,7 +31,7 @@ class TokenBucketConfig(_BaseRateLimiterConfig, frozen=True, extra="forbid"):
     Read more in the [Rate Limiter](../resilience/rate-limiter.md) docs.
     """
 
-    type: Annotated[
+    kind: Annotated[
         Literal["token_bucket"],
         Doc("Discriminator for the algorithm Pydantic union."),
     ] = "token_bucket"

--- a/grelmicro/resilience/backoffs/__init__.py
+++ b/grelmicro/resilience/backoffs/__init__.py
@@ -25,7 +25,7 @@ RetryBackoffConfig = Annotated[
     | LinearBackoff
     | FibonacciBackoff
     | RandomBackoff,
-    Discriminator("type"),
+    Discriminator("kind"),
 ]
 """Discriminated union of supported retry backoff configurations."""
 

--- a/grelmicro/resilience/backoffs/constant.py
+++ b/grelmicro/resilience/backoffs/constant.py
@@ -29,7 +29,7 @@ class ConstantBackoff(BaseModel, frozen=True, extra="forbid"):
     Read more in the [Retry](../resilience/retry.md) docs.
     """
 
-    type: Annotated[
+    kind: Annotated[
         Literal["constant"],
         Doc("Discriminator for the backoff Pydantic union."),
     ] = "constant"

--- a/grelmicro/resilience/backoffs/exponential.py
+++ b/grelmicro/resilience/backoffs/exponential.py
@@ -30,7 +30,7 @@ class ExponentialBackoff(BaseModel, frozen=True, extra="forbid"):
     Read more in the [Retry](../resilience/retry.md) docs.
     """
 
-    type: Annotated[
+    kind: Annotated[
         Literal["exponential"],
         Doc("Discriminator for the backoff Pydantic union."),
     ] = "exponential"

--- a/grelmicro/resilience/backoffs/fibonacci.py
+++ b/grelmicro/resilience/backoffs/fibonacci.py
@@ -37,7 +37,7 @@ class FibonacciBackoff(BaseModel, frozen=True, extra="forbid"):
     Read more in the [Retry](../resilience/retry.md) docs.
     """
 
-    type: Annotated[
+    kind: Annotated[
         Literal["fibonacci"],
         Doc("Discriminator for the backoff Pydantic union."),
     ] = "fibonacci"

--- a/grelmicro/resilience/backoffs/linear.py
+++ b/grelmicro/resilience/backoffs/linear.py
@@ -34,7 +34,7 @@ class LinearBackoff(BaseModel, frozen=True, extra="forbid"):
     Read more in the [Retry](../resilience/retry.md) docs.
     """
 
-    type: Annotated[
+    kind: Annotated[
         Literal["linear"],
         Doc("Discriminator for the backoff Pydantic union."),
     ] = "linear"

--- a/grelmicro/resilience/backoffs/random.py
+++ b/grelmicro/resilience/backoffs/random.py
@@ -36,7 +36,7 @@ class RandomBackoff(BaseModel, frozen=True, extra="forbid"):
     Read more in the [Retry](../resilience/retry.md) docs.
     """
 
-    type: Annotated[
+    kind: Annotated[
         Literal["random"],
         Doc("Discriminator for the backoff Pydantic union."),
     ] = "random"

--- a/grelmicro/resilience/retry.py
+++ b/grelmicro/resilience/retry.py
@@ -327,7 +327,7 @@ class _AttemptLoop:
 
 def _backoff_name(config: RetryBackoffConfig) -> str:
     """Return a human-readable name for the backoff config."""
-    return config.type
+    return config.kind
 
 
 async def _async_iter(

--- a/tests/resilience/backoffs/test_constant.py
+++ b/tests/resilience/backoffs/test_constant.py
@@ -14,9 +14,9 @@ _NEW_DELAY = 2.0
 
 
 def test_default_config() -> None:
-    """Default config: type=constant, delay=1.0."""
+    """Default config: kind=constant, delay=1.0."""
     config = ConstantBackoff()
-    assert config.type == "constant"
+    assert config.kind == "constant"
     assert config.delay == _DEFAULT_DELAY
 
 

--- a/tests/resilience/backoffs/test_exponential.py
+++ b/tests/resilience/backoffs/test_exponential.py
@@ -18,9 +18,9 @@ _CAPPED_MAX = 4.0
 
 
 def test_default_config() -> None:
-    """Default config: type=exponential, base=0.1, max=30, jitter=full."""
+    """Default config: kind=exponential, base=0.1, max=30, jitter=full."""
     config = ExponentialBackoff()
-    assert config.type == "exponential"
+    assert config.kind == "exponential"
     assert config.base_delay == _DEFAULT_BASE
     assert config.max_delay == _DEFAULT_MAX
     assert config.jitter == "full"

--- a/tests/resilience/backoffs/test_fibonacci.py
+++ b/tests/resilience/backoffs/test_fibonacci.py
@@ -14,9 +14,9 @@ _FIB_DELAYS = [1.0, 1.0, 2.0, 3.0, 5.0, 8.0, 13.0]
 
 
 def test_default_config() -> None:
-    """Default config: type=fibonacci, base=1.0, max=30.0."""
+    """Default config: kind=fibonacci, base=1.0, max=30.0."""
     config = FibonacciBackoff()
-    assert config.type == "fibonacci"
+    assert config.kind == "fibonacci"
     assert config.base_delay == _DEFAULT_BASE
     assert config.max_delay == _DEFAULT_MAX
 

--- a/tests/resilience/backoffs/test_linear.py
+++ b/tests/resilience/backoffs/test_linear.py
@@ -13,9 +13,9 @@ _DEFAULT_MAX = 30.0
 
 
 def test_default_config() -> None:
-    """Default config: type=linear, base=1.0, max=30.0."""
+    """Default config: kind=linear, base=1.0, max=30.0."""
     config = LinearBackoff()
-    assert config.type == "linear"
+    assert config.kind == "linear"
     assert config.base_delay == _DEFAULT_BASE
     assert config.max_delay == _DEFAULT_MAX
 

--- a/tests/resilience/backoffs/test_random.py
+++ b/tests/resilience/backoffs/test_random.py
@@ -13,9 +13,9 @@ _DEFAULT_MAX = 2.0
 
 
 def test_default_config() -> None:
-    """Default config: type=random, min=0.5, max=2.0."""
+    """Default config: kind=random, min=0.5, max=2.0."""
     config = RandomBackoff()
-    assert config.type == "random"
+    assert config.kind == "random"
     assert config.min_delay == _DEFAULT_MIN
     assert config.max_delay == _DEFAULT_MAX
 

--- a/tests/resilience/test_ratelimiter_config.py
+++ b/tests/resilience/test_ratelimiter_config.py
@@ -100,11 +100,11 @@ def test_from_config_classmethod() -> None:
 def test_discriminator_values() -> None:
     """Discriminator values are part of the public serialized API surface."""
     assert (
-        TokenBucketConfig(capacity=CAPACITY, refill_rate=REFILL_RATE).type
+        TokenBucketConfig(capacity=CAPACITY, refill_rate=REFILL_RATE).kind
         == "token_bucket"
     )
     assert (
-        SlidingWindowConfig(limit=LIMIT, window=WINDOW).type == "sliding_window"
+        SlidingWindowConfig(limit=LIMIT, window=WINDOW).kind == "sliding_window"
     )
 
 
@@ -112,11 +112,11 @@ def test_rate_limiter_config_union_round_trips() -> None:
     """`RateLimiterConfig` parses both discriminator values."""
     adapter = TypeAdapter(RateLimiterConfig)
     sliding = adapter.validate_python(
-        {"type": "sliding_window", "limit": LIMIT, "window": WINDOW}
+        {"kind": "sliding_window", "limit": LIMIT, "window": WINDOW}
     )
     bucket = adapter.validate_python(
         {
-            "type": "token_bucket",
+            "kind": "token_bucket",
             "capacity": CAPACITY,
             "refill_rate": REFILL_RATE,
         }

--- a/tests/resilience/test_retry.py
+++ b/tests/resilience/test_retry.py
@@ -513,7 +513,7 @@ async def test_env_backoff_via_json(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GREL_RETRY_FOO_ATTEMPTS", "3")
     monkeypatch.setenv("GREL_RETRY_FOO_WHEN", "builtins.ValueError")
     monkeypatch.setenv(
-        "GREL_RETRY_FOO_BACKOFF", '{"type":"constant","delay":2.5}'
+        "GREL_RETRY_FOO_BACKOFF", '{"kind":"constant","delay":2.5}'
     )
     policy = Retry("foo")  # type: ignore[call-arg]
     assert isinstance(policy.config.backoff, ConstantBackoff)


### PR DESCRIPTION
## Summary

Rename the Pydantic discriminator field from `type` to `kind` on every tagged union:

- `RateLimiterConfig` — `TokenBucketConfig`, `SlidingWindowConfig`
- `RetryBackoffConfig` — `ExponentialBackoff`, `ConstantBackoff`, `LinearBackoff`, `FibonacciBackoff`, `RandomBackoff`

`type` shadows the Python builtin on every config object. `kind` matches the convention used by Kubernetes, Argo, Tekton, and similar operator-style configs. Pre-1.0 clean cut, no deprecation shim.

User-visible breaking change: serialized YAML and JSON configs must replace `type:` with `kind:`. The example env var becomes `GREL_RETRY_FOO_BACKOFF={"kind":"exponential",...}`.

Closes #268.

## Test plan

- [x] `uv run pytest` (1627 passed)
- [x] `uv run ty check grelmicro`
- [x] `uv run ruff check grelmicro tests`
- [x] `uv run ruff format --check`
- [x] Discriminator round-trip tests already in `test_ratelimiter_config.py` updated to use `kind`.