### PR TITLE
📝 R2 docs: drop idioms, lifespan-only example, reference landings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ______________________________________________________________________
 
 ## Why grelmicro
 
-grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, Pydantic-validated. The pre-commit hook enforces 100% pytest coverage on every commit.
+grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, Pydantic-validated. A local pre-commit hook gates commits on 100% pytest coverage (`coverage --fail-under=100`).
 
 It is built for any Python application that coordinates work across processes, workers, or replicas. The same primitives serve every **distributed system**, whether you call it **microservices**, a **modular monolith**, or a **self-contained system**. A distributed lock is a distributed lock whether your system is one process or fifty. It fits naturally into **cloud-native applications**, **containerized apps**, and **Kubernetes** deployments.
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
 
 
 @asynccontextmanager
-async def lifespan(app):
+async def lifespan(app: FastAPI):
     async with micro:
         yield
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ______________________________________________________________________
 
 ## Why grelmicro
 
-grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, Pydantic-validated, with 100% pytest coverage on every release.
+grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, Pydantic-validated. The pre-commit hook enforces 100% pytest coverage on every commit.
 
 It is built for any Python application that coordinates work across processes, workers, or replicas. The same primitives serve every **distributed system**, whether you call it **microservices**, a **modular monolith**, or a **self-contained system**. A distributed lock is a distributed lock whether your system is one process or fifty. It fits naturally into **cloud-native applications**, **containerized apps**, and **Kubernetes** deployments.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ______________________________________________________________________
 
 ## Why grelmicro
 
-Stop reinventing the wheel. grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, and battle-tested in production.
+grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, Pydantic-validated, with 100% pytest coverage on every release.
 
 It is built for any Python application that coordinates work across processes, workers, or replicas. The same primitives serve every **distributed system**, whether you call it **microservices**, a **modular monolith**, or a **self-contained system**. A distributed lock is a distributed lock whether your system is one process or fifty. It fits naturally into **cloud-native applications**, **containerized apps**, and **Kubernetes** deployments.
 
@@ -92,6 +92,49 @@ async def ping() -> dict[str, str]:
 ```
 
 That is the whole thing. Pick a primitive, name it, call it. Swap to a fleet-wide backend later by composing it inside `Grelmicro(uses=[redis, RateLimiters(redis)])` as shown below.
+
+### Lifespan with one provider and one component
+
+To make the rate limiter fleet-wide, wrap it in a `Grelmicro` container with one provider and one component, then bind it to FastAPI's lifespan.
+
+```python
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from grelmicro import Grelmicro
+from grelmicro.providers.redis import RedisProvider
+from grelmicro.resilience import (
+    RateLimitExceededError,
+    RateLimiter,
+    RateLimiters,
+)
+
+redis = RedisProvider("redis://localhost:6379/0")
+micro = Grelmicro(uses=[redis, RateLimiters(redis)])
+
+api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
+
+
+@asynccontextmanager
+async def lifespan(app):
+    async with micro:
+        yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/ping")
+async def ping() -> dict[str, str]:
+    try:
+        await api_limiter.acquire_or_raise(key="global")
+    except RateLimitExceededError:
+        return {"status": "throttled"}
+    return {"status": "ok"}
+```
+
+Adding more primitives is the same shape: one extra entry in `uses=[...]`. The full demo below shows what that looks like.
 
 ### FastAPI integration
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,9 @@
 * 📝 Document the per-process scope of `Tasks` and point at `TaskLock` / `LeaderElection` for cluster-wide scheduling.
 * 📝 Add a Kubernetes operational-assumptions section covering RBAC, API server availability, etcd latency, and single-cluster scope to `docs/architecture/kubernetes.md`.
 * 📝 Fix the `sync.md → task.md#tasks` internal anchor so `mkdocs --strict` no longer reports it.
+* 📝 Add a lifespan-only example (one provider, one component) between the minimal example and the full composition demo in `README.md` and `docs/index.md`.
+* 📝 Drop unsupported claims and idioms from the landing copy ("Stop reinventing the wheel", "battle-tested in production", "TL;DR").
+* 📝 Add `Start here` / `Common recipes` lead lines to every page under `docs/reference/`.
 
 ### Internal
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -10,7 +10,7 @@ If you only need a single Pattern, a focused library is often the right pick and
 
 Tone: factual. Where the focused alternative is the better fit, this page says so.
 
