### PR TITLE
✅ Add Hypothesis property tests for rate-limiter and exponential backoff

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,7 @@
 
 * 🔧 Drop three unused `ty: ignore` directives in `grelmicro/_json.py`.
 * ✅ Add a guard test that every `_LAZY` key in `grelmicro/resilience/__init__.py` is exported in `__all__` and actually resolves at runtime.
+* ✅ Add Hypothesis property tests for token-bucket and sliding-window math and for exponential backoff jitter bounds.
 
 ## 0.25.0 - 2026-05-21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "pytest>=8.0.0",
+    "hypothesis>=6.100.0",
     "ruff>=0.7.4",
     "testcontainers[postgres,redis]>=4.8.2",
     "pytest-timeout>=2.3.1",

--- a/tests/resilience/backoffs/test_exponential_properties.py
+++ b/tests/resilience/backoffs/test_exponential_properties.py
@@ -1,0 +1,118 @@
+"""Property-based tests for the exponential backoff strategy.
+
+Hypothesis explores random `(base_delay, max_delay, attempt)`
+combinations across every jitter mode and checks the documented
+bounds hold.
+"""
+
+from __future__ import annotations
+
+import random
+from itertools import pairwise
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from grelmicro.resilience.backoffs.exponential import (
+    ExponentialBackoff,
+    _ExponentialStrategy,
+)
+
+pytestmark = [pytest.mark.timeout(5)]
+
+
+_BASES = st.floats(
+    min_value=1e-4, max_value=1.0, allow_nan=False, allow_infinity=False
+)
+_MAX_DELAYS = st.floats(
+    min_value=1.0, max_value=60.0, allow_nan=False, allow_infinity=False
+)
+_ATTEMPTS = st.integers(min_value=1, max_value=30)
+
+
+def _raw(base: float, cap: float, attempt: int) -> float:
+    return min(base * (2 ** (attempt - 1)), cap)
+
+
+@given(base=_BASES, cap=_MAX_DELAYS, attempt=_ATTEMPTS)
+@settings(max_examples=200, deadline=None)
+def test_no_jitter_matches_formula(
+    base: float, cap: float, attempt: int
+) -> None:
+    """Without jitter, delay equals the documented closed form."""
+    config = ExponentialBackoff(base_delay=base, max_delay=cap, jitter="none")
+    strategy = _ExponentialStrategy(config)
+    assert strategy.delay(attempt) == _raw(base, cap, attempt)
+
+
+@given(base=_BASES, cap=_MAX_DELAYS, attempt=_ATTEMPTS)
+@settings(max_examples=200, deadline=None)
+def test_full_jitter_within_zero_and_raw(
+    base: float, cap: float, attempt: int
+) -> None:
+    """`full` jitter samples from `[0, raw]`."""
+    config = ExponentialBackoff(base_delay=base, max_delay=cap, jitter="full")
+    strategy = _ExponentialStrategy(config)
+    random.seed(0)
+    delay = strategy.delay(attempt)
+    assert 0.0 <= delay <= _raw(base, cap, attempt)
+
+
+@given(base=_BASES, cap=_MAX_DELAYS, attempt=_ATTEMPTS)
+@settings(max_examples=200, deadline=None)
+def test_equal_jitter_within_half_raw_and_raw(
+    base: float, cap: float, attempt: int
+) -> None:
+    """`equal` jitter samples from `[raw/2, raw]`."""
+    config = ExponentialBackoff(base_delay=base, max_delay=cap, jitter="equal")
+    strategy = _ExponentialStrategy(config)
+    random.seed(0)
+    delay = strategy.delay(attempt)
+    raw = _raw(base, cap, attempt)
+    assert raw / 2 <= delay <= raw
+
+
+@given(
+    base=_BASES,
+    cap=_MAX_DELAYS,
+    attempts=st.lists(_ATTEMPTS, min_size=1, max_size=10),
+)
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_decorrelated_jitter_stays_in_bounds(
+    base: float, cap: float, attempts: list[int]
+) -> None:
+    """`decorrelated` jitter stays in `[base_delay, max_delay]`."""
+    config = ExponentialBackoff(
+        base_delay=base, max_delay=cap, jitter="decorrelated"
+    )
+    strategy = _ExponentialStrategy(config)
+    random.seed(0)
+    for attempt in attempts:
+        delay = strategy.delay(attempt)
+        assert base <= delay <= cap
+
+
+@given(
+    base=_BASES,
+    cap=_MAX_DELAYS,
+    attempts=st.lists(_ATTEMPTS, min_size=2, max_size=10),
+)
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_no_jitter_raw_is_non_decreasing_with_attempt(
+    base: float, cap: float, attempts: list[int]
+) -> None:
+    """For `jitter=none`, `delay(N+1) >= delay(N)` when both are below cap."""
+    config = ExponentialBackoff(base_delay=base, max_delay=cap, jitter="none")
+    strategy = _ExponentialStrategy(config)
+    delays = [strategy.delay(n) for n in sorted(attempts)]
+    for a, b in pairwise(delays):
+        assert b >= a

