### PR TITLE
✅ Add typing samples that lock cache generic inference

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,6 +51,7 @@
 * 🔧 Comment why `_env_prefix=env_prefix` needs a type-ignore in `RedisProvider` and `PostgresProvider` (pydantic-settings runtime kwarg the stubs do not expose).
 * ⚡ Snapshot hot config fields (`cost`, `allowed_repetitions`, `ttl_seconds`, `cache_size`) onto `RateLimitFilter` and `DuplicateFilter` instances during setup so the per-record `filter()` path reads plain attrs instead of walking the Pydantic config.
 * 🔧 Drop three unused `ty: ignore` directives in `grelmicro/_json.py`.
+* ✅ Add a `tests/typing/` sample (`test_cache_generics.py`) that uses `typing.assert_type` to lock in `TTLCache[T]`, `PickleSerializer[T]`, and `PydanticSerializer[T]` inference end-to-end. A regression that widens inference back to `Any` fails `uv run ty check`.
 * ✅ Add a guard test that every `_LAZY` key in `grelmicro/resilience/__init__.py` is exported in `__all__` and actually resolves at runtime.
 * ✅ Add Hypothesis property tests for token-bucket and sliding-window math and for exponential backoff jitter bounds.
 * ✅ Enable branch coverage (`--cov-branch`). The 100% gate now covers both lines and branches. Defensive guards against impossible state are marked with `# pragma: no branch`.

--- a/tests/typing/__init__.py
+++ b/tests/typing/__init__.py
@@ -1,0 +1,1 @@
+"""Static typing samples checked by `uv run ty check`."""

--- a/tests/typing/test_cache_generics.py
+++ b/tests/typing/test_cache_generics.py
@@ -1,0 +1,68 @@
+"""Static typing samples for cache generic inference.
+
+Runs as a pytest module so the imports execute, and is also picked up
+by `uv run ty check` so the `assert_type` calls validate that
+`TTLCache[T]`, generic serializers, and `JsonSerializer` keep
+composing end-to-end. A regression that widens inference back to
+`Any` fails ty even when all runtime tests pass.
+"""
+
+from __future__ import annotations
+
+from typing import assert_type
+
+from pydantic import BaseModel
+
+from grelmicro._json import JSONDecodable
+from grelmicro.cache import serializers
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache.ttl import TTLCache
+
+
+class _User(BaseModel):
+    id: int
+    name: str
+
+
+async def test_binary_serializer_preserves_t() -> None:
+    """`TTLCache[int]` with a generic serializer keeps `int | None` on get."""
+    cache = TTLCache[int](
+        ttl=60,
+        serializer=serializers.PickleSerializer[int](),
+        backend=MemoryCacheAdapter(),
+    )
+    await cache.set("k", 1)
+    value = await cache.get("k")
+    assert_type(value, int | None)
+
+
+async def test_pydantic_serializer_preserves_t() -> None:
+    """`TTLCache[User]` with `PydanticSerializer(User)` keeps `User | None` on get."""
+    cache = TTLCache[_User](
+        ttl=60,
+        serializer=serializers.PydanticSerializer(_User),
+        backend=MemoryCacheAdapter(),
+    )
+    await cache.set("k", _User(id=1, name="alice"))
+    value = await cache.get("k")
+    assert_type(value, _User | None)
+
+
+async def test_json_serializer_typed_cache_returns_json_decodable() -> None:
+    """`TTLCache[JSONDecodable]` with `JsonSerializer` keeps `JSONDecodable | None`."""
+    cache: TTLCache[JSONDecodable] = TTLCache(
+        ttl=60,
+        serializer=serializers.JsonSerializer(),
+        backend=MemoryCacheAdapter(),
+    )
+    await cache.set("k", {"a": 1})
+    value = await cache.get("k")
+    assert_type(value, JSONDecodable | None)
+
+
+async def test_default_serializer_get_returns_bytes_or_none() -> None:
+    """`TTLCache[bytes]` with no serializer keeps `bytes | None` on get."""
+    cache = TTLCache[bytes](ttl=60, backend=MemoryCacheAdapter())
+    await cache.set("k", b"raw")
+    value = await cache.get("k")
+    assert_type(value, bytes | None)


### PR DESCRIPTION
## Summary

Closes R4 F6.

Add `tests/typing/test_cache_generics.py` with four samples that use `typing.assert_type` to verify the end-to-end generic inference for the cache surface:

- `TTLCache[int]` with `PickleSerializer[int]()` keeps `int | None` on `get`.
- `TTLCache[User]` with `PydanticSerializer(User)` keeps `User | None` on `get`.
- `TTLCache[JSONDecodable]` with `JsonSerializer()` keeps `JSONDecodable | None` on `get`.
- `TTLCache[bytes]` with no serializer keeps `bytes | None` on `get`.

The samples run as regular async pytest tests using `MemoryCacheAdapter`. The `assert_type` calls are runtime no-ops; the real check runs under `uv run ty check`. A regression that widens inference back to `Any` (or any other type drift) fails ty even when the runtime tests still pass. Verified locally by flipping one `assert_type` target and watching ty report the mismatch.

## Test plan

- [x] `uv run ty check`
- [x] `uv run pytest tests/typing/` (4 passed)
- [x] Pre-commit (unit + integration suite)