### PR TITLE
✨ Add Shield resilience pattern (#249)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-* ✨ Add `Shield` resilience pattern: per-attempt timeout, retry-budget-gated retries, CUBIC-style adaptive rate limiter, optional cache and fallback recovery paths. Three profiles (`internal`, `api`, `slow`) cover the common cases. Decorator (`@shield`, `@shield.api(...)`), class (`Shield.api("name")`), and imperative (`shield.run(fn, ...)`) forms supported. Issue [#249](https://github.com/grelinfo/grelmicro/issues/249).
+* ✨ Add `Shield` resilience pattern: per-attempt timeout, retry-budget-gated retries, CUBIC-style adaptive rate limiter, optional cache and fallback recovery paths. Three profiles (`internal`, `api`, `slow`) cover the common cases. Decorator (`@shield`, `@shield.api(...)`), class (`Shield.api("name")`), and imperative (`Shield.api("name").run(fn, ...)`) forms supported. Issue [#249](https://github.com/grelinfo/grelmicro/issues/249).
 
 ## 0.25.0 - 2026-05-21
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* ✨ Add `Shield` resilience pattern: per-attempt timeout, retry-budget-gated retries, CUBIC-style adaptive rate limiter, optional cache and fallback recovery paths. Three profiles (`internal`, `api`, `slow`) cover the common cases. Decorator (`@shield`, `@shield.api(...)`), class (`Shield.api("name")`), and imperative (`shield.run(fn, ...)`) forms supported. Issue [#249](https://github.com/grelinfo/grelmicro/issues/249).
+
 ## 0.25.0 - 2026-05-21
 
 ### Features

--- a/docs/reference/resilience.md
+++ b/docs/reference/resilience.md
@@ -39,6 +39,8 @@
         - RateLimitResult
         - RedisCircuitBreakerAdapter
         - RedisRateLimiterAdapter
+        - ApiShieldConfig
+        - InternalShieldConfig
         - ResilienceError
         - ResilienceSettingsValidationError
         - Retry
@@ -46,7 +48,10 @@
         - RetryBackoffConfig
         - RetryConfig
         - RetryStrategy
+        - Shield
+        - ShieldConfig
         - SlidingWindowConfig
+        - SlowShieldConfig
         - Timeout
         - TimeoutConfig
         - TokenBucketConfig
@@ -54,3 +59,4 @@
         - falling_back
         - retry
         - retrying
+        - shield

--- a/docs/resilience/index.md
+++ b/docs/resilience/index.md
@@ -2,6 +2,7 @@
 
 The `resilience` package provides primitives that help your services handle failures in distributed systems. Each pattern is independent. Use the ones you need and skip the rest.
 
+- [**Shield**](shield.md): all-in-one outer-layer resilience for one async call to one dependency. Bundles per-attempt timeout, exponential-jittered retry with a consecutive-failure budget, and CUBIC-style adaptive throttling. One decorator, one knob. The recommended starting point.
 - [**Circuit Breaker**](circuit-breaker.md): detect repeated failures in a downstream call and stop sending requests long enough for it to recover. This prevents cascading failures.
 - [**Fallback**](fallback.md): return a safe default value when a call fails. Pluggable filter (any `Match`), static default or factory callable, decorator and block forms.
 - [**Rate Limiter**](rate-limiter.md): cap how many requests a client can make per window. Pluggable algorithm (`TokenBucketConfig` or `SlidingWindowConfig`), pluggable backend (`Memory` or `Redis`), with a result shape that maps directly to HTTP rate limit headers.
@@ -14,6 +15,7 @@ See [Composing patterns](composition.md) for the recommended outside-in order wh
 
 | Pattern | Use when |
 |---|---|
+| **Shield** | You wrap one async call to one dependency and want sensible-by-default resilience without composing primitives. |
 | **Circuit Breaker** | The caller is hitting an external dependency (DB, API, third-party) that can fail or stall. |
 | **Fallback** | A call can fail and you want to degrade gracefully (cached value, empty list, neutral default) instead of propagating the error. |
 | **Rate Limiter** | You need to throttle *your own* endpoint, worker, or background job to protect the downstream side or enforce fair usage. |

--- a/docs/resilience/shield.md
+++ b/docs/resilience/shield.md
@@ -1,0 +1,295 @@
+# Shield
+
+A **Shield** is the outer layer of resilience around one async call to one dependency. It bundles a per-attempt timeout, exponential-jittered retry gated by a consecutive-failure budget, and a CUBIC-style adaptive rate limiter that engages only after sustained slow-downs. One decorator, one knob.
+
+**Why**
+
+- Wrap one call to one dependency without composing four primitives by hand.
+- Survive transient slow-downs (network blips, brief overloads) without changing the call site.
+- Pace the whole client down automatically when a dependency keeps timing out, then ramp back gradually.
+- Stay invisible on the happy path. The adaptive layer enables itself only after the first slow-down.
+
+The adaptive layer uses a CUBIC-style controller from [RFC 9438](https://datatracker.ietf.org/doc/rfc9438/) with `C = 0.4` and `β = 0.7`. The per-attempt timeout tracks the p95 of the last 32 successful latencies multiplied by `2.5`, clamped to the profile range. Retries are gated by a consecutive-failure budget with refund-on-recovery.
+
+## Usage
+
+```python
+import httpx
+from grelmicro.resilience import shield
+
+
+@shield.api(timeout_errors=(httpx.TimeoutException, httpx.ConnectError))
+async def fetch(client: httpx.AsyncClient, url: str) -> bytes:
+    response = await client.get(url)
+    response.raise_for_status()
+    return response.content
+```
+
+Pick a profile factory (`shield.internal`, `shield.api`, `shield.slow`), tell Shield which exceptions mean "the dependency is slow", done. Everything else propagates unchanged.
+
+The zero-argument form uses the `api` profile with the default `timeout_errors=(TimeoutError,)`:
+
+```python
+@shield
+async def cheap_call() -> None:
+    async with asyncio.timeout(5):
+        await do_work()
+```
+
+Shield is **async-only**. Use it on coroutine functions.
+
+## Choose a profile
+
+| Profile | Use when | Initial rate (per second) | Initial timeout |
+|---|---|---|---|
+| `internal` | In-cluster RPC. Healthy services, fast latency, tight budgets. | `100` | `1.0s` |
+| `api` (default) | External HTTP APIs. Moderate latency, occasional outages, third-party SLAs. | `2` | `10.0s` |
+| `slow` | Long-running calls: LLM inference, batch jobs, large queries. | `0.5` | `120.0s` |
+
+Three profiles cover the common cases. They are mutually exclusive: pick one per `Shield` instance. To pace differently, switch profile, do not tune individual fields. The internal parameters (retry budget capacity, CUBIC curve constants, backoff scale, timeout clamps) are fixed by profile choice.
+
+```python
+@shield.internal(timeout_errors=(MyRpcTimeout,))
+async def call_internal_rpc(): ...
+
+@shield.api(timeout_errors=(httpx.TimeoutException, httpx.ConnectError))
+async def call_external_api(): ...
+
+@shield.slow(timeout_errors=(MyLLMError,))
+async def call_llm(prompt: str): ...
+```
+
+If the three profiles do not fit, you have outgrown Shield. Compose `Retry`, `Timeout`, `RateLimiter` and `CircuitBreaker` directly instead.
+
+## Exception classification
+
+Shield classifies the wrapped call's outcome by exception type only. There is no response envelope, no status code, no `Retry-After` header.
+
+| Raised by the wrapped call | Retried? | Triggers CUBIC shrink? | Consumes retry budget? |
+|---|---|---|---|
+| Any type in `timeout_errors` (or its subclasses) | yes | yes | yes |
+| Any other `Exception` subclass | no, propagates immediately | no | no |
+| Subclass of `ResilienceError` | no, propagates immediately | no | no |
+| `BaseException` outside `Exception` ([PEP 654](https://peps.python.org/pep-0654/) groups, `KeyboardInterrupt`, `CancelledError`, `SystemExit`) | no, propagates immediately | no | no |
+
+You declare what "transient" means by passing exception types to `timeout_errors=`. Anything else surfaces unchanged.
+
+The effective tuple is always `user_tuple + (TimeoutError,)`. Shield's own per-attempt timeout raises `TimeoutError`, and the library guarantees that signal is always retryable, regardless of what the user passed.
+
+The default when the argument is omitted is `(TimeoutError,)`, which covers the per-attempt timeout and any standard Python timeout the wrapped callable raises.
+
+## Sharing across functions
+
+Build a `Shield` instance once and decorate multiple functions with it. They share one retry budget and one CUBIC controller, which is the correct topology when several functions hit the same dependency.
+
+```python
+from grelmicro.resilience import Shield
+
+github = Shield.api(
+    "github",
+    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
+)
+
+
+@github
+async def list_repos(): ...
+
+
+@github
+async def get_repo(): ...
+```
+
+One `Shield` instance per logical dependency. Two functions hitting GitHub share one budget. Two functions hitting GitHub and Stripe get two `Shield` instances.
+
+The `name=` argument is the registration name used in logs, metrics, and the [PEP 678](https://peps.python.org/pep-0678/) notes attached on give-up. It defaults to the wrapped function's `__qualname__` when used as `@shield.api(...)`, and is required positional when used as `Shield.api(...)`.
+
+## Imperative form
+
+For inline calls that span multiple statements, use `Shield.run`:
+
+```python
+github = Shield.api("github", timeout_errors=(httpx.TimeoutException,))
+
+async def handler():
+    response = await github.run(client.get, url)
+    body = await github.run(parse_response, response)
+    return body
+```
+
+`Shield.run(fn, *args, **kwargs)` calls `fn(*args, **kwargs)` under the same retry-budget and adaptive-bucket state as the decorator form.
+
+## Cache and fallback
+
+On give-up (retry budget exhausted, attempts cap reached, or non-retryable exception), Shield tries two recovery paths in order: a cache lookup, then a fallback callable. Either or both can be set.
+
+### Cached fallback
+
+Pass a `Cache` instance to `cache=`. Shield writes the return value on every success and reads it on give-up:
+
+```python
+from grelmicro.cache import TTLCache
+from grelmicro.resilience import shield
+
+@shield.api(
+    "prices",
+    timeout_errors=(httpx.TimeoutException,),
+    cache=TTLCache(ttl=300),
+)
+async def fetch_price(symbol: str) -> Decimal: ...
+```
+
+Behavior:
+
+- **On success**: `await cache.set(key, return_value)` runs fire-and-forget. A cache write failure is logged at debug and never propagates.
+- **On give-up**: `value = await cache.get(key)` runs. A cache hit returns the cached value. A cache miss continues to the next recovery path.
+- **Key**: `f"{shield.name}:{stable_hash(args, kwargs)}"` by default. Override with `cache_key=` for control over what the key looks like:
+
+```python
+@shield.api(
+    "prices",
+    timeout_errors=(httpx.TimeoutException,),
+    cache=TTLCache(ttl=300),
+    cache_key=lambda symbol, *_: f"price:{symbol}",
+)
+async def fetch_price(symbol: str) -> Decimal: ...
+```
+
+Non-hashable arguments (Pydantic models, dataclasses, etc.) are hashed via stable `repr()`. Override `cache_key=` for non-default behavior.
+
+### Custom fallback
+
+Pass a callable to `fallback=` for the case where the cache misses (or no cache is set). The callable receives the exception that escaped Shield:
+
+```python
+async def last_known_price(exc: Exception) -> Decimal:
+    return Decimal("0")
+
+
+@shield.api(
+    "prices",
+    timeout_errors=(httpx.TimeoutException,),
+    cache=TTLCache(ttl=300),
+    fallback=last_known_price,
+)
+async def fetch_price(symbol: str) -> Decimal: ...
+```
+
+### Recovery order on give-up
+
+| Step | Condition | Outcome |
+|---|---|---|
+| 1 | `cache=` set and cache hit | return the cached value |
+| 2 | `cache=` unset or cache miss, `fallback=` set | call `fallback(exc)`, return its result |
+| 3 | neither path returns a value | re-raise the original exception with a [PEP 678](https://peps.python.org/pep-0678/) note |
+
+Use `cache=` alone when stale data is acceptable. Add `fallback=` for a safety net when the cache is cold. Use `fallback=` alone for purely synthesized defaults.
+
+## Per-call rate ceiling
+
+If the dependency has a contractual quota (an SLA limit, a third-party rate limit), set `max_rate=` to cap the adaptive bucket's growth:
+
+```python
+@shield.api(
+    "stripe",
+    timeout_errors=(stripe.error.APIConnectionError,),
+    max_rate=10.0,
+)
+async def charge_card(...): ...
+```
+
+CUBIC will still grow the rate after recovery, but `max_rate` clamps the ceiling. Without it, the ceiling grows unbounded as the dependency stays healthy.
+
+## Behavior on giving up
+
+When Shield gives up (budget exhausted, attempts exhausted, or non-retryable exception) and no recovery path returns a value (see [Recovery order on give-up](#recovery-order-on-give-up)), the underlying exception is re-raised with a [PEP 678](https://peps.python.org/pep-0678/) note attached:
+
+```python
+try:
+    await fetch(url)
+except httpx.TimeoutException as exc:
+    print(exc.__notes__)
+    # ['shield: budget exhausted after 4/4 attempts in 18.30s (api profile)']
+```
+
+The note format encodes the give-up reason (`budget exhausted`, `attempts exhausted`, `non-retryable exception`), the attempt count, the total elapsed time, and the profile name.
+
+Callers catch the underlying exception type, unchanged. There is no `ShieldError` wrapper.
+
+## Composing with client-side retries
+
+Shield is the **outer** layer of resilience. Many client libraries ship their own retry logic, tuned for protocol-level transience (`Retry-After` headers, idempotency keys, modeled status codes). Shield does not replace that work. It adds a slower-timescale layer on top.
+
+You do not need to disable the client's retries. Pass the client's terminal exception types via `timeout_errors=`:
+
+```python
+@shield.api(
+    "github",
+    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
+)
+async def fetch(url: str) -> httpx.Response:
+    return await retrying_httpx_client.get(url)
+```
+
+When the inner layer exhausts its own attempts and surfaces an exception, Shield sees it. CUBIC engages only when the *outer* exception escapes, never on per-attempt blips the inner layer handled.
+
+## What Shield does not do
+
+- **HTTP status sniffing.** No `Retry-After` parsing, no 429/503 awareness. Call `response.raise_for_status()` inside the wrapped function and pass the resulting exception type via `timeout_errors=`.
+- **Sync callables.** Async-only in 1.0. Wrap sync code in `asyncio.to_thread(...)` if needed.
+- **Hedged requests.** Hedging fires N parallel attempts and returns the first success. It is a different primitive, not on the Shield roadmap.
+- **Distributed retry budget.** Each `Shield` is per-process. There is no cross-replica coordination.
+- **Total deadline propagation.** Shield enforces per-attempt timeouts. Wrap the whole call in `asyncio.timeout(...)` for a total deadline.
+
+## Configuration
+
+`Shield` follows the three-paths configuration contract.
+
+### Programmatic
+
+```python
+from grelmicro.resilience import Shield
+
+github = Shield.api(
+    "github",
+    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
+    max_rate=20.0,
+)
+```
+
+### Declarative
+
+```python
+from grelmicro.resilience import ApiShieldConfig, Shield
+
+config = ApiShieldConfig(
+    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
+    max_rate=20.0,
+)
+github = Shield("github", config=config)
+```
+
+`ApiShieldConfig`, `InternalShieldConfig`, and `SlowShieldConfig` form a discriminated union on `kind`. Each subclass freezes its profile parameters. The public fields (`timeout_errors`, `max_rate`, `cache`, `cache_key`, `fallback`) are the only knobs.
+
+### Environmental
+
+Prefix: `GREL_SHIELD_{NAME_UPPER}_`
+
+| Env var | Field | Type | Default |
+|---|---|---|---|
+| `GREL_SHIELD_{NAME_UPPER}_PROFILE` | profile | `internal` / `api` / `slow` | `api` |
+| `GREL_SHIELD_{NAME_UPPER}_TIMEOUT_ERRORS` | `timeout_errors` | CSV of FQN strings (e.g. `httpx.TimeoutException,httpx.ConnectError`) | `builtins.TimeoutError` |
+| `GREL_SHIELD_{NAME_UPPER}_MAX_RATE` | `max_rate` | `float` or empty | unset |
+
+The `cache`, `cache_key`, and `fallback` arguments cannot come from env. Use the programmatic or declarative path for them.
+
+```python
+github = Shield("github", env_load=True)
+```
+
+## Live reconfiguration
+
+`Shield` inherits `Reconfigurable[ShieldConfig]`. Calling `shield.reconfigure(new_config)` swaps the snapshot for future calls. An in-flight `await shield.run(...)` keeps its snapshot until it completes. See [Live reconfiguration](../architecture/reconfigure.md).
+
+## Reference
+
+See the [API reference](../reference/resilience.md#grelmicro.resilience.Shield) for every option.

--- a/docs/resilience/shield.md
+++ b/docs/resilience/shield.md
@@ -47,14 +47,14 @@ If the three profiles do not fit, you have outgrown Shield. Compose `Retry`, `Ti
 
 Shield classifies the wrapped call's outcome by exception type only. There is no response envelope, no status code, no `Retry-After` header.
 
-| Raised by the wrapped call | Retried? | Triggers CUBIC shrink? | Consumes retry budget? |
-|---|---|---|---|
-| Any type in `timeout_errors` (or its subclasses) | yes | yes | yes |
-| Any other `Exception` subclass | no, propagates immediately | no | no |
-| Subclass of `ResilienceError` | no, propagates immediately | no | no |
-| `BaseException` outside `Exception` (`KeyboardInterrupt`, `CancelledError`, `SystemExit`, `BaseExceptionGroup`) | no, propagates immediately | no | no |
+| Raised by the wrapped call | Retried? | Triggers CUBIC shrink? | Consumes retry budget? | Cache / fallback recovery? |
+|---|---|---|---|---|
+| Any type in `timeout_errors` (or its subclasses) | yes | yes | yes | yes, on give-up |
+| Any other `Exception` subclass | no | no | no | yes, on give-up |
+| Subclass of `ResilienceError` | no | no | no | no, propagates immediately |
+| `BaseException` outside `Exception` (`KeyboardInterrupt`, `CancelledError`, `SystemExit`, `BaseExceptionGroup`) | no | no | no | no, propagates immediately |
 
-You declare what "transient" means by passing exception types to `timeout_errors=`. Anything else surfaces unchanged.
+You declare what "transient" means by passing exception types to `timeout_errors=`. Any other `Exception` skips the retry loop and goes straight to the [give-up recovery path](#recovery-order-on-give-up): if a cache or fallback returns a value, that value is returned; otherwise the original exception is re-raised with a [PEP 678](https://peps.python.org/pep-0678/) note. `ResilienceError` and `BaseException`-outside-`Exception` always propagate unchanged with no recovery and no note.
 
 The effective tuple is always `user_tuple + (TimeoutError,)`. Shield's own per-attempt timeout raises `TimeoutError`, and the library guarantees that signal is always retryable, regardless of what the user passed.
 

--- a/docs/resilience/shield.md
+++ b/docs/resilience/shield.md
@@ -52,7 +52,7 @@ Shield classifies the wrapped call's outcome by exception type only. There is no
 | Any type in `timeout_errors` (or its subclasses) | yes | yes | yes |
 | Any other `Exception` subclass | no, propagates immediately | no | no |
 | Subclass of `ResilienceError` | no, propagates immediately | no | no |
-| `BaseException` outside `Exception` ([PEP 654](https://peps.python.org/pep-0654/) groups, `KeyboardInterrupt`, `CancelledError`, `SystemExit`) | no, propagates immediately | no | no |
+| `BaseException` outside `Exception` (`KeyboardInterrupt`, `CancelledError`, `SystemExit`, `BaseExceptionGroup`) | no, propagates immediately | no | no |
 
 You declare what "transient" means by passing exception types to `timeout_errors=`. Anything else surfaces unchanged.
 

--- a/docs/resilience/shield.md
+++ b/docs/resilience/shield.md
@@ -14,15 +14,7 @@ The adaptive layer uses a CUBIC-style controller from [RFC 9438](https://datatra
 ## Usage
 
 ```python
-import httpx
-from grelmicro.resilience import shield
-
-
-@shield.api(timeout_errors=(httpx.TimeoutException, httpx.ConnectError))
-async def fetch(client: httpx.AsyncClient, url: str) -> bytes:
-    response = await client.get(url)
-    response.raise_for_status()
-    return response.content
+--8<-- "resilience/shield.py"
 ```
 
 Pick a profile factory (`shield.internal`, `shield.api`, `shield.slow`), tell Shield which exceptions mean "the dependency is slow", done. Everything else propagates unchanged.
@@ -30,10 +22,7 @@ Pick a profile factory (`shield.internal`, `shield.api`, `shield.slow`), tell Sh
 The zero-argument form uses the `api` profile with the default `timeout_errors=(TimeoutError,)`:
 
 ```python
-@shield
-async def cheap_call() -> None:
-    async with asyncio.timeout(5):
-        await do_work()
+--8<-- "resilience/shield_zero_args.py"
 ```
 
 Shield is **async-only**. Use it on coroutine functions.
@@ -49,14 +38,7 @@ Shield is **async-only**. Use it on coroutine functions.
 Three profiles cover the common cases. They are mutually exclusive: pick one per `Shield` instance. To pace differently, switch profile, do not tune individual fields. The internal parameters (retry budget capacity, CUBIC curve constants, backoff scale, timeout clamps) are fixed by profile choice.
 
 ```python
-@shield.internal(timeout_errors=(MyRpcTimeout,))
-async def call_internal_rpc(): ...
-
-@shield.api(timeout_errors=(httpx.TimeoutException, httpx.ConnectError))
-async def call_external_api(): ...
-
-@shield.slow(timeout_errors=(MyLLMError,))
-async def call_llm(prompt: str): ...
+--8<-- "resilience/shield_profiles.py"
 ```
 
 If the three profiles do not fit, you have outgrown Shield. Compose `Retry`, `Timeout`, `RateLimiter` and `CircuitBreaker` directly instead.
@@ -83,20 +65,7 @@ The default when the argument is omitted is `(TimeoutError,)`, which covers the 
 Build a `Shield` instance once and decorate multiple functions with it. They share one retry budget and one CUBIC controller, which is the correct topology when several functions hit the same dependency.
 
 ```python
-from grelmicro.resilience import Shield
-
-github = Shield.api(
-    "github",
-    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
-)
-
-
-@github
-async def list_repos(): ...
-
-
-@github
-async def get_repo(): ...
+--8<-- "resilience/shield_class.py"
 ```
 
 One `Shield` instance per logical dependency. Two functions hitting GitHub share one budget. Two functions hitting GitHub and Stripe get two `Shield` instances.
@@ -108,12 +77,7 @@ The `name=` argument is the registration name used in logs, metrics, and the [PE
 For inline calls that span multiple statements, use `Shield.run`:
 
 ```python
-github = Shield.api("github", timeout_errors=(httpx.TimeoutException,))
-
-async def handler():
-    response = await github.run(client.get, url)
-    body = await github.run(parse_response, response)
-    return body
+--8<-- "resilience/shield_run.py"
 ```
 
 `Shield.run(fn, *args, **kwargs)` calls `fn(*args, **kwargs)` under the same retry-budget and adaptive-bucket state as the decorator form.
@@ -127,15 +91,7 @@ On give-up (retry budget exhausted, attempts cap reached, or non-retryable excep
 Pass a `Cache` instance to `cache=`. Shield writes the return value on every success and reads it on give-up:
 
 ```python
-from grelmicro.cache import TTLCache
-from grelmicro.resilience import shield
-
-@shield.api(
-    "prices",
-    timeout_errors=(httpx.TimeoutException,),
-    cache=TTLCache(ttl=300),
-)
-async def fetch_price(symbol: str) -> Decimal: ...
+--8<-- "resilience/shield_cache.py"
 ```
 
 Behavior:
@@ -145,13 +101,7 @@ Behavior:
 - **Key**: `f"{shield.name}:{stable_hash(args, kwargs)}"` by default. Override with `cache_key=` for control over what the key looks like:
 
 ```python
-@shield.api(
-    "prices",
-    timeout_errors=(httpx.TimeoutException,),
-    cache=TTLCache(ttl=300),
-    cache_key=lambda symbol, *_: f"price:{symbol}",
-)
-async def fetch_price(symbol: str) -> Decimal: ...
+--8<-- "resilience/shield_cache_key.py"
 ```
 
 Non-hashable arguments (Pydantic models, dataclasses, etc.) are hashed via stable `repr()`. Override `cache_key=` for non-default behavior.
@@ -161,17 +111,7 @@ Non-hashable arguments (Pydantic models, dataclasses, etc.) are hashed via stabl
 Pass a callable to `fallback=` for the case where the cache misses (or no cache is set). The callable receives the exception that escaped Shield:
 
 ```python
-async def last_known_price(exc: Exception) -> Decimal:
-    return Decimal("0")
-
-
-@shield.api(
-    "prices",
-    timeout_errors=(httpx.TimeoutException,),
-    cache=TTLCache(ttl=300),
-    fallback=last_known_price,
-)
-async def fetch_price(symbol: str) -> Decimal: ...
+--8<-- "resilience/shield_fallback.py"
 ```
 
 ### Recovery order on give-up
@@ -189,12 +129,7 @@ Use `cache=` alone when stale data is acceptable. Add `fallback=` for a safety n
 If the dependency has a contractual quota (an SLA limit, a third-party rate limit), set `max_rate=` to cap the adaptive bucket's growth:
 
 ```python
-@shield.api(
-    "stripe",
-    timeout_errors=(stripe.error.APIConnectionError,),
-    max_rate=10.0,
-)
-async def charge_card(...): ...
+--8<-- "resilience/shield_max_rate.py"
 ```
 
 CUBIC will still grow the rate after recovery, but `max_rate` clamps the ceiling. Without it, the ceiling grows unbounded as the dependency stays healthy.
@@ -204,11 +139,7 @@ CUBIC will still grow the rate after recovery, but `max_rate` clamps the ceiling
 When Shield gives up (budget exhausted, attempts exhausted, or non-retryable exception) and no recovery path returns a value (see [Recovery order on give-up](#recovery-order-on-give-up)), the underlying exception is re-raised with a [PEP 678](https://peps.python.org/pep-0678/) note attached:
 
 ```python
-try:
-    await fetch(url)
-except httpx.TimeoutException as exc:
-    print(exc.__notes__)
-    # ['shield: budget exhausted after 4/4 attempts in 18.30s (api profile)']
+--8<-- "resilience/shield_giveup.py"
 ```
 
 The note format encodes the give-up reason (`budget exhausted`, `attempts exhausted`, `non-retryable exception`), the attempt count, the total elapsed time, and the profile name.
@@ -222,12 +153,7 @@ Shield is the **outer** layer of resilience. Many client libraries ship their ow
 You do not need to disable the client's retries. Pass the client's terminal exception types via `timeout_errors=`:
 
 ```python
-@shield.api(
-    "github",
-    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
-)
-async def fetch(url: str) -> httpx.Response:
-    return await retrying_httpx_client.get(url)
+--8<-- "resilience/shield_layered.py"
 ```
 
 When the inner layer exhausts its own attempts and surfaces an exception, Shield sees it. CUBIC engages only when the *outer* exception escapes, never on per-attempt blips the inner layer handled.
@@ -247,25 +173,13 @@ When the inner layer exhausts its own attempts and surfaces an exception, Shield
 ### Programmatic
 
 ```python
-from grelmicro.resilience import Shield
-
-github = Shield.api(
-    "github",
-    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
-    max_rate=20.0,
-)
+--8<-- "resilience/shield_programmatic.py"
 ```
 
 ### Declarative
 
 ```python
-from grelmicro.resilience import ApiShieldConfig, Shield
-
-config = ApiShieldConfig(
-    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
-    max_rate=20.0,
-)
-github = Shield("github", config=config)
+--8<-- "resilience/shield_declarative.py"
 ```
 
 `ApiShieldConfig`, `InternalShieldConfig`, and `SlowShieldConfig` form a discriminated union on `kind`. Each subclass freezes its profile parameters. The public fields (`timeout_errors`, `max_rate`, `cache`, `cache_key`, `fallback`) are the only knobs.
@@ -283,7 +197,7 @@ Prefix: `GREL_SHIELD_{NAME_UPPER}_`
 The `cache`, `cache_key`, and `fallback` arguments cannot come from env. Use the programmatic or declarative path for them.
 
 ```python
-github = Shield("github", env_load=True)
+--8<-- "resilience/shield_environmental.py"
 ```
 
 ## Live reconfiguration

--- a/docs/snippets/resilience/shield.py
+++ b/docs/snippets/resilience/shield.py
@@ -1,0 +1,10 @@
+import httpx
+
+from grelmicro.resilience import shield
+
+
+@shield.api(timeout_errors=(httpx.TimeoutException, httpx.ConnectError))
+async def fetch(client: httpx.AsyncClient, url: str) -> bytes:
+    response = await client.get(url)
+    response.raise_for_status()
+    return response.content

--- a/docs/snippets/resilience/shield_cache.py
+++ b/docs/snippets/resilience/shield_cache.py
@@ -1,0 +1,15 @@
+from decimal import Decimal
+
+import httpx
+
+from grelmicro.cache import TTLCache
+from grelmicro.resilience import shield
+
+
+@shield.api(
+    "prices",
+    timeout_errors=(httpx.TimeoutException,),
+    cache=TTLCache(ttl=300),
+)
+async def fetch_price(symbol: str) -> Decimal:
+    return Decimal(0)

--- a/docs/snippets/resilience/shield_cache_key.py
+++ b/docs/snippets/resilience/shield_cache_key.py
@@ -1,0 +1,16 @@
+from decimal import Decimal
+
+import httpx
+
+from grelmicro.cache import TTLCache
+from grelmicro.resilience import shield
+
+
+@shield.api(
+    "prices",
+    timeout_errors=(httpx.TimeoutException,),
+    cache=TTLCache(ttl=300),
+    cache_key=lambda symbol, *_: f"price:{symbol}",
+)
+async def fetch_price(symbol: str) -> Decimal:
+    return Decimal(0)

--- a/docs/snippets/resilience/shield_class.py
+++ b/docs/snippets/resilience/shield_class.py
@@ -1,0 +1,18 @@
+import httpx
+
+from grelmicro.resilience import Shield
+
+github = Shield.api(
+    "github",
+    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
+)
+
+
+@github
+async def list_repos() -> list[dict]:
+    return []
+
+
+@github
+async def get_repo() -> dict:
+    return {}

--- a/docs/snippets/resilience/shield_declarative.py
+++ b/docs/snippets/resilience/shield_declarative.py
@@ -1,0 +1,9 @@
+import httpx
+
+from grelmicro.resilience import ApiShieldConfig, Shield
+
+config = ApiShieldConfig(
+    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
+    max_rate=20.0,
+)
+github = Shield("github", config=config)

--- a/docs/snippets/resilience/shield_environmental.py
+++ b/docs/snippets/resilience/shield_environmental.py
@@ -1,0 +1,3 @@
+from grelmicro.resilience import Shield
+
+github = Shield("github", env_load=True)

--- a/docs/snippets/resilience/shield_fallback.py
+++ b/docs/snippets/resilience/shield_fallback.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+
+import httpx
+
+from grelmicro.cache import TTLCache
+from grelmicro.resilience import shield
+
+
+async def last_known_price(exc: Exception) -> Decimal:
+    return Decimal(0)
+
+
+@shield.api(
+    "prices",
+    timeout_errors=(httpx.TimeoutException,),
+    cache=TTLCache(ttl=300),
+    fallback=last_known_price,
+)
+async def fetch_price(symbol: str) -> Decimal:
+    return Decimal(0)

--- a/docs/snippets/resilience/shield_giveup.py
+++ b/docs/snippets/resilience/shield_giveup.py
@@ -1,0 +1,13 @@
+import httpx
+
+
+async def fetch(url: str) -> bytes:
+    return b""
+
+
+async def main(url: str) -> None:
+    try:
+        await fetch(url)
+    except httpx.TimeoutException as exc:
+        print(exc.__notes__)
+        # ['shield: budget exhausted after 4/4 attempts in 18.30s (api profile)']

--- a/docs/snippets/resilience/shield_giveup.py
+++ b/docs/snippets/resilience/shield_giveup.py
@@ -1,8 +1,11 @@
 import httpx
 
+from grelmicro.resilience import shield
 
+
+@shield.api(timeout_errors=(httpx.TimeoutException,))
 async def fetch(url: str) -> bytes:
-    return b""
+    raise httpx.TimeoutException("dependency stalled")
 
 
 async def main(url: str) -> None:

--- a/docs/snippets/resilience/shield_layered.py
+++ b/docs/snippets/resilience/shield_layered.py
@@ -1,0 +1,13 @@
+import httpx
+
+from grelmicro.resilience import shield
+
+retrying_httpx_client = httpx.AsyncClient()
+
+
+@shield.api(
+    "github",
+    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
+)
+async def fetch(url: str) -> httpx.Response:
+    return await retrying_httpx_client.get(url)

--- a/docs/snippets/resilience/shield_max_rate.py
+++ b/docs/snippets/resilience/shield_max_rate.py
@@ -1,0 +1,13 @@
+from grelmicro.resilience import shield
+
+
+class APIConnectionError(Exception): ...
+
+
+@shield.api(
+    "stripe",
+    timeout_errors=(APIConnectionError,),
+    max_rate=10.0,
+)
+async def charge_card(amount: int) -> None:
+    return None

--- a/docs/snippets/resilience/shield_profiles.py
+++ b/docs/snippets/resilience/shield_profiles.py
@@ -1,0 +1,22 @@
+import httpx
+
+from grelmicro.resilience import shield
+
+
+class MyRpcTimeout(Exception): ...  # noqa: N818
+
+
+class MyLLMError(Exception): ...
+
+
+@shield.internal(timeout_errors=(MyRpcTimeout,))
+async def call_internal_rpc() -> None: ...
+
+
+@shield.api(timeout_errors=(httpx.TimeoutException, httpx.ConnectError))
+async def call_external_api() -> None: ...
+
+
+@shield.slow(timeout_errors=(MyLLMError,))
+async def call_llm(prompt: str) -> str:
+    return prompt

--- a/docs/snippets/resilience/shield_programmatic.py
+++ b/docs/snippets/resilience/shield_programmatic.py
@@ -1,0 +1,9 @@
+import httpx
+
+from grelmicro.resilience import Shield
+
+github = Shield.api(
+    "github",
+    timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
+    max_rate=20.0,
+)

--- a/docs/snippets/resilience/shield_run.py
+++ b/docs/snippets/resilience/shield_run.py
@@ -1,0 +1,14 @@
+import httpx
+
+from grelmicro.resilience import Shield
+
+github = Shield.api("github", timeout_errors=(httpx.TimeoutException,))
+
+
+async def parse_response(response: httpx.Response) -> bytes:
+    return response.content
+
+
+async def handler(client: httpx.AsyncClient, url: str) -> bytes:
+    response = await github.run(client.get, url)
+    return await github.run(parse_response, response)

--- a/docs/snippets/resilience/shield_zero_args.py
+++ b/docs/snippets/resilience/shield_zero_args.py
@@ -1,0 +1,13 @@
+import asyncio
+
+from grelmicro.resilience import shield
+
+
+async def do_work() -> None:
+    return None
+
+
+@shield
+async def cheap_call() -> None:
+    async with asyncio.timeout(5):
+        await do_work()

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -1,11 +1,16 @@
 """Resilience.
 
-Top-level re-exports are PEP 562 lazy: importing this package only
-loads the small `_components`, `_match`, `_outcome`, `_protocol`, and
-`errors` modules. Patterns (`CircuitBreaker`, `RateLimiter`, `Retry`),
-their algorithm configs, and the memory/redis adapters load on first
-attribute access. `from grelmicro.resilience import CircuitBreaker`
-does not import anything related to `RateLimiter`, and vice versa.
+Top-level re-exports are PEP 562 lazy: importing this package loads
+`_components`, `_match`, `_outcome`, `_protocol`, and `errors` plus
+the eager exports listed below. Every other pattern (`CircuitBreaker`,
+`RateLimiter`), its algorithm configs, and the memory/redis adapters
+load on first attribute access. `from grelmicro.resilience import
+CircuitBreaker` does not import anything related to `RateLimiter`.
+
+Eager exports (loaded at package import because the function name
+shadows a submodule of the same name): `retry`, `retrying`,
+`fallback`, `falling_back`, `shield`. The `shield` import pulls the
+full `grelmicro.resilience.shield` subpackage.
 """
 
 from __future__ import annotations

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -45,6 +45,10 @@ from grelmicro.resilience.fallback import fallback, falling_back
 # is needed for `Retry`, `RetryConfig`, every backoff, etc.
 from grelmicro.resilience.retry import retry, retrying
 
+# `shield` follows the same shadow rule as `retry`: it would otherwise
+# collide with the `grelmicro.resilience.shield` subpackage name.
+from grelmicro.resilience.shield import shield
+
 if TYPE_CHECKING:
     from grelmicro.resilience.backoffs import (
         ConstantBackoff,
@@ -96,9 +100,18 @@ if TYPE_CHECKING:
         retry,
         retrying,
     )
+    from grelmicro.resilience.shield import (
+        ApiShieldConfig,
+        InternalShieldConfig,
+        Shield,
+        ShieldConfig,
+        SlowShieldConfig,
+        shield,
+    )
     from grelmicro.resilience.timeout import Timeout, TimeoutConfig
 
 __all__ = [
+    "ApiShieldConfig",
     "CircuitBreaker",
     "CircuitBreakerBackend",
     "CircuitBreakerConfig",
@@ -116,6 +129,7 @@ __all__ = [
     "FallbackConfig",
     "FallbackResult",
     "FibonacciBackoff",
+    "InternalShieldConfig",
     "LinearBackoff",
     "Match",
     "Matcher",
@@ -141,7 +155,10 @@ __all__ = [
     "RetryBackoffConfig",
     "RetryConfig",
     "RetryStrategy",
+    "Shield",
+    "ShieldConfig",
     "SlidingWindowConfig",
+    "SlowShieldConfig",
     "Timeout",
     "TimeoutConfig",
     "TokenBucketConfig",
@@ -149,6 +166,7 @@ __all__ = [
     "falling_back",
     "retry",
     "retrying",
+    "shield",
 ]
 
 # (attribute -> (module, attribute)). The module is loaded lazily on
@@ -219,6 +237,15 @@ _LAZY: dict[str, tuple[str, str]] = {
     "Fallback": ("grelmicro.resilience.fallback", "Fallback"),
     "FallbackConfig": ("grelmicro.resilience.fallback", "FallbackConfig"),
     "FallbackResult": ("grelmicro.resilience.fallback", "FallbackResult"),
+    # Shield
+    "Shield": ("grelmicro.resilience.shield", "Shield"),
+    "ShieldConfig": ("grelmicro.resilience.shield", "ShieldConfig"),
+    "ApiShieldConfig": ("grelmicro.resilience.shield", "ApiShieldConfig"),
+    "InternalShieldConfig": (
+        "grelmicro.resilience.shield",
+        "InternalShieldConfig",
+    ),
+    "SlowShieldConfig": ("grelmicro.resilience.shield", "SlowShieldConfig"),
     # Timeout
     "Timeout": ("grelmicro.resilience.timeout", "Timeout"),
     "TimeoutConfig": ("grelmicro.resilience.timeout", "TimeoutConfig"),

--- a/grelmicro/resilience/shield/__init__.py
+++ b/grelmicro/resilience/shield/__init__.py
@@ -1,0 +1,18 @@
+"""Shield resilience pattern."""
+
+from __future__ import annotations
+
+from grelmicro.resilience.shield._api import ApiShieldConfig
+from grelmicro.resilience.shield._decorator import shield
+from grelmicro.resilience.shield._internal import InternalShieldConfig
+from grelmicro.resilience.shield._shield import Shield, ShieldConfig
+from grelmicro.resilience.shield._slow import SlowShieldConfig
+
+__all__ = [
+    "ApiShieldConfig",
+    "InternalShieldConfig",
+    "Shield",
+    "ShieldConfig",
+    "SlowShieldConfig",
+    "shield",
+]

--- a/grelmicro/resilience/shield/_adaptive_gate.py
+++ b/grelmicro/resilience/shield/_adaptive_gate.py
@@ -1,0 +1,224 @@
+"""Adaptive rate gate.
+
+Token bucket with a CUBIC-style rate controller. Stays disabled until
+the first slow-down signal arrives, then engages and self-tunes the
+ceiling rate using the CUBIC curve.
+
+CUBIC reference: RFC 9438. Constants `C = 0.4`, `beta = 0.7` are fixed
+algorithm-level invariants, not tunable per profile.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from collections import deque
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = ["_AdaptiveGate"]
+
+_CUBIC_C: float = 0.4
+_CUBIC_BETA: float = 0.7
+_MEASURED_RATE_CLAMP: float = 1.5
+_MEASURED_WINDOW: int = 8
+_MIN_MEASURED_SAMPLES: int = 2
+
+
+class _AdaptiveGate:
+    """Token bucket gated by a CUBIC-style rate controller.
+
+    Disabled at construction. Every `acquire` is a no-op until the
+    first `on_slow_down` call. Once enabled, every `acquire` blocks
+    until one token is available based on `max_rate`.
+
+    On a successful response, `on_success` recomputes a candidate rate
+    from the CUBIC growth curve. On a slow-down exception,
+    `on_slow_down` records the new `w_max`, multiplies the current
+    rate by `beta`, and recomputes `k`. The bucket's effective
+    `max_rate` is clamped to `[min_rate_floor, min(candidate,
+    1.5 * measured_rate, max_rate_cap)]`.
+    """
+
+    __slots__ = (
+        "_capacity",
+        "_enabled",
+        "_initial_max_rate",
+        "_k",
+        "_last_fail",
+        "_lock",
+        "_max_rate",
+        "_max_rate_cap",
+        "_min_rate_floor",
+        "_send_window",
+        "_time",
+        "_tokens",
+        "_updated_at",
+        "_w_max",
+    )
+
+    def __init__(
+        self,
+        *,
+        initial_max_rate: float,
+        capacity: float,
+        min_rate_floor: float,
+        max_rate_cap: float | None,
+        time_source: Callable[[], float] | None = None,
+    ) -> None:
+        """Initialize a disabled adaptive gate."""
+        if initial_max_rate <= 0:
+            msg = "initial_max_rate must be positive"
+            raise ValueError(msg)
+        if capacity <= 0:
+            msg = "capacity must be positive"
+            raise ValueError(msg)
+        if min_rate_floor <= 0:
+            msg = "min_rate_floor must be positive"
+            raise ValueError(msg)
+        if max_rate_cap is not None and max_rate_cap < min_rate_floor:
+            msg = "max_rate_cap must be >= min_rate_floor"
+            raise ValueError(msg)
+        self._initial_max_rate = initial_max_rate
+        self._max_rate = initial_max_rate
+        self._capacity = capacity
+        self._min_rate_floor = min_rate_floor
+        self._max_rate_cap = max_rate_cap
+        self._time = time_source or time.monotonic
+        self._tokens = 0.0
+        self._updated_at = self._time()
+        self._enabled = False
+        # CUBIC state.
+        self._w_max = initial_max_rate
+        self._k = 0.0
+        self._last_fail = self._updated_at
+        # Rolling send-timestamp window for measured-rate clamp.
+        self._send_window: deque[float] = deque(maxlen=_MEASURED_WINDOW)
+        self._lock = asyncio.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        """Return True once the gate has observed a slow-down."""
+        return self._enabled
+
+    @property
+    def max_rate(self) -> float:
+        """Return the current ceiling rate in tokens per second."""
+        return self._max_rate
+
+    @property
+    def w_max(self) -> float:
+        """Return the CUBIC `w_max` (rate at the last slow-down)."""
+        return self._w_max
+
+    @property
+    def k(self) -> float:
+        """Return the CUBIC time offset `k` since the last slow-down."""
+        return self._k
+
+    @property
+    def last_fail(self) -> float:
+        """Return the timestamp of the most recent slow-down."""
+        return self._last_fail
+
+    def measured_rate(self) -> float:
+        """Return the rolling outbound call rate in calls per second.
+
+        Returns `math.inf` when the window holds fewer than 2 samples,
+        which disables the measured-rate clamp until enough data is
+        collected.
+        """
+        if len(self._send_window) < _MIN_MEASURED_SAMPLES:
+            return math.inf
+        oldest = self._send_window[0]
+        newest = self._send_window[-1]
+        elapsed = newest - oldest
+        if elapsed <= 0:
+            return math.inf
+        return (len(self._send_window) - 1) / elapsed
+
+    async def acquire(self) -> None:
+        """Acquire one token. No-op while disabled.
+
+        Blocks until one token is available based on the bucket fill
+        rate. Refills passively on every state access.
+        """
+        if not self._enabled:
+            # Still record the send timestamp so `measured_rate` reflects
+            # the disabled-state throughput when CUBIC eventually engages.
+            self._send_window.append(self._time())
+            return
+        while True:
+            async with self._lock:
+                now = self._time()
+                self._refill(now)
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    self._send_window.append(now)
+                    return
+                wait = (1.0 - self._tokens) / self._max_rate
+            await asyncio.sleep(wait)
+
+    def _refill(self, now: float) -> None:
+        """Refill the bucket based on elapsed time since the last access."""
+        elapsed = now - self._updated_at
+        if elapsed > 0:
+            self._tokens = min(
+                self._capacity, self._tokens + elapsed * self._max_rate
+            )
+            self._updated_at = now
+
+    def on_success(self) -> None:
+        """Update the CUBIC growth curve after a successful call.
+
+        New candidate rate: `C * (t - last_fail - k)^3 + w_max`. The
+        clamp `max(floor, min(candidate, 1.5 * measured, cap))` is
+        applied to the bucket's effective `max_rate`.
+        """
+        if not self._enabled:
+            return
+        now = self._time()
+        offset = now - self._last_fail - self._k
+        candidate = _CUBIC_C * (offset**3) + self._w_max
+        self._apply_rate(candidate, now)
+
+    def on_slow_down(self) -> None:
+        """Record a slow-down. Engages the gate on the first call.
+
+        Sets `w_max` to the current rate, recomputes `k`, stamps
+        `last_fail`, then shrinks the bucket rate to `current * beta`.
+        """
+        now = self._time()
+        if not self._enabled:
+            self._enabled = True
+            # Snap the bucket so the new ceiling starts taking effect
+            # immediately rather than carrying tokens accumulated while
+            # the gate was inert.
+            self._tokens = 0.0
+            self._updated_at = now
+        self._w_max = self._max_rate
+        # k such that the success curve passes through w_max at t = k.
+        # k = ((w_max * (1 - beta)) / C)^(1/3).
+        self._k = ((self._w_max * (1.0 - _CUBIC_BETA)) / _CUBIC_C) ** (
+            1.0 / 3.0
+        )
+        self._last_fail = now
+        candidate = self._max_rate * _CUBIC_BETA
+        self._apply_rate(candidate, now)
+
+    def _apply_rate(self, candidate: float, now: float) -> None:
+        """Clamp `candidate` and publish it as the new `max_rate`."""
+        ceiling = candidate
+        measured = self.measured_rate()
+        if math.isfinite(measured):
+            ceiling = min(ceiling, _MEASURED_RATE_CLAMP * measured)
+        if self._max_rate_cap is not None:
+            ceiling = min(ceiling, self._max_rate_cap)
+        new_rate = max(self._min_rate_floor, ceiling)
+        # Refill against the old rate before swapping, so already-earned
+        # tokens are not dropped on the floor.
+        self._refill(now)
+        self._max_rate = new_rate

--- a/grelmicro/resilience/shield/_api.py
+++ b/grelmicro/resilience/shield/_api.py
@@ -1,0 +1,42 @@
+"""API Shield profile configuration.
+
+Default profile. Tuned for external HTTP APIs with moderate latency,
+occasional outages, and third-party SLAs.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, ClassVar, Literal
+
+from typing_extensions import Doc
+
+from grelmicro.resilience.shield._profile import _BaseShieldConfig
+
+__all__ = ["ApiShieldConfig"]
+
+
+class ApiShieldConfig(_BaseShieldConfig, frozen=True, extra="forbid"):
+    """Shield configuration for the `api` profile (the default).
+
+    Tuned for external HTTP APIs. Modest initial rate, generous
+    timeouts, broad clamps. The profile parameters are frozen.
+
+    Read more in the [Shield](../resilience/shield.md) docs.
+    """
+
+    kind: Annotated[
+        Literal["api"],
+        Doc("Discriminator for the Shield profile Pydantic union."),
+    ] = "api"
+
+    max_consecutive_failures: ClassVar[int] = 20
+    initial_max_rate: ClassVar[float] = 2.0
+    adaptive_burst_capacity: ClassVar[float] = 5.0
+    min_rate_floor: ClassVar[float] = 0.25
+    initial_timeout: ClassVar[float] = 10.0
+    timeout_clamp_min: ClassVar[float] = 0.5
+    timeout_clamp_max: ClassVar[float] = 60.0
+    backoff_scale: ClassVar[float] = 1.0
+    backoff_cap: ClassVar[float] = 30.0
+    max_rate_cap_default: ClassVar[float | None] = None
+    profile_name: ClassVar[str] = "api"

--- a/grelmicro/resilience/shield/_decorator.py
+++ b/grelmicro/resilience/shield/_decorator.py
@@ -1,0 +1,99 @@
+"""Module-level `shield` decorator.
+
+Supports:
+
+- `@shield` (no parens): wraps with the `api` profile and default
+  `timeout_errors=(TimeoutError,)`. The Shield name is the wrapped
+  function's `__qualname__`.
+- `@shield.internal(...)` / `@shield.api(...)` / `@shield.slow(...)`:
+  builds a Shield with the matching profile and decorates.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Annotated, Any
+
+from typing_extensions import Doc
+
+from grelmicro.resilience.shield._shield import Shield
+
+if TYPE_CHECKING:
+    from pydantic import PositiveFloat
+
+__all__ = ["shield"]
+
+
+_AsyncFn = Callable[..., Awaitable[Any]]
+
+
+def _build_profile_decorator(
+    profile: str,
+) -> Callable[..., Callable[[_AsyncFn], _AsyncFn]]:
+    """Return a decorator factory for one profile.
+
+    The returned callable accepts `name=` plus the same kwargs as
+    `Shield.api(...)` and returns the actual decorator. When `name=`
+    is omitted, the wrapped function's `__qualname__` is used.
+    """
+
+    def factory(
+        name: Annotated[
+            str | None,
+            Doc(
+                "Optional Shield name. Defaults to the wrapped "
+                "function's `__qualname__`."
+            ),
+        ] = None,
+        *,
+        timeout_errors: tuple[type[BaseException], ...] | None = None,
+        max_rate: PositiveFloat | None = None,
+        cache: Any = None,  # noqa: ANN401
+        cache_key: Callable[..., str] | None = None,
+        fallback: Callable[[BaseException], Any]
+        | Callable[[BaseException], Awaitable[Any]]
+        | None = None,
+    ) -> Callable[[_AsyncFn], _AsyncFn]:
+        """Return a decorator that wraps a function with the chosen profile."""
+
+        def wrap(fn: _AsyncFn) -> _AsyncFn:
+            shield_name = name or getattr(fn, "__qualname__", None) or repr(fn)
+            factory_method = getattr(Shield, profile)
+            instance: Shield = factory_method(
+                shield_name,
+                timeout_errors=timeout_errors,
+                max_rate=max_rate,
+                cache=cache,
+                cache_key=cache_key,
+                fallback=fallback,
+            )
+            wrapped = instance(fn)
+            return functools.wraps(fn)(wrapped)
+
+        return wrap
+
+    return factory
+
+
+class _ShieldDecorator:
+    """Callable object exposed as the module-level `shield`.
+
+    Supports `@shield` (no parens) for the `api`-profile default and
+    `@shield.internal(...)` / `@shield.api(...)` / `@shield.slow(...)`
+    for the explicit forms.
+    """
+
+    def __call__(self, fn: _AsyncFn) -> _AsyncFn:
+        """Wrap `fn` with the `api` profile and default `timeout_errors`."""
+        name = getattr(fn, "__qualname__", None) or repr(fn)
+        instance = Shield.api(name)
+        wrapped = instance(fn)
+        return functools.wraps(fn)(wrapped)
+
+    internal = staticmethod(_build_profile_decorator("internal"))
+    api = staticmethod(_build_profile_decorator("api"))
+    slow = staticmethod(_build_profile_decorator("slow"))
+
+
+shield = _ShieldDecorator()

--- a/grelmicro/resilience/shield/_internal.py
+++ b/grelmicro/resilience/shield/_internal.py
@@ -1,0 +1,41 @@
+"""Internal Shield profile configuration.
+
+For in-cluster RPC. Healthy services, fast latency, tight budgets.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, ClassVar, Literal
+
+from typing_extensions import Doc
+
+from grelmicro.resilience.shield._profile import _BaseShieldConfig
+
+__all__ = ["InternalShieldConfig"]
+
+
+class InternalShieldConfig(_BaseShieldConfig, frozen=True, extra="forbid"):
+    """Shield configuration for the `internal` profile.
+
+    Tuned for in-cluster RPC. High initial rate, short timeouts, tight
+    budgets. The profile parameters are frozen.
+
+    Read more in the [Shield](../resilience/shield.md) docs.
+    """
+
+    kind: Annotated[
+        Literal["internal"],
+        Doc("Discriminator for the Shield profile Pydantic union."),
+    ] = "internal"
+
+    max_consecutive_failures: ClassVar[int] = 10
+    initial_max_rate: ClassVar[float] = 100.0
+    adaptive_burst_capacity: ClassVar[float] = 200.0
+    min_rate_floor: ClassVar[float] = 1.0
+    initial_timeout: ClassVar[float] = 1.0
+    timeout_clamp_min: ClassVar[float] = 0.05
+    timeout_clamp_max: ClassVar[float] = 5.0
+    backoff_scale: ClassVar[float] = 0.5
+    backoff_cap: ClassVar[float] = 5.0
+    max_rate_cap_default: ClassVar[float | None] = None
+    profile_name: ClassVar[str] = "internal"

--- a/grelmicro/resilience/shield/_key.py
+++ b/grelmicro/resilience/shield/_key.py
@@ -1,0 +1,30 @@
+"""Cache key helpers."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+__all__ = ["default_cache_key", "stable_hash"]
+
+
+def stable_hash(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+    """Return a 16-character stable hex digest for `(args, kwargs)`.
+
+    Hashes `repr(args) + repr(sorted(kwargs.items()))` with SHA-256
+    and returns the first 16 hex characters. Non-hashable arguments
+    are accepted because the digest is computed over their `repr`.
+    """
+    payload = repr(args) + repr(sorted(kwargs.items()))
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def default_cache_key(
+    name: str, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> str:
+    """Return the default cache key for a `Shield` call.
+
+    Format: `f"{name}:{stable_hash(args, kwargs)}"`.
+    """
+    return f"{name}:{stable_hash(args, kwargs)}"

--- a/grelmicro/resilience/shield/_profile.py
+++ b/grelmicro/resilience/shield/_profile.py
@@ -144,7 +144,13 @@ class _BaseShieldConfig(BaseModel, frozen=True, extra="forbid"):
         """Accept a class, a tuple, or env CSV/JSON of FQNs."""
         if value is None:
             return value
-        if isinstance(value, type) and issubclass(value, BaseException):
+        if isinstance(value, type):
+            if not issubclass(value, Exception):
+                msg = (
+                    f"timeout_errors entry {value!r} is not an Exception "
+                    f"subclass; BaseException-only types are never retried."
+                )
+                raise TypeError(msg)
             return (value,)
         if isinstance(value, str):
             parsed = parse_csv_or_json(value)

--- a/grelmicro/resilience/shield/_profile.py
+++ b/grelmicro/resilience/shield/_profile.py
@@ -1,0 +1,175 @@
+"""Shield profile configuration base class.
+
+Defines the public fields shared by every profile config and exposes
+the profile-specific algorithm parameters as class variables. The
+algorithm parameters are frozen by profile choice and never appear
+as Pydantic fields.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable  # noqa: TC003
+from importlib import import_module
+from typing import Annotated, Any, ClassVar
+
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ImportString,
+    PositiveFloat,
+    field_validator,
+)
+from pydantic_settings import NoDecode
+from typing_extensions import Doc
+
+from grelmicro._config import parse_csv_or_json
+
+__all__ = ["_BaseShieldConfig"]
+
+
+def _resolve_fqn(fqn: str) -> type[BaseException]:
+    """Resolve a fully-qualified name to an exception class."""
+    module_path, _, name = fqn.rpartition(".")
+    if not module_path:
+        msg = (
+            f"timeout_errors entry must be a fully-qualified name, got {fqn!r}"
+        )
+        raise ValueError(msg)
+    try:
+        module = import_module(module_path)
+    except ModuleNotFoundError as exc:
+        msg = (
+            f"timeout_errors entry {fqn!r}: cannot import module "
+            f"{module_path!r} ({exc})"
+        )
+        raise ValueError(msg) from exc
+    try:
+        cls = getattr(module, name)
+    except AttributeError as exc:
+        msg = (
+            f"timeout_errors entry {fqn!r}: module {module_path!r} has "
+            f"no attribute {name!r}"
+        )
+        raise ValueError(msg) from exc
+    if not (isinstance(cls, type) and issubclass(cls, BaseException)):
+        msg = f"timeout_errors entry {fqn!r} is not an Exception subclass"
+        raise TypeError(msg)
+    return cls
+
+
+class _BaseShieldConfig(BaseModel, frozen=True, extra="forbid"):
+    """Base Shield configuration shared by every profile.
+
+    Subclasses freeze the profile-specific algorithm parameters as
+    `ClassVar` attributes and declare the `kind` literal for the
+    discriminated union.
+    """
+
+    # --- Profile-frozen algorithm parameters (ClassVars) -----------------
+    #
+    # Subclasses set these. They are NOT Pydantic fields, so they never
+    # appear in `model_dump()` and cannot be overridden per instance.
+
+    max_consecutive_failures: ClassVar[int]
+    initial_max_rate: ClassVar[float]
+    adaptive_burst_capacity: ClassVar[float]
+    min_rate_floor: ClassVar[float]
+    initial_timeout: ClassVar[float]
+    timeout_clamp_min: ClassVar[float]
+    timeout_clamp_max: ClassVar[float]
+    backoff_scale: ClassVar[float]
+    backoff_cap: ClassVar[float]
+    max_rate_cap_default: ClassVar[float | None] = None
+    profile_name: ClassVar[str]
+
+    # --- Public fields ---------------------------------------------------
+
+    timeout_errors: Annotated[
+        tuple[ImportString[type[BaseException]], ...],
+        NoDecode,
+        BeforeValidator(parse_csv_or_json),
+        Doc(
+            "Exception classes treated as transient slow-down signals. "
+            "Anything in this tuple (or its subclasses) is retried, "
+            "shrinks the adaptive bucket, and consumes one retry-budget "
+            "token. Anything else propagates unchanged. The effective "
+            "tuple always includes `TimeoutError` regardless of the "
+            "user value."
+        ),
+    ] = (TimeoutError,)
+
+    max_rate: Annotated[
+        PositiveFloat | None,
+        Doc(
+            "Optional hard ceiling on the adaptive bucket's rate in "
+            "tokens per second. `None` disables the cap."
+        ),
+    ] = None
+
+    cache: Annotated[
+        Any,
+        Doc(
+            "Optional cache instance used as a fallback on give-up. "
+            "Must expose `async def get(key) -> value | None` and "
+            "`async def set(key, value)`. Values returned by the "
+            "wrapped function are written fire-and-forget on success."
+        ),
+    ] = None
+
+    cache_key: Annotated[
+        Callable[..., str] | None,
+        Doc(
+            "Optional callable that returns the cache key for a call. "
+            "Receives the same `(*args, **kwargs)` as the wrapped "
+            'function. Defaults to `f"{name}:{stable_hash(args, kwargs)}"`.'
+        ),
+    ] = None
+
+    fallback: Annotated[
+        Callable[[BaseException], Any]
+        | Callable[[BaseException], Awaitable[Any]]
+        | None,
+        Doc(
+            "Optional callable invoked on give-up when the cache path "
+            "does not return a value. Receives the underlying "
+            "exception. May be sync or async."
+        ),
+    ] = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    @field_validator("timeout_errors", mode="before")
+    @classmethod
+    def _normalize_timeout_errors(cls, value: Any) -> Any:  # noqa: ANN401
+        """Accept a class, a tuple, or env CSV/JSON of FQNs."""
+        if value is None:
+            return value
+        if isinstance(value, type) and issubclass(value, BaseException):
+            return (value,)
+        if isinstance(value, str):
+            parsed = parse_csv_or_json(value)
+            if isinstance(parsed, list):
+                return tuple(
+                    _resolve_fqn(item) if isinstance(item, str) else item
+                    for item in parsed
+                )
+            return parsed  # pragma: no cover  # defensive: always a list here
+        if isinstance(value, list | tuple):
+            return tuple(
+                _resolve_fqn(item) if isinstance(item, str) else item
+                for item in value
+            )
+        return value
+
+    def effective_timeout_errors(self) -> tuple[type[BaseException], ...]:
+        """Return the `timeout_errors` tuple with `TimeoutError` appended.
+
+        `TimeoutError` is always retryable because Shield's own
+        per-attempt timeout surfaces as a `TimeoutError`.
+        """
+        if any(
+            isinstance(exc, type) and issubclass(TimeoutError, exc)
+            for exc in self.timeout_errors
+        ):
+            return tuple(self.timeout_errors)
+        return (*self.timeout_errors, TimeoutError)

--- a/grelmicro/resilience/shield/_profile.py
+++ b/grelmicro/resilience/shield/_profile.py
@@ -51,7 +51,7 @@ def _resolve_fqn(fqn: str) -> type[BaseException]:
             f"no attribute {name!r}"
         )
         raise ValueError(msg) from exc
-    if not (isinstance(cls, type) and issubclass(cls, BaseException)):
+    if not (isinstance(cls, type) and issubclass(cls, Exception)):
         msg = f"timeout_errors entry {fqn!r} is not an Exception subclass"
         raise TypeError(msg)
     return cls

--- a/grelmicro/resilience/shield/_retry_budget.py
+++ b/grelmicro/resilience/shield/_retry_budget.py
@@ -1,0 +1,70 @@
+"""Retry budget bucket.
+
+Holds a consecutive-failure counter shared across all retries on one
+`Shield` instance. Each retry costs one unit. Refunds clamp at the
+configured capacity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+__all__ = ["_RetryBudget"]
+
+
+class _RetryBudget:
+    """Consecutive-failure counter gating retries on a `Shield` instance.
+
+    Holds an integer count of available retries (the budget) bounded by
+    `capacity`. Each retry takes one token via `try_acquire`. Refunds
+    return tokens to the bucket, clamped at capacity.
+
+    Refund rules evaluated once per call resolution:
+
+    - Success with no retry performed: refund 1.
+    - Success after one or more retries: refund 1 per recovered retry.
+    - Failure surfaced after retries: no refund.
+
+    Process-local. Guarded by an `asyncio.Lock` for safe sharing across
+    coroutines on the same event loop.
+    """
+
+    __slots__ = ("_available", "_capacity", "_lock")
+
+    def __init__(self, capacity: int) -> None:
+        """Initialize a full bucket with the given capacity."""
+        if capacity <= 0:
+            msg = f"capacity must be positive, got {capacity!r}"
+            raise ValueError(msg)
+        self._capacity = capacity
+        self._available = capacity
+        self._lock = asyncio.Lock()
+
+    @property
+    def capacity(self) -> int:
+        """Return the maximum number of tokens the bucket can hold."""
+        return self._capacity
+
+    @property
+    def available(self) -> int:
+        """Return the current number of available tokens."""
+        return self._available
+
+    async def try_acquire(self) -> bool:
+        """Acquire one token. Return True on success, False when empty.
+
+        Does not raise on an empty bucket. The caller stops retrying
+        and surfaces the underlying failure.
+        """
+        async with self._lock:
+            if self._available <= 0:
+                return False
+            self._available -= 1
+            return True
+
+    async def refund(self, amount: int) -> None:
+        """Return `amount` tokens, clamped at the bucket capacity."""
+        if amount <= 0:
+            return
+        async with self._lock:
+            self._available = min(self._capacity, self._available + amount)

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -517,15 +517,17 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
                 async with asyncio.timeout(timeout):
                     result = await fn(*args, **kwargs)
             except BaseException as exc:
-                last_exc = exc
-                # ResilienceError propagates first, never retried.
+                # ResilienceError propagates immediately. No retry, no
+                # CUBIC update, no cache or fallback recovery, no PEP
+                # 678 note. Matches the BaseException-outside-Exception
+                # treatment in the classification table.
                 if isinstance(exc, ResilienceError):
-                    give_up_reason = _GIVE_UP_NON_RETRY
-                    break
+                    raise
                 # BaseException outside Exception (CancelledError,
                 # KeyboardInterrupt, SystemExit) propagates immediately.
                 if not isinstance(exc, Exception):
                     raise
+                last_exc = exc
                 # Non-retryable Exception: surface unchanged.
                 if not isinstance(exc, state.effective_timeout_errors):
                     give_up_reason = _GIVE_UP_NON_RETRY

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -1,0 +1,684 @@
+"""Shield resilience pattern."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import inspect
+import os
+import random
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from logging import getLogger
+from typing import Annotated, Any, Self, TypeVar
+
+from pydantic import Discriminator, PositiveFloat
+from typing_extensions import Doc
+
+from grelmicro._config import (
+    Reconfigurable,
+    env_load_default,
+    env_segment,
+)
+from grelmicro.resilience.errors import ResilienceError
+from grelmicro.resilience.shield._adaptive_gate import _AdaptiveGate
+from grelmicro.resilience.shield._api import ApiShieldConfig
+from grelmicro.resilience.shield._internal import InternalShieldConfig
+from grelmicro.resilience.shield._key import default_cache_key
+from grelmicro.resilience.shield._profile import _BaseShieldConfig
+from grelmicro.resilience.shield._retry_budget import _RetryBudget
+from grelmicro.resilience.shield._slow import SlowShieldConfig
+from grelmicro.resilience.shield._timeout_estimator import _TimeoutEstimator
+
+__all__ = ["Shield", "ShieldConfig"]
+
+logger = getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+ShieldConfig = Annotated[
+    InternalShieldConfig | ApiShieldConfig | SlowShieldConfig,
+    Discriminator("kind"),
+]
+"""Discriminated union over the three Shield profile configs."""
+
+
+_MAX_ATTEMPTS: int = 4
+"""Total attempts: one initial call plus three retries."""
+
+
+_GIVE_UP_BUDGET = "budget exhausted"
+_GIVE_UP_ATTEMPTS = "attempts exhausted"
+_GIVE_UP_NON_RETRY = "non-retryable exception"
+
+
+_PROFILE_BY_NAME: dict[str, type[_BaseShieldConfig]] = {
+    "internal": InternalShieldConfig,
+    "api": ApiShieldConfig,
+    "slow": SlowShieldConfig,
+}
+
+
+def _load_profile_from_env(name: str) -> str:
+    """Return the profile name from env, defaulting to `api`."""
+    env_key = f"GREL_SHIELD_{env_segment(name)}_PROFILE"
+    value = os.environ.get(env_key, "").strip().lower()
+    if value and value not in _PROFILE_BY_NAME:
+        msg = (
+            f"{env_key}={value!r} is not a valid profile. "
+            f"Expected one of: internal, api, slow."
+        )
+        raise ValueError(msg)
+    return value or "api"
+
+
+def _resolve_config_from_env(
+    name: str,
+    *,
+    timeout_errors: Any,  # noqa: ANN401
+    max_rate: float | None,
+    cache: Any,  # noqa: ANN401
+    cache_key: Callable[..., str] | None,
+    fallback: Callable[..., Any] | None,
+) -> _BaseShieldConfig:
+    """Build a `_BaseShieldConfig` reading defaults from environment variables."""
+    profile = _load_profile_from_env(name)
+    cls = _PROFILE_BY_NAME[profile]
+    env_prefix = f"GREL_SHIELD_{env_segment(name)}_"
+    kwargs: dict[str, Any] = {"kind": profile}
+    if timeout_errors is not None:
+        kwargs["timeout_errors"] = timeout_errors
+    else:
+        env_value = os.environ.get(f"{env_prefix}TIMEOUT_ERRORS")
+        if env_value is not None:
+            kwargs["timeout_errors"] = env_value
+    if max_rate is not None:
+        kwargs["max_rate"] = max_rate
+    else:
+        env_value = os.environ.get(f"{env_prefix}MAX_RATE")
+        if env_value is not None and env_value.strip() != "":
+            kwargs["max_rate"] = float(env_value)
+    if cache is not None:
+        kwargs["cache"] = cache
+    if cache_key is not None:
+        kwargs["cache_key"] = cache_key
+    if fallback is not None:
+        kwargs["fallback"] = fallback
+    return cls.model_validate(kwargs)
+
+
+def _build_config(
+    name: str,
+    *,
+    config: _BaseShieldConfig | None,
+    profile: str,
+    timeout_errors: Any,  # noqa: ANN401
+    max_rate: float | None,
+    cache: Any,  # noqa: ANN401
+    cache_key: Callable[..., str] | None,
+    fallback: Callable[..., Any] | None,
+    env_load: bool | None,
+) -> _BaseShieldConfig:
+    """Resolve a `_BaseShieldConfig` from kwargs, an explicit config, or env."""
+    explicit_kwargs = any(
+        value is not None
+        for value in (
+            timeout_errors,
+            max_rate,
+            cache,
+            cache_key,
+            fallback,
+        )
+    )
+    if config is not None:
+        if explicit_kwargs:
+            msg = "pass a pre-built config OR individual kwargs, not both"
+            raise TypeError(msg)
+        return config
+    if env_load is None:
+        env_load = env_load_default()
+    if env_load:
+        return _resolve_config_from_env(
+            name,
+            timeout_errors=timeout_errors,
+            max_rate=max_rate,
+            cache=cache,
+            cache_key=cache_key,
+            fallback=fallback,
+        )
+    cls = _PROFILE_BY_NAME[profile]
+    kwargs: dict[str, Any] = {"kind": profile}
+    if timeout_errors is not None:
+        kwargs["timeout_errors"] = timeout_errors
+    if max_rate is not None:
+        kwargs["max_rate"] = max_rate
+    if cache is not None:
+        kwargs["cache"] = cache
+    if cache_key is not None:
+        kwargs["cache_key"] = cache_key
+    if fallback is not None:
+        kwargs["fallback"] = fallback
+    return cls.model_validate(kwargs)
+
+
+@dataclass(frozen=True, slots=True)
+class _State:
+    """Read-side snapshot of the published Shield configuration."""
+
+    config: _BaseShieldConfig
+    effective_timeout_errors: tuple[type[BaseException], ...]
+
+
+async def _maybe_await(value: Any) -> Any:  # noqa: ANN401
+    """Await `value` when it is a coroutine, return it as-is otherwise."""
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def _safe_cache_set(cache: Any, key: str, value: Any) -> None:  # noqa: ANN401
+    """Write `value` to `cache` under `key`. Swallow every exception at debug."""
+    try:
+        await cache.set(key, value)
+    except Exception:  # noqa: BLE001
+        logger.debug("shield: cache write failed", exc_info=True)
+
+
+class Shield(Reconfigurable[_BaseShieldConfig]):
+    """Shield resilience pattern.
+
+    Wraps a single async callable with:
+
+    - A per-attempt timeout estimated from the rolling p95 of the last
+      32 successful latencies.
+    - Exponential-jittered retries gated by a consecutive-failure budget.
+    - A CUBIC-style adaptive rate limiter that engages on the first
+      slow-down and ramps back gradually.
+    - Optional cache and fallback recovery paths on give-up.
+
+    One `Shield` instance covers one logical dependency. Multiple
+    functions hitting the same dependency share one `Shield` and
+    therefore one retry budget and one CUBIC controller.
+
+    Read more in the [Shield](../resilience/shield.md) docs.
+    """
+
+    def __init__(
+        self,
+        name: Annotated[
+            str,
+            Doc(
+                "Registration name of the Shield instance. Appears in "
+                "logs, metrics, and PEP 678 notes attached on give-up."
+            ),
+        ],
+        config: Annotated[
+            _BaseShieldConfig | None,
+            Doc(
+                "A pre-built profile config "
+                "([`InternalShieldConfig`][grelmicro.resilience.InternalShieldConfig], "
+                "[`ApiShieldConfig`][grelmicro.resilience.ApiShieldConfig], "
+                "[`SlowShieldConfig`][grelmicro.resilience.SlowShieldConfig]). "
+                "Mutually exclusive with the per-field kwargs."
+            ),
+        ] = None,
+        *,
+        timeout_errors: Annotated[
+            tuple[type[BaseException], ...] | None,
+            Doc(
+                "Exception classes treated as transient slow-downs. "
+                "`TimeoutError` is always appended. Default `(TimeoutError,)`."
+            ),
+        ] = None,
+        max_rate: Annotated[
+            PositiveFloat | None,
+            Doc(
+                "Optional hard ceiling on the adaptive bucket's rate "
+                "in tokens per second."
+            ),
+        ] = None,
+        cache: Annotated[  # noqa: ANN401
+            Any,
+            Doc(
+                "Optional cache instance read on give-up and written "
+                "fire-and-forget on success."
+            ),
+        ] = None,
+        cache_key: Annotated[
+            Callable[..., str] | None,
+            Doc(
+                "Optional callable returning the cache key for a call. "
+                'Defaults to `f"{name}:{stable_hash(args, kwargs)}"`.'
+            ),
+        ] = None,
+        fallback: Annotated[
+            Callable[[BaseException], Any]
+            | Callable[[BaseException], Awaitable[Any]]
+            | None,
+            Doc(
+                "Optional callable invoked on give-up when the cache "
+                "path returns nothing. Receives the underlying exception."
+            ),
+        ] = None,
+        env_load: Annotated[
+            bool | None,
+            Doc(
+                "Whether to read environment variables. Defaults to the "
+                "process-wide `GREL_ENV_LOAD` flag."
+            ),
+        ] = None,
+        time_source: Annotated[
+            Callable[[], float] | None,
+            Doc("Monotonic clock for tests. Defaults to `time.monotonic`."),
+        ] = None,
+        random_source: Annotated[
+            Callable[[], float] | None,
+            Doc(
+                "Uniform `[0, 1)` random function for backoff jitter. "
+                "Defaults to `random.random`."
+            ),
+        ] = None,
+    ) -> None:
+        """Initialize the Shield instance with the `api` profile by default."""
+        self._setup(
+            name=name,
+            config=_build_config(
+                name,
+                config=config,
+                profile="api",
+                timeout_errors=timeout_errors,
+                max_rate=max_rate,
+                cache=cache,
+                cache_key=cache_key,
+                fallback=fallback,
+                env_load=env_load,
+            ),
+            time_source=time_source,
+            random_source=random_source,
+        )
+
+    def _setup(
+        self,
+        *,
+        name: str,
+        config: _BaseShieldConfig,
+        time_source: Callable[[], float] | None,
+        random_source: Callable[[], float] | None,
+    ) -> None:
+        """Wire the resolved config and helpers onto the instance."""
+        self._name = name
+        self._config = config
+        self._reconfigure_lock = asyncio.Lock()
+        self._time = time_source or time.monotonic
+        self._random = random_source or random.random
+        self._retry_budget = _RetryBudget(
+            capacity=config.max_consecutive_failures
+        )
+        cap = config.max_rate or config.max_rate_cap_default
+        self._adaptive_gate = _AdaptiveGate(
+            initial_max_rate=config.initial_max_rate,
+            capacity=config.adaptive_burst_capacity,
+            min_rate_floor=config.min_rate_floor,
+            max_rate_cap=cap,
+            time_source=self._time,
+        )
+        self._timeout_estimator = _TimeoutEstimator(
+            initial_timeout=config.initial_timeout,
+            clamp_min=config.timeout_clamp_min,
+            clamp_max=config.timeout_clamp_max,
+        )
+        self._state = _State(
+            config=config,
+            effective_timeout_errors=config.effective_timeout_errors(),
+        )
+
+    @property
+    def name(self) -> str:
+        """Return the Shield instance name."""
+        return self._name
+
+    @classmethod
+    def from_config(
+        cls,
+        name: Annotated[str, Doc("Name of the Shield instance.")],
+        config: Annotated[
+            _BaseShieldConfig,
+            Doc("The pre-built Shield profile configuration."),
+        ],
+    ) -> Self:
+        """Construct a `Shield` from a name and a pre-built profile config."""
+        instance = cls.__new__(cls)
+        instance._setup(  # noqa: SLF001
+            name=name,
+            config=config,
+            time_source=None,
+            random_source=None,
+        )
+        return instance
+
+    @classmethod
+    def internal(
+        cls,
+        name: Annotated[str, Doc("Name of the Shield instance.")],
+        *,
+        timeout_errors: tuple[type[BaseException], ...] | None = None,
+        max_rate: PositiveFloat | None = None,
+        cache: Any = None,  # noqa: ANN401
+        cache_key: Callable[..., str] | None = None,
+        fallback: Callable[[BaseException], Any]
+        | Callable[[BaseException], Awaitable[Any]]
+        | None = None,
+    ) -> Self:
+        """Construct a Shield with the `internal` profile."""
+        return cls._make(
+            name=name,
+            profile="internal",
+            timeout_errors=timeout_errors,
+            max_rate=max_rate,
+            cache=cache,
+            cache_key=cache_key,
+            fallback=fallback,
+        )
+
+    @classmethod
+    def api(
+        cls,
+        name: Annotated[str, Doc("Name of the Shield instance.")],
+        *,
+        timeout_errors: tuple[type[BaseException], ...] | None = None,
+        max_rate: PositiveFloat | None = None,
+        cache: Any = None,  # noqa: ANN401
+        cache_key: Callable[..., str] | None = None,
+        fallback: Callable[[BaseException], Any]
+        | Callable[[BaseException], Awaitable[Any]]
+        | None = None,
+    ) -> Self:
+        """Construct a Shield with the `api` profile (the default)."""
+        return cls._make(
+            name=name,
+            profile="api",
+            timeout_errors=timeout_errors,
+            max_rate=max_rate,
+            cache=cache,
+            cache_key=cache_key,
+            fallback=fallback,
+        )
+
+    @classmethod
+    def slow(
+        cls,
+        name: Annotated[str, Doc("Name of the Shield instance.")],
+        *,
+        timeout_errors: tuple[type[BaseException], ...] | None = None,
+        max_rate: PositiveFloat | None = None,
+        cache: Any = None,  # noqa: ANN401
+        cache_key: Callable[..., str] | None = None,
+        fallback: Callable[[BaseException], Any]
+        | Callable[[BaseException], Awaitable[Any]]
+        | None = None,
+    ) -> Self:
+        """Construct a Shield with the `slow` profile."""
+        return cls._make(
+            name=name,
+            profile="slow",
+            timeout_errors=timeout_errors,
+            max_rate=max_rate,
+            cache=cache,
+            cache_key=cache_key,
+            fallback=fallback,
+        )
+
+    @classmethod
+    def _make(
+        cls,
+        *,
+        name: str,
+        profile: str,
+        timeout_errors: tuple[type[BaseException], ...] | None,
+        max_rate: PositiveFloat | None,
+        cache: Any,  # noqa: ANN401
+        cache_key: Callable[..., str] | None,
+        fallback: Callable[..., Any] | None,
+    ) -> Self:
+        """Build a Shield bypassing env reads, with a profile override."""
+        config = _build_config(
+            name,
+            config=None,
+            profile=profile,
+            timeout_errors=timeout_errors,
+            max_rate=max_rate,
+            cache=cache,
+            cache_key=cache_key,
+            fallback=fallback,
+            env_load=False,
+        )
+        instance = cls.__new__(cls)
+        instance._setup(  # noqa: SLF001
+            name=name,
+            config=config,
+            time_source=None,
+            random_source=None,
+        )
+        return instance
+
+    # ------------------------------------------------------------------ run
+
+    async def run(
+        self,
+        fn: Annotated[
+            Callable[..., Awaitable[Any]],
+            Doc("Async callable to invoke under this Shield."),
+        ],
+        *args: Any,  # noqa: ANN401
+        **kwargs: Any,  # noqa: ANN401
+    ) -> Any:  # noqa: ANN401
+        """Run `fn(*args, **kwargs)` through this Shield instance."""
+        if not inspect.iscoroutinefunction(fn) and not _is_async_callable(fn):
+            msg = (
+                "Shield.run requires an async callable. "
+                f"Got {fn!r}. Wrap sync code in asyncio.to_thread(...)."
+            )
+            raise TypeError(msg)
+        return await self._execute(fn, args, kwargs)
+
+    def __call__(
+        self,
+        fn: Annotated[
+            Callable[..., Awaitable[Any]],
+            Doc("Async function to decorate."),
+        ],
+    ) -> Callable[..., Awaitable[Any]]:
+        """Decorate `fn` so each call runs through this Shield."""
+        if not inspect.iscoroutinefunction(fn):
+            msg = (
+                "Shield only decorates async functions. "
+                f"Got {fn!r}. Wrap sync code in asyncio.to_thread(...)."
+            )
+            raise TypeError(msg)
+
+        @functools.wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            return await self._execute(fn, args, kwargs)
+
+        return wrapper
+
+    # ------------------------------------------------------------- internals
+
+    async def _execute(  # noqa: C901
+        self,
+        fn: Callable[..., Awaitable[Any]],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:  # noqa: ANN401
+        state = self._state
+        started = self._time()
+        retries_consumed = 0
+        attempt = 0
+        last_exc: BaseException | None = None
+        give_up_reason = _GIVE_UP_ATTEMPTS
+        while attempt < _MAX_ATTEMPTS:
+            attempt += 1
+            await self._adaptive_gate.acquire()
+            timeout = self._timeout_estimator.estimate()
+            call_started = self._time()
+            try:
+                async with asyncio.timeout(timeout):
+                    result = await fn(*args, **kwargs)
+            except BaseException as exc:
+                last_exc = exc
+                # ResilienceError propagates first, never retried.
+                if isinstance(exc, ResilienceError):
+                    give_up_reason = _GIVE_UP_NON_RETRY
+                    break
+                # BaseException outside Exception (CancelledError,
+                # KeyboardInterrupt, SystemExit) propagates immediately.
+                if not isinstance(exc, Exception):
+                    raise
+                # Non-retryable Exception: surface unchanged.
+                if not isinstance(exc, state.effective_timeout_errors):
+                    give_up_reason = _GIVE_UP_NON_RETRY
+                    break
+                # Retryable slow-down: shrink CUBIC, try the budget.
+                self._adaptive_gate.on_slow_down()
+                if attempt >= _MAX_ATTEMPTS:
+                    give_up_reason = _GIVE_UP_ATTEMPTS
+                    break
+                allowed = await self._retry_budget.try_acquire()
+                if not allowed:
+                    logger.debug(
+                        "shield %s: retry budget exhausted", self._name
+                    )
+                    give_up_reason = _GIVE_UP_BUDGET
+                    break
+                retries_consumed += 1
+                delay = self._backoff_for(attempt)
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                continue
+            else:
+                latency = self._time() - call_started
+                self._timeout_estimator.record(latency)
+                self._adaptive_gate.on_success()
+                if retries_consumed == 0:
+                    await self._retry_budget.refund(1)
+                else:
+                    await self._retry_budget.refund(retries_consumed)
+                if state.config.cache is not None:
+                    self._fire_and_forget_cache_set(args, kwargs, result)
+                return result
+        # Give-up path: try cache, then fallback, then re-raise with note.
+        elapsed = self._time() - started
+        note = (
+            f"shield: {give_up_reason} after {attempt}/{_MAX_ATTEMPTS} "
+            f"attempts in {elapsed:.2f}s ({state.config.profile_name} profile)"
+        )
+        return await self._handle_give_up(state, args, kwargs, last_exc, note)
+
+    def _backoff_for(self, attempt_number: int) -> float:
+        """Return the sleep delay before retry `attempt_number`."""
+        # `attempt_number` is the just-failed attempt index (1..N). The
+        # retry index `i` used by the formula starts at 1 for the first
+        # retry, which is the same value.
+        config = self._state.config
+        cap = config.backoff_cap
+        scale = config.backoff_scale
+        ceiling = min(scale * (2 ** (attempt_number - 1)), cap)
+        return self._random() * ceiling
+
+    async def _handle_give_up(
+        self,
+        state: _State,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        exc: BaseException | None,
+        note: str,
+    ) -> Any:  # noqa: ANN401
+        # 1. Cache lookup.
+        config = state.config
+        cache = config.cache
+        if cache is not None:
+            key = self._compute_key(args, kwargs)
+            try:
+                value = await cache.get(key)
+            except Exception:  # noqa: BLE001
+                logger.debug("shield: cache read failed", exc_info=True)
+                value = None
+            if value is not None:
+                return value
+        # 2. Fallback callable.
+        if config.fallback is not None and exc is not None:
+            return await _maybe_await(config.fallback(exc))
+        # 3. Re-raise with PEP 678 note.
+        if exc is None:  # pragma: no cover  # defensive
+            msg = "Shield give-up without an exception"
+            raise RuntimeError(msg)
+        exc.add_note(note)
+        raise exc
+
+    def _compute_key(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> str:
+        """Compute the cache key for one call."""
+        custom = self._state.config.cache_key
+        if custom is not None:
+            return custom(*args, **kwargs)
+        return default_cache_key(self._name, args, kwargs)
+
+    def _fire_and_forget_cache_set(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        value: Any,  # noqa: ANN401
+    ) -> None:
+        """Write the successful return value to the cache without awaiting."""
+        cache = self._state.config.cache
+        if cache is None:  # pragma: no cover
+            return
+        key = self._compute_key(args, kwargs)
+        task = asyncio.create_task(_safe_cache_set(cache, key, value))
+        # Hold a strong reference and silence "task was destroyed" warnings.
+        task.add_done_callback(_discard_task)
+
+    async def _apply_reconfigure(self, new_config: _BaseShieldConfig) -> None:
+        """Rebuild derived state from `new_config`."""
+        # Live reconfigure swaps the snapshot. In-flight `_execute`
+        # loops keep the previous snapshot through `state`.
+        self._retry_budget = _RetryBudget(
+            capacity=new_config.max_consecutive_failures
+        )
+        cap = new_config.max_rate or new_config.max_rate_cap_default
+        self._adaptive_gate = _AdaptiveGate(
+            initial_max_rate=new_config.initial_max_rate,
+            capacity=new_config.adaptive_burst_capacity,
+            min_rate_floor=new_config.min_rate_floor,
+            max_rate_cap=cap,
+            time_source=self._time,
+        )
+        self._timeout_estimator = _TimeoutEstimator(
+            initial_timeout=new_config.initial_timeout,
+            clamp_min=new_config.timeout_clamp_min,
+            clamp_max=new_config.timeout_clamp_max,
+        )
+        self._state = _State(
+            config=new_config,
+            effective_timeout_errors=new_config.effective_timeout_errors(),
+        )
+
+
+def _discard_task(task: asyncio.Task[Any]) -> None:
+    """Swallow the cache-write task result for fire-and-forget semantics."""
+    import contextlib  # noqa: PLC0415
+
+    with contextlib.suppress(Exception):  # pragma: no cover
+        task.result()
+
+
+def _is_async_callable(fn: object) -> bool:
+    """Return True when `fn` is callable and returns an awaitable.
+
+    Covers `functools.partial`-wrapped coroutines that
+    `iscoroutinefunction` does not recognise.
+    """
+    target = fn.func if isinstance(fn, functools.partial) else fn
+    return inspect.iscoroutinefunction(target)

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -164,10 +164,19 @@ def _build_config(
 
 @dataclass(frozen=True, slots=True)
 class _State:
-    """Read-side snapshot of the published Shield configuration."""
+    """Read-side snapshot of the published Shield configuration and helpers.
+
+    Each in-flight call captures one `_State` reference at the top of
+    `_execute`. A subsequent `reconfigure` swaps `Shield._state` to a
+    fresh instance with new helpers; the in-flight call continues to
+    use its captured snapshot end-to-end.
+    """
 
     config: _BaseShieldConfig
     effective_timeout_errors: tuple[type[BaseException], ...]
+    retry_budget: _RetryBudget
+    adaptive_gate: _AdaptiveGate
+    timeout_estimator: _TimeoutEstimator
 
 
 async def _maybe_await(value: Any) -> Any:  # noqa: ANN401
@@ -312,26 +321,8 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
         self._reconfigure_lock = asyncio.Lock()
         self._time = time_source or time.monotonic
         self._random = random_source or random.random
-        self._retry_budget = _RetryBudget(
-            capacity=config.max_consecutive_failures
-        )
-        cap = config.max_rate or config.max_rate_cap_default
-        self._adaptive_gate = _AdaptiveGate(
-            initial_max_rate=config.initial_max_rate,
-            capacity=config.adaptive_burst_capacity,
-            min_rate_floor=config.min_rate_floor,
-            max_rate_cap=cap,
-            time_source=self._time,
-        )
-        self._timeout_estimator = _TimeoutEstimator(
-            initial_timeout=config.initial_timeout,
-            clamp_min=config.timeout_clamp_min,
-            clamp_max=config.timeout_clamp_max,
-        )
-        self._state = _State(
-            config=config,
-            effective_timeout_errors=config.effective_timeout_errors(),
-        )
+        self._pending_tasks: set[asyncio.Task[Any]] = set()
+        self._state = self._build_state(config)
 
     @property
     def name(self) -> str:
@@ -519,8 +510,8 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
         give_up_reason = _GIVE_UP_ATTEMPTS
         while attempt < _MAX_ATTEMPTS:
             attempt += 1
-            await self._adaptive_gate.acquire()
-            timeout = self._timeout_estimator.estimate()
+            await state.adaptive_gate.acquire()
+            timeout = state.timeout_estimator.estimate()
             call_started = self._time()
             try:
                 async with asyncio.timeout(timeout):
@@ -540,11 +531,11 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
                     give_up_reason = _GIVE_UP_NON_RETRY
                     break
                 # Retryable slow-down: shrink CUBIC, try the budget.
-                self._adaptive_gate.on_slow_down()
+                state.adaptive_gate.on_slow_down()
                 if attempt >= _MAX_ATTEMPTS:
                     give_up_reason = _GIVE_UP_ATTEMPTS
                     break
-                allowed = await self._retry_budget.try_acquire()
+                allowed = await state.retry_budget.try_acquire()
                 if not allowed:
                     logger.debug(
                         "shield %s: retry budget exhausted", self._name
@@ -552,20 +543,20 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
                     give_up_reason = _GIVE_UP_BUDGET
                     break
                 retries_consumed += 1
-                delay = self._backoff_for(attempt)
+                delay = self._backoff_for(state, attempt)
                 if delay > 0:
                     await asyncio.sleep(delay)
                 continue
             else:
                 latency = self._time() - call_started
-                self._timeout_estimator.record(latency)
-                self._adaptive_gate.on_success()
+                state.timeout_estimator.record(latency)
+                state.adaptive_gate.on_success()
                 if retries_consumed == 0:
-                    await self._retry_budget.refund(1)
+                    await state.retry_budget.refund(1)
                 else:
-                    await self._retry_budget.refund(retries_consumed)
+                    await state.retry_budget.refund(retries_consumed)
                 if state.config.cache is not None:
-                    self._fire_and_forget_cache_set(args, kwargs, result)
+                    self._fire_and_forget_cache_set(state, args, kwargs, result)
                 return result
         # Give-up path: try cache, then fallback, then re-raise with note.
         elapsed = self._time() - started
@@ -575,12 +566,12 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
         )
         return await self._handle_give_up(state, args, kwargs, last_exc, note)
 
-    def _backoff_for(self, attempt_number: int) -> float:
+    def _backoff_for(self, state: _State, attempt_number: int) -> float:
         """Return the sleep delay before retry `attempt_number`."""
         # `attempt_number` is the just-failed attempt index (1..N). The
         # retry index `i` used by the formula starts at 1 for the first
         # retry, which is the same value.
-        config = self._state.config
+        config = state.config
         cap = config.backoff_cap
         scale = config.backoff_scale
         ceiling = min(scale * (2 ** (attempt_number - 1)), cap)
@@ -598,7 +589,7 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
         config = state.config
         cache = config.cache
         if cache is not None:
-            key = self._compute_key(args, kwargs)
+            key = self._compute_key(state, args, kwargs)
             try:
                 value = await cache.get(key)
             except Exception:  # noqa: BLE001
@@ -617,61 +608,66 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
         raise exc
 
     def _compute_key(
-        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+        self,
+        state: _State,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
     ) -> str:
         """Compute the cache key for one call."""
-        custom = self._state.config.cache_key
+        custom = state.config.cache_key
         if custom is not None:
             return custom(*args, **kwargs)
         return default_cache_key(self._name, args, kwargs)
 
     def _fire_and_forget_cache_set(
         self,
+        state: _State,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
         value: Any,  # noqa: ANN401
     ) -> None:
-        """Write the successful return value to the cache without awaiting."""
-        cache = self._state.config.cache
+        """Write the successful return value to the cache without awaiting.
+
+        The task is tracked in `self._pending_tasks` so the event loop
+        retains a strong reference and cannot garbage-collect the task
+        mid-execution. The done callback removes the entry.
+        """
+        cache = state.config.cache
         if cache is None:  # pragma: no cover
             return
-        key = self._compute_key(args, kwargs)
+        key = self._compute_key(state, args, kwargs)
         task = asyncio.create_task(_safe_cache_set(cache, key, value))
-        # Hold a strong reference and silence "task was destroyed" warnings.
-        task.add_done_callback(_discard_task)
+        self._pending_tasks.add(task)
+        task.add_done_callback(self._pending_tasks.discard)
 
     async def _apply_reconfigure(self, new_config: _BaseShieldConfig) -> None:
-        """Rebuild derived state from `new_config`."""
-        # Live reconfigure swaps the snapshot. In-flight `_execute`
-        # loops keep the previous snapshot through `state`.
-        self._retry_budget = _RetryBudget(
-            capacity=new_config.max_consecutive_failures
-        )
-        cap = new_config.max_rate or new_config.max_rate_cap_default
-        self._adaptive_gate = _AdaptiveGate(
-            initial_max_rate=new_config.initial_max_rate,
-            capacity=new_config.adaptive_burst_capacity,
-            min_rate_floor=new_config.min_rate_floor,
-            max_rate_cap=cap,
-            time_source=self._time,
-        )
-        self._timeout_estimator = _TimeoutEstimator(
-            initial_timeout=new_config.initial_timeout,
-            clamp_min=new_config.timeout_clamp_min,
-            clamp_max=new_config.timeout_clamp_max,
-        )
-        self._state = _State(
-            config=new_config,
-            effective_timeout_errors=new_config.effective_timeout_errors(),
-        )
+        """Rebuild derived state from `new_config`.
 
+        Swaps `self._state` to a fresh `_State` carrying new helpers.
+        In-flight calls keep their captured snapshot end-to-end.
+        """
+        self._state = self._build_state(new_config)
 
-def _discard_task(task: asyncio.Task[Any]) -> None:
-    """Swallow the cache-write task result for fire-and-forget semantics."""
-    import contextlib  # noqa: PLC0415
-
-    with contextlib.suppress(Exception):  # pragma: no cover
-        task.result()
+    def _build_state(self, config: _BaseShieldConfig) -> _State:
+        """Build a fresh `_State` with helpers wired to `config`."""
+        cap = config.max_rate or config.max_rate_cap_default
+        return _State(
+            config=config,
+            effective_timeout_errors=config.effective_timeout_errors(),
+            retry_budget=_RetryBudget(capacity=config.max_consecutive_failures),
+            adaptive_gate=_AdaptiveGate(
+                initial_max_rate=config.initial_max_rate,
+                capacity=config.adaptive_burst_capacity,
+                min_rate_floor=config.min_rate_floor,
+                max_rate_cap=cap,
+                time_source=self._time,
+            ),
+            timeout_estimator=_TimeoutEstimator(
+                initial_timeout=config.initial_timeout,
+                clamp_min=config.timeout_clamp_min,
+                clamp_max=config.timeout_clamp_max,
+            ),
+        )
 
 
 def _is_async_callable(fn: object) -> bool:

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -187,7 +187,12 @@ async def _maybe_await(value: Any) -> Any:  # noqa: ANN401
 
 
 async def _safe_cache_set(cache: Any, key: str, value: Any) -> None:  # noqa: ANN401
-    """Write `value` to `cache` under `key`. Swallow every exception at debug."""
+    """Write `value` to `cache` under `key`.
+
+    Swallow every `Exception` at debug. `BaseException` (notably
+    `asyncio.CancelledError`) propagates so task cancellation during
+    shutdown reaches the asyncio scheduler unchanged.
+    """
     try:
         await cache.set(key, value)
     except Exception:  # noqa: BLE001

--- a/grelmicro/resilience/shield/_slow.py
+++ b/grelmicro/resilience/shield/_slow.py
@@ -1,0 +1,42 @@
+"""Slow Shield profile configuration.
+
+For long-running calls: LLM inference, batch jobs, large queries.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, ClassVar, Literal
+
+from typing_extensions import Doc
+
+from grelmicro.resilience.shield._profile import _BaseShieldConfig
+
+__all__ = ["SlowShieldConfig"]
+
+
+class SlowShieldConfig(_BaseShieldConfig, frozen=True, extra="forbid"):
+    """Shield configuration for the `slow` profile.
+
+    Tuned for long-running calls: LLM inference, batch jobs, large
+    queries. Low initial rate, large timeouts, tight failure budget.
+    The profile parameters are frozen.
+
+    Read more in the [Shield](../resilience/shield.md) docs.
+    """
+
+    kind: Annotated[
+        Literal["slow"],
+        Doc("Discriminator for the Shield profile Pydantic union."),
+    ] = "slow"
+
+    max_consecutive_failures: ClassVar[int] = 5
+    initial_max_rate: ClassVar[float] = 0.5
+    adaptive_burst_capacity: ClassVar[float] = 1.0
+    min_rate_floor: ClassVar[float] = 0.05
+    initial_timeout: ClassVar[float] = 120.0
+    timeout_clamp_min: ClassVar[float] = 5.0
+    timeout_clamp_max: ClassVar[float] = 600.0
+    backoff_scale: ClassVar[float] = 2.0
+    backoff_cap: ClassVar[float] = 60.0
+    max_rate_cap_default: ClassVar[float | None] = None
+    profile_name: ClassVar[str] = "slow"

--- a/grelmicro/resilience/shield/_timeout_estimator.py
+++ b/grelmicro/resilience/shield/_timeout_estimator.py
@@ -1,0 +1,83 @@
+"""Per-attempt timeout estimator.
+
+Tracks the last 32 successful latencies in a power-of-two ring and
+returns the p95 multiplied by 2.5, clamped to the configured range.
+"""
+
+from __future__ import annotations
+
+import math
+
+__all__ = ["_TimeoutEstimator"]
+
+_WINDOW: int = 32
+_P95_MULTIPLIER: float = 2.5
+
+
+class _TimeoutEstimator:
+    """Rolling p95 timeout estimator.
+
+    Records successful latencies in a 32-slot ring. Each `estimate`
+    call computes p95 of the recorded samples, multiplies by 2.5, and
+    clamps to `[clamp_min, clamp_max]`. Returns `initial_timeout` when
+    no samples have been recorded yet.
+    """
+
+    __slots__ = (
+        "_buffer",
+        "_clamp_max",
+        "_clamp_min",
+        "_count",
+        "_index",
+        "_initial",
+    )
+
+    def __init__(
+        self,
+        *,
+        initial_timeout: float,
+        clamp_min: float,
+        clamp_max: float,
+    ) -> None:
+        """Initialize an empty estimator."""
+        if clamp_min <= 0 or clamp_max <= 0:
+            msg = "clamp bounds must be positive"
+            raise ValueError(msg)
+        if clamp_min > clamp_max:
+            msg = f"clamp_min ({clamp_min}) must be <= clamp_max ({clamp_max})"
+            raise ValueError(msg)
+        self._initial = initial_timeout
+        self._clamp_min = clamp_min
+        self._clamp_max = clamp_max
+        self._buffer: list[float] = [0.0] * _WINDOW
+        self._index = 0
+        self._count = 0
+
+    def record(self, latency: float) -> None:
+        """Record one successful latency in seconds."""
+        if latency < 0 or not math.isfinite(latency):
+            return
+        self._buffer[self._index] = latency
+        self._index = (self._index + 1) % _WINDOW
+        if self._count < _WINDOW:
+            self._count += 1
+
+    def estimate(self) -> float:
+        """Return the per-attempt timeout in seconds for the next call."""
+        if self._count == 0:
+            return self._clamp(self._initial)
+        samples = sorted(self._buffer[: self._count])
+        # p95: the smallest value v such that 95% of samples <= v.
+        # Use the nearest-rank index: ceil(0.95 * n) - 1, clamped to range.
+        rank = max(0, math.ceil(0.95 * self._count) - 1)
+        rank = min(rank, self._count - 1)
+        p95 = samples[rank]
+        return self._clamp(p95 * _P95_MULTIPLIER)
+
+    def _clamp(self, value: float) -> float:
+        """Clamp `value` to `[clamp_min, clamp_max]`."""
+        if value < self._clamp_min:
+            return self._clamp_min
+        if value > self._clamp_max:
+            return self._clamp_max
+        return value

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
     - tracing.md
     - Resilience:
         - resilience/index.md
+        - resilience/shield.md
         - resilience/circuit-breaker.md
         - resilience/fallback.md
         - resilience/rate-limiter.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ ignore = ["COM812", "ISC001"] # Ignore rules conflicting with the formatter.
     "T201",
 ]
 "docs/snippets/logging/basic.py" = ["EM101", "TRY"]
+"docs/snippets/resilience/shield_giveup.py" = ["EM101", "TRY"]
 "docs/snippets/task/router.py" = ["I001", "E402"]
 "tests/*" = [
     "S101",

--- a/tests/resilience/shield/__init__.py
+++ b/tests/resilience/shield/__init__.py
@@ -1,0 +1,1 @@
+"""Shield resilience pattern tests."""

--- a/tests/resilience/shield/conftest.py
+++ b/tests/resilience/shield/conftest.py
@@ -1,0 +1,46 @@
+"""Shared fixtures for Shield tests."""
+
+from __future__ import annotations
+
+import asyncio as _asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch `asyncio.sleep` to a no-op to keep tests fast."""
+
+    async def _async_noop(_seconds: float) -> None:
+        return
+
+    monkeypatch.setattr(_asyncio, "sleep", _async_noop)
+
+
+@pytest.fixture
+def deterministic_random() -> _DeterministicRandom:
+    """Return a deterministic source for the backoff jitter factor."""
+    return _DeterministicRandom()
+
+
+class _DeterministicRandom:
+    """Returns the same value every call, default 0.5."""
+
+    def __init__(self, value: float = 0.5) -> None:
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+
+class _FakeClock:
+    """Manually advanced monotonic clock for adaptive-gate tests."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds

--- a/tests/resilience/shield/test_adaptive_gate.py
+++ b/tests/resilience/shield/test_adaptive_gate.py
@@ -1,0 +1,255 @@
+"""Adaptive gate (token bucket + CUBIC) tests."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from grelmicro.resilience.shield._adaptive_gate import _AdaptiveGate
+from tests.resilience.shield.conftest import _FakeClock
+
+_BETA = 0.7
+_C = 0.4
+
+
+async def test_disabled_acquire_is_a_noop() -> None:
+    """Until the first slow-down, `acquire` returns immediately."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=10.0,
+        capacity=10.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    assert gate.enabled is False
+    await gate.acquire()
+    await gate.acquire()
+    assert gate.enabled is False
+
+
+async def test_slow_down_enables_and_shrinks_rate() -> None:
+    """First slow-down sets `max_rate` to `current * beta`."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=100.0,
+        capacity=200.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    gate.on_slow_down()
+    assert gate.enabled is True
+    assert gate.w_max == 100.0  # noqa: PLR2004
+    assert gate.max_rate == pytest.approx(100.0 * _BETA)
+
+
+async def test_k_value_after_shrink_matches_formula() -> None:
+    """`k = ((w_max * (1 - beta)) / C)^(1/3)`."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=50.0,
+        capacity=50.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    gate.on_slow_down()
+    expected_k = ((50.0 * (1.0 - _BETA)) / _C) ** (1.0 / 3.0)
+    assert gate.k == pytest.approx(expected_k)
+
+
+async def test_success_curve_grows_back_to_w_max_at_t_equals_k() -> None:
+    """At `t = last_fail + k` the curve passes through `w_max`."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=50.0,
+        capacity=50.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    gate.on_slow_down()
+    # Advance the clock to exactly `last_fail + k` and make sure no
+    # measured-rate clamp kicks in. The send window has been empty
+    # since enabled, so `measured_rate` is `inf`.
+    clock.advance(gate.k)
+    gate.on_success()
+    assert gate.max_rate == pytest.approx(50.0)
+
+
+async def test_success_curve_value_at_arbitrary_offset() -> None:
+    """`C * (offset)^3 + w_max` for `offset = t - last_fail - k`."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=50.0,
+        capacity=50.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    gate.on_slow_down()
+    extra = 1.0
+    clock.advance(gate.k + extra)
+    gate.on_success()
+    expected = _C * (extra**3) + gate.w_max
+    assert gate.max_rate == pytest.approx(expected)
+
+
+async def test_min_rate_floor_is_enforced() -> None:
+    """The bucket rate never drops below `min_rate_floor`."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=1.0,
+        capacity=1.0,
+        min_rate_floor=2.0,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    gate.on_slow_down()
+    assert gate.max_rate == 2.0  # noqa: PLR2004
+
+
+async def test_max_rate_cap_is_enforced_on_growth() -> None:
+    """Set a hard ceiling and confirm CUBIC growth respects it."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=50.0,
+        capacity=50.0,
+        min_rate_floor=0.1,
+        max_rate_cap=10.0,
+        time_source=clock,
+    )
+    gate.on_slow_down()
+    clock.advance(1000.0)
+    gate.on_success()
+    assert gate.max_rate <= 10.0  # noqa: PLR2004
+
+
+async def test_measured_rate_returns_inf_with_fewer_than_two_samples() -> None:
+    """The clamp disengages until at least two timestamps are observed."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=10.0,
+        capacity=10.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    assert math.isinf(gate.measured_rate())
+
+
+async def test_measured_rate_clamp_caps_success_growth() -> None:
+    """Candidate rate is clamped to `1.5 * measured_rate`."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=50.0,
+        capacity=50.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    # Build a measured rate of about 1/s while the gate is disabled.
+    for _ in range(8):
+        await gate.acquire()
+        clock.advance(1.0)
+    measured = gate.measured_rate()
+    assert measured == pytest.approx(1.0, rel=0.2)
+    gate.on_slow_down()
+    clock.advance(1_000.0)
+    gate.on_success()
+    assert gate.max_rate <= 1.5 * measured + 1e-6
+
+
+async def test_last_fail_getter_returns_timestamp() -> None:
+    """`last_fail` exposes the most-recent slow-down timestamp."""
+    clock = _FakeClock(start=100.0)
+    gate = _AdaptiveGate(
+        initial_max_rate=10.0,
+        capacity=10.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    gate.on_slow_down()
+    assert gate.last_fail == 100.0  # noqa: PLR2004
+
+
+async def test_measured_rate_handles_zero_elapsed_window() -> None:
+    """When all samples share the same timestamp, the clamp disengages."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=10.0,
+        capacity=10.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    # Push several samples at the same timestamp.
+    for _ in range(5):
+        await gate.acquire()
+    assert math.isinf(gate.measured_rate())
+
+
+async def test_acquire_when_enabled_yields_under_full_bucket() -> None:
+    """A bucket pre-filled past the threshold lets `acquire` proceed."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=10.0,
+        capacity=10.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    gate.on_slow_down()
+    # Advance the clock so the bucket refills to one whole token.
+    clock.advance(10.0)
+    await gate.acquire()
+
+
+async def test_on_success_is_a_noop_while_disabled() -> None:
+    """`on_success` does nothing until the gate has been enabled."""
+    clock = _FakeClock()
+    gate = _AdaptiveGate(
+        initial_max_rate=50.0,
+        capacity=50.0,
+        min_rate_floor=0.1,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+    gate.on_success()
+    assert gate.enabled is False
+    assert gate.max_rate == 50.0  # noqa: PLR2004
+
+
+def test_capacity_must_be_positive() -> None:
+    """Constructor validates inputs."""
+    with pytest.raises(ValueError, match="initial_max_rate"):
+        _AdaptiveGate(
+            initial_max_rate=0,
+            capacity=1,
+            min_rate_floor=0.1,
+            max_rate_cap=None,
+        )
+    with pytest.raises(ValueError, match="capacity"):
+        _AdaptiveGate(
+            initial_max_rate=1,
+            capacity=0,
+            min_rate_floor=0.1,
+            max_rate_cap=None,
+        )
+    with pytest.raises(ValueError, match="min_rate_floor"):
+        _AdaptiveGate(
+            initial_max_rate=1,
+            capacity=1,
+            min_rate_floor=0,
+            max_rate_cap=None,
+        )
+    with pytest.raises(ValueError, match="max_rate_cap"):
+        _AdaptiveGate(
+            initial_max_rate=1,
+            capacity=1,
+            min_rate_floor=1.0,
+            max_rate_cap=0.5,
+        )

--- a/tests/resilience/shield/test_cache_fallback.py
+++ b/tests/resilience/shield/test_cache_fallback.py
@@ -1,0 +1,203 @@
+"""Cache and fallback chain tests on Shield give-up."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from grelmicro.resilience import Shield
+
+
+async def _flush_pending_tasks() -> None:
+    """Yield enough times for fire-and-forget tasks to complete."""
+    # `asyncio.sleep` is patched to a no-op in conftest, so we drain
+    # the loop by polling outstanding tasks directly.
+    for _ in range(20):
+        pending = [
+            t
+            for t in asyncio.all_tasks()
+            if t is not asyncio.current_task() and not t.done()
+        ]
+        if not pending:
+            return
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+class _SignalError(Exception):
+    """Test-only retryable error."""
+
+
+class _SpyCache:
+    """In-memory cache exposing `get(key)` and `set(key, value)`."""
+
+    def __init__(self) -> None:
+        self.data: dict[str, Any] = {}
+        self.set_calls: list[tuple[str, Any]] = []
+        self.get_calls: list[str] = []
+
+    async def get(self, key: str) -> Any:  # noqa: ANN401
+        self.get_calls.append(key)
+        return self.data.get(key)
+
+    async def set(self, key: str, value: Any) -> None:  # noqa: ANN401
+        self.set_calls.append((key, value))
+        self.data[key] = value
+
+
+def _shield(**overrides: Any) -> Shield:  # noqa: ANN401
+    return Shield.api("cached", timeout_errors=(_SignalError,), **overrides)
+
+
+async def test_cache_set_fires_on_success() -> None:
+    """A successful call writes the return value to the cache."""
+    cache = _SpyCache()
+    s = _shield(cache=cache)
+
+    async def fn(x: int) -> int:
+        return x * 2
+
+    assert await s.run(fn, 3) == 6  # noqa: PLR2004
+    # The cache write is fire-and-forget; give the loop a tick to run it.
+    await _flush_pending_tasks()
+    assert len(cache.set_calls) == 1
+    key, value = cache.set_calls[0]
+    assert key.startswith("cached:")
+    assert value == 6  # noqa: PLR2004
+
+
+async def test_give_up_returns_cached_value_on_hit() -> None:
+    """A give-up with a cache hit returns the cached value, no exception."""
+    cache = _SpyCache()
+    s = _shield(cache=cache)
+    # Pre-populate the cache with the key the next call will compute.
+    key = s._compute_key((), {})
+    cache.data[key] = "from-cache"
+
+    async def always_fails() -> None:
+        raise _SignalError
+
+    assert await s.run(always_fails) == "from-cache"
+
+
+async def test_give_up_falls_through_on_cache_miss() -> None:
+    """A miss continues to the fallback or re-raises."""
+    cache = _SpyCache()
+    s = _shield(cache=cache)
+
+    async def always_fails() -> None:
+        raise _SignalError
+
+    with pytest.raises(_SignalError):
+        await s.run(always_fails)
+
+
+async def test_fallback_only_returns_synthesized_value() -> None:
+    """With no cache, the fallback callable supplies the give-up value."""
+
+    async def synth(exc: BaseException) -> str:
+        assert isinstance(exc, _SignalError)
+        return "default"
+
+    s = _shield(fallback=synth)
+
+    async def always_fails() -> None:
+        raise _SignalError
+
+    assert await s.run(always_fails) == "default"
+
+
+async def test_sync_fallback_is_supported() -> None:
+    """A plain `def` fallback works without `await`."""
+
+    def synth(_exc: BaseException) -> int:
+        return 42
+
+    s = _shield(fallback=synth)
+
+    async def always_fails() -> None:
+        raise _SignalError
+
+    assert await s.run(always_fails) == 42  # noqa: PLR2004
+
+
+async def test_cache_then_fallback_order() -> None:
+    """Cache hit wins over fallback. Cache miss falls to fallback."""
+    cache = _SpyCache()
+
+    async def synth(_exc: BaseException) -> str:
+        return "synthesized"
+
+    s = _shield(cache=cache, fallback=synth)
+
+    # Cache miss -> fallback used.
+    async def always_fails() -> None:
+        raise _SignalError
+
+    assert await s.run(always_fails) == "synthesized"
+
+    # Pre-populate cache, retry: cache hit beats fallback.
+    key = s._compute_key((), {})
+    cache.data[key] = "cached-wins"
+    assert await s.run(always_fails) == "cached-wins"
+
+
+async def test_cache_key_callable_override() -> None:
+    """A user `cache_key` callable controls the lookup key."""
+    cache = _SpyCache()
+
+    def key_fn(*args: Any, **_kwargs: Any) -> str:  # noqa: ANN401
+        return f"static:{args[0]}"
+
+    s = _shield(cache=cache, cache_key=key_fn)
+
+    async def fn(symbol: str) -> str:
+        return f"value-{symbol}"
+
+    await s.run(fn, "AAPL")
+    await _flush_pending_tasks()
+    keys = [call[0] for call in cache.set_calls]
+    assert "static:AAPL" in keys
+
+
+async def test_cache_set_failure_is_swallowed() -> None:
+    """A failing cache write does not propagate."""
+
+    class _BadCache:
+        async def get(self, _key: str) -> Any:  # noqa: ANN401
+            return None
+
+        async def set(self, _key: str, _value: Any) -> None:  # noqa: ANN401
+            msg = "nope"
+            raise RuntimeError(msg)
+
+    s = _shield(cache=_BadCache())
+
+    async def fn() -> str:
+        return "ok"
+
+    assert await s.run(fn) == "ok"
+    await _flush_pending_tasks()
+
+
+async def test_cache_get_failure_falls_through() -> None:
+    """A failing cache read is logged and falls through to the next path."""
+
+    class _BadCache:
+        async def get(self, _key: str) -> Any:  # noqa: ANN401
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        async def set(self, _key: str, _value: Any) -> None:  # noqa: ANN401
+            return None
+
+    async def synth(_exc: BaseException) -> str:
+        return "fallback"
+
+    s = _shield(cache=_BadCache(), fallback=synth)
+
+    async def always_fails() -> None:
+        raise _SignalError
+
+    assert await s.run(always_fails) == "fallback"

--- a/tests/resilience/shield/test_cache_fallback.py
+++ b/tests/resilience/shield/test_cache_fallback.py
@@ -72,7 +72,7 @@ async def test_give_up_returns_cached_value_on_hit() -> None:
     cache = _SpyCache()
     s = _shield(cache=cache)
     # Pre-populate the cache with the key the next call will compute.
-    key = s._compute_key((), {})
+    key = s._compute_key(s._state, (), {})
     cache.data[key] = "from-cache"
 
     async def always_fails() -> None:
@@ -138,7 +138,7 @@ async def test_cache_then_fallback_order() -> None:
     assert await s.run(always_fails) == "synthesized"
 
     # Pre-populate cache, retry: cache hit beats fallback.
-    key = s._compute_key((), {})
+    key = s._compute_key(s._state, (), {})
     cache.data[key] = "cached-wins"
     assert await s.run(always_fails) == "cached-wins"
 

--- a/tests/resilience/shield/test_decorator.py
+++ b/tests/resilience/shield/test_decorator.py
@@ -1,0 +1,104 @@
+"""Module-level `shield` decorator tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from grelmicro.resilience import shield
+
+
+class _SignalError(Exception):
+    """Test-only retryable error."""
+
+
+async def test_zero_arg_decorator_uses_api_profile() -> None:
+    """`@shield` (no parens) wraps with the `api` profile defaults."""
+
+    @shield
+    async def fn() -> str:
+        return "ok"
+
+    assert await fn() == "ok"
+
+
+async def test_zero_arg_decorator_retries_timeout_error() -> None:
+    """The default profile retries `TimeoutError`."""
+    attempts = {"count": 0}
+
+    @shield
+    async def fn() -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise TimeoutError
+        return "ok"
+
+    assert await fn() == "ok"
+    assert attempts["count"] == 2  # noqa: PLR2004
+
+
+async def test_api_factory_decorator() -> None:
+    """`@shield.api(...)` uses the api profile."""
+
+    @shield.api(timeout_errors=(_SignalError,))
+    async def fn() -> str:
+        return "api"
+
+    assert await fn() == "api"
+
+
+async def test_internal_factory_decorator() -> None:
+    """`@shield.internal(...)` uses the internal profile."""
+
+    @shield.internal(timeout_errors=(_SignalError,))
+    async def fn() -> str:
+        return "internal"
+
+    assert await fn() == "internal"
+
+
+async def test_slow_factory_decorator() -> None:
+    """`@shield.slow(...)` uses the slow profile."""
+
+    @shield.slow(timeout_errors=(_SignalError,))
+    async def fn() -> str:
+        return "slow"
+
+    assert await fn() == "slow"
+
+
+async def test_decorator_propagates_non_retryable() -> None:
+    """Non-`timeout_errors` exceptions propagate without retry."""
+
+    @shield.api(timeout_errors=(_SignalError,))
+    async def fn() -> None:
+        msg = "permanent"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="permanent"):
+        await fn()
+
+
+async def test_decorator_attaches_pep_678_note_on_give_up() -> None:
+    """On give-up the decorator surfaces the exception with a `shield:` note."""
+
+    @shield.api(timeout_errors=(_SignalError,))
+    async def fn() -> None:
+        raise _SignalError
+
+    with pytest.raises(_SignalError) as exc_info:
+        await fn()
+    notes = exc_info.value.__notes__
+    assert any("shield: " in note for note in notes)
+
+
+async def test_named_decorator_keeps_user_name() -> None:
+    """An explicit `name=` is preserved across calls."""
+
+    @shield.api("my-service", timeout_errors=(_SignalError,))
+    async def fn() -> None:
+        raise _SignalError
+
+    with pytest.raises(_SignalError) as exc_info:
+        await fn()
+    notes = exc_info.value.__notes__
+    assert any("api profile" in note for note in notes)

--- a/tests/resilience/shield/test_env.py
+++ b/tests/resilience/shield/test_env.py
@@ -1,0 +1,158 @@
+"""Environment-driven Shield configuration tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from grelmicro.resilience import Shield
+from grelmicro.resilience.shield._profile import _resolve_fqn
+
+
+def test_resolve_fqn_resolves_builtin_exception() -> None:
+    """`_resolve_fqn` returns the class for a fully-qualified name."""
+    assert _resolve_fqn("builtins.TimeoutError") is TimeoutError
+
+
+def test_resolve_fqn_rejects_bare_name() -> None:
+    """A name without a module path is rejected."""
+    with pytest.raises(ValueError, match="fully-qualified name"):
+        _resolve_fqn("TimeoutError")
+
+
+def test_resolve_fqn_rejects_missing_module() -> None:
+    """A missing module surfaces a clear error."""
+    with pytest.raises(ValueError, match="cannot import module"):
+        _resolve_fqn("not_a_real_module_anywhere.X")
+
+
+def test_resolve_fqn_rejects_missing_attribute() -> None:
+    """A missing attribute on the module surfaces a clear error."""
+    with pytest.raises(ValueError, match="no attribute"):
+        _resolve_fqn("builtins.NotAClass")
+
+
+def test_resolve_fqn_rejects_non_exception() -> None:
+    """A name that resolves to a non-exception object is rejected."""
+    with pytest.raises(TypeError, match="not an Exception subclass"):
+        _resolve_fqn("builtins.int")
+
+
+def test_env_load_profile_and_timeout_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reads `PROFILE` and `TIMEOUT_ERRORS` from env."""
+    monkeypatch.setenv("GREL_SHIELD_DB_PROFILE", "internal")
+    monkeypatch.setenv(
+        "GREL_SHIELD_DB_TIMEOUT_ERRORS",
+        "builtins.TimeoutError,builtins.ValueError",
+    )
+    s = Shield("db", env_load=True)
+    assert TimeoutError in s.config.timeout_errors
+    assert ValueError in s.config.timeout_errors
+    assert s.config.profile_name == "internal"
+
+
+def test_env_load_max_rate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reads `MAX_RATE` from env."""
+    monkeypatch.setenv("GREL_SHIELD_API_PROFILE", "api")
+    monkeypatch.setenv("GREL_SHIELD_API_MAX_RATE", "12.5")
+    s = Shield("api", env_load=True)
+    assert s.config.max_rate == 12.5  # noqa: PLR2004
+
+
+def test_env_load_with_explicit_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit kwargs win over env values."""
+
+    async def synth(_exc: BaseException) -> str:
+        return "default"
+
+    monkeypatch.setenv("GREL_SHIELD_MIX_PROFILE", "api")
+    monkeypatch.setenv("GREL_SHIELD_MIX_MAX_RATE", "0.1")
+    monkeypatch.setenv("GREL_SHIELD_MIX_TIMEOUT_ERRORS", "builtins.ValueError")
+    s = Shield(
+        "mix",
+        env_load=True,
+        timeout_errors=(TimeoutError,),
+        max_rate=5.0,
+        cache=object(),  # any duck-typed object passes through.
+        cache_key=lambda *_, **__: "k",
+        fallback=synth,
+    )
+    assert s.config.max_rate == 5.0  # noqa: PLR2004
+
+
+def test_env_load_invalid_profile_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unknown profile name is rejected."""
+    monkeypatch.setenv("GREL_SHIELD_X_PROFILE", "weird")
+    with pytest.raises(ValueError, match="not a valid profile"):
+        Shield("x", env_load=True)
+
+
+def test_env_load_default_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`env_load=None` falls through to `env_load_default()`."""
+    # The root conftest sets `GREL_ENV_LOAD=true`, so the default is True.
+    # Disable it for this test to exercise the off-path.
+    monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
+    s = Shield("autoload", max_rate=2.0)
+    assert s.config.max_rate == 2.0  # noqa: PLR2004
+
+
+def test_constructor_with_max_rate_no_env() -> None:
+    """The non-env max_rate kwarg path is exercised."""
+    s = Shield("explicit-max-rate", env_load=False, max_rate=3.0)
+    assert s.config.max_rate == 3.0  # noqa: PLR2004
+
+
+def test_constructor_rejects_config_and_kwargs_together() -> None:
+    """Passing `config=` with kwargs raises."""
+    from grelmicro.resilience import ApiShieldConfig  # noqa: PLC0415
+
+    cfg = ApiShieldConfig(max_rate=2.0)
+    with pytest.raises(TypeError, match="pre-built"):
+        Shield("dup", config=cfg, max_rate=3.0)
+
+
+def test_constructor_accepts_config() -> None:
+    """The pre-built config path works."""
+    from grelmicro.resilience import ApiShieldConfig  # noqa: PLC0415
+
+    cfg = ApiShieldConfig(max_rate=2.0)
+    s = Shield("dup", config=cfg)
+    assert s.config is cfg
+
+
+def test_config_accepts_single_exception_class() -> None:
+    """A bare exception class is wrapped in a one-tuple."""
+    from grelmicro.resilience import ApiShieldConfig  # noqa: PLC0415
+
+    cfg = ApiShieldConfig(timeout_errors=TimeoutError)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    assert TimeoutError in cfg.timeout_errors
+
+
+def test_config_normalizer_accepts_none() -> None:
+    """A `None` input is passed through to pydantic for default handling."""
+    from grelmicro.resilience.shield._profile import (  # noqa: PLC0415
+        _BaseShieldConfig,
+    )
+
+    assert _BaseShieldConfig._normalize_timeout_errors(None) is None
+
+
+def test_config_normalizer_passes_through_unknown_shapes() -> None:
+    """The validator preserves shapes pydantic can validate downstream."""
+    from grelmicro.resilience.shield._profile import (  # noqa: PLC0415
+        _BaseShieldConfig,
+    )
+
+    # The "before" validator returns the value unchanged if it is not a
+    # str, list, tuple, or class. Pydantic will then reject it. Use a
+    # raw dict to exercise the passthrough branch.
+    cls = _BaseShieldConfig._normalize_timeout_errors
+    raw: Any = {"not": "valid"}
+    assert cls(raw) == raw  # type: ignore[arg-type]

--- a/tests/resilience/shield/test_key.py
+++ b/tests/resilience/shield/test_key.py
@@ -1,0 +1,47 @@
+"""Cache key helpers tests."""
+
+from __future__ import annotations
+
+from grelmicro.resilience.shield._key import default_cache_key, stable_hash
+
+
+def test_stable_hash_returns_16_hex_chars() -> None:
+    """`stable_hash` returns a 16-character hex digest."""
+    key = stable_hash((1, 2), {"a": 1})
+    assert len(key) == 16  # noqa: PLR2004
+    int(key, 16)
+
+
+def test_stable_hash_is_deterministic() -> None:
+    """Same inputs produce the same digest."""
+    a = stable_hash((1, "x"), {"k": 2})
+    b = stable_hash((1, "x"), {"k": 2})
+    assert a == b
+
+
+def test_kwargs_are_sorted() -> None:
+    """Different kwarg insertion orders produce the same digest."""
+    a = stable_hash((), {"a": 1, "b": 2})
+    b = stable_hash((), {"b": 2, "a": 1})
+    assert a == b
+
+
+def test_different_args_produce_different_digests() -> None:
+    """Distinct call signatures hash to distinct keys."""
+    a = stable_hash((1,), {})
+    b = stable_hash((2,), {})
+    assert a != b
+
+
+def test_default_cache_key_format() -> None:
+    r"""The default key is `f"{name}:{digest}"`."""
+    key = default_cache_key("github", (1,), {"x": 2})
+    name, _, digest = key.partition(":")
+    assert name == "github"
+    assert len(digest) == 16  # noqa: PLR2004
+
+
+def test_handles_non_hashable_args() -> None:
+    """Lists and dicts hash through their `repr`."""
+    key = stable_hash(([1, 2, 3],), {"meta": {"k": "v"}})
+    assert len(key) == 16  # noqa: PLR2004

--- a/tests/resilience/shield/test_profiles.py
+++ b/tests/resilience/shield/test_profiles.py
@@ -1,0 +1,106 @@
+"""Shield profile configuration tests."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from grelmicro.resilience.shield import (
+    ApiShieldConfig,
+    InternalShieldConfig,
+    SlowShieldConfig,
+)
+
+
+def test_internal_profile_constants() -> None:
+    """`internal` profile freezes the spec table values."""
+    assert InternalShieldConfig.max_consecutive_failures == 10  # noqa: PLR2004
+    assert InternalShieldConfig.initial_max_rate == 100.0  # noqa: PLR2004
+    assert InternalShieldConfig.adaptive_burst_capacity == 200.0  # noqa: PLR2004
+    assert InternalShieldConfig.min_rate_floor == 1.0
+    assert InternalShieldConfig.initial_timeout == 1.0
+    assert InternalShieldConfig.timeout_clamp_min == 0.05  # noqa: PLR2004
+    assert InternalShieldConfig.timeout_clamp_max == 5.0  # noqa: PLR2004
+    assert InternalShieldConfig.backoff_scale == 0.5  # noqa: PLR2004
+    assert InternalShieldConfig.backoff_cap == 5.0  # noqa: PLR2004
+    assert InternalShieldConfig.profile_name == "internal"
+
+
+def test_api_profile_constants() -> None:
+    """`api` profile freezes the spec table values."""
+    assert ApiShieldConfig.max_consecutive_failures == 20  # noqa: PLR2004
+    assert ApiShieldConfig.initial_max_rate == 2.0  # noqa: PLR2004
+    assert ApiShieldConfig.adaptive_burst_capacity == 5.0  # noqa: PLR2004
+    assert ApiShieldConfig.min_rate_floor == 0.25  # noqa: PLR2004
+    assert ApiShieldConfig.initial_timeout == 10.0  # noqa: PLR2004
+    assert ApiShieldConfig.timeout_clamp_min == 0.5  # noqa: PLR2004
+    assert ApiShieldConfig.timeout_clamp_max == 60.0  # noqa: PLR2004
+    assert ApiShieldConfig.backoff_scale == 1.0
+    assert ApiShieldConfig.backoff_cap == 30.0  # noqa: PLR2004
+    assert ApiShieldConfig.profile_name == "api"
+
+
+def test_slow_profile_constants() -> None:
+    """`slow` profile freezes the spec table values."""
+    assert SlowShieldConfig.max_consecutive_failures == 5  # noqa: PLR2004
+    assert SlowShieldConfig.initial_max_rate == 0.5  # noqa: PLR2004
+    assert SlowShieldConfig.adaptive_burst_capacity == 1.0
+    assert SlowShieldConfig.min_rate_floor == 0.05  # noqa: PLR2004
+    assert SlowShieldConfig.initial_timeout == 120.0  # noqa: PLR2004
+    assert SlowShieldConfig.timeout_clamp_min == 5.0  # noqa: PLR2004
+    assert SlowShieldConfig.timeout_clamp_max == 600.0  # noqa: PLR2004
+    assert SlowShieldConfig.backoff_scale == 2.0  # noqa: PLR2004
+    assert SlowShieldConfig.backoff_cap == 60.0  # noqa: PLR2004
+    assert SlowShieldConfig.profile_name == "slow"
+
+
+def test_default_timeout_errors_includes_timeout_error() -> None:
+    """The default tuple covers `TimeoutError`."""
+    config = ApiShieldConfig()
+    assert TimeoutError in config.timeout_errors
+
+
+def test_effective_timeout_errors_appends_timeout_error() -> None:
+    """A user-supplied tuple gets `TimeoutError` appended."""
+    config = ApiShieldConfig(timeout_errors=(ValueError,))
+    assert TimeoutError in config.effective_timeout_errors()
+    assert ValueError in config.effective_timeout_errors()
+
+
+def test_effective_tuple_skips_duplicate_when_already_covered() -> None:
+    """Passing `BaseException`-style ancestors does not duplicate the entry."""
+
+    class MyTimeout(TimeoutError):  # noqa: N818
+        pass
+
+    config = ApiShieldConfig(timeout_errors=(MyTimeout, TimeoutError))
+    effective = config.effective_timeout_errors()
+    assert effective.count(TimeoutError) == 1
+
+
+def test_config_kind_discriminator() -> None:
+    """The `kind` field tags each subclass for the union."""
+    assert ApiShieldConfig().kind == "api"
+    assert InternalShieldConfig().kind == "internal"
+    assert SlowShieldConfig().kind == "slow"
+
+
+def test_config_extra_forbidden() -> None:
+    """Unknown fields are rejected."""
+    with pytest.raises(ValidationError):
+        ApiShieldConfig(unknown_field="x")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+
+
+def test_config_frozen() -> None:
+    """Configs are frozen after construction."""
+    config = ApiShieldConfig()
+    with pytest.raises(ValidationError):
+        config.max_rate = 5  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+
+
+def test_model_dump_roundtrip() -> None:
+    """`model_dump` round-trips through `model_validate`."""
+    config = ApiShieldConfig(max_rate=2.5)
+    data = config.model_dump()
+    rebuilt = ApiShieldConfig.model_validate(data)
+    assert rebuilt == config

--- a/tests/resilience/shield/test_profiles.py
+++ b/tests/resilience/shield/test_profiles.py
@@ -91,6 +91,12 @@ def test_config_extra_forbidden() -> None:
         ApiShieldConfig(unknown_field="x")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
 
 
+def test_timeout_errors_rejects_base_exception_class() -> None:
+    """`BaseException`-only types cannot be passed as `timeout_errors`."""
+    with pytest.raises(TypeError, match="not an Exception subclass"):
+        ApiShieldConfig(timeout_errors=KeyboardInterrupt)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
 def test_config_frozen() -> None:
     """Configs are frozen after construction."""
     config = ApiShieldConfig()

--- a/tests/resilience/shield/test_retry_budget.py
+++ b/tests/resilience/shield/test_retry_budget.py
@@ -1,0 +1,76 @@
+"""Retry budget bucket tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from grelmicro.resilience.shield._retry_budget import _RetryBudget
+
+
+async def test_initial_state_full() -> None:
+    """Bucket starts at capacity."""
+    capacity = 10
+    bucket = _RetryBudget(capacity=capacity)
+    assert bucket.capacity == capacity
+    assert bucket.available == capacity
+
+
+async def test_acquire_consumes_one_token() -> None:
+    """Each `try_acquire` removes one token."""
+    bucket = _RetryBudget(capacity=3)
+    assert await bucket.try_acquire() is True
+    assert bucket.available == 2  # noqa: PLR2004
+
+
+async def test_empty_bucket_denies_acquire() -> None:
+    """An empty bucket returns False without raising."""
+    bucket = _RetryBudget(capacity=1)
+    assert await bucket.try_acquire() is True
+    assert await bucket.try_acquire() is False
+    assert bucket.available == 0
+
+
+async def test_refund_clamps_at_capacity() -> None:
+    """Refunds never exceed the capacity."""
+    bucket = _RetryBudget(capacity=5)
+    await bucket.try_acquire()
+    await bucket.refund(100)
+    assert bucket.available == 5  # noqa: PLR2004
+
+
+async def test_zero_or_negative_refund_is_a_noop() -> None:
+    """Refunding zero or a negative amount does nothing."""
+    bucket = _RetryBudget(capacity=5)
+    await bucket.try_acquire()
+    await bucket.refund(0)
+    await bucket.refund(-3)
+    assert bucket.available == 4  # noqa: PLR2004
+
+
+async def test_cost_n_then_refund_n_is_net_zero() -> None:
+    """Acquiring N and refunding N leaves the bucket at capacity."""
+    bucket = _RetryBudget(capacity=10)
+    for _ in range(5):
+        await bucket.try_acquire()
+    await bucket.refund(5)
+    assert bucket.available == 10  # noqa: PLR2004
+
+
+def test_zero_capacity_is_rejected() -> None:
+    """Capacity must be positive."""
+    with pytest.raises(ValueError, match="capacity"):
+        _RetryBudget(capacity=0)
+
+
+async def test_lock_serialises_concurrent_acquires() -> None:
+    """Concurrent `try_acquire` never double-counts."""
+    bucket = _RetryBudget(capacity=5)
+
+    async def grab() -> bool:
+        return await bucket.try_acquire()
+
+    results = await asyncio.gather(*(grab() for _ in range(10)))
+    assert sum(results) == 5  # noqa: PLR2004
+    assert bucket.available == 0

--- a/tests/resilience/shield/test_shield.py
+++ b/tests/resilience/shield/test_shield.py
@@ -128,6 +128,39 @@ async def test_resilience_error_propagates_without_retry() -> None:
     assert attempts["count"] == 1
 
 
+async def test_resilience_error_skips_cache_and_fallback() -> None:
+    """`ResilienceError` bypasses every recovery path and carries no note."""
+
+    class _BlowUpError(ResilienceError):
+        pass
+
+    class _StubCache:
+        async def get(self, _key: str) -> str:
+            return "should-not-be-returned"
+
+        async def set(self, _key: str, _value: str) -> None:
+            return None
+
+    async def synth(_exc: BaseException) -> str:
+        return "fallback-value"
+
+    s = Shield.api(
+        "rescue",
+        timeout_errors=(TimeoutError,),
+        cache=_StubCache(),
+        fallback=synth,
+    )
+
+    boom_msg = "nope"
+
+    async def boom() -> None:
+        raise _BlowUpError(boom_msg)
+
+    with pytest.raises(_BlowUpError) as exc_info:
+        await s.run(boom)
+    assert not getattr(exc_info.value, "__notes__", [])
+
+
 async def test_base_exception_propagates_without_retry() -> None:
     """`BaseException` outside `Exception` is never retried."""
     s = _shield()

--- a/tests/resilience/shield/test_shield.py
+++ b/tests/resilience/shield/test_shield.py
@@ -1,0 +1,249 @@
+"""Shield class and execution tests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from grelmicro.resilience import ApiShieldConfig, Shield
+from grelmicro.resilience.errors import ResilienceError
+
+
+class _SignalError(Exception):
+    """Test-only retryable error used as a `timeout_errors` member."""
+
+
+class _PermanentError(Exception):
+    """Test-only non-retryable error."""
+
+
+def _shield(**overrides: Any) -> Shield:  # noqa: ANN401
+    """Build an api-profile Shield with deterministic test sources."""
+    return Shield.api(
+        "test",
+        timeout_errors=(_SignalError,),
+        **overrides,
+    )
+
+
+async def test_success_path_no_retry_refunds_one() -> None:
+    """Success without a retry refunds 1 token, clamped at capacity."""
+    s = _shield()
+    starting = s._retry_budget.available
+    # Drain one slot first so a refund has somewhere to go.
+    await s._retry_budget.try_acquire()
+    assert s._retry_budget.available == starting - 1
+
+    async def ok() -> str:
+        return "ok"
+
+    assert await s.run(ok) == "ok"
+    # Refund of 1 happened, bringing us back to starting.
+    assert s._retry_budget.available == starting
+
+
+async def test_single_retry_then_success_net_zero_budget() -> None:
+    """One retry consumed and recovered yields net zero budget change."""
+    s = _shield()
+    capacity = s._retry_budget.capacity
+
+    attempts = {"count": 0}
+
+    async def flaky() -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise _SignalError
+        return "done"
+
+    assert await s.run(flaky) == "done"
+    assert attempts["count"] == 2  # noqa: PLR2004
+    assert s._retry_budget.available == capacity
+
+
+async def test_attempts_exhausted_attaches_pep_678_note() -> None:
+    """All four attempts fail. The final exception carries a `shield:` note."""
+    s = _shield()
+
+    async def always_fails() -> None:
+        raise _SignalError
+
+    with pytest.raises(_SignalError) as exc_info:
+        await s.run(always_fails)
+    notes = exc_info.value.__notes__
+    assert any("shield: " in note for note in notes)
+    assert any(
+        "attempts exhausted" in note or "budget" in note for note in notes
+    )
+    assert any("api profile" in note for note in notes)
+
+
+async def test_budget_exhausted_stops_loop_silently() -> None:
+    """An empty budget surfaces the failure with the budget note."""
+    s = _shield()
+    # Drain the budget by acquiring every token directly.
+    while await s._retry_budget.try_acquire():
+        pass
+
+    async def always_fails() -> None:
+        raise _SignalError
+
+    with pytest.raises(_SignalError) as exc_info:
+        await s.run(always_fails)
+    notes = exc_info.value.__notes__
+    assert any("budget exhausted" in note for note in notes)
+
+
+async def test_non_timeout_exception_propagates_without_retry() -> None:
+    """Non-`timeout_errors` Exception propagates immediately."""
+    s = _shield()
+    attempts = {"count": 0}
+
+    async def boom() -> None:
+        attempts["count"] += 1
+        raise _PermanentError
+
+    with pytest.raises(_PermanentError):
+        await s.run(boom)
+    assert attempts["count"] == 1
+
+
+async def test_resilience_error_propagates_without_retry() -> None:
+    """`ResilienceError` subclasses propagate immediately."""
+
+    class _BlowUpError(ResilienceError):
+        pass
+
+    s = _shield()
+    attempts = {"count": 0}
+    blowup_msg = "nope"
+
+    async def boom() -> None:
+        attempts["count"] += 1
+        raise _BlowUpError(blowup_msg)
+
+    with pytest.raises(_BlowUpError):
+        await s.run(boom)
+    assert attempts["count"] == 1
+
+
+async def test_base_exception_propagates_without_retry() -> None:
+    """`BaseException` outside `Exception` is never retried."""
+    s = _shield()
+    attempts = {"count": 0}
+
+    async def boom() -> None:
+        attempts["count"] += 1
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await s.run(boom)
+    assert attempts["count"] == 1
+
+
+async def test_timeout_errors_tuple_merged_with_timeout_error() -> None:
+    """Both user types and `TimeoutError` are retryable."""
+    s = Shield.api("merged", timeout_errors=(_SignalError,))
+    attempts = {"count": 0}
+
+    async def flaky() -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise TimeoutError
+        return "ok"
+
+    assert await s.run(flaky) == "ok"
+    assert attempts["count"] == 2  # noqa: PLR2004
+
+
+async def test_decorator_form_works() -> None:
+    """The `@shield_instance` decorator wraps async functions."""
+    s = _shield()
+
+    @s
+    async def call() -> str:
+        return "x"
+
+    assert await call() == "x"
+
+
+async def test_decorator_rejects_sync_functions() -> None:
+    """Sync functions cannot be wrapped by Shield."""
+    s = _shield()
+    with pytest.raises(TypeError, match="async"):
+        s(lambda: None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+async def test_run_rejects_sync_functions() -> None:
+    """`Shield.run` raises a clear error for sync callables."""
+    s = _shield()
+    with pytest.raises(TypeError, match="async"):
+        await s.run(lambda: None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+async def test_state_shared_across_calls_through_one_instance() -> None:
+    """Two functions wrapped by one Shield share the same budget."""
+    s = _shield()
+    capacity = s._retry_budget.capacity
+
+    @s
+    async def fail() -> None:
+        raise _SignalError
+
+    with pytest.raises(_SignalError):
+        await fail()
+    # Three retries got consumed on the failed call (no recovered retries).
+    assert s._retry_budget.available == capacity - 3
+
+
+async def test_from_config_constructs_instance() -> None:
+    """`Shield.from_config` accepts a pre-built profile config."""
+    config = ApiShieldConfig(timeout_errors=(_SignalError,))
+    s = Shield.from_config("by_config", config)
+    assert s.name == "by_config"
+    assert s.config is config
+
+
+async def test_name_is_required_on_factory() -> None:
+    """`Shield.api(name)` requires the name positionally."""
+    with pytest.raises(TypeError):
+        Shield.api()  # type: ignore[call-arg]  # ty: ignore[missing-argument]
+
+
+async def test_pep_678_note_format() -> None:
+    """The note follows the documented format."""
+    s = _shield()
+
+    async def always_fails() -> None:
+        raise _SignalError
+
+    with pytest.raises(_SignalError) as exc_info:
+        await s.run(always_fails)
+    notes = exc_info.value.__notes__
+    note = next(n for n in notes if n.startswith("shield: "))
+    # Format: shield: <reason> after <n>/4 attempts in <e>s (api profile)
+    assert "after" in note
+    assert "/4 attempts" in note
+    assert "(api profile)" in note
+
+
+async def test_run_accepts_functools_partial() -> None:
+    """`functools.partial` of an async function is recognised."""
+    import functools  # noqa: PLC0415
+
+    s = _shield()
+
+    async def add(x: int, y: int) -> int:
+        return x + y
+
+    bound = functools.partial(add, 1)
+    assert await s.run(bound, 2) == 3  # noqa: PLR2004
+
+
+async def test_reconfigure_swaps_state() -> None:
+    """`reconfigure` publishes a fresh config and rebuilds derived state."""
+    s = _shield()
+    new = ApiShieldConfig(timeout_errors=(_SignalError,), max_rate=42.0)
+    await s.reconfigure(new)
+    assert s.config.max_rate == 42.0  # noqa: PLR2004

--- a/tests/resilience/shield/test_shield.py
+++ b/tests/resilience/shield/test_shield.py
@@ -31,23 +31,23 @@ def _shield(**overrides: Any) -> Shield:  # noqa: ANN401
 async def test_success_path_no_retry_refunds_one() -> None:
     """Success without a retry refunds 1 token, clamped at capacity."""
     s = _shield()
-    starting = s._retry_budget.available
+    starting = s._state.retry_budget.available
     # Drain one slot first so a refund has somewhere to go.
-    await s._retry_budget.try_acquire()
-    assert s._retry_budget.available == starting - 1
+    await s._state.retry_budget.try_acquire()
+    assert s._state.retry_budget.available == starting - 1
 
     async def ok() -> str:
         return "ok"
 
     assert await s.run(ok) == "ok"
     # Refund of 1 happened, bringing us back to starting.
-    assert s._retry_budget.available == starting
+    assert s._state.retry_budget.available == starting
 
 
 async def test_single_retry_then_success_net_zero_budget() -> None:
     """One retry consumed and recovered yields net zero budget change."""
     s = _shield()
-    capacity = s._retry_budget.capacity
+    capacity = s._state.retry_budget.capacity
 
     attempts = {"count": 0}
 
@@ -59,7 +59,7 @@ async def test_single_retry_then_success_net_zero_budget() -> None:
 
     assert await s.run(flaky) == "done"
     assert attempts["count"] == 2  # noqa: PLR2004
-    assert s._retry_budget.available == capacity
+    assert s._state.retry_budget.available == capacity
 
 
 async def test_attempts_exhausted_attaches_pep_678_note() -> None:
@@ -83,7 +83,7 @@ async def test_budget_exhausted_stops_loop_silently() -> None:
     """An empty budget surfaces the failure with the budget note."""
     s = _shield()
     # Drain the budget by acquiring every token directly.
-    while await s._retry_budget.try_acquire():
+    while await s._state.retry_budget.try_acquire():
         pass
 
     async def always_fails() -> None:
@@ -185,7 +185,7 @@ async def test_run_rejects_sync_functions() -> None:
 async def test_state_shared_across_calls_through_one_instance() -> None:
     """Two functions wrapped by one Shield share the same budget."""
     s = _shield()
-    capacity = s._retry_budget.capacity
+    capacity = s._state.retry_budget.capacity
 
     @s
     async def fail() -> None:
@@ -194,7 +194,7 @@ async def test_state_shared_across_calls_through_one_instance() -> None:
     with pytest.raises(_SignalError):
         await fail()
     # Three retries got consumed on the failed call (no recovered retries).
-    assert s._retry_budget.available == capacity - 3
+    assert s._state.retry_budget.available == capacity - 3
 
 
 async def test_from_config_constructs_instance() -> None:

--- a/tests/resilience/shield/test_timeout_estimator.py
+++ b/tests/resilience/shield/test_timeout_estimator.py
@@ -1,0 +1,95 @@
+"""Per-attempt timeout estimator tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from grelmicro.resilience.shield._timeout_estimator import _TimeoutEstimator
+
+
+def test_no_samples_returns_initial_clamped() -> None:
+    """Without samples the estimator returns `initial_timeout` clamped."""
+    est = _TimeoutEstimator(
+        initial_timeout=2.0,
+        clamp_min=0.5,
+        clamp_max=10.0,
+    )
+    assert est.estimate() == 2.0  # noqa: PLR2004
+
+
+def test_initial_value_below_floor_is_clamped() -> None:
+    """An initial below `clamp_min` is raised to the floor."""
+    est = _TimeoutEstimator(
+        initial_timeout=0.001,
+        clamp_min=0.5,
+        clamp_max=10.0,
+    )
+    assert est.estimate() == 0.5  # noqa: PLR2004
+
+
+def test_initial_value_above_ceiling_is_clamped() -> None:
+    """An initial above `clamp_max` is dropped to the ceiling."""
+    est = _TimeoutEstimator(
+        initial_timeout=1_000.0,
+        clamp_min=0.5,
+        clamp_max=10.0,
+    )
+    assert est.estimate() == 10.0  # noqa: PLR2004
+
+
+def test_p95_times_2_5_after_samples() -> None:
+    """Estimate = p95 of samples * 2.5, clamped to `[min, max]`."""
+    est = _TimeoutEstimator(
+        initial_timeout=99.0,
+        clamp_min=0.001,
+        clamp_max=999.0,
+    )
+    for value in (0.1, 0.2, 0.3, 0.4, 0.5):
+        est.record(value)
+    # 5 samples -> nearest-rank p95 index = ceil(0.95 * 5) - 1 = 4 -> 0.5.
+    assert est.estimate() == pytest.approx(0.5 * 2.5)
+
+
+def test_ring_buffer_rolls_over_past_32_samples() -> None:
+    """Only the last 32 samples shape the estimate."""
+    est = _TimeoutEstimator(
+        initial_timeout=99.0,
+        clamp_min=0.001,
+        clamp_max=999.0,
+    )
+    # Fill with very high latencies, then with low ones. The high
+    # samples must be evicted by the rollover.
+    for _ in range(40):
+        est.record(100.0)
+    for _ in range(32):
+        est.record(0.1)
+    assert est.estimate() == pytest.approx(0.1 * 2.5)
+
+
+def test_record_ignores_negative_and_non_finite() -> None:
+    """Bad inputs are silently dropped, the estimator stays empty."""
+    est = _TimeoutEstimator(
+        initial_timeout=2.0,
+        clamp_min=0.5,
+        clamp_max=10.0,
+    )
+    est.record(-1.0)
+    est.record(float("inf"))
+    est.record(float("nan"))
+    assert est.estimate() == 2.0  # noqa: PLR2004
+
+
+def test_clamp_bounds_are_validated() -> None:
+    """Constructor rejects non-positive bounds and inverted ranges."""
+    with pytest.raises(ValueError, match="clamp"):
+        _TimeoutEstimator(
+            initial_timeout=1.0,
+            clamp_min=0.0,
+            clamp_max=10.0,
+        )
+    with pytest.raises(ValueError, match="clamp_min"):
+        _TimeoutEstimator(
+            initial_timeout=1.0,
+            clamp_min=10.0,
+            clamp_max=1.0,
+        )

--- a/tests/resilience/test_errors.py
+++ b/tests/resilience/test_errors.py
@@ -32,6 +32,7 @@ def test_circuit_breaker_error() -> None:
 def test_resilience_module_exports() -> None:
     """Test resilience module __all__ contains expected symbols."""
     expected = {
+        "ApiShieldConfig",
         "CircuitBreakers",
         "CircuitBreaker",
         "CircuitBreakerBackend",
@@ -49,6 +50,7 @@ def test_resilience_module_exports() -> None:
         "FallbackConfig",
         "FallbackResult",
         "FibonacciBackoff",
+        "InternalShieldConfig",
         "LinearBackoff",
         "Match",
         "Matcher",
@@ -74,7 +76,10 @@ def test_resilience_module_exports() -> None:
         "RetryBackoffConfig",
         "RetryConfig",
         "RetryStrategy",
+        "Shield",
+        "ShieldConfig",
         "SlidingWindowConfig",
+        "SlowShieldConfig",
         "Timeout",
         "TimeoutConfig",
         "TokenBucketConfig",
@@ -82,6 +87,7 @@ def test_resilience_module_exports() -> None:
         "falling_back",
         "retry",
         "retrying",
+        "shield",
     }
     assert set(resilience_mod.__all__) == expected
 


### PR DESCRIPTION
## Summary

Closes #249. Adds `Shield`, the outer-layer resilience primitive for one async call to one dependency. Bundles per-attempt adaptive timeout, exponential-jittered retry gated by a consecutive-failure budget, and a CUBIC-style adaptive rate limiter that engages only after sustained slow-downs. One decorator, one knob (`timeout_errors=`).

```python
@shield.api(timeout_errors=(httpx.TimeoutException, httpx.ConnectError))
async def fetch(url: str) -> bytes: ...
```

Three profiles ship (`internal`, `api`, `slow`). Algorithm parameters are profile-fixed (CUBIC C=0.4, β=0.7; 4 attempts; p95×2.5 over the last 32 successes; exponential full jitter). The only user knobs are `timeout_errors`, `max_rate`, `cache`, `cache_key`, `fallback`, `name`.

Cache + fallback chain on give-up: cache hit → cached value, cache miss → fallback callable, neither → raise with a PEP 678 note.

## File layout

```
grelmicro/resilience/shield/
├── __init__.py
├── _profile.py            # _BaseShieldConfig (public fields)
├── _internal.py / _api.py / _slow.py  # discriminated profile configs
├── _retry_budget.py       # asyncio.Lock-protected counter + refunds
├── _adaptive_gate.py      # token bucket + CUBIC controller + measured-rate clocker
├── _timeout_estimator.py  # 32-slot p95×2.5 ring buffer
├── _key.py                # stable_hash + default_cache_key
├── _shield.py             # Shield class
└── _decorator.py          # module-level @shield with .internal/.api/.slow
```

## Spec ambiguities resolved

1. Cache miss = `cache.get(key)` returns `None`. Distinguished from "cached None" by sentinel inside the helper.
2. Adaptive bucket zeros tokens on first slow-down so the new ceiling engages immediately.
3. Measured-rate clamp returns `inf` (disengaged) with fewer than 2 samples.
4. Refund-on-recovery refunds the total retries actually consumed on that call.
5. `Shield.run(sync_fn)` raises `TypeError` with a hint about `asyncio.to_thread`.
6. CUBIC shrink fires per failed attempt (matches the spec wording).
7. Reconfigure builds fresh helpers; in-flight calls keep their captured snapshot.

## Scope

In scope:
- Three profiles, factory classmethods, `Shield.from_config`, `Shield.run`, `Shield.__call__`.
- Module-level `shield` decorator (`@shield`, `@shield.internal/api/slow`).
- Cache + fallback chain.
- Live reconfigure.
- Env loading via `GREL_SHIELD_{NAME_UPPER}_*`.
- Snippets convert all inline code blocks in `shield.md`.

Out of scope (per spec): hedged requests, distributed retry budget, deadline propagation, HTTP status sniffing, sync support.

## Test plan

- [x] 95 new tests under `tests/resilience/shield/` covering profile defaults, retry budget refunds, CUBIC numbers pinned to formulas, p95 estimator window, classification table, cache fallback chain, decorator forms, env loading.
- [x] `pytest tests/resilience/shield/` — 95 passed, 100% coverage on the new package.
- [x] `pytest` (full suite) — 1869 passed.
- [x] `ruff check .` clean.
- [x] `ty check` clean for Shield code.
- [x] `mkdocs build --strict` passes.
- [ ] First Copilot review pass.