### PR TITLE
✨ Add Postgres Adapter for Cache

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -14,7 +14,7 @@ into a `Grelmicro` app via the `Cache` component. For Redis, pass the
 `RedisProvider` directly to `Cache(...)`.
 
 !!! tip "Install"
-    The Redis backend needs the `redis` extra: `pip install "grelmicro[redis]"`. See the [installation guide](installation.md) for `uv` and `poetry`.
+    The Redis backend needs the `redis` extra and the Postgres backend needs the `postgres` extra: `pip install "grelmicro[redis]"` or `pip install "grelmicro[postgres]"`. See the [installation guide](installation.md) for `uv` and `poetry`.
 
 === "Memory"
     ```python
@@ -35,7 +35,25 @@ into a `Grelmicro` app via the `Cache` component. For Redis, pass the
     micro = Grelmicro(uses=[redis, Cache(redis)])
     ```
 
+=== "Postgres"
+    ```python
+    from grelmicro import Grelmicro
+    from grelmicro.cache import Cache
+    from grelmicro.providers.postgres import PostgresProvider
+
+    postgres = PostgresProvider("postgresql://localhost:5432/app")
+    micro = Grelmicro(uses=[postgres, Cache(postgres)])
+    ```
+
 `async with micro:` opens the provider and the cache backend together.
