### PR TITLE
🎨 Polish pickle guidance, env_prefix comments, and log-filter snapshots

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -114,9 +114,13 @@ Backends store raw bytes. To cache Python objects, pass a serializer:
     user = await cache.get("user")  # returns dict
     ```
 
-=== "Pickle"
+=== "Pickle (trusted backends only)"
 
-    For any picklable Python object:
+    For any picklable Python object. **Use only with trusted, in-process
+    backends.** Deserialization can execute arbitrary code, so a shared
+    or compromised backend can run code inside the application. Prefer
+    `JsonSerializer` or `PydanticSerializer` for shared backends like
+    Redis or Memcached.
 
     ```python
     from grelmicro.cache import PickleSerializer, TTLCache
@@ -142,9 +146,9 @@ await cache.set("session", b"token", ttl=3600)  # 1 hour instead of default
 The `@cached` decorator automatically caches function results. It works with both sync and async functions.
 
 ```python
-from grelmicro.cache import TTLCache, cached
+from grelmicro.cache import JsonSerializer, TTLCache, cached
 
-cache = TTLCache(ttl=300, serializer=PickleSerializer())
+cache = TTLCache(ttl=300, serializer=JsonSerializer())
 
 @cached(cache)
 async def get_user(user_id: int) -> dict:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,9 @@
 
 ### Internal
 
+* 🔒 `PickleSerializer` docs upgraded to a Danger callout. Pickle is now framed as trusted in-process backends only, and the `@cached` decorator example leads with `JsonSerializer`. The `TTLCache` docstring lists Pydantic and JSON before Pickle.
+* 🔧 Comment why `_env_prefix=env_prefix` needs a type-ignore in `RedisProvider` and `PostgresProvider` (pydantic-settings runtime kwarg the stubs do not expose).
+* ⚡ Snapshot hot config fields (`cost`, `allowed_repetitions`, `ttl_seconds`, `cache_size`) onto `RateLimitFilter` and `DuplicateFilter` instances during setup so the per-record `filter()` path reads plain attrs instead of walking the Pydantic config.
 * 🔧 Drop three unused `ty: ignore` directives in `grelmicro/_json.py`.
 * ✅ Add a guard test that every `_LAZY` key in `grelmicro/resilience/__init__.py` is exported in `__all__` and actually resolves at runtime.
 * ✅ Add Hypothesis property tests for token-bucket and sliding-window math and for exponential backoff jitter bounds.

--- a/grelmicro/cache/serializers.py
+++ b/grelmicro/cache/serializers.py
@@ -62,13 +62,17 @@ class PickleSerializer(Generic[T]):
     Supports any picklable Python object. Fast and transparent,
     but produces opaque binary data.
 
-    Warning:
-        Pickle can execute arbitrary code during deserialization.
-        Only use with trusted data sources.
+    Danger:
+        Deserialization can execute arbitrary code. A compromised cache
+        backend can run code inside the application process. Use this
+        serializer only when the backend is fully trusted (in-process,
+        single-tenant). For shared backends (Redis, Memcached, any
+        multi-tenant store), use ``JsonSerializer`` or
+        ``PydanticSerializer`` instead.
 
     Args:
-        protocol: Pickle protocol version. Defaults to the highest
-            available protocol.
+        protocol: Serialization protocol version. Defaults to the
+            highest available protocol.
     """
 
     def __init__(self, *, protocol: int = pickle.HIGHEST_PROTOCOL) -> None:

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -132,9 +132,10 @@ class TTLCache(Generic[T]):
 
                 Built-in options:
 
-                - ``PickleSerializer()``: Any picklable object.
-                - ``JsonSerializer()``: JSON-native types (dict, list, etc.).
                 - ``PydanticSerializer(Model)``: Type-safe Pydantic roundtrips.
+                - ``JsonSerializer()``: JSON-native types (dict, list, etc.).
+                - ``PickleSerializer()``: Any picklable object. Trusted
+                  backends only: deserialization can execute arbitrary code.
                 - ``None``: Raw bytes only (no serialization).
                 """,
             ),

--- a/grelmicro/log/_dedup.py
+++ b/grelmicro/log/_dedup.py
@@ -238,6 +238,9 @@ class DuplicateFilter(Filter):
     ) -> None:
         """Wire the validated config and runtime deps onto the instance."""
         self._config = config
+        self._allowed = config.allowed_repetitions
+        self._ttl = config.ttl_seconds
+        self._cache_size = config.cache_size
         self._key_fn = key if key is not None else _KEY_FUNCS[config.key_mode]
         self._counts: OrderedDict[Hashable, tuple[int, float]] = OrderedDict()
         self._lock = Lock()
@@ -251,15 +254,15 @@ class DuplicateFilter(Filter):
         """Return ``True`` if the record should pass, ``False`` to drop."""
         key = self._key_fn(record)
         counts = self._counts
-        config = self._config
-        allowed = config.allowed_repetitions
-        ttl = config.ttl_seconds
+        allowed = self._allowed
+        ttl = self._ttl
+        cache_size = self._cache_size
         now = monotonic()
         with self._lock:
             entry = counts.get(key)
             if entry is None:
                 counts[key] = (1, now)
-                if len(counts) > config.cache_size:
+                if len(counts) > cache_size:
                     counts.popitem(last=False)
                 return True
             count, last_seen = entry

--- a/grelmicro/log/_ratelimit.py
+++ b/grelmicro/log/_ratelimit.py
@@ -262,6 +262,7 @@ class RateLimitFilter(Filter):
     ) -> None:
         """Wire the validated config and runtime deps onto the instance."""
         self._config = config
+        self._cost = config.cost
         self._key_fn = key if key is not None else _KEY_FUNCS[config.key_mode]
         self._bucket = MemoryTokenBucket(
             capacity=config.capacity,
@@ -276,7 +277,7 @@ class RateLimitFilter(Filter):
     def filter(self, record: LogRecord) -> bool:
         """Return `True` to keep the record, `False` to drop it."""
         key = self._key_fn(record)
-        return self._bucket.try_acquire(key, cost=self._config.cost)
+        return self._bucket.try_acquire(key, cost=self._cost)
 
     def reset(
         self,

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -317,6 +317,9 @@ def _resolve_url(
         raise PostgresProviderConfigError(msg)
 
     try:
+        # `_env_prefix` is a pydantic-settings runtime kwarg that overrides
+        # `model_config["env_prefix"]` per call. The stubs do not expose it,
+        # so static checkers reject it even though the runtime accepts it.
         settings = _PostgresEnvSettings(_env_prefix=env_prefix)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
     except ValidationError as error:
         raise PostgresProviderConfigError(error) from None

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -298,6 +298,9 @@ def _resolve_url(
         raise RedisProviderConfigError(msg)
 
     try:
+        # `_env_prefix` is a pydantic-settings runtime kwarg that overrides
+        # `model_config["env_prefix"]` per call. The stubs do not expose it,
+        # so static checkers reject it even though the runtime accepts it.
         settings = _RedisEnvSettings(_env_prefix=env_prefix)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
     except ValidationError as error:
         raise RedisProviderConfigError(error) from None


### PR DESCRIPTION
## Summary

Three small road-to-1.0 review punch-list items:

- **R9 F4** — `PickleSerializer` docs upgraded to a `Danger:` callout explicitly limiting pickle to trusted in-process backends. The `@cached` example in `docs/cache.md` now leads with `JsonSerializer`, the Pickle tab carries an inline warning, and the `TTLCache` docstring lists Pydantic and JSON before Pickle.
- **R4 F4** — Added a short comment at each `_env_prefix=env_prefix` call site in `RedisProvider` and `PostgresProvider` explaining that `_env_prefix` is a pydantic-settings runtime kwarg not exposed by the stubs (so the type-ignore is intentional).
- **R6 F3** — `RateLimitFilter._setup` and `DuplicateFilter._setup` now snapshot the hot config fields (`cost`, `allowed_repetitions`, `ttl_seconds`, `cache_size`) onto plain instance attrs. The per-record `filter()` path no longer walks through the Pydantic config on every call, matching the pattern measured in `benchmarks/config_attr_benchmark.py`.

Changelog entries added under `Unreleased > Internal`.

## Test plan

- [x] `uv run ty check`
- [x] `uv run pytest` (full unit + integration via pre-commit)
- [x] `uv run --group docs mkdocs build --strict`