### PR TITLE
✨ R1 Public API: TTLCacheConfig, minimal example, fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,9 +110,10 @@ The rules below are the ones the tooling can't check:
 - Every configuration class is
   `BaseModel, frozen=True, extra="forbid"`.
 - Every field is annotated with `Annotated[type, Doc("...")]`.
-- For discriminated unions, include a `type: Literal["..."]`
+- For discriminated unions, include a `kind: Literal["..."]`
   discriminator field and wrap the union with
-  `Annotated[A | B, Discriminator("type")]`.
+  `Annotated[A | B, Discriminator("kind")]`. `kind` avoids
+  shadowing the Python `type` builtin on every config object.
 - Expose the config through a `@property def config(self) -> XConfig`
   on the front-door class.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See the [Installation guide](https://grelinfo.github.io/grelmicro/installation/)
 The smallest grelmicro program: a FastAPI route protected by a process-local rate limiter. No `Grelmicro(...)`, no Redis, no lifespan.
 
 ```python
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 
 from grelmicro.resilience import RateLimitExceededError, RateLimiter
 
@@ -83,9 +83,9 @@ api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
 
 
 @app.get("/ping")
-async def ping() -> dict[str, str]:
+async def ping(request: Request) -> dict[str, str]:
     try:
-        await api_limiter.acquire()
+        await api_limiter.acquire_or_raise(key=request.client.host)
     except RateLimitExceededError:
         return {"status": "throttled"}
     return {"status": "ok"}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ See the [Installation guide](https://grelinfo.github.io/grelmicro/installation/)
 
 ## Example
 
+### One route, one primitive
+
+The smallest grelmicro program: a FastAPI route protected by a process-local rate limiter. No `Grelmicro(...)`, no Redis, no lifespan.
+
+```python
+from fastapi import FastAPI
+
+from grelmicro.resilience import RateLimitExceededError, RateLimiter
+
+app = FastAPI()
+api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
+
+
+@app.get("/ping")
+async def ping() -> dict[str, str]:
+    try:
+        await api_limiter.acquire()
+    except RateLimitExceededError:
+        return {"status": "throttled"}
+    return {"status": "ok"}
+```
+
+That is the whole thing. Pick a primitive, name it, call it. Swap to a fleet-wide backend later by composing it inside `Grelmicro(uses=[redis, RateLimiters(redis)])` as shown below.
+
 ### FastAPI integration
 
 Create a file `main.py` with:
@@ -86,9 +110,9 @@ from grelmicro.log import configure as configure_logging
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience import (
     CircuitBreaker,
-    RateLimit,
     RateLimitExceededError,
     RateLimiter,
+    RateLimiters,
 )
 from grelmicro.sync import LeaderElection, Lock, Sync
 from grelmicro.task import Tasks
@@ -107,7 +131,7 @@ micro = Grelmicro(uses=[
     redis,
     Sync(redis),
     Cache(redis),
-    RateLimit(redis),
+    RateLimiters(redis),
     tasks,
     health,
 ])
@@ -190,7 +214,7 @@ def leader_only_task():
 The key shape:
 
 - **One container, one lifespan.** `Grelmicro(uses=[...])` lists every Provider, Component, and active manager. `async with micro:` opens them all in order, closes in reverse.
-- **One Provider, many Components.** `Sync(redis)`, `Cache(redis)`, `RateLimit(redis)` all share the same `RedisProvider` pool. The Provider holds the connection, the Components attach to it.
+- **One Provider, many Components.** `Sync(redis)`, `Cache(redis)`, `RateLimiters(redis)` all share the same `RedisProvider` pool. The Provider holds the connection, the Components attach to it.
 - **Patterns are declared at module load.** `Lock("cart")`, `TTLCache(ttl=60)`, `CircuitBreaker("svc")` carry no backend reference. They resolve through the active app inside `async with`. The same `Lock` works in production with Redis and in tests with `MemorySyncAdapter`, no rewiring.
 - **Pay only for what you import.** `import grelmicro` does not pull in `redis`, `psycopg`, or any other vendor SDK. First-party Providers live under `grelmicro.providers.{vendor}` and load only when you import them.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See the [Installation guide](https://grelinfo.github.io/grelmicro/installation/)
 The smallest grelmicro program: a FastAPI route protected by a process-local rate limiter. No `Grelmicro(...)`, no Redis, no lifespan.
 
 ```python
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 
 from grelmicro.resilience import RateLimitExceededError, RateLimiter
 
@@ -83,9 +83,9 @@ api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
 
 
 @app.get("/ping")
-async def ping(request: Request) -> dict[str, str]:
+async def ping() -> dict[str, str]:
     try:
-        await api_limiter.acquire_or_raise(key=request.client.host)
+        await api_limiter.acquire_or_raise(key="global")
     except RateLimitExceededError:
         return {"status": "throttled"}
     return {"status": "ok"}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,13 @@
 ### Features
 
 * ✨ Add `Shield` resilience pattern: per-attempt timeout, retry-budget-gated retries, CUBIC-style adaptive rate limiter, optional cache and fallback recovery paths. Three profiles (`internal`, `api`, `slow`) cover the common cases. Decorator (`@shield`, `@shield.api(...)`), class (`Shield.api("name")`), and imperative (`Shield.api("name").run(fn, ...)`) forms supported. Issue [#249](https://github.com/grelinfo/grelmicro/issues/249).
+* ✨ Add `TTLCacheConfig` and expose it via `TTLCache.config`. Matches the frozen-config shape used by every other primitive.
+
+### Docs
+
+* 📝 Lead `README.md` and `docs/index.md` with a one-route, one-primitive FastAPI example before the full composition demo.
+* 📝 Annotate `Grelmicro.use`, `Grelmicro.get`, `instrument`, and `CacheBackend` protocol parameters with `Annotated[..., Doc(...)]`.
+* 📝 Align the `CONTRIBUTING.md` discriminator rule with the code: `kind` (not `type`).
 
 ## 0.25.0 - 2026-05-21
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ See the [Installation guide](https://grelinfo.github.io/grelmicro/installation/)
 The smallest grelmicro program: a FastAPI route protected by a process-local rate limiter. No `Grelmicro(...)`, no Redis, no lifespan.
 
 ```python
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 
 from grelmicro.resilience import RateLimitExceededError, RateLimiter
 
@@ -83,9 +83,9 @@ api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
 
 
 @app.get("/ping")
-async def ping() -> dict[str, str]:
+async def ping(request: Request) -> dict[str, str]:
     try:
-        await api_limiter.acquire()
+        await api_limiter.acquire_or_raise(key=request.client.host)
     except RateLimitExceededError:
         return {"status": "throttled"}
     return {"status": "ok"}

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,30 @@ See the [Installation guide](https://grelinfo.github.io/grelmicro/installation/)
 
 ## Example
 
+### One route, one primitive
+
+The smallest grelmicro program: a FastAPI route protected by a process-local rate limiter. No `Grelmicro(...)`, no Redis, no lifespan.
+
+```python
+from fastapi import FastAPI
+
+from grelmicro.resilience import RateLimitExceededError, RateLimiter
+
+app = FastAPI()
+api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
+
+
+@app.get("/ping")
+async def ping() -> dict[str, str]:
+    try:
+        await api_limiter.acquire()
+    except RateLimitExceededError:
+        return {"status": "throttled"}
+    return {"status": "ok"}
+```
+
+That is the whole thing. Pick a primitive, name it, call it. Swap to a fleet-wide backend later by composing it inside `Grelmicro(uses=[redis, RateLimiters(redis)])` as shown below.
+
 ### FastAPI integration
 
 Create a file `main.py` with:
@@ -86,9 +110,9 @@ from grelmicro.log import configure as configure_logging
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience import (
     CircuitBreaker,
-    RateLimit,
     RateLimitExceededError,
     RateLimiter,
+    RateLimiters,
 )
 from grelmicro.sync import LeaderElection, Lock, Sync
 from grelmicro.task import Tasks
@@ -107,7 +131,7 @@ micro = Grelmicro(uses=[
     redis,
     Sync(redis),
     Cache(redis),
-    RateLimit(redis),
+    RateLimiters(redis),
     tasks,
     health,
 ])
@@ -190,7 +214,7 @@ def leader_only_task():
 The key shape:
 
 - **One container, one lifespan.** `Grelmicro(uses=[...])` lists every Provider, Component, and active manager. `async with micro:` opens them all in order, closes in reverse.
-- **One Provider, many Components.** `Sync(redis)`, `Cache(redis)`, `RateLimit(redis)` all share the same `RedisProvider` pool. The Provider holds the connection, the Components attach to it.
+- **One Provider, many Components.** `Sync(redis)`, `Cache(redis)`, `RateLimiters(redis)` all share the same `RedisProvider` pool. The Provider holds the connection, the Components attach to it.
 - **Patterns are declared at module load.** `Lock("cart")`, `TTLCache(ttl=60)`, `CircuitBreaker("svc")` carry no backend reference. They resolve through the active app inside `async with`. The same `Lock` works in production with Redis and in tests with `MemorySyncAdapter`, no rewiring.
 - **Pay only for what you import.** `import grelmicro` does not pull in `redis`, `psycopg`, or any other vendor SDK. First-party Providers live under `grelmicro.providers.{vendor}` and load only when you import them.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ See the [Installation guide](https://grelinfo.github.io/grelmicro/installation/)
 The smallest grelmicro program: a FastAPI route protected by a process-local rate limiter. No `Grelmicro(...)`, no Redis, no lifespan.
 
 ```python
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 
 from grelmicro.resilience import RateLimitExceededError, RateLimiter
 
@@ -83,9 +83,9 @@ api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
 
 
 @app.get("/ping")
-async def ping(request: Request) -> dict[str, str]:
+async def ping() -> dict[str, str]:
     try:
-        await api_limiter.acquire_or_raise(key=request.client.host)
+        await api_limiter.acquire_or_raise(key="global")
     except RateLimitExceededError:
         return {"status": "throttled"}
     return {"status": "ok"}

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -121,7 +121,21 @@ class Grelmicro:
         except LookupError as exc:
             raise NoActiveAppError from exc
 
-    def use(self, item: AbstractAsyncContextManager[object]) -> None:
+    def use(
+        self,
+        item: Annotated[
+            AbstractAsyncContextManager[object],
+            Doc(
+                """
+                The item to register and lifecycle with the app. A `Component`
+                instance is indexed under `(kind, name)` and exposed on
+                `micro.<kind>`. A first-party backend is auto-wrapped into its
+                matching `Component`. Any other async context manager is just
+                lifecycled, and the caller keeps the reference.
+                """,
+            ),
+        ],
+    ) -> None:
         """Register an item to be lifecycled with the app.
 
         Three shapes are accepted:
@@ -188,7 +202,30 @@ class Grelmicro:
             self._by_kind[component.kind] = component
         self._items.append(component)
 
-    def get(self, kind: str, name: str = "default") -> Any:  # noqa: ANN401
+    def get(
+        self,
+        kind: Annotated[
+            str,
+            Doc(
+                """
+                Component category, matching the `kind` class attribute on
+                the registered component (`"sync"`, `"cache"`, `"ratelimiter"`,
+                `"circuitbreaker"`, `"log"`, `"trace"`, `"tasks"`, `"health"`).
+                """,
+            ),
+        ],
+        name: Annotated[
+            str,
+            Doc(
+                """
+                Component instance name. `"default"` matches the entry that
+                also backs `micro.<kind>`. Pass the explicit name to resolve
+                a secondary registration such as
+                `Sync(backend, name="analytics")`.
+                """,
+            ),
+        ] = "default",
+    ) -> Any:  # noqa: ANN401
         """Resolve a registered component by `(kind, name)`.
 
         Returns `Any` for the same reason `micro.<kind>` does: the dynamic

--- a/grelmicro/cache/__init__.py
+++ b/grelmicro/cache/__init__.py
@@ -10,7 +10,7 @@ from grelmicro.cache.serializers import (
     PickleSerializer,
     PydanticSerializer,
 )
-from grelmicro.cache.ttl import CacheInfo, TTLCache
+from grelmicro.cache.ttl import CacheInfo, TTLCache, TTLCacheConfig
 
 __all__ = [
     "Cache",
@@ -23,5 +23,6 @@ __all__ = [
     "PickleSerializer",
     "PydanticSerializer",
     "TTLCache",
+    "TTLCacheConfig",
     "cached",
 ]

--- a/grelmicro/cache/_protocol.py
+++ b/grelmicro/cache/_protocol.py
@@ -1,7 +1,9 @@
 """Cache Backend Protocol."""
 
 from types import TracebackType
-from typing import Protocol, Self, runtime_checkable
+from typing import Annotated, Protocol, Self, runtime_checkable
+
+from typing_extensions import Doc
 
 
 @runtime_checkable
@@ -30,18 +32,50 @@ class CacheBackend(Protocol):
         """Close the backend connection."""
         ...
 
-    async def get(self, *, key: str) -> bytes | None:
+    async def get(
+        self,
+        *,
+        key: Annotated[
+            str,
+            Doc("Fully qualified cache key, already namespaced by `TTLCache`."),
+        ],
+    ) -> bytes | None:
         """Get raw bytes by key.
 
         Returns None if the key is missing or expired.
         """
         ...
 
-    async def set(self, *, key: str, value: bytes, ttl: float) -> None:
+    async def set(
+        self,
+        *,
+        key: Annotated[
+            str,
+            Doc("Fully qualified cache key, already namespaced by `TTLCache`."),
+        ],
+        value: Annotated[
+            bytes,
+            Doc("Serialized payload to store. Opaque to the backend."),
+        ],
+        ttl: Annotated[
+            float,
+            Doc(
+                "Time-to-live in seconds. The backend must drop the entry once"
+                " this many seconds have elapsed since the write."
+            ),
+        ],
+    ) -> None:
         """Store raw bytes with a TTL in seconds."""
         ...
 
-    async def delete(self, *, key: str) -> None:
+    async def delete(
+        self,
+        *,
+        key: Annotated[
+            str,
+            Doc("Fully qualified cache key. No-op if absent."),
+        ],
+    ) -> None:
         """Delete a key (no-op if absent)."""
         ...
 

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -86,7 +86,9 @@ class TTLCache(Generic[T]):
     for typed caching.
 
     Raises:
-        ValueError: If maxsize is negative or ttl is not positive.
+        pydantic.ValidationError: If `maxsize` is negative or `ttl` is not
+            positive. `ValidationError` is a subclass of `ValueError`, so
+            existing `except ValueError:` blocks still catch it.
     """
 
     def __init__(

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Any, Generic
 
+from pydantic import BaseModel, NonNegativeInt, PositiveFloat
 from typing_extensions import Doc, TypeVar
 
 from grelmicro._app import Grelmicro
@@ -15,6 +16,36 @@ if TYPE_CHECKING:
     from grelmicro.cache.serializers import CacheSerializer
 
 T = TypeVar("T", default=Any)
+
+
+class TTLCacheConfig(BaseModel, frozen=True, extra="forbid"):
+    """Frozen snapshot of the `TTLCache` declarative settings.
+
+    Carries the settings that round-trip in serialized form. Runtime
+    dependencies (`backend`, `serializer`) stay as constructor kwargs
+    on `TTLCache` since they are object references, not values.
+    """
+
+    maxsize: Annotated[
+        NonNegativeInt,
+        Doc(
+            """
+            Maximum number of entries tracked locally for LRU eviction.
+            `0` disables the cap and the LRU bookkeeping. Only enforced
+            in-process: a shared backend may still hold more entries.
+            """,
+        ),
+    ] = 0
+
+    ttl: Annotated[
+        PositiveFloat,
+        Doc(
+            """
+            Default TTL in seconds applied when `set` is called without
+            a per-entry override.
+            """,
+        ),
+    ] = 60
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,15 +139,12 @@ class TTLCache(Generic[T]):
         ] = None,
     ) -> None:
         """Initialize the cache."""
-        if maxsize < 0:
-            msg = "maxsize must be non-negative"
-            raise ValueError(msg)
-        if ttl <= 0:
-            msg = "ttl must be positive"
-            raise ValueError(msg)
-
-        self._maxsize = maxsize
-        self._ttl = ttl
+        self._config = TTLCacheConfig(maxsize=maxsize, ttl=ttl)
+        # Snapshot the validated config to instance attributes so the
+        # hot path (`get`, `set`) reads a single attribute instead of
+        # walking through `self._config.<field>`.
+        self._maxsize = self._config.maxsize
+        self._ttl = self._config.ttl
         self._backend = backend
         self._serializer = serializer
         self._hits = 0
@@ -124,6 +152,11 @@ class TTLCache(Generic[T]):
         self._evictions = 0
         # LRU tracking (OrderedDict for O(1) move_to_end / popitem)
         self._keys: OrderedDict[str, None] = OrderedDict()
+
+    @property
+    def config(self) -> TTLCacheConfig:
+        """Return the frozen config snapshot."""
+        return self._config
 
     def _get_backend(self) -> CacheBackend:
         """Resolve the backend on every call.

--- a/grelmicro/trace/_instrument.py
+++ b/grelmicro/trace/_instrument.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import functools
 import inspect
 import sys
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, overload
+from typing import TYPE_CHECKING, Annotated, Any, ParamSpec, TypeVar, overload
+
+from typing_extensions import Doc
 
 from grelmicro._context import pop_context as _pop_context
 from grelmicro._context import push_context as _push_context
@@ -77,11 +79,46 @@ def instrument(
 
 
 def instrument[**P, R](  # type: ignore[return-value]
-    func: Callable[P, R] | None = None,
+    func: Annotated[
+        Callable[P, R] | None,
+        Doc(
+            """
+            The function to instrument. Bound automatically when `@instrument`
+            is used bare. `None` when called with arguments (`@instrument(...)`)
+            so the inner decorator can wrap the target.
+            """,
+        ),
+    ] = None,
     *,
-    name: str | None = None,
-    skip: AbstractSet[str] | None = None,
-    skip_all: bool = False,
+    name: Annotated[
+        str | None,
+        Doc(
+            """
+            Override the span name. Defaults to the wrapped function's
+            qualified name.
+            """,
+        ),
+    ] = None,
+    skip: Annotated[
+        AbstractSet[str] | None,
+        Doc(
+            """
+            Argument names to exclude from the span attributes and log
+            context. Use this for arguments whose string form may carry
+            sensitive data (tokens, credentials, raw request bodies).
+            """,
+        ),
+    ] = None,
+    skip_all: Annotated[
+        bool,
+        Doc(
+            """
+            If `True`, record no argument values at all. The span is still
+            emitted and the function is still wrapped; only the per-argument
+            attributes are dropped.
+            """,
+        ),
+    ] = False,
 ) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
     """Instrument a function with span context and logging enrichment.
 

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache
+from grelmicro.cache import Cache, TTLCacheConfig
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.serializers import JsonSerializer, PickleSerializer
 from grelmicro.cache.ttl import CacheInfo, TTLCache
@@ -56,22 +56,34 @@ class TestInit:
         assert info.currsize == 0
 
     def test_negative_maxsize_raises(self, backend: MemoryCacheAdapter) -> None:
-        """Test that negative maxsize raises ValueError."""
+        """Test that negative maxsize raises a Pydantic validation error."""
         # Act / Assert
-        with pytest.raises(ValueError, match="maxsize must be non-negative"):
+        with pytest.raises(ValueError, match="maxsize"):
             TTLCache(maxsize=-1, ttl=60, backend=backend)
 
     def test_zero_ttl_raises(self, backend: MemoryCacheAdapter) -> None:
-        """Test that zero ttl raises ValueError."""
+        """Test that zero ttl raises a Pydantic validation error."""
         # Act / Assert
-        with pytest.raises(ValueError, match="ttl must be positive"):
+        with pytest.raises(ValueError, match="ttl"):
             TTLCache(maxsize=10, ttl=0, backend=backend)
 
     def test_negative_ttl_raises(self, backend: MemoryCacheAdapter) -> None:
-        """Test that negative ttl raises ValueError."""
+        """Test that negative ttl raises a Pydantic validation error."""
         # Act / Assert
-        with pytest.raises(ValueError, match="ttl must be positive"):
+        with pytest.raises(ValueError, match="ttl"):
             TTLCache(maxsize=10, ttl=-1, backend=backend)
+
+    def test_config_property(self, backend: MemoryCacheAdapter) -> None:
+        """Test that `config` exposes the frozen `TTLCacheConfig`."""
+        # Arrange / Act
+        cache = TTLCache(maxsize=50, ttl=30, backend=backend)
+
+        # Assert
+        assert isinstance(cache.config, TTLCacheConfig)
+        expected_maxsize = 50
+        expected_ttl = 30
+        assert cache.config.maxsize == expected_maxsize
+        assert cache.config.ttl == expected_ttl
 
     def test_default_backend_resolved_lazily(self) -> None:
         """Test that TTLCache created without backend resolves it lazily."""

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -6,6 +6,7 @@ from time import monotonic
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from grelmicro import Grelmicro
 from grelmicro.cache import Cache, TTLCacheConfig
@@ -58,19 +59,19 @@ class TestInit:
     def test_negative_maxsize_raises(self, backend: MemoryCacheAdapter) -> None:
         """Test that negative maxsize raises a Pydantic validation error."""
         # Act / Assert
-        with pytest.raises(ValueError, match="maxsize"):
+        with pytest.raises(ValidationError, match="maxsize"):
             TTLCache(maxsize=-1, ttl=60, backend=backend)
 
     def test_zero_ttl_raises(self, backend: MemoryCacheAdapter) -> None:
         """Test that zero ttl raises a Pydantic validation error."""
         # Act / Assert
-        with pytest.raises(ValueError, match="ttl"):
+        with pytest.raises(ValidationError, match="ttl"):
             TTLCache(maxsize=10, ttl=0, backend=backend)
 
     def test_negative_ttl_raises(self, backend: MemoryCacheAdapter) -> None:
         """Test that negative ttl raises a Pydantic validation error."""
         # Act / Assert
-        with pytest.raises(ValueError, match="ttl"):
+        with pytest.raises(ValidationError, match="ttl"):
             TTLCache(maxsize=10, ttl=-1, backend=backend)
 
     def test_config_property(self, backend: MemoryCacheAdapter) -> None:


### PR DESCRIPTION
## Summary

Addresses Finding #1-#5 from the R1 Public API Designer road-to-1.0 review.

- ✨ Add `TTLCacheConfig` (frozen Pydantic) and expose it via `TTLCache.config`, matching every other primitive (Finding #5).
- 📝 Add a one-route, one-primitive FastAPI example above the full composition demo in `README.md` and `docs/index.md` (Finding #2).
- 📝 Replace stale `RateLimit` import/usage with `RateLimiters` in both `README.md` and `docs/index.md` (Finding #1).
- 📝 Annotate `Grelmicro.use`, `Grelmicro.get`, `instrument`, and `CacheBackend.{get,set,delete}` parameters with `Annotated[..., Doc(...)]` (Finding #3).
- 📝 Update the `CONTRIBUTING.md` discriminator rule from `type` to `kind` to match the deliberate 0.23.0 rename ([#268](https://github.com/grelinfo/grelmicro/issues/268)) that freed the Python `type` builtin (Finding #4 reversed: code was right, rule was stale).

## Test plan

- [x] `pytest` (1872 passed, +1 new `TTLCacheConfig` test)
- [x] `mkdocs build --strict`
- [x] `ty check` clean on touched modules
- [x] Verified `from grelmicro.resilience import RateLimiters` imports cleanly
- [x] Verified minimal README example imports and constructs without a `Grelmicro(...)` app