### PR TITLE
📝 Annotate protocol parameters with Doc metadata

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,7 @@
 * 📝 Add an explicit `Running tests` section to `CONTRIBUTING.md` with the commands for unit-only, integration-only, and the full local gate.
 * 📝 Add a `What should I pick?` decision tree to the top of `docs/comparison.md` so readers can map their situation to the right tool (one primitive, two or more, task queue, workflow engine, web framework).
 * 📝 Add a `Your first contribution` section to `CONTRIBUTING.md` with the expected code, test, and docs shape and a pointer to the `good first issue` label.
+* 📝 Add `Annotated[..., Doc(...)]` to the `SyncBackend`, `RetryStrategy`, `RateLimiterStrategy`, `RateLimiterBackend`, `CircuitBreakerStrategy`, and `CircuitBreakerBackend` protocol parameters so IDE and LLM tools surface the same hints on backends as on user-facing primitives.
 
 ### Internal
 

--- a/grelmicro/resilience/_protocol.py
+++ b/grelmicro/resilience/_protocol.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     ClassVar,
     NamedTuple,
     Protocol,
     Self,
     runtime_checkable,
 )
+
+from typing_extensions import Doc
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -30,13 +33,20 @@ class RetryStrategy(Protocol):
     upcoming attempt.
     """
 
-    def delay(self, attempt: int) -> float:
-        """Return the delay in seconds before retry ``attempt``.
+    def delay(
+        self,
+        attempt: Annotated[
+            int,
+            Doc(
+                "Upcoming retry number. `attempt=1` is the delay before"
+                " the first retry, after the initial call failed."
+            ),
+        ],
+    ) -> float:
+        """Return the delay in seconds before retry `attempt`.
 
-        ``attempt`` is the upcoming retry number. ``attempt=1`` is
-        the delay before the first retry (after the initial call
-        failed). The strategy may apply jitter and clamp to its
-        configured maximum.
+        The strategy may apply jitter and clamp to its configured
+        maximum.
         """
         ...
 
@@ -81,46 +91,42 @@ class RateLimiterStrategy(Protocol):
     async def acquire(
         self,
         *,
-        key: str,
-        cost: int,
+        key: Annotated[
+            str,
+            Doc("Rate-limit key (e.g. IP, user ID, session)."),
+        ],
+        cost: Annotated[
+            int,
+            Doc("Number of tokens to consume on this request."),
+        ],
     ) -> RateLimitResult:
-        """Try to acquire rate limit tokens.
+        """Try to acquire rate-limit tokens for `key`.
 
-        Args:
-            key: The rate limit key (e.g. IP, user ID, session).
-            cost: Number of tokens to consume.
-
-        Returns:
-            RateLimitResult with allowed, limit, remaining,
-            retry_after, and reset_after fields.
+        Returns a `RateLimitResult` with `allowed`, `limit`,
+        `remaining`, `retry_after`, and `reset_after`.
         """
         ...
 
     async def peek(
         self,
         *,
-        key: str,
+        key: Annotated[
+            str,
+            Doc("Rate-limit key to inspect."),
+        ],
     ) -> RateLimitResult:
-        """Check rate limit state without consuming tokens.
-
-        Args:
-            key: The rate limit key.
-
-        Returns:
-            RateLimitResult reflecting the current state.
-        """
+        """Return the current state for `key` without consuming tokens."""
         ...
 
     async def reset(
         self,
         *,
-        key: str,
+        key: Annotated[
+            str,
+            Doc("Rate-limit key to reset to full quota."),
+        ],
     ) -> None:
-        """Delete rate limit state for a key, restoring full quota.
-
-        Args:
-            key: The rate limit key to reset.
-        """
+        """Delete rate-limit state for `key`, restoring full quota."""
         ...
 
 
@@ -153,22 +159,21 @@ class RateLimiterBackend(Protocol):
 
     def bind(
         self,
-        config: RateLimiterConfig,
+        config: Annotated[
+            RateLimiterConfig,
+            Doc(
+                "Algorithm configuration."
+                " `TokenBucketConfig` or `SlidingWindowConfig`."
+            ),
+        ],
     ) -> RateLimiterStrategy:
         """Build a strategy for the given algorithm config.
 
         Called exactly once per
