### PR TITLE
📝 docs: Release 0.23.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.23.0 - 2026-05-17
 
 ### Breaking
 


### PR DESCRIPTION
Cuts the 0.23.0 changelog header.