### PR TITLE
📝 Add Pattern × Adapter capability matrix page

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -7,9 +7,9 @@ The [roadmap](https://github.com/grelinfo/grelmicro/issues/124) and the [milesto
 ## Vocabulary
 
 - **Pattern**: user-facing class. `Lock`, `LeaderElection`, `TaskLock`, `TTLCache`, `RateLimiter`, `CircuitBreaker`, `Retry`, `Bulkhead`, `Fallback`.
-- **Adapter**: concrete implementation over a Provider. `RedisSyncAdapter`, `PostgresCacheAdapter`, and so on.
+- **Adapter**: concrete implementation of a Backend Protocol. `RedisSyncAdapter`, `PostgresSyncAdapter`, `MemoryCacheAdapter`, `SQLiteSyncAdapter`, `KubernetesSyncAdapter`, and so on.
 - **Backend**: the Protocol class an Adapter satisfies. `SyncBackend`, `CacheBackend`, `RateLimiterBackend`, `CircuitBreakerBackend`.
-- **Provider**: vendor configuration plus native client. `RedisProvider`, `PostgresProvider`, `SQLiteProvider`.
+- **Provider**: vendor configuration plus native client, shared by Adapters that talk to the same service. `RedisProvider`, `PostgresProvider`. Memory, SQLite, and Kubernetes Adapters do not use a Provider.
 
 See [Backends and Adapters](architecture/backends.md) for the full model.
 
@@ -40,7 +40,7 @@ Closing every gap above that links to an issue. Anything marked `Future` is out 
 
 ## Picking an Adapter
 
-- **Memory** for tests, single-process apps, and Patterns that have no distributed variant (`Retry`, `Bulkhead`, `Fallback`).
+- **Memory** for tests, single-process apps, and `Retry` (the only in-process Pattern that ships today). `Bulkhead` and `Fallback` will join this group at `1.0.0`.
 - **Redis** when you already run Redis and want the lowest-latency distributed option.
 - **Postgres** when Postgres is your only stateful dependency and you want one fewer service to run.
 - **SQLite** for single-host deployments that still need durability across restarts.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,4 +1,4 @@
-# Compatibility matrix
+# Capability matrix
 
 Which Pattern × Adapter combinations ship today, and which gaps the `1.0.0` milestone closes.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@
 ### Docs
 
 * 📝 Add [Testing](architecture/testing.md) page documenting `micro.override(...)` and the conftest recipe. Issue [#236](https://github.com/grelinfo/grelmicro/issues/236).
+* 📝 Add [Compatibility matrix](compatibility.md) page covering Pattern × Adapter pairs for `1.0.0`. Issue [#161](https://github.com/grelinfo/grelmicro/issues/161).
 
 ## 0.22.0 - 2026-05-16
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,7 @@
 ### Docs
 
 * 📝 Add [Testing](architecture/testing.md) page documenting `micro.override(...)` and the conftest recipe. Issue [#236](https://github.com/grelinfo/grelmicro/issues/236).
-* 📝 Add [Compatibility matrix](compatibility.md) page covering Pattern × Adapter pairs for `1.0.0`. Issue [#161](https://github.com/grelinfo/grelmicro/issues/161).
+* 📝 Add [Capability matrix](capabilities.md) page covering Pattern × Adapter pairs for `1.0.0`. Issue [#161](https://github.com/grelinfo/grelmicro/issues/161).
 
 ## 0.22.0 - 2026-05-16
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,47 @@
+# Compatibility matrix
+
+Which Pattern × Adapter combinations ship today, and which gaps the `1.0.0` milestone closes.
+
+The [roadmap](https://github.com/grelinfo/grelmicro/issues/124) and the [milestones](https://github.com/grelinfo/grelmicro/milestones) carry the live state. This page is the at-a-glance view.
+
+## Vocabulary
+
+- **Pattern**: user-facing class. `Lock`, `LeaderElection`, `TaskLock`, `TTLCache`, `RateLimiter`, `CircuitBreaker`, `Retry`, `Bulkhead`, `Fallback`.
+- **Adapter**: concrete implementation over a Provider. `RedisSyncAdapter`, `PostgresCacheAdapter`, and so on.
+- **Backend**: the Protocol class an Adapter satisfies. `SyncBackend`, `CacheBackend`, `RateLimiterBackend`, `CircuitBreakerBackend`.
+- **Provider**: vendor configuration plus native client. `RedisProvider`, `PostgresProvider`, `SQLiteProvider`.
+
+See [Backends and Adapters](architecture/backends.md) for the full model.
+
+## Matrix
+
+| Pattern             | Memory                                                         | Redis                                                          | Postgres                                                       | SQLite                                                         | Kubernetes |
+| ------------------- | :------------------------------------------------------------: | :------------------------------------------------------------: | :------------------------------------------------------------: | :------------------------------------------------------------: | :--------: |
+| `Lock`              | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | ✅         |
+| `TaskLock`          | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | ✅         |
+| `LeaderElection`    | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | ✅         |
+| `TTLCache`          | ✅                                                             | ✅                                                             | [#167](https://github.com/grelinfo/grelmicro/issues/167)       | Future                                                         | N/A        |
+| `RateLimiter`       | ✅                                                             | ✅                                                             | [#164](https://github.com/grelinfo/grelmicro/issues/164)       | [#173](https://github.com/grelinfo/grelmicro/issues/173)       | N/A        |
+| `CircuitBreaker`    | ✅                                                             | [#163](https://github.com/grelinfo/grelmicro/issues/163)       | Future                                                         | Future                                                         | N/A        |
+| `Retry`             | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
+| `Bulkhead`          | [#168](https://github.com/grelinfo/grelmicro/issues/168)       | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
+| `Fallback`          | [#199](https://github.com/grelinfo/grelmicro/issues/199)       | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
+
+Legend:
+
+- ✅ ships today.
+- `#N` planned for `1.0.0`, tracked by the linked issue.
+- `Future` planned past `1.0.0`.
+- `N/A` does not apply. `Retry`, `Bulkhead`, and `Fallback` are in-process Patterns with no remote state to share.
+
+## What `1.0.0` commits to
+
+Closing every gap above that links to an issue. Anything marked `Future` is out of scope for `1.0.0`.
+
+## Picking an Adapter
+
+- **Memory** for tests, single-process apps, and Patterns that have no distributed variant (`Retry`, `Bulkhead`, `Fallback`).
+- **Redis** when you already run Redis and want the lowest-latency distributed option.
+- **Postgres** when Postgres is your only stateful dependency and you want one fewer service to run.
+- **SQLite** for single-host deployments that still need durability across restarts.
+- **Kubernetes** for `Lock` and `LeaderElection` when you want the cluster API as the coordination plane and no extra infrastructure.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
 - grelmicro: index.md
 - installation.md
 - comparison.md
+- compatibility.md
 - User Guide:
     - config.md
     - cache.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,7 @@ nav:
 - grelmicro: index.md
 - installation.md
 - comparison.md
-- compatibility.md
+- capabilities.md
 - User Guide:
     - config.md
     - cache.md


### PR DESCRIPTION
## Summary

- New `docs/capabilities.md` page with the Pattern × Adapter matrix toward `1.0.0`. Ships ✅ today, links open issues for gaps the `1.0.0` milestone closes, marks `Future` and `N/A` cells.
- Verified against current code: `Retry` ships as memory-only (no longer a gap); `Bulkhead` and `Fallback` still gap-memory; resilience adapters are `Memory` + `Redis` only; cache adapters are `Memory` + `Redis`; sync adapters are full coverage across Memory/Redis/Postgres/SQLite/Kubernetes.
- Naming picked after surveying real-world docs: matches Apache Beam's [Capability Matrix](https://beam.apache.org/documentation/runners/capability-matrix/) (runners × features), the closest structural analog.
- Wired into mkdocs nav (top-level, after `comparison.md`) and changelog under Unreleased › Docs.

Closes #161.

## Test plan

- [x] `mkdocs build --strict` passes (only pre-existing link warnings unrelated to this PR).
- [ ] Visual check on the rendered page once the docs preview deploys.