### PR TITLE
📝 Sweep stale docstrings and add missing API reference entries

### DIFF
--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -8,6 +8,7 @@
         - DuplicateFilterConfig
         - ErrorDict
         - JSONRecordDict
+        - Log
         - LoggingConfig
         - LoggingError
         - RateLimitFilter

--- a/docs/reference/resilience.md
+++ b/docs/reference/resilience.md
@@ -4,12 +4,24 @@
     options:
       show_submodules: true
       members:
+        - Breaker
         - CircuitBreaker
+        - CircuitBreakerBackend
+        - CircuitBreakerConfig
         - CircuitBreakerError
         - CircuitBreakerMetrics
         - CircuitBreakerState
+        - ConstantBackoff
         - ErrorDetails
+        - ExponentialBackoff
+        - FibonacciBackoff
+        - LinearBackoff
+        - Match
+        - Matcher
         - MemoryTokenBucket
+        - Outcome
+        - RandomBackoff
+        - RateLimit
         - RateLimiter
         - RateLimiterBackend
         - RateLimiterConfig
@@ -18,8 +30,15 @@
         - RateLimitResult
         - ResilienceError
         - ResilienceSettingsValidationError
+        - Retry
+        - RetryAttempt
+        - RetryBackoffConfig
+        - RetryConfig
+        - RetryStrategy
         - SlidingWindowConfig
         - TokenBucketConfig
+        - retry
+        - retrying
 
 ::: grelmicro.resilience.memory
     options:

--- a/docs/reference/trace.md
+++ b/docs/reference/trace.md
@@ -1,0 +1,16 @@
+# Tracing
+
+::: grelmicro.trace
+    options:
+      show_submodules: true
+      members:
+        - Trace
+        - TracingConfig
+        - TracingError
+        - TracingExporterType
+        - TracingProcessorType
+        - TracingSamplerType
+        - add_context
+        - get_context
+        - instrument
+        - span

--- a/grelmicro/resilience/backoffs/constant.py
+++ b/grelmicro/resilience/backoffs/constant.py
@@ -21,7 +21,7 @@ class ConstantBackoff(BaseModel, frozen=True, extra="forbid"):
     policy = Retry(
         "wait_job",
         ConstantBackoff(delay=1.0),
-        on=NotReady,
+        when=NotReady,
         attempts=20,
     )
     ```

--- a/grelmicro/resilience/backoffs/exponential.py
+++ b/grelmicro/resilience/backoffs/exponential.py
@@ -23,7 +23,7 @@ class ExponentialBackoff(BaseModel, frozen=True, extra="forbid"):
     policy = Retry(
         "payments",
         ExponentialBackoff(base_delay=0.2, max_delay=10.0),
-        on=httpx.HTTPError,
+        when=httpx.HTTPError,
     )
     ```
 

--- a/grelmicro/resilience/backoffs/fibonacci.py
+++ b/grelmicro/resilience/backoffs/fibonacci.py
@@ -29,7 +29,7 @@ class FibonacciBackoff(BaseModel, frozen=True, extra="forbid"):
     policy = Retry(
         "deferred",
         FibonacciBackoff(base_delay=1.0, max_delay=60.0),
-        on=ServiceError,
+        when=ServiceError,
         attempts=8,
     )
     ```

--- a/grelmicro/resilience/backoffs/linear.py
+++ b/grelmicro/resilience/backoffs/linear.py
@@ -26,7 +26,7 @@ class LinearBackoff(BaseModel, frozen=True, extra="forbid"):
     policy = Retry(
         "ramp",
         LinearBackoff(base_delay=1.0, max_delay=10.0),
-        on=ServiceError,
+        when=ServiceError,
         attempts=5,
     )
     ```

--- a/grelmicro/resilience/backoffs/random.py
+++ b/grelmicro/resilience/backoffs/random.py
@@ -28,7 +28,7 @@ class RandomBackoff(BaseModel, frozen=True, extra="forbid"):
     policy = Retry(
         "stampede",
         RandomBackoff(min_delay=0.5, max_delay=2.0),
-        on=CacheMissError,
+        when=CacheMissError,
         attempts=3,
     )
     ```

--- a/grelmicro/resilience/ratelimiter.py
+++ b/grelmicro/resilience/ratelimiter.py
@@ -106,7 +106,7 @@ class RateLimiter(Reconfigurable[RateLimiterConfig]):
                 [`SlidingWindowConfig`][grelmicro.resilience.algorithms.SlidingWindowConfig].
                 Both carry algorithm parameters plus the shared
                 `fail_open` setting. The classes share a
-                discriminated `type` field so serialization
+                discriminated `kind` field so serialization
                 round-trips and pydantic-settings composition both
                 work.
                 """

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
     - reference/resilience.md
     - reference/sync.md
     - reference/task.md
+    - reference/trace.md
 - Architecture:
     - architecture/index.md
     - architecture/asyncio.md


### PR DESCRIPTION
## Summary

Polish pass before the next release. Two kinds of changes:

**Stale docstrings caught up to recent renames.**

- `grelmicro/resilience/ratelimiter.py` constructor doc said "discriminated `type` field". Now `kind` (#269).
- 5 backoff config examples (`exponential`, `constant`, `fibonacci`, `linear`, `random`) used `Retry(on=...)`. Now `when=` (caught up to #242).

**Missing API reference entries for public exports.**

- `docs/reference/logging.md` did not list `Log`. Added.
- `docs/reference/resilience.md` was missing every 0.22.0 addition (`Retry`, `RetryAttempt`, `RetryConfig`, `retry`, `retrying`, `Match`, `Matcher`, `Outcome`, `Breaker`, `RateLimit`, 5 backoffs, `RetryBackoffConfig`, `RetryStrategy`, `CircuitBreakerBackend`, `CircuitBreakerConfig`). Synced to `__all__`. Resolves the broken `#grelmicro.resilience.Retry` anchor from `retry.md`.
- No `docs/reference/trace.md` existed. Added one surfacing `Trace`, `TracingConfig`, `TracingExporterType`, `TracingProcessorType`, `TracingSamplerType`, `TracingError`, `add_context`, `get_context`, `instrument`, `span`. Wired into `mkdocs.yml` nav.

## Test plan

- [x] `pytest tests/` (1627 passed)
- [x] `mkdocs build --strict` (clean, only one pre-existing unrelated anchor info note)