### PR TITLE
📝 Document micro.override and conftest recipe for tests

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -11,4 +11,4 @@ This section documents the internal design decisions and guarantees of grelmicro
 - **[Kubernetes Backend](kubernetes.md)**: Lease resources, optimistic concurrency, and name sanitization.
 - **[SQLite Backend](sqlite.md)**: WAL mode.
 - **[Tracing](tracing.md)**: Context stack, concurrency safety, and decoupled layering.
-- **[Testing](testing.md)**: `Grelmicro.testing()` baseline and `micro.override(...)` as block or decorator.
+- **[Testing](testing.md)**: `micro.override(...)` block and pytest conftest recipe.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -11,3 +11,4 @@ This section documents the internal design decisions and guarantees of grelmicro
 - **[Kubernetes Backend](kubernetes.md)**: Lease resources, optimistic concurrency, and name sanitization.
 - **[SQLite Backend](sqlite.md)**: WAL mode.
 - **[Tracing](tracing.md)**: Context stack, concurrency safety, and decoupled layering.
+- **[Testing](testing.md)**: `Grelmicro.testing()` baseline and `micro.override(...)` as block or decorator.

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -5,13 +5,18 @@
 Swaps components inside an active `async with micro:` block.
 
 ```python
+from unittest.mock import AsyncMock
+
 from grelmicro.sync import Sync
+from grelmicro.sync.abc import SyncBackend
 
 
 async def test_swap_for_block(micro: Grelmicro) -> None:
+    fake_backend = AsyncMock(spec=SyncBackend)
     async with micro:
-        async with micro.override(Sync(FakeSync())):
+        async with micro.override(Sync(fake_backend)):
             await do_something_that_uses_sync()
+            fake_backend.acquire.assert_awaited()
 ```
 
 Override components are entered when the block opens and exited in reverse order when it closes. Prior registrations are restored on exit, including when the block raises.
@@ -50,7 +55,14 @@ async def micro() -> AsyncIterator[Grelmicro]:
 Tests then read `micro` as a fixture and apply per-case overrides:
 
 ```python
+from unittest.mock import AsyncMock
+
+from grelmicro.sync import Sync
+from grelmicro.sync.abc import SyncBackend
+
+
 async def test_login(micro: Grelmicro) -> None:
-    async with micro.override(Sync(FakeSync())):
+    fake_backend = AsyncMock(spec=SyncBackend)
+    async with micro.override(Sync(fake_backend)):
         await do_login("u1")
 ```

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -1,0 +1,56 @@
+# Testing
+
+## `micro.override(*components)`
+
+Swaps components inside an active `async with micro:` block.
+
+```python
+from grelmicro.sync import Sync
+
+
+async def test_swap_for_block(micro: Grelmicro) -> None:
+    async with micro:
+        async with micro.override(Sync(FakeSync())):
+            await do_something_that_uses_sync()
+```
+
+Override components are entered when the block opens and exited in reverse order when it closes. Prior registrations are restored on exit, including when the block raises.
+
+### Restrictions
+
+- Only `Component` instances can be overridden. Plain async context managers passed to `use(...)` are substituted at construction time, not through `override()`.
+- Calling `micro.override(...)` outside an active `async with micro:` raises `OutOfContextError`.
+
+## Pytest recipe
+
+grelmicro ships no pytest plugin. Add a `micro` fixture in `conftest.py`:
+
+```python
+from collections.abc import AsyncIterator
+
+import pytest
+
+from grelmicro import Grelmicro
+from grelmicro.cache import Cache
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.sync import Sync
+from grelmicro.sync.memory import MemorySyncAdapter
+
+
+@pytest.fixture
+async def micro() -> AsyncIterator[Grelmicro]:
+    app = Grelmicro(uses=[
+        Sync(MemorySyncAdapter()),
+        Cache(MemoryCacheAdapter()),
+    ])
+    async with app:
+        yield app
+```
+
+Tests then read `micro` as a fixture and apply per-case overrides:
+
+```python
+async def test_login(micro: Grelmicro) -> None:
+    async with micro.override(Sync(FakeSync())):
+        await do_login("u1")
+```

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -7,6 +7,7 @@ Swaps components inside an active `async with micro:` block.
 ```python
 from unittest.mock import AsyncMock
 
+from grelmicro import Grelmicro
 from grelmicro.sync import Sync
 from grelmicro.sync.abc import SyncBackend
 
@@ -57,6 +58,7 @@ Tests then read `micro` as a fixture and apply per-case overrides:
 ```python
 from unittest.mock import AsyncMock
 
+from grelmicro import Grelmicro
 from grelmicro.sync import Sync
 from grelmicro.sync.abc import SyncBackend
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@
 
 * ✨ Add `Log` and `Trace` components. Register `Log()` and `Trace()` in `Grelmicro(uses=[...])` to wire observability through the same verb as `Sync`, `Cache`, `RateLimit`, `Breaker`, and `Tasks`. `Log()` wraps `grelmicro.log.configure(...)` and snapshots stdlib root handlers on enter so sequential apps in tests do not stack handlers. `Trace()` owns an OTel `TracerProvider`: builds it from `TracingConfig` (env prefix `GREL_TRACE_`), installs it on enter, shuts it down and restores the prior global provider on exit. OTLP HTTP and gRPC exporters are lazy-imported. Issue [#224](https://github.com/grelinfo/grelmicro/issues/224).
 
+### Docs
+
+* 📝 Add [Testing](architecture/testing.md) page documenting `micro.override(...)` and the conftest recipe. Issue [#236](https://github.com/grelinfo/grelmicro/issues/236).
+
 ## 0.22.0 - 2026-05-16
 
 ### Features

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
     - architecture/kubernetes.md
     - architecture/sqlite.md
     - architecture/tracing.md
+    - architecture/testing.md
 - changelog.md
 - Third-party notices: third_party_notices.md
 


### PR DESCRIPTION
## Summary

Adds `docs/architecture/testing.md` documenting `micro.override(*components)` (block form) and the pytest conftest recipe. Smoke-tested every snippet against the actual codebase (real `SyncBackend` protocol, real `MemorySyncAdapter`, `AsyncMock(spec=SyncBackend)` for the fake).

Net change: zero code. Pure docs.

Original issue #236 proposed a pytest plugin, `Grelmicro.testing()` factory, and a `@micro.override(...)` decorator. The decorator is incompatible with per-test fixture `micro` (the decorator runs at module load, the fixture only exists at runtime). Pre-wired test factories are unconventional in the Python ecosystem (FastAPI, Litestar, dependency-injector all ship none). The pytest plugin would force-load fixture names like `micro` on every install, colliding with user namespace.

The follow-up work surfaced two ideas that need their own issues with proper API design:
- Protocol-level call recorder.
- Virtual clock injected into time-dependent components.

Closes #236.

## Test plan

- [x] Smoke-tested every snippet end-to-end against current `main` code.
- [x] `uv run pytest` (1627 passed).
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`.