-        [`RateLimiter`][grelmicro.resilience.RateLimiter] when
-        it is created. The returned strategy shares storage with
-        the backend. Later requests call the strategy methods
-        directly, with no extra algorithm lookup.
-
-        Args:
-            config: The algorithm configuration
-                (`TokenBucketConfig` or `SlidingWindowConfig`).
-
-        Returns:
-            A strategy bound to `config` and this backend's storage.
+        [`RateLimiter`][grelmicro.resilience.RateLimiter] when it is
+        created. The returned strategy shares storage with the
+        backend. Later requests call the strategy methods directly,
+        with no extra algorithm lookup.
         """
         ...
 
@@ -226,35 +231,42 @@ class CircuitBreakerStrategy(Protocol):
     async def record_outcome(
         self,
         *,
-        success: bool,
-        duration: float = 0.0,
+        success: Annotated[
+            bool,
+            Doc(
+                "Whether the call completed without an error that counts"
+                " against the breaker."
+            ),
+        ],
+        duration: Annotated[
+            float,
+            Doc(
+                "Wall-clock seconds the call took. Consumed by algorithms"
+                " that classify slow calls. Ignored by the"
+                " consecutive-count algorithm."
+            ),
+        ] = 0.0,
     ) -> CircuitBreakerSnapshot:
-        """Record a call outcome and return the resulting snapshot.
-
-        Args:
-            success: Whether the call completed without an error that
-                counts against the breaker.
-            duration: Wall-clock seconds the call took. Consumed by
-                algorithms that classify slow calls; ignored by the
-                consecutive-count algorithm.
-        """
+        """Record a call outcome and return the resulting snapshot."""
         ...
 
     async def transition(
         self,
         *,
-        desired: CircuitBreakerState,
-        cool_down: float | None = None,
+        desired: Annotated[
+            CircuitBreakerState,
+            Doc("Target state to force the breaker into."),
+        ],
+        cool_down: Annotated[
+            float | None,
+            Doc(
+                "Seconds the breaker stays OPEN before moving to"
+                " HALF_OPEN. `None` uses the configured `reset_timeout`."
+                " Ignored when `desired` is not OPEN."
+            ),
+        ] = None,
     ) -> None:
-        """Force the breaker into ``desired``.
-
-        Args:
-            desired: Target state.
-            cool_down: Seconds the breaker should stay OPEN before
-                transitioning to HALF_OPEN. When ``None`` the strategy
-                uses its configured ``reset_timeout``. Ignored for
-                non-OPEN targets.
-        """
+        """Force the breaker into `desired`."""
         ...
 
     async def get_snapshot(self) -> CircuitBreakerSnapshot:
@@ -306,8 +318,14 @@ class CircuitBreakerBackend(Protocol):
     def bind(
         self,
         *,
-        name: str,
-        config: CircuitBreakerConfig,
+        name: Annotated[
+            str,
+            Doc("Breaker name, used as the storage key in shared backends."),
+        ],
+        config: Annotated[
+            CircuitBreakerConfig,
+            Doc("Algorithm configuration for the breaker."),
+        ],
     ) -> CircuitBreakerStrategy:
         """Build a strategy for the named breaker and algorithm config.
 

--- a/grelmicro/sync/abc.py
+++ b/grelmicro/sync/abc.py
@@ -1,9 +1,10 @@
 """Synchronization Abstract Base Classes and Protocols."""
 
 from types import TracebackType
-from typing import Protocol, Self, runtime_checkable
+from typing import Annotated, Protocol, Self, runtime_checkable
 
 from pydantic import PositiveFloat
+from typing_extensions import Doc
 
 
 @runtime_checkable
@@ -30,64 +31,82 @@ class SyncBackend(Protocol):
         """Close the synchronization backend."""
         ...
 
-    async def acquire(self, *, name: str, token: str, duration: float) -> bool:
+    async def acquire(
+        self,
+        *,
+        name: Annotated[
+            str,
+            Doc("Identifier of the lock to acquire."),
+        ],
+        token: Annotated[
+            str,
+            Doc(
+                "Caller-supplied ownership token. The same token must"
+                " be passed to `release` and `owned`."
+            ),
+        ],
+        duration: Annotated[
+            float,
+            Doc(
+                "Seconds the lock is held before the backend may release"
+                " it automatically. The acquirer should renew before"
+                " this elapses."
+            ),
+        ],
+    ) -> bool:
         """Acquire the lock.
 
-        Args:
-            name: The name of the lock.
-            token: The token to acquire the lock.
-            duration: The duration in seconds to hold the lock.
-
-        Returns:
-            True if the lock is acquired, False if the lock is already acquired by another token.
-
-        Raises:
-            Exception: Any exception can be raised if the lock cannot be acquired.
+        Returns `True` when the lock was granted, `False` when another
+        token already holds it.
         """
         ...
 
