### PR TITLE
📝 Add FastStream resilience recipe and formalize test naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,8 +326,12 @@ class RateLimiter:
 
 ## Testing
 
-- Name tests for the behaviour, not the method
-  (`test_acquire_rejected_when_limit_exceeded`).
+- Name tests with the shape
+  `test_<component>_<scenario>_<expected_outcome>`. For example:
+  `test_ratelimiter_acquire_rejected_when_limit_exceeded`,
+  `test_cache_get_returns_none_when_expired`,
+  `test_lock_release_raises_when_not_owned`.
+  Existing tests that follow an older shape are migrated opportunistically.
 - Every test function has a one-line docstring.
 - Use **Arrange / Act / Assert** comments to separate phases.
 - Parametrize related cases with `pytest.mark.parametrize`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,8 @@
 * 📝 Add a `Why Python 3.12` section to `docs/installation.md` listing the language features (PEP 695, `asyncio.timeout`) that drive the floor, and note that CI runs the matrix on every advertised classifier (3.12, 3.13, 3.14).
 * 📝 Add a `Platforms` column to the Optional extras table in `docs/installation.md` calling out that `uvloop` is skipped on Windows and PyPy.
 * 📝 Document `RateLimitResult.remaining` as an estimate for continuous-state algorithms (GCRA-based sliding window). Enforcement still uses exact state, so the next `acquire` may be denied even when `remaining > 0`.
+* 📝 Add a FastStream resilience recipe (`docs/snippets/resilience/faststream.py`) that uses a fleet-wide per-key `Lock` and a sliding-window `RateLimiter` inside a Redis-broker subscriber. Linked from `docs/resilience/index.md`.
+* 📝 Formalize the `test_<component>_<scenario>_<expected_outcome>` test-name shape in `CONTRIBUTING.md` with three concrete examples.
 
 ### Internal
 

--- a/docs/resilience/index.md
+++ b/docs/resilience/index.md
@@ -23,3 +23,17 @@ See [Composing patterns](composition.md) for the recommended outside-in order wh
 | **Timeout** | An async call may stall and you need a hard deadline on it. |
 
 For synchronous, in-process token-bucket rate limiting on a performance-critical sync path (the main example is the logging pipeline), see [`MemoryTokenBucket`](rate-limiter.md#standalone-memorytokenbucket). It powers `grelmicro.log.RateLimitFilter`.
+
+## With FastStream
+
+The same primitives drop into a FastStream consumer without changes.
+The lifespan opens the shared Redis provider, `Sync`, and
+`RateLimiters` once. A handler can then hold a per-key `Lock` and
+consume rate-limit tokens before the actual work runs.
+
+```python
+--8<-- "resilience/faststream.py"
+```
+
+The lock and limiter are fleet-wide: every consumer replica sees the
+same budget per key.

--- a/docs/snippets/resilience/faststream.py
+++ b/docs/snippets/resilience/faststream.py
@@ -1,0 +1,57 @@
+"""FastStream consumer protected by a distributed lock and rate limiter.
+
+The same primitives used in FastAPI routes drop into FastStream message
+handlers without changes. The `Grelmicro(uses=[...])` container opens
+every backend and component for the consumer's lifespan.
+"""
+
+from contextlib import asynccontextmanager
+
+from faststream import ContextRepo, FastStream
+from faststream.redis import RedisBroker
+
+from grelmicro import Grelmicro
+from grelmicro.providers.redis import RedisProvider
+from grelmicro.resilience import (
+    RateLimiter,
+    RateLimiters,
+    RateLimitExceededError,
+)
+from grelmicro.sync import Lock, Sync
+
+redis = RedisProvider("redis://localhost:6379/0")
+micro = Grelmicro(uses=[redis, Sync(redis), RateLimiters(redis)])
+
+per_user_limiter = RateLimiter.sliding_window("messages", limit=10, window=60)
+
+
+@asynccontextmanager
+async def lifespan(context: ContextRepo):
+    async with micro:
+        yield
+
+
+broker = RedisBroker()
+app = FastStream(broker, lifespan=lifespan)
+
+
+@broker.subscriber("user-events")
+async def handle_user_event(message: dict) -> None:
+    """Process a user event under a per-user lock and a fleet rate limit."""
+    user_id = message["user_id"]
+
+    try:
+        await per_user_limiter.acquire_or_raise(key=str(user_id))
+    except RateLimitExceededError:
+        # Drop or requeue: enforcement is fleet-wide, so every consumer
+        # replica sees the same budget per user.
+        return
+
+    async with Lock(f"user:{user_id}"):
+        # Only one consumer (across the whole fleet) processes events
+        # for this user at a time.
+        await _process(message)
+
+
+async def _process(message: dict) -> None:
+    print("processing:", message)


### PR DESCRIPTION
## Summary

Two small-effort batches:

- **R11 F2**: Add `docs/snippets/resilience/faststream.py` showing a FastStream Redis-broker subscriber that uses a fleet-wide per-key `Lock` and a sliding-window `RateLimiter` before processing each message. Linked from `docs/resilience/index.md` under a new `With FastStream` section.
- **R5 F5**: Formalize the `test_<component>_<scenario>_<expected_outcome>` test-name shape in `CONTRIBUTING.md` with three concrete examples (ratelimiter / cache / lock). Existing tests migrate opportunistically.

## Test plan

- [x] `uv run pre-commit run --all-files`