### PR TITLE
🔒 Follow-up: urlencode query redaction, log exc_info on shutdown

### DIFF
--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -383,16 +383,19 @@ def _redact_query(query: str | None) -> str | None:
     """
     if not query:
         return query
-    from urllib.parse import parse_qsl  # noqa: PLC0415
+    from urllib.parse import parse_qsl, urlencode  # noqa: PLC0415
 
     pairs = parse_qsl(query, keep_blank_values=True)
     if not any(k.lower() in _CREDENTIAL_QUERY_KEYS for k, _ in pairs):
         return query
     redacted = "***"
-    return "&".join(
-        f"{k}={redacted if k.lower() in _CREDENTIAL_QUERY_KEYS else v}"
+    redacted_pairs = [
+        (k, redacted if k.lower() in _CREDENTIAL_QUERY_KEYS else v)
         for k, v in pairs
-    )
+    ]
+    # `safe="*"` keeps the `***` marker readable; other values are
+    # properly escaped by `urlencode`.
+    return urlencode(redacted_pairs, safe="*")
 
 
 def _redact_url(url: str) -> str:

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -355,16 +355,19 @@ def _redact_query(query: str | None) -> str | None:
     """
     if not query:
         return query
-    from urllib.parse import parse_qsl  # noqa: PLC0415
+    from urllib.parse import parse_qsl, urlencode  # noqa: PLC0415
 
     pairs = parse_qsl(query, keep_blank_values=True)
     if not any(k.lower() in _CREDENTIAL_QUERY_KEYS for k, _ in pairs):
         return query
     redacted = "***"
-    return "&".join(
-        f"{k}={redacted if k.lower() in _CREDENTIAL_QUERY_KEYS else v}"
+    redacted_pairs = [
+        (k, redacted if k.lower() in _CREDENTIAL_QUERY_KEYS else v)
         for k, v in pairs
-    )
+    ]
+    # `safe="*"` keeps the `***` marker readable; other values are
+    # properly escaped by `urlencode`.
+    return urlencode(redacted_pairs, safe="*")
 
 
 def _redact_url(url: str) -> str:

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -246,9 +246,8 @@ async def _run_with_timeout(fn: Any, timeout: float) -> bool:  # noqa: ANN401, A
     finished = await loop.run_in_executor(None, done.wait, timeout)
     if finished and captured:
         _logger.warning(
-            "TracerProvider.shutdown raised %s: %s",
-            type(captured[0]).__name__,
-            captured[0],
+            "TracerProvider.shutdown raised an exception; spans may be dropped",
+            exc_info=captured[0],
         )
     return finished
 

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -201,6 +201,8 @@ async def test_trace_shutdown_exception_logged_not_propagated(
         micro.trace.provider.shutdown = _raise  # type: ignore[method-assign]
 
     assert any(
-        "TracerProvider.shutdown raised RuntimeError" in record.message
+        "TracerProvider.shutdown raised an exception" in record.message
+        and record.exc_info is not None
+        and isinstance(record.exc_info[1], RuntimeError)
         for record in caplog.records
     )


### PR DESCRIPTION
## Summary

Address the final two valid Copilot comments on PR #291 that didn't land before merge:

- **`_redact_query` uses `urlencode`**: The manual `&`-join lost URL-encoding for values containing `&`, `=`, spaces, or `%xx` escapes. Switched to `urlencode(pairs, safe="*")` so the `***` redaction marker stays readable while other values are properly escaped.
- **Trace shutdown log includes `exc_info`**: When `TracerProvider.shutdown()` raises inside the daemon thread, the warning now passes `exc_info=` so the traceback is retained for diagnosis.

Tests updated to assert against `record.exc_info`.

## Test plan

- [x] `pytest` (1893 passed)
- [x] `ty check` clean
- [x] Manual: `_redact_url("redis://host/0?foo=hello world&password=secret")` returns `redis://host/0?foo=hello+world&password=***`