### PR TITLE
🔒 Tighten OTel, lifecycle, instrument secrets, and orjson typing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+* ✨ Add `Grelmicro(strict=True)` to raise `LifecycleOrderError` instead of warning when a Component holds a Provider that is missing from `uses=` or listed after the dependent Component. The default `False` preserves the lenient warn-only behavior. `LifecycleOrderError` is exported from `grelmicro`.
 * ✨ Add `Shield` resilience pattern: per-attempt timeout, retry-budget-gated retries, CUBIC-style adaptive rate limiter, optional cache and fallback recovery paths. Three profiles (`internal`, `api`, `slow`) cover the common cases. Decorator (`@shield`, `@shield.api(...)`), class (`Shield.api("name")`), and imperative (`Shield.api("name").run(fn, ...)`) forms supported. Issue [#249](https://github.com/grelinfo/grelmicro/issues/249).
 * ✨ Add `TTLCacheConfig` and expose it via `TTLCache.config`. Matches the frozen-config shape used by every other primitive.
 * ✨ Add `RedisProvider.safe_url` and `PostgresProvider.safe_url` returning the resolved URL with the password replaced by `***`. The new `__repr__` on both providers uses the safe form so credentials never leak through logs or tracebacks.
@@ -43,6 +44,9 @@
 
 ### Internal
 
+* 🔒 `@instrument` now filters arguments whose names match common secret keywords (`password`, `token`, `secret`, `api_key`, `authorization`, `cookie`, ... matched case-insensitively) from both span attributes and log context. Pass extra names via `skip=` for custom secret-bearing parameters. Unchanged for non-sensitive args.
+* 🔧 Replace the optional `orjson` redef-as-`Any | None` pattern in `grelmicro/_json.py` with try/except branches that define the dumps/loads functions in scope. The per-call `# type: ignore[union-attr]` directives are gone; `orjson` keeps its real type from the stub package in the available branch.
+* 🚨 `Trace.__aenter__` now raises `TracingError` if `opentelemetry.trace._TRACER_PROVIDER` is missing instead of silently no-op patching. A future OTel that drops the private global surfaces a clear error pointing at the workaround. An inline comment near the patch documents why the private attribute is required.
 * 🔒 `PickleSerializer` docs upgraded to a Danger callout. Pickle is now framed as trusted in-process backends only, and the `@cached` decorator example leads with `JsonSerializer`. The `TTLCache` docstring lists Pydantic and JSON before Pickle.
 * 🔧 Comment why `_env_prefix=env_prefix` needs a type-ignore in `RedisProvider` and `PostgresProvider` (pydantic-settings runtime kwarg the stubs do not expose).
 * ⚡ Snapshot hot config fields (`cost`, `allowed_repetitions`, `ttl_seconds`, `cache_size`) onto `RateLimitFilter` and `DuplicateFilter` instances during setup so the per-record `filter()` path reads plain attrs instead of walking the Pydantic config.

--- a/grelmicro/__init__.py
+++ b/grelmicro/__init__.py
@@ -4,6 +4,7 @@ from grelmicro._app import (
     ComponentAlreadyRegisteredError,
     ComponentNotRegisteredError,
     Grelmicro,
+    LifecycleOrderError,
     NoActiveAppError,
 )
 from grelmicro._component import Component
@@ -13,5 +14,6 @@ __all__ = [
     "ComponentAlreadyRegisteredError",
     "ComponentNotRegisteredError",
     "Grelmicro",
+    "LifecycleOrderError",
     "NoActiveAppError",
 ]

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -86,6 +86,18 @@ class Grelmicro:
                 """,
             ),
         ] = None,
+        strict: Annotated[
+            bool,
+            Doc(
+                """
+                Raise `LifecycleOrderError` instead of warning when a
+                Component holds a Provider that is missing from `uses=`
+                or listed after the dependent Component. Default `False`
+                preserves the lenient warn-only behavior so existing
+                apps keep starting.
+                """,
+            ),
+        ] = False,
     ) -> None:
         """Initialize the app and register any items passed at construction."""
         self._items: list[AbstractAsyncContextManager[object]] = []
@@ -93,6 +105,7 @@ class Grelmicro:
         self._by_kind: dict[str, Component] = {}
         self._exit_stack: AsyncExitStack | None = None
         self._token: Any = None
+        self._strict = strict
         if uses is not None:
             for item in uses:
                 self.use(item)
@@ -450,7 +463,7 @@ class Grelmicro:
         but do not lifecycle it. The user must list the provider in `uses=`
         *before* the Component so the provider opens first.
 
-        Two warnings:
+        Two issues are reported:
 
         1. The provider is missing from `uses=`. The provider is never opened
            or closed, so its client leaks on shutdown.
@@ -459,6 +472,9 @@ class Grelmicro:
            order. Providers with lazy resources (`PostgresProvider` builds
            its pool on `__aenter__`) raise `OutOfContextError` when the
            Component opens first.
+
+        Reported as `UserWarning` by default, or as `LifecycleOrderError`
+        when the app was built with `strict=True`.
         """
         import warnings  # noqa: PLC0415
 
@@ -473,26 +489,28 @@ class Grelmicro:
             try:
                 provider_index = self._items.index(provider)
             except ValueError:
-                warnings.warn(
+                msg = (
                     f"{type(target).__name__} holds a "
                     f"{type(provider).__name__} that is not listed in "
                     f"Grelmicro(uses=[...]). The provider will not be "
                     f"lifecycled with the app and its connection will "
                     f"leak. Add the provider to uses= so it is opened "
-                    f"and closed with the components that depend on it.",
-                    UserWarning,
-                    stacklevel=3,
+                    f"and closed with the components that depend on it."
                 )
+                if self._strict:
+                    raise LifecycleOrderError(msg) from None
+                warnings.warn(msg, UserWarning, stacklevel=3)
                 continue
             if provider_index > index:
-                warnings.warn(
+                msg = (
                     f"{type(provider).__name__} is listed after "
                     f"{type(target).__name__} in Grelmicro(uses=[...]). "
                     f"Providers must be listed before the components that "
-                    f"depend on them so they open first.",
-                    UserWarning,
-                    stacklevel=3,
+                    f"depend on them so they open first."
                 )
+                if self._strict:
+                    raise LifecycleOrderError(msg)
+                warnings.warn(msg, UserWarning, stacklevel=3)
 
 
 def _sys_exc_info_or_none() -> tuple[Any, Any, Any]:
@@ -543,3 +561,7 @@ class ComponentNotRegisteredError(GrelmicroError, LookupError):
 
 class NoActiveAppError(GrelmicroError, LookupError):
     """Raised by `Grelmicro.current()` when called outside any `async with micro:` block."""
+
+
+class LifecycleOrderError(GrelmicroError, ValueError):
+    """Raised when `Grelmicro(strict=True)` detects misordered provider/component lifecycles."""

--- a/grelmicro/_json.py
+++ b/grelmicro/_json.py
@@ -36,11 +36,6 @@ JSONDecodable: TypeAlias = (  # noqa: UP040
 )
 """Types returned by ``json_loads``."""
 
-try:
-    import orjson
-except ImportError:
-    orjson: Any = None  # type: ignore[no-redef]
-
 
 def json_default(obj: object) -> str:
     """Handle non-serializable types for stdlib json.
@@ -54,26 +49,23 @@ def json_default(obj: object) -> str:
     raise TypeError(msg)
 
 
-def has_orjson() -> bool:
-    """Check if orjson is available."""
-    return orjson is not None
-
-
-if orjson is not None:
+try:
+    import orjson
 
     def json_dumps_bytes(obj: JSONEncodable) -> bytes:
         """Serialize object to JSON bytes using orjson."""
-        return orjson.dumps(obj)  # type: ignore[union-attr]
+        return orjson.dumps(obj)
 
     def json_dumps_str(obj: JSONEncodable) -> str:
         """Serialize object to JSON string using orjson."""
-        return orjson.dumps(obj).decode("utf-8")  # type: ignore[union-attr]
+        return orjson.dumps(obj).decode("utf-8")
 
     def json_loads(data: bytes | str) -> JSONDecodable:
         """Deserialize JSON bytes or string using orjson."""
-        return orjson.loads(data)  # type: ignore[union-attr]
+        return orjson.loads(data)
 
-else:
+    _HAS_ORJSON = True
+except ImportError:
     import json
 
     def json_dumps_bytes(obj: JSONEncodable) -> bytes:
@@ -89,3 +81,10 @@ else:
     def json_loads(data: bytes | str) -> JSONDecodable:
         """Deserialize JSON bytes or string using stdlib json."""
         return json.loads(data)  # type: ignore[return-value]
+
+    _HAS_ORJSON = False
+
+
+def has_orjson() -> bool:
+    """Check if orjson is available."""
+    return _HAS_ORJSON

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -17,6 +17,7 @@ from grelmicro.trace.config import (
     TracingProcessorType,
     TracingSamplerType,
 )
+from grelmicro.trace.errors import TracingError
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -175,7 +176,20 @@ class Trace:
             env_prefix="GREL_TRACE_",
             env_load=self._env_load,
         )
-        self._prior_provider = getattr(trace, "_TRACER_PROVIDER", None)
+        # `opentelemetry.trace.set_tracer_provider()` refuses to replace an
+        # already-installed provider, so `Trace` patches the private
+        # `trace._TRACER_PROVIDER` global directly. A future OTel release
+        # can rename or remove this attribute; the guard below turns that
+        # into a clear error rather than a silent no-op patch.
+        if not hasattr(trace, "_TRACER_PROVIDER"):
+            msg = (
+                "opentelemetry.trace no longer exposes `_TRACER_PROVIDER`. "
+                "Trace relies on this private global to override the "
+                "installed provider. Pin a compatible opentelemetry-api "
+                "release or open an issue against grelmicro."
+            )
+            raise TracingError(msg)
+        self._prior_provider = trace._TRACER_PROVIDER  # type: ignore[attr-defined]  # noqa: SLF001
         self._provider = _build_provider(self._resolved)
         trace._TRACER_PROVIDER = self._provider  # type: ignore[attr-defined]  # noqa: SLF001
         return self

--- a/grelmicro/trace/_instrument.py
+++ b/grelmicro/trace/_instrument.py
@@ -22,6 +22,34 @@ R = TypeVar("R")
 
 _IMPLICIT_PARAMS = frozenset({"self", "cls"})
 
+_DEFAULT_SENSITIVE_NAMES = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "passphrase",
+        "secret",
+        "client_secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "apikey",
+        "api_key",
+        "authorization",
+        "auth_header",
+        "bearer",
+        "credential",
+        "credentials",
+        "private_key",
+        "privatekey",
+        "cookie",
+        "cookies",
+        "session_id",
+        "sessionid",
+    }
+)
+
 
 def _record_exception(otel_span: object) -> None:
     """Record the current exception on an OTel span."""
@@ -59,7 +87,9 @@ def _make_extract_fields(
         return {
             k: v
             for k, v in bound.arguments.items()
-            if k not in skip_set and k not in _IMPLICIT_PARAMS
+            if k not in skip_set
+            and k not in _IMPLICIT_PARAMS
+            and k.lower() not in _DEFAULT_SENSITIVE_NAMES
         }
 
     return _extract_fields
@@ -104,8 +134,11 @@ def instrument[**P, R](  # type: ignore[return-value]
         Doc(
             """
             Argument names to exclude from the span attributes and log
-            context. Use this for arguments whose string form may carry
-            sensitive data (tokens, credentials, raw request bodies).
+            context, in addition to the built-in sensitive-name filter
+            (`password`, `token`, `secret`, `authorization`, `cookie`,
+            ... matched case-insensitively). Use this for arguments
+            whose string form may carry sensitive data not covered by
+            the default list (raw request bodies, custom auth headers).
             """,
         ),
     ] = None,
@@ -130,8 +163,11 @@ def instrument[**P, R](  # type: ignore[return-value]
 
     Note:
         Argument values are stringified (``str()``) when sent to OTel.
-        Use ``skip`` for arguments whose string representation may contain
-        sensitive data.
+        Arguments named like common secrets (``password``, ``token``,
+        ``secret``, ``authorization``, ``cookie``, ...) are filtered out
+        by default. Pass extra names via ``skip`` for arguments whose
+        string representation may contain sensitive data outside the
+        default list.
 
     Args:
         func: The function to instrument (set automatically for bare decorator).

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -15,6 +15,7 @@ from grelmicro import (
     ComponentAlreadyRegisteredError,
     ComponentNotRegisteredError,
     Grelmicro,
+    LifecycleOrderError,
     NoActiveAppError,
 )
 from grelmicro.errors import OutOfContextError
@@ -591,3 +592,38 @@ async def test_warns_when_provider_listed_after_component(
         issubclass(w.category, UserWarning) and "listed after" in str(w.message)
         for w in recwarn
     )
+
+
+async def test_strict_raises_when_provider_missing_from_uses() -> None:
+    """`strict=True` turns the missing-provider warning into an error."""
+    from grelmicro.providers.redis import RedisProvider  # noqa: PLC0415
+    from grelmicro.sync import Sync  # noqa: PLC0415
+
+    redis = RedisProvider("redis://localhost:6379/0")
+    micro = Grelmicro(uses=[Sync(redis)], strict=True)
+    with pytest.raises(LifecycleOrderError, match="not listed in"):
+        async with micro:
+            pass
+
+
+async def test_strict_raises_when_provider_listed_after_component() -> None:
+    """`strict=True` turns the ordering warning into an error."""
+    from grelmicro.providers.redis import RedisProvider  # noqa: PLC0415
+    from grelmicro.sync import Sync  # noqa: PLC0415
+
+    redis = RedisProvider("redis://localhost:6379/0")
+    micro = Grelmicro(uses=[Sync(redis), redis], strict=True)
+    with pytest.raises(LifecycleOrderError, match="listed after"):
+        async with micro:
+            pass
+
+
+async def test_strict_accepts_well_ordered_app() -> None:
+    """`strict=True` is a no-op when provider/component order is correct."""
+    from grelmicro.providers.redis import RedisProvider  # noqa: PLC0415
+    from grelmicro.sync import Sync  # noqa: PLC0415
+
+    redis = RedisProvider("redis://localhost:6379/0")
+    micro = Grelmicro(uses=[redis, Sync(redis)], strict=True)
+    async with micro:
+        pass

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -13,6 +13,7 @@ from grelmicro.trace import (
     TracingExporterType,
     TracingSamplerType,
 )
+from grelmicro.trace.errors import TracingError
 
 
 def test_tracing_config_accepts_case_insensitive_enums() -> None:
@@ -206,3 +207,14 @@ async def test_trace_shutdown_exception_logged_not_propagated(
         and isinstance(record.exc_info[1], RuntimeError)
         for record in caplog.records
     )
+
+
+async def test_trace_raises_when_private_otel_global_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A future OTel that drops `_TRACER_PROVIDER` surfaces a clear error."""
+    monkeypatch.delattr(otel_trace, "_TRACER_PROVIDER", raising=False)
+    micro = Grelmicro(uses=[Trace(exporter=TracingExporterType.NONE)])
+    with pytest.raises(TracingError, match="_TRACER_PROVIDER"):
+        async with micro:
+            pass

--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -199,6 +199,34 @@ class TestInstrument:
         assert log_record["order_id"] == "ORD-1"
         assert "cls" not in log_record
 
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_filters_default_sensitive_names(
+        self,
+        backend: str,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        reset_backend: None,  # noqa: ARG002
+    ) -> None:
+        """@instrument drops common sensitive arg names without an explicit `skip`."""
+        _setup_json_logging(monkeypatch, backend)
+
+        @instrument
+        def authenticate(
+            user_id: str,  # noqa: ARG001
+            password: str,  # noqa: ARG001
+            api_key: str,  # noqa: ARG001
+            Authorization: str,  # noqa: ARG001, N803
+        ) -> None:
+            log_message(backend, "auth")
+
+        authenticate("USR-1", "hunter2", "ak-123", "Bearer xyz")
+
+        log_record = parse_json_log(capsys.readouterr().out)
+        assert log_record["user_id"] == "USR-1"
+        assert "password" not in log_record
+        assert "api_key" not in log_record
+        assert "Authorization" not in log_record
+
 
 class TestSpan:
     """Test span() context manager across all backends."""


### PR DESCRIPTION
## Summary

Four road-to-1.0 review punch-list items bundled into one PR. Each addresses a separate finding (R7 F3, R7 F6, R9 F1, R4 F2).

### R7 F3 — Trace OTel `_TRACER_PROVIDER` guard

`Trace.__aenter__` now raises `TracingError` with a clear message if `opentelemetry.trace._TRACER_PROVIDER` is missing instead of silently no-op patching. A future OTel release that drops the private global surfaces a loud error pointing at the workaround. Added an inline comment near the patch explaining why the private attribute is required (the public `set_tracer_provider` refuses to replace an installed provider). Test: `test_trace_raises_when_private_otel_global_missing` deletes the attribute via `monkeypatch.delattr` and verifies the error.

### R7 F6 — `Grelmicro(strict=True)` lifecycle errors

New `strict` keyword turns the existing UserWarnings into a `LifecycleOrderError` (new exception class, exported from `grelmicro`). Catches:

- A Component holds a Provider that is missing from `uses=`.
- A Provider is listed after the dependent Component in `uses=`.

Default `False` preserves the lenient warn-only behavior. Three tests cover the two error paths and the no-op happy path.

### R9 F1 — `@instrument` filters secret arg names by default

A frozenset of common secret-bearing parameter names (`password`, `token`, `secret`, `api_key`, `authorization`, `cookie`, `bearer`, `credential`, ...) is filtered case-insensitively from span attributes and log context. Pass extra names via `skip=` for custom parameters. Docstring and `skip` Doc metadata both call out the default filter list. Test: `test_filters_default_sensitive_names` confirms `user_id` is kept while `password`, `api_key`, and `Authorization` are dropped.

### R4 F2 — orjson optional-import without per-call type-ignores

Restructured `grelmicro/_json.py` to define the dumps/loads functions inside the try/except branches. The `orjson: Any = None` redef is gone, so `orjson.dumps()` is typed against the real stub package in the orjson branch. The three `# type: ignore[union-attr]` directives are no longer needed.

## Test plan

- [x] `uv run ty check`
- [x] `uv run pytest` (unit + integration via pre-commit)
- [x] `uv run --group docs mkdocs build --strict`