### PR TITLE
⬆️ ci: Bump astral-sh/setup-uv to v8.1.0 and dependabot/fetch-metadata to v3.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v7.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           activate-environment: true
@@ -61,7 +61,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v7.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           activate-environment: true

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v2.4.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for patch/minor Python updates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ env.RELEASE_VERSION }}
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v7.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: false
       - name: Set Package Version
@@ -70,7 +70,7 @@ jobs:
           git config user.name "$GH_ACTOR"
           git config user.email "${GH_ACTOR_ID}+${GH_ACTOR}@users.noreply.github.com"
       - name: Install uv and Activate Environment
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v7.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           activate-environment: true


### PR DESCRIPTION
## Summary

Replaces Dependabot PR #134, which bumped the action SHAs but left the trailing `# vX.Y.Z` version comments stale. This caused 5 zizmor code-scanning alerts (#40-#44) and 3 Copilot review comments flagging the mismatch.

This PR bumps the SHA **and** the comment together, so audit tools and human readers see consistent versions.

## Changes

- `astral-sh/setup-uv@cec20831... # v7.1.0` → `@08807647... # v8.1.0` (4 sites: `ci.yml` × 2, `release.yml` × 2)
- `dependabot/fetch-metadata@ffa630c6... # v2.4.0` → `@25dd0e34... # v3.1.0` (1 site: `dependabot-auto-merge.yml`)

Both bumps cross major versions:
- `setup-uv` v7 → v8: CI rerun on #134 passed with this exact SHA, confirming our usage stays compatible.
- `fetch-metadata` v2 → v3: breaking change is requiring Node.js 24 in the Actions runtime, which GitHub-hosted runners ship by default. Our `dependabot-auto-merge.yml` job uses `ubuntu-latest`, so this is a no-op for us.

## Test plan

- [x] Local pre-commit hooks pass (ruff, codespell, uv-lock, ty-check, pytest-unit, pytest-integration, coverage-report all green)
- [ ] CI green on this PR
- [ ] Copilot review (no comments expected — fixes the issues Copilot raised on #134)
- [ ] zizmor alerts #40-#44 close once this lands on main
- [ ] Close #134 with reference to this PR