### PR TITLE
🔧 Document type-ignore rationale and attribution cues

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,7 +10,7 @@ outlines of the Funnel Display typeface under the SIL Open Font License
 
 ## Upstash Ratelimit
 
-The Redis Lua scripts in `grelmicro/resilience/redis.py` are adapted
+The Redis Lua scripts in `grelmicro/resilience/ratelimiter/redis.py` are adapted
 from [Upstash Ratelimit](https://github.com/upstash/ratelimit):
 
 - `_RedisTokenBucket._LUA_ACQUIRE` and `_LUA_PEEK`: hash-based

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,10 @@
 * ✅ Add a guard test that every `_LAZY` key in `grelmicro/resilience/__init__.py` is exported in `__all__` and actually resolves at runtime.
 * ✅ Add Hypothesis property tests for token-bucket and sliding-window math and for exponential backoff jitter bounds.
 * ✅ Enable branch coverage (`--cov-branch`). The 100% gate now covers both lines and branches. Defensive guards against impossible state are marked with `# pragma: no branch`.
+* 🔧 Document why every `type: ignore` and `ty: ignore` in `grelmicro/_config.py` is required (Pydantic dynamic-subclass boundary).
+* 🔧 Explain the double-checked `pragma: no cover` in `Reconfigurable.reconfigure` so future contributors see the concurrent-caller intent.
+* 🔧 Add inline attribution cues to `grelmicro/task/_utils.py` and `grelmicro/resilience/_protocol.py` / `grelmicro/cache/_protocol.py` so readers immediately see where third-party adaptations live and that protocol bodies live in concrete adapters.
+* 🔧 Fix the `THIRD_PARTY_NOTICES.md` path to `grelmicro/resilience/ratelimiter/redis.py`.
 
 ## 0.25.0 - 2026-05-21
 

--- a/docs/third_party_notices.md
+++ b/docs/third_party_notices.md
@@ -10,7 +10,7 @@ outlines of the Funnel Display typeface under the SIL Open Font License
 
 ## Upstash Ratelimit
 
-The Redis Lua scripts in `grelmicro/resilience/redis.py` are adapted
+The Redis Lua scripts in `grelmicro/resilience/ratelimiter/redis.py` are adapted
 from [Upstash Ratelimit](https://github.com/upstash/ratelimit):
 
 - `_RedisTokenBucket._LUA_ACQUIRE` and `_LUA_PEEK`: hash-based

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -155,6 +155,10 @@ def resolve_config[C: BaseModel](
         return config_cls.model_validate(provided)
 
     settings_cls = _build_settings_cls(config_cls, env_prefix)
+    # The dynamic subclass is built at runtime via `type(...)` below, so
+    # neither mypy nor ty can prove that `settings_cls` accepts the kwargs
+    # declared on `config_cls` or that it returns `C`. Pydantic's runtime
+    # validation enforces the contract.
     return settings_cls(**provided)  # type: ignore[return-value, arg-type]  # ty: ignore[invalid-return-type, invalid-argument-type]
 
 
@@ -174,12 +178,15 @@ def _build_settings_cls[C: BaseModel](
     instance per process); the bound is a safety net for long-
     running processes that derive prefixes from runtime inputs.
     """
-    # `model_config` is a TypedDict (`SettingsConfigDict`/`ConfigDict`);
-    # spreading it into a plain dict so we can add `env_prefix` widens
-    # it to `dict[str, object]`, which the downstream constructors
-    # accept but the type checker can't narrow back.
+    # `model_config` is a TypedDict (`SettingsConfigDict`/`ConfigDict`).
+    # Spreading it into a plain dict to add `env_prefix` widens the value
+    # type to `dict[str, object]`, which downstream constructors accept
+    # at runtime but mypy/ty cannot narrow back to the TypedDict shape.
     merged_config: dict[str, object] = {**(config_cls.model_config or {})}  # type: ignore[dict-item]
     merged_config["env_prefix"] = env_prefix
+    # `SettingsConfigDict(**merged_config)` round-trips a `dict[str, object]`
+    # through a TypedDict constructor. Static checkers reject the widened
+    # value types even though Pydantic's runtime validator accepts them.
     return type(
         f"_{config_cls.__name__}Settings",
         (config_cls, BaseSettings),
@@ -228,6 +235,10 @@ class Reconfigurable[ConfigT: BaseModel]:
         if new_config == current:
             return
         async with self._reconfigure_lock:
+            # Double-checked locking. A concurrent caller can win the lock
+            # first and install the same `new_config`; this re-read avoids
+            # rebinding twice. Not deterministically reachable from a
+            # single-event-loop test, so coverage is excluded by design.
             if new_config == self._config:  # pragma: no cover
                 return
             await self._apply_reconfigure(new_config)

--- a/grelmicro/cache/_protocol.py
+++ b/grelmicro/cache/_protocol.py
@@ -1,4 +1,10 @@
-"""Cache Backend Protocol."""
+"""Cache Backend Protocol.
+
+This module defines a `typing.Protocol`. Methods end with `...`
+because the protocol describes a structural contract, not an
+implementation. Concrete backends (`RedisCacheAdapter`,
+`MemoryCacheAdapter`, `PostgresCacheAdapter`) provide the bodies.
+"""
 
 from types import TracebackType
 from typing import Annotated, Protocol, Self, runtime_checkable

--- a/grelmicro/resilience/_protocol.py
+++ b/grelmicro/resilience/_protocol.py
@@ -1,4 +1,11 @@
-"""Rate Limiter, Circuit Breaker, and Retry Protocols."""
+"""Rate Limiter, Circuit Breaker, and Retry Protocols.
+
+This module defines `typing.Protocol` types. Methods end with `...`
+because the protocols describe structural contracts, not
+implementations. Concrete strategies and backends (e.g.
+`_MemoryTokenBucket`, `RedisRateLimiterAdapter`,
+`_ExponentialStrategy`) provide the bodies.
+"""
 
 from __future__ import annotations
 

--- a/grelmicro/task/_utils.py
+++ b/grelmicro/task/_utils.py
@@ -1,4 +1,8 @@
-"""Task Utilities."""
+"""Task Utilities.
+
+`validate_and_generate_reference` is adapted from an upstream project.
+See THIRD_PARTY_NOTICES.md for the source, license, and changes.
+"""
 
 from collections.abc import Callable
 from functools import partial


### PR DESCRIPTION
## Summary

R8 small-effort cleanup batch (findings 2, 3, 4, 5):

- **R8 F2**: Add comments next to each `type: ignore` / `ty: ignore` in `grelmicro/_config.py` explaining the Pydantic dynamic-subclass boundary.
- **R8 F5**: Explain the `pragma: no cover` on the double-checked branch in `Reconfigurable.reconfigure` (concurrent callers, not deterministically reachable in a single event loop).
- **R8 F4**: Add module-doc notes to `grelmicro/cache/_protocol.py` and `grelmicro/resilience/_protocol.py` so readers immediately see that `...` bodies are protocol contracts, not unfinished code.
- **R8 F3**: Add an inline attribution cue at the top of `grelmicro/task/_utils.py` pointing at `THIRD_PARTY_NOTICES.md`, and fix the path in `THIRD_PARTY_NOTICES.md` from `grelmicro/resilience/redis.py` to `grelmicro/resilience/ratelimiter/redis.py`.

## Test plan

- [x] `uv run pre-commit run --all-files` (1799 unit + integration + coverage all pass)
- [x] `uv run ty check` clean