### PR TITLE
📝 Document explicit test commands in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,7 +262,25 @@ class RateLimiter:
 - Prefer fixtures with a `_` prefix for side-effect-only setups
   (consumed via `@pytest.mark.usefixtures`). Fixtures returning a
   value the test uses drop the prefix.
-- **100 % coverage** across unit + integration is enforced.
+- **100 % line + branch coverage** across unit + integration is
+  enforced by the pre-commit `coverage-report` hook
+  (`coverage report --fail-under=100`). CI runs unit, slow, and
+  integration tests on every pull request and push to `main`.
+
+### Running tests
+
+```bash
+# Unit tests only (no Docker required)
+uv run pytest -m "not integration"
+
+# Integration tests (requires Docker for Redis and Postgres containers)
+uv run pytest -m integration
+
+# Full suite with combined coverage (matches the local pre-commit gate)
+uv run pytest -m "not integration" --cov
+uv run pytest -m integration --cov --cov-append
+uv run coverage report --fail-under=100
+```
 
 ## Documentation
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@
 * 📝 Add a lifespan-only example (one provider, one component) between the minimal example and the full composition demo in `README.md` and `docs/index.md`.
 * 📝 Drop unsupported claims and idioms from the landing copy ("Stop reinventing the wheel", "battle-tested in production", "TL;DR").
 * 📝 Add `Start here` / `Common recipes` lead lines to every page under `docs/reference/`.
+* 📝 Add an explicit `Running tests` section to `CONTRIBUTING.md` with the commands for unit-only, integration-only, and the full local gate.
 
 ### Internal
 


### PR DESCRIPTION
## Summary

- Add a `Running tests` subsection with the exact commands for unit-only, integration-only, and the full local gate to `CONTRIBUTING.md`.
- Clarify that the 100% line + branch coverage gate is enforced locally by the pre-commit hook (`coverage report --fail-under=100`) and that CI runs unit + slow + integration on every PR and push to `main`.

CI behavior is unchanged: the existing `.github/workflows/ci.yml` already runs integration tests on every pull request to `main`. This PR closes R5 finding #4 by publishing the commands in `CONTRIBUTING.md`.

## Test plan

- [x] `uv run pre-commit run --all-files` passes (pre-commit hooks ran on commit)