### PR TITLE
🐛 Serialize Log lifecycle and surface health-check exception details

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,8 @@
 * 🔒 `SettingsValidationError` no longer echoes the offending input value. Env-loaded credentials (DSNs, tokens) no longer surface in error messages.
 * 🚨 `ComponentNotRegisteredError` from `Grelmicro.get(kind, name)` now lists every registered `(kind, name)` pair (or states that none are registered). Agents and developers see what is available without inspecting the container.
 * 🚨 `HealthChecks.add` invalid-name errors now include valid examples (`'redis'`, `'db-primary'`, `'weather:circuitbreaker'`) alongside the regex.
+* 🐛 `Log.__aenter__` and `Log.__aexit__` now serialize on a class-level `threading.Lock` so concurrent `Grelmicro` lifecycles in the same process cannot interleave the stdlib root-logger snapshot / restore sequence.
+* 🐛 Unexpected exceptions inside a health check now surface as `"TypeName: message"` in the `CheckResult.error` field instead of the generic `"Health check failed"`. Operators reading only the `/healthz` payload can identify the failing class without grepping logs.
 
 ### Docs
 

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -475,7 +475,7 @@ async def _run_check(entry: _Entry) -> CheckResult:
             error=str(exc),
             details=exc.details,
         )
-    except Exception:
+    except Exception as exc:
         logger.exception(
             "Health check '%s' raised unexpectedly",
             entry.name,
@@ -483,6 +483,6 @@ async def _run_check(entry: _Entry) -> CheckResult:
         return CheckResult(
             status=HealthStatus.ERROR,
             critical=entry.critical,
-            error="Health check failed",
+            error=f"{type(exc).__name__}: {exc}",
             details=None,
         )

--- a/grelmicro/log/_component.py
+++ b/grelmicro/log/_component.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from typing import TYPE_CHECKING, Annotated, ClassVar, Self
 
 from typing_extensions import Doc
@@ -45,14 +46,17 @@ class Log:
     `loguru` and `structlog` backends keep the configuration installed on
     enter (no restore).
 
-    A single process should not run two `Grelmicro` apps with `Log`
-    components concurrently: stdlib's root logger is a single global, so
-    overlapping lifecycles would clobber each other's snapshots.
+    The stdlib root logger is a single global. `Log.__aenter__` and
+    `Log.__aexit__` serialize on a class-level `threading.Lock` so the
+    snapshot/restore sequence cannot interleave across concurrent
+    `Grelmicro` lifecycles in the same process. Run one `Log` at a
+    time per process.
 
     Read more in the [Logging](../logging.md) docs.
     """
 
     kind: ClassVar[str] = "log"
+    _lifecycle_lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(
         self,
@@ -138,17 +142,18 @@ class Log:
 
     async def __aenter__(self) -> Self:
         """Snapshot stdlib root logger state, then configure logging."""
-        root = logging.getLogger()
-        self._snapshot_handlers = list(root.handlers)
-        self._snapshot_level = root.level
-        self._resolved = resolve_config(
-            LoggingConfig,
-            explicit=self._explicit_config,
-            kwargs=self._kwargs,
-            env_prefix="GREL_LOG_",
-            env_load=self._env_load,
-        )
-        _apply(self._resolved)
+        with self._lifecycle_lock:
+            root = logging.getLogger()
+            self._snapshot_handlers = list(root.handlers)
+            self._snapshot_level = root.level
+            self._resolved = resolve_config(
+                LoggingConfig,
+                explicit=self._explicit_config,
+                kwargs=self._kwargs,
+                env_prefix="GREL_LOG_",
+                env_load=self._env_load,
+            )
+            _apply(self._resolved)
         return self
 
     async def __aexit__(
@@ -158,14 +163,15 @@ class Log:
         tb: TracebackType | None,
     ) -> bool | None:
         """Restore the snapshotted stdlib root handlers and level."""
-        root = logging.getLogger()
-        for handler in list(root.handlers):
-            root.removeHandler(handler)
-        if self._snapshot_handlers is not None:  # pragma: no branch
-            for handler in self._snapshot_handlers:
-                root.addHandler(handler)
-        if self._snapshot_level is not None:  # pragma: no branch
-            root.setLevel(self._snapshot_level)
-        self._snapshot_handlers = None
-        self._snapshot_level = None
+        with self._lifecycle_lock:
+            root = logging.getLogger()
+            for handler in list(root.handlers):
+                root.removeHandler(handler)
+            if self._snapshot_handlers is not None:  # pragma: no branch
+                for handler in self._snapshot_handlers:
+                    root.addHandler(handler)
+            if self._snapshot_level is not None:  # pragma: no branch
+                root.setLevel(self._snapshot_level)
+            self._snapshot_handlers = None
+            self._snapshot_level = None
         return None

--- a/tests/health/test_checks.py
+++ b/tests/health/test_checks.py
@@ -45,7 +45,7 @@ async def test_user_timeout_error_is_not_classified_as_registry_timeout() -> (
 
     result = report["checks"]["downstream"]
     assert result["status"] == HealthStatus.ERROR
-    assert result["error"] == "Health check failed"
+    assert result["error"] == "TimeoutError: downstream call timed out"
 
 
 async def test_empty_registry_is_ok() -> None:
@@ -144,7 +144,7 @@ async def test_critical_failure_produces_error() -> None:
     assert report["status"] == HealthStatus.ERROR
     redis = report["checks"]["redis"]
     assert redis["status"] == HealthStatus.ERROR
-    assert redis["error"] == "Health check failed"
+    assert redis["error"] == "ConnectionError: Connection refused"
     assert redis["details"] is None
 
 
@@ -432,13 +432,16 @@ async def test_health_error_exposes_message() -> None:
 
 
 async def test_generic_exception_hides_message() -> None:
-    """Non-HealthError exceptions get a generic message."""
+    """Non-HealthError exceptions surface the type and message."""
     registry = HealthChecks(cache_ttl=0)
     registry.add("redis", unhealthy())
 
     report = await registry.run()
 
-    assert report["checks"]["redis"]["error"] == "Health check failed"
+    assert (
+        report["checks"]["redis"]["error"]
+        == "ConnectionError: Connection refused"
+    )
 
 
 async def test_health_error_logs_warning(


### PR DESCRIPTION
## Summary

R7 small-effort batch (findings 1 and 4):

- **R7 F1**: `Log.__aenter__` and `Log.__aexit__` now take a class-level `threading.Lock` so concurrent `Grelmicro` lifecycles in the same process cannot interleave the stdlib root-logger snapshot / restore sequence. The single-`Log`-per-process constraint is documented in the class docstring.
- **R7 F4**: Unexpected exceptions inside a health check now produce a `CheckResult.error` of `"TypeName: message"` (e.g. `"ConnectionError: Connection refused"`) instead of the generic `"Health check failed"`. Operators reading only the `/healthz` payload can identify the failing class without grepping logs.
- Updated three existing health tests to assert the structured error string.

## Test plan

- [x] `uv run pre-commit run --all-files` (1799 unit + integration + coverage pass)
- [x] `uv run ty check` clean