### PR TITLE
✨ Add Timeout resilience pattern (#176)

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,7 +6,7 @@ The [roadmap](https://github.com/grelinfo/grelmicro/issues/124) and the [milesto
 
 ## Vocabulary
 
-- **Pattern**: user-facing class. `Lock`, `LeaderElection`, `TaskLock`, `TTLCache`, `RateLimiter`, `CircuitBreaker`, `Retry`, `Bulkhead`, `Fallback`.
+- **Pattern**: user-facing class. `Lock`, `LeaderElection`, `TaskLock`, `TTLCache`, `RateLimiter`, `CircuitBreaker`, `Retry`, `Bulkhead`, `Fallback`, `Timeout`.
 - **Adapter**: concrete implementation of a Backend Protocol. `RedisSyncAdapter`, `PostgresSyncAdapter`, `MemoryCacheAdapter`, `SQLiteSyncAdapter`, `KubernetesSyncAdapter`, and so on.
 - **Backend**: the Protocol class an Adapter satisfies. `SyncBackend`, `CacheBackend`, `RateLimiterBackend`, `CircuitBreakerBackend`.
 - **Provider**: vendor configuration plus native client, shared by Adapters that talk to the same service. `RedisProvider`, `PostgresProvider`. Memory, SQLite, and Kubernetes Adapters do not use a Provider.
@@ -26,13 +26,14 @@ See [Backends and Adapters](architecture/backends.md) for the full model.
 | `Retry`             | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
 | `Bulkhead`          | [#168](https://github.com/grelinfo/grelmicro/issues/168)       | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
 | `Fallback`          | [#199](https://github.com/grelinfo/grelmicro/issues/199)       | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
+| `Timeout`           | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
 
 Legend:
 
 - ✅ ships today.
 - `#N` planned for `1.0.0`, tracked by the linked issue.
 - `Future` planned past `1.0.0`.
-- `N/A` does not apply. `Retry`, `Bulkhead`, and `Fallback` are in-process Patterns with no remote state to share.
+- `N/A` does not apply. `Retry`, `Bulkhead`, `Fallback`, and `Timeout` are in-process Patterns with no remote state to share.
 
 ## What `1.0.0` commits to
 
@@ -40,7 +41,7 @@ Closing every gap above that links to an issue. Anything marked `Future` is out 
 
 ## Picking an Adapter
 
-- **Memory** for tests, single-process apps, and `Retry` (the only in-process Pattern that ships today). `Bulkhead` and `Fallback` will join this group at `1.0.0`.
+- **Memory** for tests, single-process apps, and `Retry`, `Fallback`, and `Timeout` (in-process Patterns that ship today). `Bulkhead` will join this group at `1.0.0`.
 - **Redis** when you already run Redis and want the lowest-latency distributed option.
 - **Postgres** when Postgres is your only stateful dependency and you want one fewer service to run.
 - **SQLite** for single-host deployments that still need durability across restarts.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+* ✨ Add `Timeout` reconfigurable resilience pattern. `Timeout("db", seconds=2.0)` wraps `asyncio.timeout`, usable as an async context manager (`async with db_timeout:`) or decorator on async functions. `TimeoutConfig` is a frozen three-paths Pydantic config with `seconds: PositiveFloat`. Env prefix `GREL_TIMEOUT_{NAME_UPPER}_`. Inherits `Reconfigurable[TimeoutConfig]` for live deadline swaps. Issue [#176](https://github.com/grelinfo/grelmicro/issues/176).
+
 * ✨ Add `Fallback` primitive with decorator, block, and class forms. `@fallback(when=..., default=...)` / `@fallback(when=..., factory=...)` swap a matched exception for a safe value. `async with falling_back(when=..., default=...) as result:` covers inline blocks. `Fallback("name", when=..., default=...)` is the named, reconfigurable class form. `FallbackConfig` is a frozen three-paths Pydantic config with `default` / `factory` mutually exclusive. `when=` matches Retry's keyword so the `Match` DSL stays universal. Composition order documented in [Composing patterns](resilience/composition.md). Issue [#199](https://github.com/grelinfo/grelmicro/issues/199).
 
 * ✨ Add `PostgresCacheAdapter` for Postgres-backed cache storage. Register via `Grelmicro(uses=[postgres, Cache(postgres)])`. Entries land in a single `grelmicro_cache` table keyed on `key TEXT PRIMARY KEY` with `value BYTEA` and `expires_at TIMESTAMPTZ`. `get` filters expired rows with `WHERE expires_at > NOW()`, `set` is one `INSERT ... ON CONFLICT DO UPDATE`. Schema auto-migrates on first connect, opt out with `auto_migrate=False`. Optional janitor reclaims storage when `cleanup_interval=` is set (off by default). Issue [#167](https://github.com/grelinfo/grelmicro/issues/167).

--- a/docs/reference/resilience.md
+++ b/docs/reference/resilience.md
@@ -47,6 +47,8 @@
         - RetryConfig
         - RetryStrategy
         - SlidingWindowConfig
+        - Timeout
+        - TimeoutConfig
         - TokenBucketConfig
         - fallback
         - falling_back

--- a/docs/resilience/index.md
+++ b/docs/resilience/index.md
@@ -6,6 +6,7 @@ The `resilience` package provides primitives that help your services handle fail
 - [**Fallback**](fallback.md): return a safe default value when a call fails. Pluggable filter (any `Match`), static default or factory callable, decorator and block forms.
 - [**Rate Limiter**](rate-limiter.md): cap how many requests a client can make per window. Pluggable algorithm (`TokenBucketConfig` or `SlidingWindowConfig`), pluggable backend (`Memory` or `Redis`), with a result shape that maps directly to HTTP rate limit headers.
 - [**Retry**](retry.md): repeat a failing call with backoff and jitter. Pluggable algorithm (`ExponentialBackoff`, `ConstantBackoff`, `LinearBackoff`, `FibonacciBackoff`, `RandomBackoff`), required exception filter, decorator and block forms.
+- [**Timeout**](timeout.md): bound how long an async call may run. Reconfigurable deadline, async context manager and decorator forms. Wraps `asyncio.timeout`.
 
 See [Composing patterns](composition.md) for the recommended outside-in order when stacking decorators.
 
@@ -17,5 +18,6 @@ See [Composing patterns](composition.md) for the recommended outside-in order wh
 | **Fallback** | A call can fail and you want to degrade gracefully (cached value, empty list, neutral default) instead of propagating the error. |
 | **Rate Limiter** | You need to throttle *your own* endpoint, worker, or background job to protect the downstream side or enforce fair usage. |
 | **Retry** | A call fails for transient reasons (network blip, brief overload) and is safe to repeat. |
+| **Timeout** | An async call may stall and you need a hard deadline on it. |
 
 For synchronous, in-process token-bucket rate limiting on a performance-critical sync path (the main example is the logging pipeline), see [`MemoryTokenBucket`](rate-limiter.md#standalone-memorytokenbucket). It powers `grelmicro.log.RateLimitFilter`.

--- a/docs/resilience/timeout.md
+++ b/docs/resilience/timeout.md
@@ -1,0 +1,69 @@
+# Timeout
+
+A **Timeout** policy bounds how long an async call may run. Use it to keep a slow dependency from blocking a request indefinitely.
+
+**Why**
+
+- Cap the worst-case latency of a downstream call.
+- Reconfigure the deadline at runtime from a `ConfigMap` without redeploying.
+- Compose with `Retry`, `CircuitBreaker`, `Bulkhead`, and `Fallback`.
+
+`Timeout` wraps `asyncio.timeout`. When the deadline elapses, the inner block is cancelled and `TimeoutError` is raised.
+
+## Usage
+
+```python
+--8<-- "resilience/timeout.py"
+```
+
+The policy works as an async context manager and as a decorator on async functions. Sync functions are not supported (asyncio cannot cancel sync code).
+
+```python
+--8<-- "resilience/timeout_decorator.py"
+```
+
+## Configuration
+
+`Timeout` follows the three-paths configuration contract.
+
+### Programmatic
+
+```python
+--8<-- "resilience/timeout_programmatic.py"
+```
+
+### Declarative
+
+```python
+--8<-- "resilience/timeout_declarative.py"
+```
+
+### Environmental
+
+Prefix: `GREL_TIMEOUT_{NAME_UPPER}_`
+
+| Env var | Field | Type | Default |
+|---|---|---|---|
+| `GREL_TIMEOUT_{NAME_UPPER}_SECONDS` | `seconds` | `PositiveFloat` | required |
+
+```python
+--8<-- "resilience/timeout_environmental.py"
+```
+
+## Composition
+
+The recommended outside-in order is **Fallback : Retry : CircuitBreaker : Bulkhead : Timeout : call**. Read more in [Composing patterns](composition.md).
+
+```python
+--8<-- "resilience/timeout_composition.py"
+```
+
+A per-attempt `Timeout` placed under `Retry` shrinks the deadline of each retry while the retry budget stays the same.
+
+## Live reconfiguration
+
+`Timeout` inherits `Reconfigurable[TimeoutConfig]`. Calling `policy.reconfigure(new_config)` swaps the deadline for future entries. Scopes already inside `async with` keep their original deadline. See [Live reconfiguration](../architecture/reconfigure.md).
+
+## Reference
+
+See the [API reference](../reference/resilience.md#grelmicro.resilience.Timeout) for every option.

--- a/docs/snippets/resilience/timeout.py
+++ b/docs/snippets/resilience/timeout.py
@@ -1,0 +1,8 @@
+from grelmicro.resilience import Timeout
+
+db_timeout = Timeout("db", seconds=2.0)
+
+
+async def fetch_rows(db) -> list[dict]:
+    async with db_timeout:
+        return await db.fetch_all("SELECT * FROM accounts")

--- a/docs/snippets/resilience/timeout_composition.py
+++ b/docs/snippets/resilience/timeout_composition.py
@@ -1,0 +1,19 @@
+import httpx
+
+from grelmicro.resilience import CircuitBreaker, Retry, Timeout, fallback
+
+breaker = CircuitBreaker("recs")
+retrier = Retry.exponential("recs", when=httpx.HTTPError, attempts=3)
+call_timeout = Timeout("recs", seconds=1.0)
+
+
+@fallback(when=Exception, default=[])
+@retrier
+@breaker
+@call_timeout
+async def get_recommendations(
+    client: httpx.AsyncClient, user_id: str
+) -> list[dict]:
+    response = await client.get(f"/recs/{user_id}")
+    response.raise_for_status()
+    return response.json()

--- a/docs/snippets/resilience/timeout_declarative.py
+++ b/docs/snippets/resilience/timeout_declarative.py
@@ -1,0 +1,4 @@
+from grelmicro.resilience import Timeout, TimeoutConfig
+
+config = TimeoutConfig(seconds=2.0)
+db_timeout = Timeout("db", config=config)

--- a/docs/snippets/resilience/timeout_decorator.py
+++ b/docs/snippets/resilience/timeout_decorator.py
@@ -1,0 +1,8 @@
+from grelmicro.resilience import Timeout
+
+db_timeout = Timeout("db", seconds=2.0)
+
+
+@db_timeout
+async def fetch_rows(db) -> list[dict]:
+    return await db.fetch_all("SELECT * FROM accounts")

--- a/docs/snippets/resilience/timeout_environmental.py
+++ b/docs/snippets/resilience/timeout_environmental.py
@@ -1,0 +1,6 @@
+from grelmicro.resilience import Timeout
+
+# Reads the deadline from environment variables.
+#
+# - GREL_TIMEOUT_DB_SECONDS=2.0
+db_timeout = Timeout("db")

--- a/docs/snippets/resilience/timeout_programmatic.py
+++ b/docs/snippets/resilience/timeout_programmatic.py
@@ -1,0 +1,3 @@
+from grelmicro.resilience import Timeout
+
+db_timeout = Timeout("db", seconds=2.0)

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -96,6 +96,7 @@ if TYPE_CHECKING:
         retry,
         retrying,
     )
+    from grelmicro.resilience.timeout import Timeout, TimeoutConfig
 
 __all__ = [
     "CircuitBreaker",
@@ -141,6 +142,8 @@ __all__ = [
     "RetryConfig",
     "RetryStrategy",
     "SlidingWindowConfig",
+    "Timeout",
+    "TimeoutConfig",
     "TokenBucketConfig",
     "fallback",
     "falling_back",
@@ -216,6 +219,9 @@ _LAZY: dict[str, tuple[str, str]] = {
     "Fallback": ("grelmicro.resilience.fallback", "Fallback"),
     "FallbackConfig": ("grelmicro.resilience.fallback", "FallbackConfig"),
     "FallbackResult": ("grelmicro.resilience.fallback", "FallbackResult"),
+    # Timeout
+    "Timeout": ("grelmicro.resilience.timeout", "Timeout"),
+    "TimeoutConfig": ("grelmicro.resilience.timeout", "TimeoutConfig"),
     # `retry` and `retrying` are imported eagerly above to win the
     # shadow-conflict with the submodule of the same name.
     # Backoff configs (retry-specific)

--- a/grelmicro/resilience/timeout.py
+++ b/grelmicro/resilience/timeout.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-from contextvars import ContextVar
 from dataclasses import dataclass
 from inspect import iscoroutinefunction
 from typing import TYPE_CHECKING, Annotated, Any, Self
@@ -26,6 +25,15 @@ __all__ = [
     "Timeout",
     "TimeoutConfig",
 ]
+
+
+def _current_task() -> asyncio.Task[Any]:
+    """Return the current asyncio task or raise if none is running."""
+    task = asyncio.current_task()
+    if task is None:  # pragma: no cover
+        msg = "Timeout requires a running asyncio task"
+        raise RuntimeError(msg)
+    return task
 
 
 class TimeoutConfig(BaseModel, frozen=True, extra="forbid"):
@@ -107,9 +115,7 @@ class Timeout(Reconfigurable[TimeoutConfig]):
         self._config = resolved
         self._state = _State(config=resolved)
         self._reconfigure_lock = asyncio.Lock()
-        self._scopes: ContextVar[tuple[asyncio.Timeout, ...]] = ContextVar(
-            f"grelmicro.resilience.timeout.{name}", default=()
-        )
+        self._scopes: dict[asyncio.Task[Any], list[asyncio.Timeout]] = {}
 
     @property
     def name(self) -> str:
@@ -130,9 +136,14 @@ class Timeout(Reconfigurable[TimeoutConfig]):
 
     async def __aenter__(self) -> Self:
         """Open a fresh deadline scope for the current task."""
+        task = _current_task()
         scope = asyncio.timeout(self._state.config.seconds)
         await scope.__aenter__()
-        self._scopes.set((*self._scopes.get(), scope))
+        stack = self._scopes.get(task)
+        if stack is None:
+            self._scopes[task] = [scope]
+        else:
+            stack.append(scope)
         return self
 
     async def __aexit__(
@@ -142,9 +153,11 @@ class Timeout(Reconfigurable[TimeoutConfig]):
         tb: TracebackType | None,
     ) -> bool | None:
         """Close the most recently opened scope for the current task."""
-        stack = self._scopes.get()
-        scope = stack[-1]
-        self._scopes.set(stack[:-1])
+        task = _current_task()
+        stack = self._scopes[task]
+        scope = stack.pop()
+        if not stack:
+            del self._scopes[task]
         return await scope.__aexit__(exc_type, exc, tb)
 
     def __call__(

--- a/grelmicro/resilience/timeout.py
+++ b/grelmicro/resilience/timeout.py
@@ -1,0 +1,170 @@
+"""Timeout."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from contextvars import ContextVar
+from dataclasses import dataclass
+from inspect import iscoroutinefunction
+from typing import TYPE_CHECKING, Annotated, Any, Self
+
+from pydantic import BaseModel, PositiveFloat
+from typing_extensions import Doc
+
+from grelmicro._config import (
+    Reconfigurable,
+    env_segment,
+    resolve_config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from types import TracebackType
+
+__all__ = [
+    "Timeout",
+    "TimeoutConfig",
+]
+
+
+class TimeoutConfig(BaseModel, frozen=True, extra="forbid"):
+    """Timeout policy configuration.
+
+    Frozen Pydantic data class. Three-paths configuration: kwargs,
+    instance, or env vars.
+
+    Read more in the [Timeout](../resilience/timeout.md) docs.
+    """
+
+    seconds: Annotated[
+        PositiveFloat,
+        Doc(
+            "Deadline in seconds. The inner block is cancelled and "
+            "``TimeoutError`` is raised when the deadline elapses."
+        ),
+    ]
+
+
+@dataclass(frozen=True, slots=True)
+class _State:
+    """Read-side snapshot of the timeout config."""
+
+    config: TimeoutConfig
+
+
+class Timeout(Reconfigurable[TimeoutConfig]):
+    """Timeout policy.
+
+    A named, reusable async deadline with three-paths configuration
+    and live reconfiguration. Use as an async context manager or as
+    a decorator on async functions.
+
+    Read more in the [Timeout](../resilience/timeout.md) docs.
+    """
+
+    def __init__(
+        self,
+        name: Annotated[
+            str,
+            Doc(
+                "The name of the timeout policy. Used as the env "
+                "namespace and exposed via the ``name`` property."
+            ),
+        ],
+        *,
+        seconds: Annotated[
+            PositiveFloat | None,
+            Doc(
+                "Deadline in seconds. Required unless ``config=`` is "
+                "given or the value comes from env."
+            ),
+        ] = None,
+        config: Annotated[
+            TimeoutConfig | None,
+            Doc(
+                "A pre-built [`TimeoutConfig`][grelmicro.resilience.TimeoutConfig]. "
+                "Mutually exclusive with the per-field kwargs."
+            ),
+        ] = None,
+        env_load: Annotated[
+            bool | None,
+            Doc(
+                "Whether to read environment variables. Defaults to "
+                "the process-wide ``GREL_ENV_LOAD`` flag."
+            ),
+        ] = None,
+    ) -> None:
+        """Initialize the timeout policy."""
+        self._name = name
+        resolved = resolve_config(
+            TimeoutConfig,
+            explicit=config,
+            kwargs={"seconds": seconds},
+            env_prefix=f"GREL_TIMEOUT_{env_segment(name)}_",
+            env_load=env_load,
+        )
+        self._config = resolved
+        self._state = _State(config=resolved)
+        self._reconfigure_lock = asyncio.Lock()
+        self._scopes: ContextVar[tuple[asyncio.Timeout, ...]] = ContextVar(
+            f"grelmicro.resilience.timeout.{name}", default=()
+        )
+
+    @property
+    def name(self) -> str:
+        """Return the timeout policy identity."""
+        return self._name
+
+    @classmethod
+    def from_config(
+        cls,
+        name: Annotated[str, Doc("The name of the timeout policy.")],
+        config: Annotated[
+            TimeoutConfig,
+            Doc("The pre-built timeout configuration."),
+        ],
+    ) -> Self:
+        """Construct a `Timeout` from a name and a pre-built `TimeoutConfig`."""
+        return cls(name, config=config)
+
+    async def __aenter__(self) -> Self:
+        """Open a fresh deadline scope for the current task."""
+        scope = asyncio.timeout(self._state.config.seconds)
+        await scope.__aenter__()
+        self._scopes.set((*self._scopes.get(), scope))
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        """Close the most recently opened scope for the current task."""
+        stack = self._scopes.get()
+        scope = stack[-1]
+        self._scopes.set(stack[:-1])
+        return await scope.__aexit__(exc_type, exc, tb)
+
+    def __call__(
+        self, fn: Callable[..., Awaitable[Any]], /
+    ) -> Callable[..., Awaitable[Any]]:
+        """Decorate ``fn`` so each call runs under this timeout."""
+        if not iscoroutinefunction(fn):
+            msg = (
+                "Timeout only decorates async functions. asyncio cannot "
+                f"cancel sync code, got {fn!r}."
+            )
+            raise TypeError(msg)
+
+        @functools.wraps(fn)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            async with self:
+                return await fn(*args, **kwargs)
+
+        return async_wrapper
+
+    async def _apply_reconfigure(self, new_config: TimeoutConfig) -> None:
+        """Publish a fresh snapshot. In-flight scopes keep their deadline."""
+        self._state = _State(config=new_config)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
         - resilience/fallback.md
         - resilience/rate-limiter.md
         - resilience/retry.md
+        - resilience/timeout.md
         - resilience/composition.md
     - sync.md
     - task.md

--- a/tests/resilience/test_errors.py
+++ b/tests/resilience/test_errors.py
@@ -75,6 +75,8 @@ def test_resilience_module_exports() -> None:
         "RetryConfig",
         "RetryStrategy",
         "SlidingWindowConfig",
+        "Timeout",
+        "TimeoutConfig",
         "TokenBucketConfig",
         "fallback",
         "falling_back",

--- a/tests/resilience/test_timeout.py
+++ b/tests/resilience/test_timeout.py
@@ -1,0 +1,257 @@
+"""Timeout policy tests."""
+
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from grelmicro.resilience import Retry, Timeout, TimeoutConfig
+
+_TWO = 2.0
+_THREE_HALF = 3.5
+_ONE_QUARTER = 1.25
+_ONE = 1.0
+
+# --- TimeoutConfig validation ---------------------------------------------
+
+
+def test_config_requires_seconds() -> None:
+    """`TimeoutConfig` raises when `seconds` is missing."""
+    with pytest.raises(ValidationError):
+        TimeoutConfig()  # type: ignore[call-arg]  # ty: ignore[missing-argument]
+
+
+def test_config_rejects_zero_seconds() -> None:
+    """`seconds` must be strictly positive."""
+    with pytest.raises(ValidationError):
+        TimeoutConfig(seconds=0)
+
+
+def test_config_rejects_negative_seconds() -> None:
+    """`seconds` must be strictly positive."""
+    with pytest.raises(ValidationError):
+        TimeoutConfig(seconds=-1.0)
+
+
+def test_config_frozen() -> None:
+    """`TimeoutConfig` is frozen."""
+    cfg = TimeoutConfig(seconds=1.0)
+    with pytest.raises(ValidationError):
+        cfg.seconds = 2.0  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+
+
+def test_config_forbids_extra() -> None:
+    """`TimeoutConfig` rejects unknown fields."""
+    with pytest.raises(ValidationError):
+        TimeoutConfig(seconds=1.0, policy="raise")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+
+
+# --- Class-form construction ----------------------------------------------
+
+
+def test_constructs_with_seconds_kwarg() -> None:
+    """The simple `seconds=` path builds a valid policy."""
+    policy = Timeout("db", seconds=2.0)
+    assert policy.name == "db"
+    assert policy.config.seconds == _TWO
+
+
+def test_constructs_from_config() -> None:
+    """`from_config` accepts a pre-built `TimeoutConfig`."""
+    cfg = TimeoutConfig(seconds=0.5)
+    policy = Timeout.from_config("db", cfg)
+    assert policy.config is cfg
+
+
+def test_rejects_seconds_and_config_together() -> None:
+    """Mixing kwargs with a pre-built config is rejected."""
+    with pytest.raises(TypeError):
+        Timeout(
+            "db",
+            seconds=1.0,
+            config=TimeoutConfig(seconds=2.0),
+        )
+
+
+def test_requires_seconds_when_env_off() -> None:
+    """No kwargs and no env path means construction fails."""
+    with pytest.raises(ValidationError):
+        Timeout("db")
+
+
+def test_env_load_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The env path reads `GREL_TIMEOUT_{NAME}_SECONDS`."""
+    monkeypatch.setenv("GREL_TIMEOUT_DB_SECONDS", "3.5")
+    policy = Timeout("db", env_load=True)
+    assert policy.config.seconds == _THREE_HALF
+
+
+def test_env_segment_normalises_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Names with dashes map to underscored env segments."""
+    monkeypatch.setenv("GREL_TIMEOUT_PAYMENTS_EU_SECONDS", "1.25")
+    policy = Timeout("payments-eu", env_load=True)
+    assert policy.config.seconds == _ONE_QUARTER
+
+
+# --- Async context manager behavior ---------------------------------------
+
+
+async def test_context_manager_success() -> None:
+    """A fast inner block completes without raising."""
+    policy = Timeout("t", seconds=1.0)
+    async with policy:
+        await asyncio.sleep(0)
+
+
+async def test_context_manager_times_out() -> None:
+    """A slow inner block hits the deadline and raises `TimeoutError`."""
+    policy = Timeout("t", seconds=0.01)
+    with pytest.raises(TimeoutError):
+        async with policy:
+            await asyncio.sleep(0.5)
+
+
+async def test_context_manager_concurrent_tasks() -> None:
+    """The same policy can be entered concurrently by multiple tasks."""
+    policy = Timeout("t", seconds=0.1)
+
+    async def task() -> bool:
+        try:
+            async with policy:
+                await asyncio.sleep(0.5)
+        except TimeoutError:
+            return True
+        return False
+
+    results = await asyncio.gather(task(), task(), task())
+    assert results == [True, True, True]
+
+
+async def test_context_manager_nested() -> None:
+    """Nested entries of the same policy each get their own deadline."""
+    policy = Timeout("t", seconds=1.0)
+    async with policy, policy:
+        await asyncio.sleep(0)
+
+
+# --- Decorator behavior ---------------------------------------------------
+
+
+async def test_decorator_returns_function_value_on_success() -> None:
+    """Fast async function returns its value."""
+    policy = Timeout("t", seconds=1.0)
+
+    @policy
+    async def fn() -> str:
+        return "ok"
+
+    assert await fn() == "ok"
+
+
+async def test_decorator_raises_on_timeout() -> None:
+    """A slow decorated function raises `TimeoutError`."""
+    policy = Timeout("t", seconds=0.01)
+
+    @policy
+    async def fn() -> None:
+        await asyncio.sleep(0.5)
+
+    with pytest.raises(TimeoutError):
+        await fn()
+
+
+def test_decorator_rejects_sync_function() -> None:
+    """Sync functions cannot be timed out via asyncio."""
+    policy = Timeout("t", seconds=1.0)
+
+    def sync_fn() -> None: ...
+
+    with pytest.raises(TypeError):
+        policy(sync_fn)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+# --- Live reconfiguration -------------------------------------------------
+
+
+async def test_reconfigure_updates_deadline() -> None:
+    """`reconfigure` swaps the snapshot for future entries."""
+    policy = Timeout("t", seconds=0.01)
+
+    new_config = policy.config.model_copy(update={"seconds": 1.0})
+    await policy.reconfigure(new_config)
+    assert policy.config.seconds == _ONE
+
+    async with policy:
+        await asyncio.sleep(0)
+
+
+async def test_reconfigure_requires_same_type() -> None:
+    """`reconfigure` rejects a different config type."""
+    policy = Timeout("t", seconds=1.0)
+    with pytest.raises(TypeError):
+        await policy.reconfigure("not a config")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+async def test_reconfigure_does_not_affect_in_flight_scope() -> None:
+    """In-flight scopes keep their original deadline across `reconfigure`."""
+    policy = Timeout("t", seconds=1.0)
+
+    started = asyncio.Event()
+    swap_done = asyncio.Event()
+
+    async def long_call() -> None:
+        async with policy:
+            started.set()
+            await swap_done.wait()
+            await asyncio.sleep(0)
+
+    task = asyncio.create_task(long_call())
+    await started.wait()
+    tight = policy.config.model_copy(update={"seconds": 0.001})
+    await policy.reconfigure(tight)
+    swap_done.set()
+    await task
+
+
+# --- Cancellation and composition -----------------------------------------
+
+
+async def test_outer_cancellation_propagates_as_cancelled_error() -> None:
+    """Cancelling the outer task surfaces `CancelledError`, not `TimeoutError`."""
+    policy = Timeout("t", seconds=10.0)
+
+    started = asyncio.Event()
+
+    async def runner() -> None:
+        async with policy:
+            started.set()
+            await asyncio.sleep(10)
+
+    task = asyncio.create_task(runner())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+_THREE = 3
+
+
+async def test_composes_under_retry() -> None:
+    """A `Timeout` placed inside a `Retry` retries each timed-out attempt."""
+    policy = Timeout("t", seconds=0.01)
+    retrier = Retry.constant("t", when=TimeoutError, attempts=3, delay=0.001)
+
+    attempts = 0
+
+    @retrier
+    @policy
+    async def call() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts < _THREE:
+            await asyncio.sleep(0.5)
+        return "ok"
+
+    assert await call() == "ok"
+    assert attempts == _THREE

--- a/tests/resilience/test_timeout.py
+++ b/tests/resilience/test_timeout.py
@@ -134,6 +134,22 @@ async def test_context_manager_nested() -> None:
         await asyncio.sleep(0)
 
 
+async def test_child_task_does_not_inherit_parent_scope() -> None:
+    """A task spawned inside a scope does not see the parent's scope state."""
+    policy = Timeout("t", seconds=1.0)
+    spawned_view: list[bool] = []
+
+    async def child() -> None:
+        spawned_view.append(asyncio.current_task() in policy._scopes)
+
+    async with policy:
+        task = asyncio.create_task(child())
+        await task
+
+    assert spawned_view == [False]
+    assert policy._scopes == {}
+
+
 # --- Decorator behavior ---------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Adds `Timeout`, a reconfigurable resilience pattern wrapping `asyncio.timeout`. `Timeout("db", seconds=2.0)` works as an async context manager (`async with db_timeout:`) and as a decorator on async functions.
- `TimeoutConfig` is a frozen three-paths Pydantic config with `seconds: PositiveFloat`. Env prefix `GREL_TIMEOUT_{NAME_UPPER}_`.
- Inherits `Reconfigurable[TimeoutConfig]`. Live deadline swaps leave in-flight scopes on the original deadline.
- Per-instance `ContextVar` stack so concurrent tasks and nested entries each get their own `asyncio.Timeout` scope.
- Sync functions rejected at decoration: asyncio cannot cancel sync code.

Closes #176.

## Scope cut from the original issue

\`policy: Literal["raise", "shield"]\` was in the issue sketch. First cut ships \`seconds\` only with raise semantics (the asyncio.timeout default). Shield-style "silent timeout" can land later if there is demand.

## Test plan

- [x] \`pytest tests/resilience/test_timeout.py\` 23 cases (config validation, three-paths construction, env path with name normalisation, success/timeout, concurrent reuse, nested entries, decorator sync rejection, reconfigure, in-flight scope keeps original deadline, outer-task cancellation propagates as \`CancelledError\`, composition under \`Retry\`)
- [x] \`pytest tests/\` full suite 1773 passed
- [x] \`ruff check\` + \`ruff format --check\`
- [x] \`ty check\`
- [x] \`mkdocs build --strict\`
- [ ] CI green
- [ ] Copilot review