### PR TITLE
📝 Add a first-contribution guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,64 @@ The pre-commit configuration (`.pre-commit-config.yaml`) is the
 single source of truth for what "passes CI": ruff, ty, pytest
 (unit and integration), coverage, and file-hygiene hooks.
 
+## Your first contribution
+
+Browse [issues labelled `good first issue`](https://github.com/grelinfo/grelmicro/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+They are scoped so a contributor unfamiliar with the codebase can
+finish them in one sitting.
+
+A typical first contribution touches three places:
+
+- **Code** in `grelmicro/<module>/...`. Public functions and
+  parameters use `Annotated[..., Doc("one-line behavior")]`.
+- **Test** in `tests/<module>/test_<thing>.py`. One docstring per
+  test, Arrange / Act / Assert comments, name describes the
+  scenario and expected outcome.
+- **Docs** in `docs/<module>.md` and a runnable example under
+  `docs/snippets/<module>/`. The snippet must run on its own.
+
+Example shapes (copy and adapt):
+
+```python
+# grelmicro/widgets/tally.py
+from typing import Annotated
+from typing_extensions import Doc
+
+
+class Tally:
+    """Count events in a fixed window."""
+
+    def __init__(
+        self,
+        *,
+        window: Annotated[
+            float,
+            Doc("Window duration in seconds."),
+        ],
+    ) -> None:
+        self._window = window
+```
+
+```python
+# tests/widgets/test_tally.py
+from grelmicro.widgets.tally import Tally
+
+
+def test_tally_window_is_exposed() -> None:
+    """Tally exposes the window as `.window`."""
+    # Arrange / Act
+    tally = Tally(window=5.0)
+    # Assert
+    assert tally.window == 5.0
+```
+
+A `docs/changelog.md` entry under `## Unreleased` is required.
+One short bullet, the PR link at the end. Match the surrounding
+entries.
+
+If anything is unclear, open the PR as a draft and ask. Reviewing
+a partially-correct PR is faster than guessing.
+
 ## Branch and commit conventions
 
 - Work on a branch named for the change, e.g. `feat/<name>` or

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@
 * 📝 Add `Start here` / `Common recipes` lead lines to every page under `docs/reference/`.
 * 📝 Add an explicit `Running tests` section to `CONTRIBUTING.md` with the commands for unit-only, integration-only, and the full local gate.
 * 📝 Add a `What should I pick?` decision tree to the top of `docs/comparison.md` so readers can map their situation to the right tool (one primitive, two or more, task queue, workflow engine, web framework).
+* 📝 Add a `Your first contribution` section to `CONTRIBUTING.md` with the expected code, test, and docs shape and a pointer to the `good first issue` label.
 
 ### Internal
 


### PR DESCRIPTION
## Summary

- Add a `Your first contribution` section to `CONTRIBUTING.md`, placed after `Quick start` and before `Branch and commit conventions`.
- Point at the `good first issue` label and give copy-pasteable shapes for a typical three-file contribution (code with `Annotated[..., Doc(...)]`, test with one-line docstring + Arrange/Act/Assert, changelog entry).

Closes R12 finding #6 (contribution bar high for first-time contributors).

## Test plan

- [x] `uv run pre-commit run --all-files` (pre-commit ran on commit)