-    async def release(self, *, name: str, token: str) -> bool:
-        """Release a lock.
+    async def release(
+        self,
+        *,
+        name: Annotated[
+            str,
+            Doc("Identifier of the lock to release."),
+        ],
+        token: Annotated[
+            str,
+            Doc(
+                "Ownership token previously passed to `acquire`. The"
+                " backend only releases when the token matches."
+            ),
+        ],
+    ) -> bool:
+        """Release the lock.
 
-        Args:
-            name: The name of the lock.
-            token: The token to release the lock.
-
-        Returns:
-            True if the lock was released, False otherwise.
-
-        Raises:
-            Exception: Any exception can be raised if the lock cannot be released.
+        Returns `True` when the lock was released, `False` when the
+        token did not own the lock.
         """
         ...
 
-    async def locked(self, *, name: str) -> bool:
-        """Check if the lock is acquired.
-
-        Args:
-            name: The name of the lock.
-
-        Returns:
-            True if the lock is acquired, False otherwise.
-
-        Raises:
-            Exception: Any exception can be raised if the lock status cannot be checked.
-        """
+    async def locked(
+        self,
+        *,
+        name: Annotated[
+            str,
+            Doc("Identifier of the lock to inspect."),
+        ],
+    ) -> bool:
+        """Return `True` when the lock is currently held by any token."""
         ...
 
-    async def owned(self, *, name: str, token: str) -> bool:
-        """Check if the lock is owned.
-
-        Args:
-            name: The name of the lock.
-            token: The token to check.
-
-        Returns:
-            True if the lock is owned by the token, False otherwise.
-
-        Raises:
-            Exception: Any exception can be raised if the lock status cannot be checked.
-        """
+    async def owned(
+        self,
+        *,
+        name: Annotated[
+            str,
+            Doc("Identifier of the lock to inspect."),
+        ],
+        token: Annotated[
+            str,
+            Doc("Ownership token to compare against the current holder."),
+        ],
+    ) -> bool:
+        """Return `True` when the lock is currently held by `token`."""
         ...
 
 

--- a/tests/resilience/test_ratelimiter_properties.py
+++ b/tests/resilience/test_ratelimiter_properties.py
@@ -41,15 +41,24 @@ _KEYS = st.text(min_size=0, max_size=8)
 # --- MemoryTokenBucket -------------------------------------------------------
 
 
-@given(capacity=_CAPACITIES, refill_rate=_REFILL_RATES)
+@given(
+    capacity=_CAPACITIES,
+    refill_rate=st.floats(
+        min_value=0.001, max_value=1.0, allow_nan=False, allow_infinity=False
+    ),
+)
 @settings(max_examples=200, deadline=None)
 def test_token_bucket_never_grants_more_than_capacity(
     capacity: int, refill_rate: float
 ) -> None:
-    """Tight burst never grants more than capacity tokens."""
+    """Tight burst never grants more than capacity tokens.
+
+    A slow refill (`<= 1 tps`) makes the burst loop short enough that
+    refill cannot grant an extra token even under parallel CPU load.
+    """
     bucket = MemoryTokenBucket(capacity=capacity, refill_rate=refill_rate)
     granted = sum(bucket.try_acquire() for _ in range(capacity + 5))
-    assert capacity <= granted <= capacity + 1
+    assert granted == capacity
 
 
 @given(


### PR DESCRIPTION
## Summary

- Add `Annotated[..., Doc(...)]` to every public parameter on `SyncBackend`, `RetryStrategy`, `RateLimiterStrategy`, `RateLimiterBackend`, `CircuitBreakerStrategy`, and `CircuitBreakerBackend`. Backend protocols now match the hover surface of the user-facing primitives.
- Replace the Google-style `Args:` blocks in those protocol docstrings with one-line behavior summaries (the parameter context lives in `Doc` now).
- Tighten the `test_token_bucket_never_grants_more_than_capacity` Hypothesis test: cap `refill_rate <= 1 tps` so the burst loop can't refill an extra token under parallel CPU load (previously flaky under the pre-commit `pytest-xdist` worker pool).

Closes R10 finding #1.

## Test plan

- [x] `uv run pre-commit run --all-files`: unit + integration + coverage pass
- [x] `uv run ty check` clean