### PR TITLE
🔒 Validate lock names and document task-name leakage

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@
 * 🚨 `HealthChecks.add` invalid-name errors now include valid examples (`'redis'`, `'db-primary'`, `'weather:circuitbreaker'`) alongside the regex.
 * 🐛 `Log.__aenter__` and `Log.__aexit__` now serialize on a class-level `threading.Lock` so concurrent `Grelmicro` lifecycles in the same process cannot interleave the stdlib root-logger snapshot / restore sequence.
 * 🐛 Unexpected exceptions inside a health check now surface as `"TypeName: message"` in the `CheckResult.error` field instead of the generic `"Health check failed"`. Operators reading only the `/healthz` payload can identify the failing class without grepping logs.
+* 🔒 `Lock("...")` now validates the name against `^[A-Za-z0-9][A-Za-z0-9._:/-]*$` (max 200 chars). Names with whitespace, control characters, or leading separators are rejected with a message that includes valid examples. Existing namespaced names (`users:42`, `payments/eu`, `weather.svc`) keep working.
 
 ### Docs
 
@@ -33,6 +34,7 @@
 * 📝 Add a `Your first contribution` section to `CONTRIBUTING.md` with the expected code, test, and docs shape and a pointer to the `good first issue` label.
 * 📝 Add `Annotated[..., Doc(...)]` to the `SyncBackend`, `RetryStrategy`, `RateLimiterStrategy`, `RateLimiterBackend`, `CircuitBreakerStrategy`, and `CircuitBreakerBackend` protocol parameters so IDE and LLM tools surface the same hints on backends as on user-facing primitives.
 * 📝 Group the `grelmicro.resilience` package docstring into front doors, components, adapters, and configs so import-site hover help guides agents and humans to the preferred entry point.
+* 📝 Document that auto-generated task references (`module:qualname`) surface in logs, distributed lock keys, and metric labels. Suggest passing an explicit `name=` for sensitive workflows in `validate_and_generate_reference` and the `docs/task.md` Interval Task section.
 
 ### Internal
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -59,6 +59,14 @@ Use the `interval` decorator to run a task at a fixed interval:
 !!! note
     The interval specifies the waiting time between task executions. Ensure that the task execution duration is considered to meet deadlines effectively.
 
+!!! tip "Sensitive workflows: pass an explicit `name=`"
+    When `name=` is omitted, the task reference is derived from the function's
+    `module:qualname`. That reference appears in logs, distributed
+    coordination keys (when `TaskLock` is used), and metric labels.
+    Pass an explicit `name="..."` for tasks that handle credentials,
+    customer data, or other workflows where the internal module path
+    should not leak through operational surfaces.
+
 === "Tasks"
 
     ```python

--- a/grelmicro/sync/lock.py
+++ b/grelmicro/sync/lock.py
@@ -1,6 +1,7 @@
 """Lock."""
 
 import asyncio
+import re
 from threading import get_ident
 from types import TracebackType
 from typing import Annotated, Self
@@ -26,6 +27,26 @@ from grelmicro.sync.errors import (
 )
 
 _MIN_RETRY_INTERVAL: float = 0.001
+_NAME_MAX_LEN = 200
+_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\-]*$")
+
+
+def _validate_lock_name(name: str) -> None:
+    """Reject lock names that would land as ugly or ambiguous backend keys.
+
+    The pattern accepts letters, digits, and the separators ``._:/-`` after
+    a leading alphanumeric, up to 200 characters. This blocks whitespace,
+    control characters, and shell metacharacters while staying broad
+    enough for namespaced names like ``users:42`` or ``payments/eu``.
+    """
+    if not name or len(name) > _NAME_MAX_LEN or not _NAME_PATTERN.match(name):
+        msg = (
+            f"Invalid lock name {name!r}: must match "
+            f"^[A-Za-z0-9][A-Za-z0-9._:/-]*$ and be at most "
+            f"{_NAME_MAX_LEN} chars. "
+            f"Valid examples: 'cart', 'users:42', 'payments/eu'."
+        )
+        raise ValueError(msg)
 
 
 class LockConfig(BaseLockConfig, frozen=True, extra="forbid"):  # ty: ignore[invalid-frozen-dataclass-subclass]
@@ -227,6 +248,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         backend: SyncBackend | str | None,
     ) -> None:
         """Wire the validated config and runtime deps onto the instance."""
+        _validate_lock_name(name)
         self._name = name
         self._config = config
         self._reconfigure_lock = asyncio.Lock()

--- a/grelmicro/task/_utils.py
+++ b/grelmicro/task/_utils.py
@@ -20,6 +20,11 @@ def validate_and_generate_reference(function: Callable[..., Any]) -> str:
     are accepted. Anything whose identity depends on a closure, a bound
     instance, or runtime construction is rejected.
 
+    The returned reference surfaces in logs, distributed coordination
+    keys, and metric labels. For tasks that handle sensitive workflows,
+    pass an explicit ``name=`` to the task decorator or registration
+    call instead of relying on the auto-generated module path.
+
     Raises:
         FunctionTypeError: If ``function`` cannot be referenced by name.
 

--- a/tests/sync/test_lock.py
+++ b/tests/sync/test_lock.py
@@ -758,3 +758,37 @@ async def test_reconfigure_while_held_keeps_release_working(lock: Lock) -> None:
     await lock.release()
 
     assert await lock.locked() is False
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "has space",
+        "has\ttab",
+        "control\x00char",
+        "-leading-dash",
+        "/leading-slash",
+        ":leading-colon",
+        "a" * 201,
+    ],
+)
+def test_lock_rejects_unsafe_names(name: str) -> None:
+    """Names with whitespace, control chars, or bad leaders are rejected."""
+    with pytest.raises(ValueError, match="Invalid lock name") as exc:
+        Lock(name)
+    assert "Valid examples:" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "cart",
+        "users:42",
+        "payments/eu",
+        "weather.svc",
+        "a-b_c.d:e/f",
+    ],
+)
+def test_lock_accepts_safe_names(name: str) -> None:
+    """Namespaced names with dots, dashes, slashes, and colons are accepted."""
+    Lock(name)


### PR DESCRIPTION
## Summary

R9 small-effort batch (findings 5 and 6):

- **R9 F5**: `Lock("name")` now validates against `^[A-Za-z0-9][A-Za-z0-9._:/-]*$` (≤200 chars). Whitespace, control characters, and leading separators are rejected with a message that includes valid examples (`'cart'`, `'users:42'`, `'payments/eu'`). Existing namespaced names continue to work.
- **R9 F6**: Add a docs nudge to `docs/task.md` (Interval Task section) and a paragraph in `validate_and_generate_reference` explaining that auto-generated `module:qualname` references appear in logs, distributed lock keys, and metric labels. Recommends explicit `name=` for sensitive workflows.

## Test plan

- [x] 12 new parametrized lock-name tests (7 rejected, 5 accepted) cover the validator boundary.
- [x] `uv run pre-commit run --all-files` (1811 unit + integration + coverage pass)
- [x] `uv run ty check` clean