### PR TITLE
📝 Document Python floor rationale, extras platforms, and GCRA remaining estimate

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,9 @@
 * 📝 Add `Annotated[..., Doc(...)]` to the `SyncBackend`, `RetryStrategy`, `RateLimiterStrategy`, `RateLimiterBackend`, `CircuitBreakerStrategy`, and `CircuitBreakerBackend` protocol parameters so IDE and LLM tools surface the same hints on backends as on user-facing primitives.
 * 📝 Group the `grelmicro.resilience` package docstring into front doors, components, adapters, and configs so import-site hover help guides agents and humans to the preferred entry point.
 * 📝 Document that auto-generated task references (`module:qualname`) surface in logs, distributed lock keys, and metric labels. Suggest passing an explicit `name=` for sensitive workflows in `validate_and_generate_reference` and the `docs/task.md` Interval Task section.
+* 📝 Add a `Why Python 3.12` section to `docs/installation.md` listing the language features (PEP 695, `asyncio.timeout`) that drive the floor, and note that CI runs the matrix on every advertised classifier (3.12, 3.13, 3.14).
+* 📝 Add a `Platforms` column to the Optional extras table in `docs/installation.md` calling out that `uvloop` is skipped on Windows and PyPy.
+* 📝 Document `RateLimitResult.remaining` as an estimate for continuous-state algorithms (GCRA-based sliding window). Enforcement still uses exact state, so the next `acquire` may be denied even when `remaining > 0`.
 
 ### Internal
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,18 @@
 
 grelmicro supports Python 3.12+ and depends on Pydantic v2+ and FastDepends. The async runtime is `asyncio`. Trio is not supported.
 
+## Why Python 3.12
+
+grelmicro uses [PEP 695](https://peps.python.org/pep-0695/) type
+parameter syntax, structural [`Self`](https://peps.python.org/pep-0673/)
+returns, and [`asyncio.timeout`](https://docs.python.org/3/library/asyncio-task.html#asyncio.timeout)
+on every primitive. These are 3.11/3.12 features. Pinning the floor
+to 3.12 keeps the codebase free of conditional imports and lets `ty`
+check a single typing dialect.
+
+CI runs the test matrix on every advertised classifier (3.12, 3.13,
+3.14). Older Python versions are not in scope before 1.0.
+
 ## Quick install
 
 === "pip"
@@ -23,15 +35,15 @@ grelmicro supports Python 3.12+ and depends on Pydantic v2+ and FastDepends. The
 
 grelmicro is modular. Install only the extras you need.
 
-| Extra | Pulls in |
-|---|---|
-| `standard` | `orjson` for fast JSON serialization. `uvloop` for a faster event loop on Linux and macOS (skipped on Windows). Activate with `uvloop.run(main())`. |
-| `redis` | `redis-py` for the Redis backends. |
-| `postgres` | `asyncpg` for the PostgreSQL sync backend. |
-| `sqlite` | `aiosqlite` for the SQLite sync backend. |
-| `kubernetes` | `lightkube` for the Kubernetes Lease sync backend. |
-| `opentelemetry` | OpenTelemetry API and SDK for tracing integration. |
-| `structlog` | `structlog` as an alternative logging backend. |
+| Extra | Pulls in | Platforms |
+|---|---|---|
+| `standard` | `orjson` for fast JSON serialization. `uvloop` for a faster event loop. Activate with `uvloop.run(main())`. | `orjson` everywhere. `uvloop` only on Linux/macOS CPython (skipped on Windows and PyPy). |
+| `redis` | `redis-py` for the Redis backends. | All platforms. |
+| `postgres` | `asyncpg` for the PostgreSQL sync backend. | All platforms. |
+| `sqlite` | `aiosqlite` for the SQLite sync backend. | All platforms. |
+| `kubernetes` | `lightkube` for the Kubernetes Lease sync backend. | All platforms. |
+| `opentelemetry` | OpenTelemetry API and SDK for tracing integration. | All platforms. |
+| `structlog` | `structlog` as an alternative logging backend. | All platforms. |
 
 === "pip"
     ```bash

--- a/grelmicro/resilience/_protocol.py
+++ b/grelmicro/resilience/_protocol.py
@@ -76,7 +76,13 @@ class RateLimitResult(NamedTuple):
     """Total quota (`capacity` for TokenBucketConfig, `limit` for SlidingWindowConfig)."""
 
     remaining: int
-    """Remaining tokens or requests."""
+    """Remaining tokens or requests.
+
+    For algorithms with continuous state (`SlidingWindowConfig`,
+    GCRA-based strategies) this is an estimate rounded to the nearest
+    whole request. Enforcement still uses the exact internal state, so
+    the next `acquire` may be denied even when `remaining > 0`.
+    """
 
     retry_after: float
     """Seconds until the next request is allowed (0.0 if allowed)."""


### PR DESCRIPTION
## Summary

Three small-effort doc/contract clarifications across reviews:

- **R3 F3**: Document `RateLimitResult.remaining` as an estimate for continuous-state algorithms (GCRA-based sliding window). Enforcement still uses exact internal state, so the next `acquire` may be denied even when `remaining > 0`. Keeps the existing rounding (no behavioral change) but is now honest about it.
- **R11 F1**: Add a `Why Python 3.12` section to `docs/installation.md` listing the language features (PEP 695, `asyncio.timeout`) that drive the floor, and note that CI runs the matrix on every advertised classifier (3.12, 3.13, 3.14).
- **R11 F5**: Add a `Platforms` column to the Optional extras table in `docs/installation.md` calling out that `uvloop` is skipped on Windows and PyPy.

## Test plan

- [x] `uv run pre-commit run --all-files` (1811 unit + integration + coverage pass)