+
+| | Redis | Postgres | Memory |
+|---|---|---|---|
+| **Use case** | Production | Production (when Postgres is already deployed) | Testing / single-process |
+| **Multi-node** | Yes | Yes | No |
+| **Persistence** | Yes (auto-expiring keys) | Yes (table-backed) | No |
+
+The Postgres adapter stores entries in a single `grelmicro_cache` table keyed on `key TEXT PRIMARY KEY` with `value BYTEA` and `expires_at TIMESTAMPTZ`. `get` filters expired rows with `WHERE expires_at > NOW()`, `set` is one `INSERT ... ON CONFLICT DO UPDATE`, `delete` and `clear` are single statements. The table is created on first connect: pass `auto_migrate=False` when your own migration tool owns the schema. Set `cleanup_interval=` to enable a background janitor that reclaims rows expired for more than one hour.
 
 ## TTLCache
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+* ✨ Add `PostgresCacheAdapter` for Postgres-backed cache storage. Register via `Grelmicro(uses=[postgres, Cache(postgres)])`. Entries land in a single `grelmicro_cache` table keyed on `key TEXT PRIMARY KEY` with `value BYTEA` and `expires_at TIMESTAMPTZ`. `get` filters expired rows with `WHERE expires_at > NOW()`, `set` is one `INSERT ... ON CONFLICT DO UPDATE`. Schema auto-migrates on first connect, opt out with `auto_migrate=False`. Optional janitor reclaims storage when `cleanup_interval=` is set (off by default). Issue [#167](https://github.com/grelinfo/grelmicro/issues/167).
 * ✨ Add `PostgresRateLimiterAdapter` for fleet-wide rate limiting on Postgres. Register via `Grelmicro(uses=[postgres, RateLimiters(postgres)])` and `RateLimiter.token_bucket(...)` or `RateLimiter.sliding_window(...)` runs against a single `grelmicro_rate_limiter` table. `acquire` and `peek` each run one round-trip to a PL/pgSQL function. Concurrent writes for the same key are serialized with `pg_advisory_xact_lock`. Schema and functions auto-migrate on first connect, opt out with `auto_migrate=False`. Issue [#164](https://github.com/grelinfo/grelmicro/issues/164).
 
 ## 0.24.0 - 2026-05-18

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -14,7 +14,7 @@ Tone: factual. Where the focused alternative is the better fit, this page says s
 
 | If you only need this | Use this | Pick grelmicro when you also need |
 |---|---|---|
-| Async cache decorator over Redis | [`aiocache`](https://github.com/aio-libs/aiocache) or [`fastapi-cache`](https://github.com/long2ice/fastapi-cache) | Opt-in per-key stampede protection (`lock=True`), type-safe `TTLCache[T]`, Postgres backend (planned, see [#167](https://github.com/grelinfo/grelmicro/issues/167)) |
+| Async cache decorator over Redis | [`aiocache`](https://github.com/aio-libs/aiocache) or [`fastapi-cache`](https://github.com/long2ice/fastapi-cache) | Opt-in per-key stampede protection (`lock=True`), type-safe `TTLCache[T]`, Postgres backend |
 | FastAPI rate limiter | [`slowapi`](https://github.com/laurentS/slowapi) or [`fastapi-limiter`](https://github.com/long2ice/fastapi-limiter) | Sliding-window algorithm, structured `RateLimitResult` for retry-after headers, swap Memory and Redis with the same API |
 | Async circuit breaker | [`pybreaker`](https://github.com/danielfm/pybreaker) or [`aiobreaker`](https://github.com/arlyon/aiobreaker) | Reconfigurable thresholds, frozen Pydantic config, structured logging context, distributed backend (planned, see [#163](https://github.com/grelinfo/grelmicro/issues/163)) |
 | Retry with `@retry(stop=, wait=)` | [`tenacity`](https://github.com/jd/tenacity) | A `Retry` that shares the same config + reconfigure shape as the rest of grelmicro |
@@ -59,7 +59,7 @@ If you build microservices on FastAPI today, grelmicro is the missing batteries.
 
 | Axis | [`aiocache`](https://github.com/aio-libs/aiocache) | [`fastapi-cache`](https://github.com/long2ice/fastapi-cache) | grelmicro `Cache` |
 |---|---|---|---|
-| Backends | Memory, Redis, Memcached | Memory, Redis, Memcached, DynamoDB | Memory, Redis (Postgres at 1.0, see [#167](https://github.com/grelinfo/grelmicro/issues/167)) |
+| Backends | Memory, Redis, Memcached | Memory, Redis, Memcached, DynamoDB | Memory, Redis, Postgres |
 | Decorator | `@cached` | `@cache` | `@cached` |
 | Type-safe `Cache[T]` | no | no | yes (`TTLCache[T]` plus `PydanticSerializer(T)`) |
 | Per-key stampede protection | local lock via `lock_value` | none | opt-in via `lock=True` (off by default). Distributed lock planned (see [#235](https://github.com/grelinfo/grelmicro/issues/235)) |

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -24,3 +24,8 @@
     options:
       members:
         - RedisCacheAdapter
+
+::: grelmicro.cache.postgres
+    options:
+      members:
+        - PostgresCacheAdapter

--- a/docs/snippets/cache/postgres_basic.py
+++ b/docs/snippets/cache/postgres_basic.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel
+
+from grelmicro import Grelmicro
+from grelmicro.cache import Cache, PydanticSerializer, cached
+from grelmicro.providers.postgres import PostgresProvider
+
+
+class User(BaseModel):
+    id: int
+    name: str
+
+
+postgres = PostgresProvider("postgresql://localhost:5432/app")
+cache = Cache(postgres)
+micro = Grelmicro(uses=[postgres, cache])
+
+ttl_cache = cache.ttl(ttl=300, serializer=PydanticSerializer(User))
+
+
+@cached(ttl_cache, lock=True)
+async def get_user(user_id: int) -> User:
+    return User(id=user_id, name="Alice")
+
+
+async def main() -> None:
+    async with micro:
+        user = await get_user(1)
+        print(user)

--- a/grelmicro/cache/postgres.py
+++ b/grelmicro/cache/postgres.py
@@ -137,6 +137,10 @@ class PostgresCacheAdapter:
             msg = f"Table name '{table_name}' is not a valid SQL identifier"
             raise ValueError(msg)
 
+        if cleanup_interval is not None and cleanup_interval <= 0:
+            msg = f"cleanup_interval must be positive, got {cleanup_interval!r}"
+            raise ValueError(msg)
+
         if provider is None:
             self._provider = PostgresProvider(env_prefix=env_prefix)
             self._owns_provider = True

--- a/grelmicro/cache/postgres.py
+++ b/grelmicro/cache/postgres.py
@@ -1,0 +1,249 @@
+"""Postgres Cache Adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import re
+from typing import TYPE_CHECKING, Annotated, Self
+
+from typing_extensions import Doc
+
+from grelmicro.providers.postgres import PostgresProvider
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+
+class PostgresCacheAdapter:
+    """Postgres cache storage backend.
+
+    Wraps a `PostgresProvider` and implements the cache protocol:
+    `get`, `set` (with per-entry TTL via `expires_at`), `delete`,
+    and a prefix-scoped `clear`. Entries live in a single table
+    keyed on `key` with `value BYTEA` and `expires_at TIMESTAMPTZ`.
+
+    Pass an explicit `provider=` to share a pool with other
+    components, or rely on the default `env_prefix=` to build one
+    from environment variables.
+
+    Set `cleanup_interval=` to enable a background janitor that
+    deletes expired rows. Off by default. Lazy expiry on `get`
+    keeps reads correct, the janitor only reclaims storage.
+
+    Example:
+    ```python
+    from grelmicro.cache import Cache
+    from grelmicro.providers.postgres import PostgresProvider
+
+    postgres = PostgresProvider("postgresql://localhost:5432/app")
+    cache = Cache(postgres)
+    ```
+
+    Read more in the [Cache](../cache.md) docs.
+    """
+
+    _SQL_CREATE_TABLE = """
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            key TEXT PRIMARY KEY,
+            value BYTEA NOT NULL,
+            expires_at TIMESTAMPTZ NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS {table_name}_expires_at_idx
+            ON {table_name} (expires_at);
+    """
+
+    _SQL_GET = (
+        "SELECT value FROM {table_name} WHERE key = $1 AND expires_at > NOW();"
+    )
+
+    _SQL_SET = (
+        "INSERT INTO {table_name} (key, value, expires_at) "
+        "VALUES ($1, $2, NOW() + make_interval(secs => $3)) "
+        "ON CONFLICT (key) DO UPDATE "
+        "SET value = EXCLUDED.value, expires_at = EXCLUDED.expires_at;"
+    )
+
+    _SQL_DELETE = "DELETE FROM {table_name} WHERE key = $1;"
+
+    _SQL_CLEAR_PREFIX = "DELETE FROM {table_name} WHERE key LIKE $1;"
+
+    _SQL_CLEAR_ALL = "DELETE FROM {table_name};"
+
+    _SQL_JANITOR = (
+        "DELETE FROM {table_name} WHERE expires_at < NOW() - INTERVAL '1 hour';"
+    )
+
+    def __init__(
+        self,
+        *,
+        provider: Annotated[
+            PostgresProvider | None,
+            Doc(
+                """
+                A pre-built `PostgresProvider`. When set, the adapter
+                borrows the provider's pool and does not manage its
+                lifecycle.
+                """,
+            ),
+        ] = None,
+        env_prefix: Annotated[
+            str,
+            Doc(
+                """
+                Environment variable prefix used by the implicit
+                `PostgresProvider` when `provider` is not set. Defaults
+                to `POSTGRES_`. Use a custom prefix to split pools.
+                """,
+            ),
+        ] = "POSTGRES_",
+        prefix: Annotated[
+            str,
+            Doc("Prefix prepended to every key (cache namespace)."),
+        ] = "",
+        table_name: Annotated[
+            str,
+            Doc(
+                """
+                Table that stores cache entries. Auto-created on first
+                connect (set `auto_migrate=False` to opt out).
+                """,
+            ),
+        ] = "grelmicro_cache",
+        auto_migrate: Annotated[
+            bool,
+            Doc(
+                """
+                When True (the default), the adapter creates the table
+                on `__aenter__`. Set to False when the schema is
+                managed by your own migration tool.
+                """,
+            ),
+        ] = True,
+        cleanup_interval: Annotated[
+            float | None,
+            Doc(
+                """
+                Period in seconds between janitor runs that delete
+                rows expired for more than one hour. Default `None`
+                disables the janitor: lazy expiry on `get` still
+                works, only storage reclamation is skipped.
+                """,
+            ),
+        ] = None,
+    ) -> None:
+        """Initialize the Postgres cache backend."""
+        if not re.fullmatch(r"[a-zA-Z_][a-zA-Z0-9_]*", table_name):
+            msg = f"Table name '{table_name}' is not a valid SQL identifier"
+            raise ValueError(msg)
+
+        if provider is None:
+            self._provider = PostgresProvider(env_prefix=env_prefix)
+            self._owns_provider = True
+        else:
+            self._provider = provider
+            self._owns_provider = False
+        self._env_prefix = env_prefix
+        self._key_prefix = prefix
+        self._table_name = table_name
+        self._auto_migrate = auto_migrate
+        self._cleanup_interval = cleanup_interval
+        self._get_sql = self._SQL_GET.format(table_name=table_name)
+        self._set_sql = self._SQL_SET.format(table_name=table_name)
+        self._delete_sql = self._SQL_DELETE.format(table_name=table_name)
+        self._clear_prefix_sql = self._SQL_CLEAR_PREFIX.format(
+            table_name=table_name
+        )
+        self._clear_all_sql = self._SQL_CLEAR_ALL.format(table_name=table_name)
+        self._janitor_sql = self._SQL_JANITOR.format(table_name=table_name)
+        self._janitor_task: asyncio.Task[None] | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def provider(self) -> PostgresProvider:
+        """The bound `PostgresProvider`."""
+        return self._provider
+
+    def _rebind_provider(self, provider: PostgresProvider) -> None:
+        """Swap the underlying provider (used by `Grelmicro` for sharing)."""
+        self._provider = provider
+        self._owns_provider = False
+
+    async def __aenter__(self) -> Self:
+        """Open the cache connection, install the schema, start the janitor."""
+        self._loop = asyncio.get_running_loop()
+        if self._owns_provider:
+            await self._provider.__aenter__()
+        if self._auto_migrate:
+            await self._provider.client.execute(
+                self._SQL_CREATE_TABLE.format(table_name=self._table_name)
+            )
+        if self._cleanup_interval is not None:
+            self._janitor_task = asyncio.create_task(self._janitor_loop())
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Stop the janitor and close the provider when owned."""
+        if self._janitor_task is not None:
+            self._janitor_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._janitor_task
+            self._janitor_task = None
+        if self._owns_provider:
+            await self._provider.__aexit__(exc_type, exc_value, traceback)
+
+    async def get(self, *, key: str) -> bytes | None:
+        """Get raw bytes by key.
+
+        Returns None if the key is missing or expired.
+        """
+        row = await self._provider.client.fetchrow(
+            self._get_sql, f"{self._key_prefix}{key}"
+        )
+        return row["value"] if row is not None else None
+
+    async def set(self, *, key: str, value: bytes, ttl: float) -> None:
+        """Store raw bytes with a TTL in seconds."""
+        await self._provider.client.execute(
+            self._set_sql,
+            f"{self._key_prefix}{key}",
+            value,
+            float(ttl),
+        )
+
+    async def delete(self, *, key: str) -> None:
+        """Delete a key (no-op if absent)."""
+        await self._provider.client.execute(
+            self._delete_sql, f"{self._key_prefix}{key}"
+        )
+
+    async def clear(self) -> None:
+        """Remove all entries matching the configured prefix.
+
+        Falls back to a full table delete when no prefix is set.
+        """
+        if self._key_prefix:
+            await self._provider.client.execute(
+                self._clear_prefix_sql,
+                f"{_escape_like(self._key_prefix)}%",
+            )
+        else:
+            await self._provider.client.execute(self._clear_all_sql)
+
+    async def _janitor_loop(self) -> None:
+        """Periodically delete rows expired for more than one hour."""
+        interval = self._cleanup_interval or 0
+        while True:
+            await asyncio.sleep(interval)
+            with contextlib.suppress(Exception):
+                await self._provider.client.execute(self._janitor_sql)
+
+
+def _escape_like(value: str) -> str:
+    r"""Escape `%`, `_`, and `\` for a SQL `LIKE` pattern."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -16,6 +16,7 @@ from grelmicro.providers._base import Provider
 if TYPE_CHECKING:
     from types import TracebackType
 
+    from grelmicro.cache.postgres import PostgresCacheAdapter
     from grelmicro.resilience.ratelimiter.postgres import (
         PostgresRateLimiterAdapter,
     )
@@ -226,6 +227,14 @@ class PostgresProvider(Provider):
         from grelmicro.sync.postgres import PostgresSyncAdapter  # noqa: PLC0415
 
         return PostgresSyncAdapter(provider=self, **kwargs)
+
+    def cache(self, **kwargs: Any) -> PostgresCacheAdapter:  # noqa: ANN401
+        """Build a `PostgresCacheAdapter` bound to this provider."""
+        from grelmicro.cache.postgres import (  # noqa: PLC0415
+            PostgresCacheAdapter,
+        )
+
+        return PostgresCacheAdapter(provider=self, **kwargs)
 
     def ratelimiter(self, **kwargs: Any) -> PostgresRateLimiterAdapter:  # noqa: ANN401
         """Build a `PostgresRateLimiterAdapter` bound to this provider."""

--- a/tests/cache/test_cache_backends.py
+++ b/tests/cache/test_cache_backends.py
@@ -4,14 +4,18 @@ from asyncio import sleep
 from collections.abc import AsyncGenerator, Generator
 
 import pytest
+from testcontainers.core.container import DockerContainer
+from testcontainers.postgres import PostgresContainer
 from testcontainers.redis import RedisContainer
 
 from grelmicro.cache._protocol import CacheBackend
 from grelmicro.cache.cached import cached
 from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache.postgres import PostgresCacheAdapter
 from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.cache.serializers import JsonSerializer
 from grelmicro.cache.ttl import TTLCache
+from grelmicro.providers.postgres import PostgresProvider
 from grelmicro.providers.redis import RedisProvider
 
 pytestmark = [pytest.mark.timeout(30)]
@@ -24,6 +28,7 @@ pytestmark = [pytest.mark.timeout(30)]
     params=[
         "memory",
         pytest.param("redis", marks=[pytest.mark.integration]),
+        pytest.param("postgres", marks=[pytest.mark.integration]),
     ],
     scope="module",
 )
@@ -35,18 +40,21 @@ def backend_name(request: pytest.FixtureRequest) -> str:
 @pytest.fixture(scope="module")
 def container(
     backend_name: str,
-) -> Generator[RedisContainer | None, None, None]:
-    """Docker container (only for Redis)."""
+) -> Generator[DockerContainer | None, None, None]:
+    """Docker container (only for Redis and Postgres)."""
     if backend_name == "redis":
         with RedisContainer() as redis_container:
             yield redis_container
+    elif backend_name == "postgres":
+        with PostgresContainer() as pg_container:
+            yield pg_container
     else:
         yield None
 
 
 @pytest.fixture(scope="module")
 async def backend(
-    backend_name: str, container: RedisContainer | None
+    backend_name: str, container: DockerContainer | None
 ) -> AsyncGenerator[CacheBackend]:
     """Cache backend instance."""
     if backend_name == "redis" and container:
@@ -56,6 +64,18 @@ async def backend(
             prefix="test:",
         ) as redis_backend:
             yield redis_backend
+    elif backend_name == "postgres" and container:
+        port = container.get_exposed_port(5432)
+        provider = PostgresProvider(
+            f"postgresql://test:test@localhost:{port}/test"
+        )
+        async with (
+            provider,
+            PostgresCacheAdapter(
+                provider=provider, prefix="test:"
+            ) as pg_backend,
+        ):
+            yield pg_backend
     elif backend_name == "memory":
         async with MemoryCacheAdapter() as memory_backend:
             yield memory_backend
@@ -154,6 +174,59 @@ async def test_redis_prefix_isolation() -> None:
 
 
 # --- End-to-end: TTLCache + @cached ---
+
+
+@pytest.mark.integration
+async def test_postgres_prefix_isolation() -> None:
+    """Test that clearing one prefix does not affect another."""
+    with PostgresContainer() as pg_container:
+        port = pg_container.get_exposed_port(5432)
+        url = f"postgresql://test:test@localhost:{port}/test"
+        async with (
+            PostgresProvider(url) as provider,
+            PostgresCacheAdapter(provider=provider, prefix="alpha:") as alpha,
+            PostgresCacheAdapter(provider=provider, prefix="beta:") as beta,
+        ):
+            await alpha.set(key="k", value=b"alpha", ttl=60)
+            await beta.set(key="k", value=b"beta", ttl=60)
+
+            await alpha.clear()
+
+            assert await alpha.get(key="k") is None
+            assert await beta.get(key="k") == b"beta"
+
+
+@pytest.mark.integration
+async def test_cached_end_to_end_with_postgres() -> None:
+    """Test @cached with TTLCache backed by Postgres."""
+    with PostgresContainer() as pg_container:
+        port = pg_container.get_exposed_port(5432)
+        url = f"postgresql://test:test@localhost:{port}/test"
+        async with (
+            PostgresProvider(url) as provider,
+            PostgresCacheAdapter(
+                provider=provider, prefix="e2e:"
+            ) as pg_backend,
+        ):
+            cache = TTLCache(
+                ttl=60,
+                backend=pg_backend,
+                serializer=JsonSerializer(),
+            )
+            call_count = 0
+
+            @cached(cache, lock=True)
+            async def fetch_user(user_id: int) -> dict:
+                nonlocal call_count
+                call_count += 1
+                return {"id": user_id}
+
+            first = await fetch_user(1)
+            second = await fetch_user(1)
+
+            assert first == {"id": 1}
+            assert second == {"id": 1}
+            assert call_count == 1
 
 
 @pytest.mark.integration

--- a/tests/cache/test_component.py
+++ b/tests/cache/test_component.py
@@ -7,6 +7,7 @@ import pytest
 from grelmicro import Component, Grelmicro
 from grelmicro.cache import Cache, JsonSerializer, TTLCache
 from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache.postgres import PostgresCacheAdapter
 from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.providers.postgres import PostgresProvider
 from grelmicro.providers.redis import RedisProvider
@@ -156,8 +157,9 @@ def test_cache_accepts_redis_provider() -> None:
     assert cache.backend.provider is provider
 
 
-def test_cache_with_postgres_provider_raises() -> None:
-    """`Cache(PostgresProvider(...))` raises `NotImplementedError` (no cache adapter)."""
+def test_cache_with_postgres_provider() -> None:
+    """`Cache(PostgresProvider(...))` builds a `PostgresCacheAdapter`."""
     provider = PostgresProvider("postgresql://localhost:5432/app")
-    with pytest.raises(NotImplementedError, match="no cache adapter"):
-        Cache(provider)
+    cache = Cache(provider)
+    assert isinstance(cache.backend, PostgresCacheAdapter)
+    assert cache.backend.provider is provider

--- a/tests/cache/test_postgres.py
+++ b/tests/cache/test_postgres.py
@@ -150,6 +150,15 @@ def test_auto_migrate_flag() -> None:
     assert backend._auto_migrate is False
 
 
+@pytest.mark.parametrize("interval", [0, 0.0, -1, -0.5])
+def test_cleanup_interval_non_positive_raises(interval: float) -> None:
+    """`cleanup_interval` must be positive when set."""
+    with pytest.raises(ValueError, match="cleanup_interval must be positive"):
+        PostgresCacheAdapter(
+            provider=PostgresProvider(URL), cleanup_interval=interval
+        )
+
+
 def test_cleanup_interval_default_off() -> None:
     """The janitor is off by default."""
     backend = PostgresCacheAdapter(provider=PostgresProvider(URL))

--- a/tests/cache/test_postgres.py
+++ b/tests/cache/test_postgres.py
@@ -1,0 +1,324 @@
+"""Tests for the Postgres Cache Adapter."""
+
+import asyncio
+from types import TracebackType
+from typing import Self
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from grelmicro.cache.postgres import PostgresCacheAdapter, _escape_like
+from grelmicro.providers.postgres import (
+    PostgresProvider,
+    PostgresProviderConfigError,
+)
+
+pytestmark = [pytest.mark.timeout(1)]
+
+URL = "postgresql://test_user:test_password@test_host:1234/test_db"
+
+
+def _build_with_mock_pool(
+    *,
+    prefix: str = "",
+    auto_migrate: bool = True,
+    cleanup_interval: float | None = None,
+) -> tuple[PostgresCacheAdapter, MagicMock]:
+    """Return an adapter wired to a mocked asyncpg pool via a provider."""
+    provider = PostgresProvider(URL)
+    mock_pool = MagicMock()
+    provider._pool = mock_pool
+    backend = PostgresCacheAdapter(
+        provider=provider,
+        prefix=prefix,
+        auto_migrate=auto_migrate,
+        cleanup_interval=cleanup_interval,
+    )
+    return backend, mock_pool
+
+
+class _StubProvider:
+    """Minimal `PostgresProvider`-shaped stub tracking enter/exit calls."""
+
+    def __init__(self) -> None:
+        self.client = MagicMock()
+        self.client.execute = AsyncMock()
+        self.enter_count = 0
+        self.exit_count = 0
+
+    async def __aenter__(self) -> Self:
+        self.enter_count += 1
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.exit_count += 1
+
+
+@pytest.mark.parametrize(
+    "table_name",
+    [
+        "cache table",
+        "%cache",
+        "cache;table",
+        "cache' OR '1'='1",
+        "cache; DROP TABLE users; --",
+    ],
+)
+def test_table_name_invalid(table_name: str) -> None:
+    """Invalid SQL identifiers for the table name raise."""
+    with pytest.raises(
+        ValueError, match=r"Table name '.*' is not a valid SQL identifier"
+    ):
+        PostgresCacheAdapter(
+            provider=PostgresProvider(URL), table_name=table_name
+        )
+
+
+def test_adapter_with_implicit_env_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without `provider=`, the adapter builds its own from env vars."""
+    monkeypatch.setenv("POSTGRES_URL", URL)
+
+    backend = PostgresCacheAdapter()
+
+    assert backend.provider.url == URL
+    assert backend._owns_provider is True
+
+
+def test_adapter_borrows_external_provider() -> None:
+    """An explicit `provider=` is borrowed, not owned."""
+    provider = PostgresProvider(URL)
+    backend = PostgresCacheAdapter(provider=provider)
+
+    assert backend.provider is provider
+    assert backend._owns_provider is False
+
+
+def test_adapter_env_prefix_passed_to_implicit_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`env_prefix=` reaches the implicit provider."""
+    monkeypatch.setenv("WRITE_POSTGRES_URL", URL)
+
+    backend = PostgresCacheAdapter(env_prefix="WRITE_POSTGRES_")
+
+    assert backend.provider.url == URL
+    assert backend.provider.env_prefix == "WRITE_POSTGRES_"
+
+
+def test_env_validation_error_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Implicit provider surfaces `PostgresProviderConfigError`."""
+    monkeypatch.delenv("POSTGRES_URL", raising=False)
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+    with pytest.raises(PostgresProviderConfigError):
+        PostgresCacheAdapter()
+
+
+def test_custom_table_name() -> None:
+    """Custom `table_name=` is stored on the adapter."""
+    backend = PostgresCacheAdapter(
+        provider=PostgresProvider(URL), table_name="my_cache"
+    )
+
+    assert backend._table_name == "my_cache"
+
+
+def test_prefix_stored() -> None:
+    """`prefix=` is stored on the adapter."""
+    backend = PostgresCacheAdapter(
+        provider=PostgresProvider(URL), prefix="myapp:"
+    )
+
+    assert backend._key_prefix == "myapp:"
+
+
+def test_auto_migrate_flag() -> None:
+    """`auto_migrate=` is stored on the adapter."""
+    backend = PostgresCacheAdapter(
+        provider=PostgresProvider(URL), auto_migrate=False
+    )
+
+    assert backend._auto_migrate is False
+
+
+def test_cleanup_interval_default_off() -> None:
+    """The janitor is off by default."""
+    backend = PostgresCacheAdapter(provider=PostgresProvider(URL))
+
+    assert backend._cleanup_interval is None
+
+
+def test_cleanup_interval_stored() -> None:
+    """`cleanup_interval=` is stored on the adapter."""
+    interval = 60.0
+    backend = PostgresCacheAdapter(
+        provider=PostgresProvider(URL), cleanup_interval=interval
+    )
+
+    assert backend._cleanup_interval == interval
+
+
+def test_provider_cache_factory() -> None:
+    """`PostgresProvider.cache()` builds a `PostgresCacheAdapter`."""
+    provider = PostgresProvider(URL)
+
+    backend = provider.cache()
+
+    assert isinstance(backend, PostgresCacheAdapter)
+    assert backend.provider is provider
+    assert backend._owns_provider is False
+
+
+def test_rebind_provider_borrows_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_rebind_provider` swaps the provider and marks it as not owned."""
+    monkeypatch.setenv("POSTGRES_URL", URL)
+    backend = PostgresCacheAdapter()
+    assert backend._owns_provider is True
+    other = PostgresProvider(URL)
+
+    backend._rebind_provider(other)
+
+    assert backend.provider is other
+    assert backend._owns_provider is False
+
+
+def test_escape_like_special_chars() -> None:
+    r"""`_escape_like` escapes `%`, `_`, and `\`."""
+    assert _escape_like("a%b_c\\d") == "a\\%b\\_c\\\\d"
+
+
+class TestAsyncMethods:
+    """Tests using a mocked asyncpg pool."""
+
+    async def test_get_hit(self) -> None:
+        """`get` returns the stored bytes when the key exists."""
+        backend, pool = _build_with_mock_pool(prefix="p:")
+        pool.fetchrow = AsyncMock(return_value={"value": b"value"})
+
+        result = await backend.get(key="k")
+
+        assert result == b"value"
+        pool.fetchrow.assert_awaited_once_with(backend._get_sql, "p:k")
+
+    async def test_get_miss_returns_none(self) -> None:
+        """`get` returns None when the key is missing."""
+        backend, pool = _build_with_mock_pool()
+        pool.fetchrow = AsyncMock(return_value=None)
+
+        assert await backend.get(key="missing") is None
+
+    async def test_set_passes_key_value_ttl(self) -> None:
+        """`set` forwards the prefixed key, value, and TTL."""
+        backend, pool = _build_with_mock_pool(prefix="p:")
+        pool.execute = AsyncMock()
+
+        await backend.set(key="k", value=b"v", ttl=30)
+
+        pool.execute.assert_awaited_once_with(
+            backend._set_sql, "p:k", b"v", 30.0
+        )
+
+    async def test_delete(self) -> None:
+        """`delete` forwards the prefixed key."""
+        backend, pool = _build_with_mock_pool(prefix="p:")
+        pool.execute = AsyncMock()
+
+        await backend.delete(key="k")
+
+        pool.execute.assert_awaited_once_with(backend._delete_sql, "p:k")
+
+    async def test_clear_with_prefix(self) -> None:
+        """`clear` issues a prefix-scoped delete when a prefix is set."""
+        backend, pool = _build_with_mock_pool(prefix="p:")
+        pool.execute = AsyncMock()
+
+        await backend.clear()
+
+        pool.execute.assert_awaited_once_with(backend._clear_prefix_sql, "p:%")
+
+    async def test_clear_without_prefix(self) -> None:
+        """`clear` issues a full-table delete when no prefix is set."""
+        backend, pool = _build_with_mock_pool()
+        pool.execute = AsyncMock()
+
+        await backend.clear()
+
+        pool.execute.assert_awaited_once_with(backend._clear_all_sql)
+
+    async def test_aenter_owned_provider_opens_it(self) -> None:
+        """`__aenter__` opens the provider when the adapter owns it."""
+        stub = _StubProvider()
+        backend = PostgresCacheAdapter.__new__(PostgresCacheAdapter)
+        backend._provider = stub  # type: ignore[assignment]
+        backend._owns_provider = True
+        backend._auto_migrate = False
+        backend._cleanup_interval = None
+        backend._janitor_task = None
+        backend._loop = None
+
+        async with backend:
+            pass
+
+        assert stub.enter_count == 1
+        assert stub.exit_count == 1
+
+    async def test_aenter_runs_migration(self) -> None:
+        """`__aenter__` runs the create-table SQL when `auto_migrate=True`."""
+        backend, pool = _build_with_mock_pool()
+        pool.execute = AsyncMock()
+
+        async with backend:
+            pass
+
+        pool.execute.assert_awaited_once()
+        call = pool.execute.await_args
+        assert call is not None
+        assert "CREATE TABLE IF NOT EXISTS grelmicro_cache" in call.args[0]
+
+    async def test_aenter_skips_migration_when_disabled(self) -> None:
+        """`auto_migrate=False` skips schema installation."""
+        backend, pool = _build_with_mock_pool(auto_migrate=False)
+        pool.execute = AsyncMock()
+
+        async with backend:
+            pass
+
+        pool.execute.assert_not_awaited()
+
+    async def test_janitor_starts_and_stops(self) -> None:
+        """Setting `cleanup_interval` spawns and cancels a janitor task."""
+        backend, pool = _build_with_mock_pool(
+            cleanup_interval=0.01, auto_migrate=False
+        )
+        pool.execute = AsyncMock()
+
+        async with backend:
+            assert backend._janitor_task is not None
+            await asyncio.sleep(0.05)
+
+        assert backend._janitor_task is None
+        assert pool.execute.await_count >= 1
+        call = pool.execute.await_args
+        assert call is not None
+        assert "DELETE FROM grelmicro_cache" in call.args[0]
+
+    async def test_janitor_suppresses_errors(self) -> None:
+        """Janitor swallows errors so transient failures don't crash the task."""
+        backend, pool = _build_with_mock_pool(
+            cleanup_interval=0.01, auto_migrate=False
+        )
+        pool.execute = AsyncMock(side_effect=RuntimeError("boom"))
+
+        async with backend:
+            await asyncio.sleep(0.05)
+
+        assert pool.execute.await_count >= 1

--- a/tests/providers/test_postgres_provider.py
+++ b/tests/providers/test_postgres_provider.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from grelmicro import Grelmicro
+from grelmicro.cache.postgres import PostgresCacheAdapter
 from grelmicro.providers._base import Provider
 from grelmicro.providers.postgres import (
     PostgresConfig,
@@ -192,11 +193,12 @@ class TestBuilders:
         assert adapter.provider is provider
         assert adapter._owns_provider is False
 
-    def test_cache_factory_raises_not_implemented(self) -> None:
-        """`provider.cache()` raises (no Postgres cache adapter today)."""
+    def test_cache_factory_builds_postgres_adapter(self) -> None:
+        """`provider.cache()` builds a `PostgresCacheAdapter`."""
         provider = PostgresProvider(URL)
-        with pytest.raises(NotImplementedError, match="no cache adapter"):
-            provider.cache()
+        adapter = provider.cache()
+        assert isinstance(adapter, PostgresCacheAdapter)
+        assert adapter.provider is provider
 
     def test_ratelimiter_factory_builds_postgres_adapter(self) -> None:
         """`provider.ratelimiter()` builds a `PostgresRateLimiterAdapter`."""
@@ -212,6 +214,12 @@ class TestBuilders:
             NotImplementedError, match="no rate limiter adapter"
         ):
             Provider.ratelimiter(provider)
+
+    def test_base_cache_factory_raises_not_implemented(self) -> None:
+        """The base `Provider.cache` raises for providers that don't override it."""
+        provider = PostgresProvider(URL)
+        with pytest.raises(NotImplementedError, match="no cache adapter"):
+            Provider.cache(provider)
 
     def test_breaker_factory_raises_not_implemented(self) -> None:
         """`provider.breaker()` raises (no Postgres circuit breaker today)."""


### PR DESCRIPTION
## Summary

* Add `PostgresCacheAdapter` (`grelmicro/cache/postgres.py`) backing the `CacheBackend` protocol on top of a `PostgresProvider`. State lives in a single `grelmicro_cache` table keyed on `key TEXT PRIMARY KEY` with `value BYTEA` and `expires_at TIMESTAMPTZ`. `get` filters expired rows with `WHERE expires_at > NOW()`, `set` is one `INSERT ... ON CONFLICT DO UPDATE`, `delete` and prefix-scoped `clear` are single statements. Schema auto-migrates on first connect (opt out with `auto_migrate=False`).
* Optional janitor task: set `cleanup_interval=` to periodically delete rows expired for more than one hour. Off by default. Lazy expiry on `get` keeps reads correct, the janitor only reclaims storage.
* Wire `PostgresProvider.cache()` to build the adapter so `Grelmicro(uses=[postgres, Cache(postgres)])` auto-dispatches the Postgres backend.
* Docs: extend `docs/cache.md` with a Postgres tab plus backend table, add `docs/snippets/cache/postgres_basic.py`, register in `docs/reference/cache.md`, drop "planned" notes in `docs/comparison.md`. Changelog entry under `Unreleased > Features`.
* Tests: parametrize `tests/cache/test_cache_backends.py` over postgres with `testcontainers-postgres`, add Postgres prefix-isolation and end-to-end `@cached(lock=True)` integration tests, plus a unit-test file `tests/cache/test_postgres.py` covering construction, table-name validation, mocked async paths, janitor lifecycle, and error suppression.

Closes #167.

## Test plan

- [x] `uv run pytest -m "not integration" --cov`
- [x] `uv run pytest -m integration --cov --cov-append` (testcontainers spins up Postgres)
- [x] `uv run coverage report --fail-under=100`
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check`