-## TL;DR
+## Quick comparison
 
 | If you only need this | Use this | Pick grelmicro when you also need |
 |---|---|---|

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ ______________________________________________________________________
 
 ## Why grelmicro
 
-grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, Pydantic-validated. The pre-commit hook enforces 100% pytest coverage on every commit.
+grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, Pydantic-validated. A local pre-commit hook gates commits on 100% pytest coverage (`coverage --fail-under=100`).
 
 It is built for any Python application that coordinates work across processes, workers, or replicas. The same primitives serve every **distributed system**, whether you call it **microservices**, a **modular monolith**, or a **self-contained system**. A distributed lock is a distributed lock whether your system is one process or fifty. It fits naturally into **cloud-native applications**, **containerized apps**, and **Kubernetes** deployments.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
 
 
 @asynccontextmanager
-async def lifespan(app):
+async def lifespan(app: FastAPI):
     async with micro:
         yield
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ ______________________________________________________________________
 
 ## Why grelmicro
 
-grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, Pydantic-validated, with 100% pytest coverage on every release.
+grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, Pydantic-validated. The pre-commit hook enforces 100% pytest coverage on every commit.
 
 It is built for any Python application that coordinates work across processes, workers, or replicas. The same primitives serve every **distributed system**, whether you call it **microservices**, a **modular monolith**, or a **self-contained system**. A distributed lock is a distributed lock whether your system is one process or fifty. It fits naturally into **cloud-native applications**, **containerized apps**, and **Kubernetes** deployments.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ ______________________________________________________________________
 
 ## Why grelmicro
 
-Stop reinventing the wheel. grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, and battle-tested in production.
+grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, Pydantic-validated, with 100% pytest coverage on every release.
 
 It is built for any Python application that coordinates work across processes, workers, or replicas. The same primitives serve every **distributed system**, whether you call it **microservices**, a **modular monolith**, or a **self-contained system**. A distributed lock is a distributed lock whether your system is one process or fifty. It fits naturally into **cloud-native applications**, **containerized apps**, and **Kubernetes** deployments.
 
