### PR TITLE
🚨 Include recovery hints in component and health-name errors

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@
 ### Fixes
 
 * 🔒 `SettingsValidationError` no longer echoes the offending input value. Env-loaded credentials (DSNs, tokens) no longer surface in error messages.
+* 🚨 `ComponentNotRegisteredError` from `Grelmicro.get(kind, name)` now lists every registered `(kind, name)` pair (or states that none are registered). Agents and developers see what is available without inspecting the container.
+* 🚨 `HealthChecks.add` invalid-name errors now include valid examples (`'redis'`, `'db-primary'`, `'weather:circuitbreaker'`) alongside the regex.
 
 ### Docs
 

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -238,7 +238,12 @@ class Grelmicro:
         try:
             return self._by_key[(kind, name)]
         except KeyError as exc:
-            msg = f"no component registered for {(kind, name)!r}."
+            registered = sorted(self._by_key)
+            if registered:
+                hint = "registered: " + ", ".join(repr(k) for k in registered)
+            else:
+                hint = "no components are registered"
+            msg = f"no component registered for {(kind, name)!r}. {hint}."
             raise ComponentNotRegisteredError(msg) from exc
 
     @asynccontextmanager

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -280,7 +280,9 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
             msg = (
                 f"Invalid health check name {name!r}: must match "
                 f"^[a-z0-9][a-z0-9:_-]*$ and be at most "
-                f"{_NAME_MAX_LEN} chars"
+                f"{_NAME_MAX_LEN} chars. "
+                f"Valid examples: 'redis', 'db-primary', "
+                f"'weather:circuitbreaker'."
             )
             raise ValueError(msg)
         if name in self._entries:

--- a/tests/health/test_checks.py
+++ b/tests/health/test_checks.py
@@ -360,8 +360,9 @@ async def test_shared_cache_between_readyz_and_healthz_paths() -> None:
 async def test_invalid_name_rejected(name: str) -> None:
     """Names must match ^[a-z0-9][a-z0-9:_-]*$."""
     registry = HealthChecks()
-    with pytest.raises(ValueError, match="Invalid health check name"):
+    with pytest.raises(ValueError, match="Valid examples:") as exc:
         registry.add(name, healthy())
+    assert "Invalid health check name" in str(exc.value)
 
 
 async def test_namespaced_name_accepted() -> None:

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -169,8 +169,22 @@ def test_uses_kwarg_registers_components_in_order() -> None:
 def test_uses_kwarg_accepts_none() -> None:
     """`uses=None` (the default) constructs an empty container."""
     micro = Grelmicro()
-    with pytest.raises(ComponentNotRegisteredError):
+    with pytest.raises(
+        ComponentNotRegisteredError, match="no components are registered"
+    ):
         micro.get("rec")
+
+
+def test_get_missing_component_error_lists_registered_keys() -> None:
+    """The error names every `(kind, name)` pair that is registered."""
+    a = _RecordingComponent(name="a")
+    b = _OtherComponent(name="b")
+    micro = Grelmicro(uses=[a, b])
+    with pytest.raises(ComponentNotRegisteredError) as exc:
+        micro.get("rec", "missing")
+    msg = str(exc.value)
+    assert "('rec', 'a')" in msg
+    assert "('oth', 'b')" in msg
 
 
 # --- Lifespan: enter, LIFO teardown ---


### PR DESCRIPTION
## Summary

- `Grelmicro.get(kind, name)` errors now list every registered `(kind, name)` pair (or state that none are registered) so agents and developers see what is available without inspecting the container.
- `HealthChecks.add` invalid-name errors append valid examples (`'redis'`, `'db-primary'`, `'weather:circuitbreaker'`) after the regex.

Closes R10 finding #4 (error message actionability).

## Test plan

- [x] New unit tests cover both message shapes.
- [x] `uv run pre-commit run --all-files`