--- a/tests/resilience/test_ratelimiter_properties.py
+++ b/tests/resilience/test_ratelimiter_properties.py
@@ -1,0 +1,241 @@
+"""Property-based tests for rate-limiter algorithms.
+
+Hypothesis explores random sequences of operations against the
+public, synchronous `MemoryTokenBucket` and the async strategies
+built by `MemoryRateLimiterAdapter`. The aim is to catch boundary
+math (refill capping, retry hints, monotonic state) that
+example-based tests miss.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from time import monotonic
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
+from grelmicro.resilience.ratelimiter.memory import (
+    MemoryRateLimiterAdapter,
+    MemoryTokenBucket,
+)
+from grelmicro.resilience.ratelimiter.sliding_window import SlidingWindowConfig
+from grelmicro.resilience.ratelimiter.token_bucket import TokenBucketConfig
+
+pytestmark = [pytest.mark.timeout(10)]
+
+
+_CAPACITIES = st.integers(min_value=1, max_value=1000)
+_REFILL_RATES = st.floats(
+    min_value=0.01, max_value=1000.0, allow_nan=False, allow_infinity=False
+)
+_KEYS = st.text(min_size=0, max_size=8)
+
+
+# --- MemoryTokenBucket -------------------------------------------------------
+
+
+@given(capacity=_CAPACITIES, refill_rate=_REFILL_RATES)
+@settings(max_examples=200, deadline=None)
+def test_token_bucket_never_grants_more_than_capacity(
+    capacity: int, refill_rate: float
+) -> None:
+    """Tight burst never grants more than capacity tokens."""
+    bucket = MemoryTokenBucket(capacity=capacity, refill_rate=refill_rate)
+    granted = sum(bucket.try_acquire() for _ in range(capacity + 5))
+    assert capacity <= granted <= capacity + 1
+
+
+@given(
+    capacity=_CAPACITIES,
+    refill_rate=_REFILL_RATES,
+    cost=st.floats(
+        min_value=0.01, max_value=1000.0, allow_nan=False, allow_infinity=False
+    ),
+)
+@settings(max_examples=200, deadline=None)
+def test_token_bucket_rejects_when_cost_exceeds_capacity(
+    capacity: int, refill_rate: float, cost: float
+) -> None:
+    """`cost > capacity` always raises."""
+    assume(cost > capacity)
+    bucket = MemoryTokenBucket(capacity=capacity, refill_rate=refill_rate)
+    with pytest.raises(ValueError, match="cost must be in"):
+        bucket.try_acquire(cost=cost)
+
+
+@given(
+    capacity=_CAPACITIES,
+    refill_rate=st.floats(
+        min_value=0.001, max_value=0.01, allow_nan=False, allow_infinity=False
+    ),
+    keys=st.lists(_KEYS, min_size=1, max_size=20),
+)
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_token_bucket_keys_are_isolated(
+    capacity: int, refill_rate: float, keys: list[str]
+) -> None:
+    """Tokens consumed for one key never affect another."""
+    bucket = MemoryTokenBucket(capacity=capacity, refill_rate=refill_rate)
+    distinct = list(dict.fromkeys(keys))
+    for key in distinct:
+        for _ in range(capacity):
+            assert bucket.try_acquire(key=key) is True
+    # With negligible refill, each key is drained to < 1 token.
+    for key in distinct:
+        tokens = bucket.peek(key=key)
+        assert tokens < 1.0
+
+
+@given(capacity=_CAPACITIES, refill_rate=_REFILL_RATES)
+@settings(max_examples=100, deadline=None)
+def test_token_bucket_peek_never_exceeds_capacity(
+    capacity: int, refill_rate: float
+) -> None:
+    """`peek` after arbitrary refill stays in `[0, capacity]`."""
+    bucket = MemoryTokenBucket(capacity=capacity, refill_rate=refill_rate)
+    bucket.try_acquire()
+    tokens = bucket.peek()
+    assert 0.0 <= tokens <= float(capacity)
+
+
+# --- _MemoryTokenBucket (async strategy via adapter) -------------------------
+
+
+def _run(coro: Coroutine[None, None, None]) -> None:
+    asyncio.new_event_loop().run_until_complete(coro)
+
+
+@given(
+    capacity=st.integers(min_value=1, max_value=100),
+    refill_rate=st.floats(
+        min_value=0.1, max_value=100.0, allow_nan=False, allow_infinity=False
+    ),
+    cost=st.integers(min_value=1, max_value=50),
+)
+@settings(max_examples=100, deadline=None)
+def test_strategy_token_bucket_retry_after_non_negative(
+    capacity: int, refill_rate: float, cost: int
+) -> None:
+    """A denied acquire returns `retry_after >= 0`."""
+    assume(cost <= capacity)
+
+    async def run() -> None:
+        adapter = MemoryRateLimiterAdapter()
+        async with adapter:
+            strategy = adapter.bind(
+                TokenBucketConfig(capacity=capacity, refill_rate=refill_rate)
+            )
+            # Drain to force a denial.
+            while True:
+                result = await strategy.acquire(key="k", cost=cost)
+                if not result.allowed:
+                    assert result.retry_after >= 0
+                    assert result.reset_after >= 0
+                    assert result.remaining <= capacity
+                    return
+
+    _run(run())
+
+
+# --- _MemoryGCRA (sliding window) --------------------------------------------
+
+
+@given(
+    limit=st.integers(min_value=1, max_value=100),
+    window=st.floats(
+        min_value=0.1, max_value=600.0, allow_nan=False, allow_infinity=False
+    ),
+)
+@settings(max_examples=100, deadline=None)
+def test_strategy_gcra_burst_never_exceeds_limit(
+    limit: int, window: float
+) -> None:
+    """A fresh GCRA key allows exactly `limit` requests in a burst."""
+
+    async def run() -> None:
+        adapter = MemoryRateLimiterAdapter()
+        async with adapter:
+            strategy = adapter.bind(
+                SlidingWindowConfig(limit=limit, window=window)
+            )
+            allowed = 0
+            for _ in range(limit + 5):
+                result = await strategy.acquire(key="k", cost=1)
+                if result.allowed:
+                    allowed += 1
+                    assert result.retry_after == 0
+                else:
+                    assert result.retry_after >= 0
+                    assert result.reset_after >= 0
+            # GCRA admits `limit` then denies; round-trip math may
+            # let one extra through depending on monotonic clock drift.
+            assert limit <= allowed <= limit + 1
+
+    _run(run())
+
+
+@given(
+    limit=st.integers(min_value=1, max_value=50),
+    window=st.floats(
+        min_value=0.1, max_value=60.0, allow_nan=False, allow_infinity=False
+    ),
+)
+@settings(max_examples=100, deadline=None)
+def test_strategy_gcra_peek_does_not_mutate(limit: int, window: float) -> None:
+    """`peek` does not consume tokens."""
+
+    async def run() -> None:
+        adapter = MemoryRateLimiterAdapter()
+        async with adapter:
+            strategy = adapter.bind(
+                SlidingWindowConfig(limit=limit, window=window)
+            )
+            for _ in range(10):
+                result = await strategy.peek(key="k")
+                assert result.allowed is True
+                assert result.remaining == limit
+
+    _run(run())
+
+
+# --- Refill monotonicity ----------------------------------------------------
+
+
+@given(
+    capacity=st.integers(min_value=2, max_value=100),
+    refill_rate=st.floats(
+        min_value=0.01, max_value=100.0, allow_nan=False, allow_infinity=False
+    ),
+    elapsed=st.floats(
+        min_value=0.0, max_value=3600.0, allow_nan=False, allow_infinity=False
+    ),
+    start_tokens=st.floats(
+        min_value=0.0, max_value=100.0, allow_nan=False, allow_infinity=False
+    ),
+)
+@settings(max_examples=200, deadline=None)
+def test_token_bucket_refill_is_monotonic_and_capped(
+    capacity: int,
+    refill_rate: float,
+    elapsed: float,
+    start_tokens: float,
+) -> None:
+    """Refill increases over time and never exceeds capacity."""
+    bucket = MemoryTokenBucket(capacity=capacity, refill_rate=refill_rate)
+    tokens = min(start_tokens, float(capacity))
+    last = monotonic()
+    refilled = bucket._refill(tokens, last, last + elapsed)
+    expected = min(float(capacity), tokens + elapsed * refill_rate)
+    assert refilled <= float(capacity)
+    assert math.isclose(refilled, expected, rel_tol=1e-9, abs_tol=1e-9)

--- a/uv.lock
+++ b/uv.lock
@@ -482,6 +482,7 @@ dev = [
     { name = "fastapi-cli" },
     { name = "faststream" },
     { name = "freezegun" },
+    { name = "hypothesis" },
     { name = "lightkube" },
     { name = "loguru" },
     { name = "opentelemetry-api" },
@@ -538,6 +539,7 @@ dev = [
     { name = "fastapi-cli", specifier = ">=0.0.5" },
     { name = "faststream", specifier = ">=0.5.30" },
     { name = "freezegun", specifier = ">=1.5.2" },
+    { name = "hypothesis", specifier = ">=6.100.0" },
     { name = "lightkube", specifier = ">=0.15.0" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
@@ -689,6 +691,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.152.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/fb/a5651eb0cd03ecee644e8f4d8cd2027b40a08bf1488f46201e794aebe9b5/hypothesis-6.152.9.tar.gz", hash = "sha256:de4711d69ce3a18009047c3b44882810fd0c0348c1558e920a4b0d2c45f59e1e", size = 472009, upload-time = "2026-05-19T17:10:19.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/d9/40ef7ed22f0c45c2316467edb9afb8fc172cd089cb329c0ee6da6b74416c/hypothesis-6.152.9-py3-none-any.whl", hash = "sha256:9c4fdccb1eac0b12ec740c12290d0e6a0bea3526a3f0bf812b7643bb563c2d8b", size = 538148, upload-time = "2026-05-19T17:10:16.131Z" },
 ]
 
 [[package]]
@@ -1616,6 +1630,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add property-based tests for `MemoryTokenBucket`, `_MemoryTokenBucket`, and `_MemoryGCRA` covering capacity invariant, cost validation, key isolation, retry hints, peek non-mutation, and refill monotonicity.
- Add property-based tests for `ExponentialBackoff` covering the closed-form delay, jitter bounds (`none`, `full`, `equal`, `decorrelated`), and monotonicity.
- Add `hypothesis>=6.100.0` to dev dependencies.

Closes R5 finding #2 (property test depth, scored 1/5).

## Test plan

- [x] `uv run pytest -m "not integration" -q` (1798 passed)
- [x] `uv run pytest -m "integration" --cov --cov-append -q` (108 passed, 100% line coverage)
- [x] `uv run ty check` clean
- [x] `uv run ruff check` clean
- [x] Pre-commit hooks pass end-to-end