@@ -92,6 +92,49 @@ async def ping() -> dict[str, str]:
 ```
 
 That is the whole thing. Pick a primitive, name it, call it. Swap to a fleet-wide backend later by composing it inside `Grelmicro(uses=[redis, RateLimiters(redis)])` as shown below.
+
+### Lifespan with one provider and one component
+
+To make the rate limiter fleet-wide, wrap it in a `Grelmicro` container with one provider and one component, then bind it to FastAPI's lifespan.
+
+```python
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from grelmicro import Grelmicro
+from grelmicro.providers.redis import RedisProvider
+from grelmicro.resilience import (
+    RateLimitExceededError,
+    RateLimiter,
+    RateLimiters,
+)
+
+redis = RedisProvider("redis://localhost:6379/0")
+micro = Grelmicro(uses=[redis, RateLimiters(redis)])
+
+api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
+
+
+@asynccontextmanager
+async def lifespan(app):
+    async with micro:
+        yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/ping")
+async def ping() -> dict[str, str]:
+    try:
+        await api_limiter.acquire_or_raise(key="global")
+    except RateLimitExceededError:
+        return {"status": "throttled"}
+    return {"status": "ok"}
+```
+
+Adding more primitives is the same shape: one extra entry in `uses=[...]`. The full demo below shows what that looks like.
 
 ### FastAPI integration
 

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -1,5 +1,9 @@
 # Cache
 
+- **Start here**: [Cache guide](../cache.md)
+- **Common recipes**: [`@cached`](../cache.md#cached-decorator), [`TTLCache`](../cache.md#ttlcache)
+- **Configuration**: [Backend setup](../cache.md#backend), [Redis backend configuration](../cache.md#redis-backend-configuration)
+
 ::: grelmicro.cache
     options:
       show_submodules: true

--- a/docs/reference/health.md
+++ b/docs/reference/health.md
@@ -1,5 +1,8 @@
 # Health
 
+- **Start here**: [Health Checks guide](../health.md)
+- **FastAPI integration**: [`health_router`](../health.md) for liveness, readiness, and health endpoints.
+
 ::: grelmicro.health
     options:
       show_submodules: true

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -1,5 +1,8 @@
 # JSON
 
+- **Start here**: [JSON guide](../json.md)
+- **Common recipes**: `json_dumps_bytes`, `json_dumps_str`, `json_loads`. Uses `orjson` when installed, stdlib `json` otherwise.
+
 ::: grelmicro.json
     options:
       members:

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -1,5 +1,8 @@
 # Logging
 
+- **Start here**: [Logging guide](../logging.md)
+- **Common recipes**: [`configure(...)`](../logging.md) for JSON, LOGFMT, TEXT, PRETTY output. Filters: `DuplicateFilter`, `RateLimitFilter`.
+
 ::: grelmicro.log
     options:
       show_submodules: true

--- a/docs/reference/resilience.md
+++ b/docs/reference/resilience.md
@@ -1,5 +1,9 @@
 # Resilience
 
+- **Start here**: [Resilience guide](../resilience/index.md)
+- **Common recipes**: [Rate Limiter](../resilience/rate-limiter.md), [Circuit Breaker](../resilience/circuit-breaker.md), [Retry](../resilience/retry.md), [Fallback](../resilience/fallback.md), [Timeout](../resilience/timeout.md), [Shield](../resilience/shield.md)
+- **Configuration**: [Composing patterns](../resilience/composition.md)
+
 ::: grelmicro.resilience
     options:
       show_submodules: true

--- a/docs/reference/sync.md
+++ b/docs/reference/sync.md
@@ -1,5 +1,9 @@
 # Synchronization
 
+- **Start here**: [Synchronization Primitives guide](../sync.md)
+- **Common recipes**: [`Lock`](../sync.md#lock), [`TaskLock`](../sync.md#task-lock), [`LeaderElection`](../sync.md#leader-election)
+- **Configuration**: [Backend selection](../sync.md#backend), [environment variables](../sync.md#environment-variables)
+
 ::: grelmicro.sync
     options:
       show_submodules: true

--- a/docs/reference/task.md
+++ b/docs/reference/task.md
@@ -1,5 +1,9 @@
 # Task
 
+- **Start here**: [Task Scheduler guide](../task.md)
+- **Common recipes**: [`Tasks`](../task.md#tasks), [`Interval Task`](../task.md#interval-task), [`TaskRouter`](../task.md#task-router)
+- **Cluster-wide**: gate per-process tasks with [`TaskLock`](../sync.md#task-lock) or [`LeaderElection`](../sync.md#leader-election).
+
 ::: grelmicro.task
     options:
       show_submodules: true

--- a/docs/reference/trace.md
+++ b/docs/reference/trace.md
@@ -1,5 +1,8 @@
 # Tracing
 
+- **Start here**: [Tracing guide](../tracing.md)
+- **Common recipes**: `@instrument` to emit spans and enrich log records; `Trace()` component to install an OTel `TracerProvider` for the app's lifetime.
+
 ::: grelmicro.trace
     options:
       show_submodules: true


### PR DESCRIPTION
## Summary

Addresses R2 Documentation & DX findings #4, #7, #10. (Findings #1-#3 were covered by PR #290 / #291.)

### #4 Prose rule compliance
- Drop "Stop reinventing the wheel" and "battle-tested in production" from the landing copy in `README.md` and `docs/index.md`. Replaced with literal claims (100% pytest coverage, Pydantic-validated).
- `docs/comparison.md` "TL;DR" → "Quick comparison".

### #7 Lifespan-only example
- New "Lifespan with one provider and one component" example in `README.md` and `docs/index.md` between the minimal example and the full composition demo. One Redis provider, one `RateLimiters` component, a FastAPI lifespan, one route. Shows the lifespan pattern without piling on every other feature.

### #10 Reference page landings
- Added "Start here / Common recipes / Configuration" lead lines to every page under `docs/reference/`. Quick path back to the guide for readers landing here from search.

## Test plan

- [x] `pytest` (no code changes; tests still pass)
- [x] `mkdocs build --strict` clean (existing INFO about `task.md#task-manager` will clear once PR #291 lands)
- [x] Manual review of new lifespan example: imports correctly, lifespan ordering is right