### PR TITLE
⚡ Bound @cached per-key lock dictionaries with LRU eviction

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,6 +51,7 @@
 * 🔧 Comment why `_env_prefix=env_prefix` needs a type-ignore in `RedisProvider` and `PostgresProvider` (pydantic-settings runtime kwarg the stubs do not expose).
 * ⚡ Snapshot hot config fields (`cost`, `allowed_repetitions`, `ttl_seconds`, `cache_size`) onto `RateLimitFilter` and `DuplicateFilter` instances during setup so the per-record `filter()` path reads plain attrs instead of walking the Pydantic config.
 * 🔧 Drop three unused `ty: ignore` directives in `grelmicro/_json.py`.
+* ⚡ `@cached(lock=True)` per-key lock dictionaries now bound their size with LRU eviction (1024 entries). High-cardinality miss-heavy workloads no longer accumulate `asyncio.Lock` / `threading.Lock` objects indefinitely. Held locks are never evicted, so in-flight stampede protection is preserved.
 * ✅ Add a `tests/typing/` sample (`test_cache_generics.py`) that uses `typing.assert_type` to lock in `TTLCache[T]`, `PickleSerializer[T]`, and `PydanticSerializer[T]` inference end-to-end. A regression that widens inference back to `Any` fails `uv run ty check`.
 * ✅ Add a guard test that every `_LAZY` key in `grelmicro/resilience/__init__.py` is exported in `__all__` and actually resolves at runtime.
 * ✅ Add Hypothesis property tests for token-bucket and sliding-window math and for exponential backoff jitter bounds.

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -3,6 +3,7 @@
 import asyncio
 import functools
 import threading
+from collections import OrderedDict
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from typing import Annotated, Any, ParamSpec, TypeVar
@@ -20,6 +21,47 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 _SENTINEL = object()
+
+_PER_KEY_LOCK_BUDGET = 1024
+
+
+def _evict_idle_locks(
+    locks: OrderedDict[str, asyncio.Lock],
+) -> None:
+    """Drop the oldest unlocked entries while over the per-key budget.
+
+    Caller must hold the per-decorator guard lock. A held lock is kept
+    so a concurrent computation cannot lose its mutual-exclusion barrier
+    even if the dict has grown past the budget.
+    """
+    while len(locks) > _PER_KEY_LOCK_BUDGET:
+        for stale_key, stale_lock in locks.items():
+            if not stale_lock.locked():
+                del locks[stale_key]
+                break
+        else:  # pragma: no cover - every entry currently held
+            return
+
+
+def _evict_idle_locks_sync(
+    locks: OrderedDict[str, threading.Lock],
+) -> None:
+    """Drop the oldest unheld entries while over the per-key budget.
+
+    Caller must hold the per-decorator guard lock. ``threading.Lock``
+    has no public ``locked()`` accessor, so we probe with a non-
+    blocking ``acquire``: success means the lock was idle, and we
+    release immediately so behavior is unchanged.
+    """
+    while len(locks) > _PER_KEY_LOCK_BUDGET:
+        for stale_key, stale_lock in locks.items():
+            if stale_lock.acquire(blocking=False):
+                stale_lock.release()
+                del locks[stale_key]
+                break
+        else:  # pragma: no cover - every entry currently held
+            return
+
 
 # Lock parameter: True auto-creates, or pass your own.
 _LockType = (
@@ -161,7 +203,7 @@ def _build_async_wrapper(
     per_key: bool,
 ) -> Any:  # noqa: ANN401
     """Build async wrapper for cached decorator."""
-    key_locks: dict[str, asyncio.Lock] = {}
+    key_locks: OrderedDict[str, asyncio.Lock] = OrderedDict()
     key_locks_guard = asyncio.Lock()
 
     @functools.wraps(func)
@@ -173,7 +215,13 @@ def _build_async_wrapper(
 
         if per_key:
             async with key_locks_guard:
-                the_lock = key_locks.setdefault(key, asyncio.Lock())
+                the_lock = key_locks.get(key)
+                if the_lock is None:
+                    the_lock = asyncio.Lock()
+                    key_locks[key] = the_lock
+                    _evict_idle_locks(key_locks)
+                else:
+                    key_locks.move_to_end(key)
         else:
             the_lock = global_lock
         if the_lock is not None:
@@ -235,7 +283,7 @@ def _build_sync_wrapper(
     (typically inside lifespan startup) before the sync wrapper can
     reach it from a worker thread.
     """
-    key_locks: dict[str, threading.Lock] = {}
+    key_locks: OrderedDict[str, threading.Lock] = OrderedDict()
     key_locks_guard = threading.Lock()
 
     @functools.wraps(func)
@@ -250,7 +298,13 @@ def _build_sync_wrapper(
 
         if per_key:
             with key_locks_guard:
-                the_lock = key_locks.setdefault(key, threading.Lock())
+                the_lock = key_locks.get(key)
+                if the_lock is None:
+                    the_lock = threading.Lock()
+                    key_locks[key] = the_lock
+                    _evict_idle_locks_sync(key_locks)
+                else:
+                    key_locks.move_to_end(key)
         else:
             the_lock = global_lock
 

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -423,6 +423,75 @@ class TestAsyncCachedLock:
         await task_a
         assert "a:end" in order
 
+    async def test_per_key_lock_eviction_bounds_idle_entries(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`_evict_idle_locks` trims an oversize dict down to the budget."""
+        import sys  # noqa: PLC0415
+        from collections import OrderedDict  # noqa: PLC0415
+
+        import grelmicro.cache.cached  # noqa: F401, PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+
+        monkeypatch.setattr(cached_mod, "_PER_KEY_LOCK_BUDGET", 4)
+        locks: OrderedDict[str, asyncio.Lock] = OrderedDict()
+        for i in range(20):
+            locks[f"k{i}"] = asyncio.Lock()
+            cached_mod._evict_idle_locks(locks)
+        assert len(locks) == 4  # noqa: PLR2004
+
+    async def test_per_key_lock_eviction_keeps_held_entries(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Eviction never drops a lock that is currently held."""
+        import sys  # noqa: PLC0415
+        from collections import OrderedDict  # noqa: PLC0415
+
+        import grelmicro.cache.cached  # noqa: F401, PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+
+        monkeypatch.setattr(cached_mod, "_PER_KEY_LOCK_BUDGET", 2)
+        locks: OrderedDict[str, asyncio.Lock] = OrderedDict()
+        held = asyncio.Lock()
+        await held.acquire()
+        try:
+            locks["held"] = held
+            for i in range(10):
+                locks[f"idle-{i}"] = asyncio.Lock()
+            cached_mod._evict_idle_locks(locks)
+            assert "held" in locks
+        finally:
+            held.release()
+
+    def test_per_key_lock_eviction_keeps_held_sync_entries(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sync eviction never drops a threading.Lock that is held."""
+        import sys  # noqa: PLC0415
+        from collections import OrderedDict  # noqa: PLC0415
+
+        import grelmicro.cache.cached  # noqa: F401, PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+
+        monkeypatch.setattr(cached_mod, "_PER_KEY_LOCK_BUDGET", 2)
+        locks: OrderedDict[str, threading.Lock] = OrderedDict()
+        held = threading.Lock()
+        held.acquire()
+        try:
+            locks["held"] = held
+            for i in range(10):
+                locks[f"idle-{i}"] = threading.Lock()
+            cached_mod._evict_idle_locks_sync(locks)
+            assert "held" in locks
+        finally:
+            held.release()
+
     async def test_custom_asyncio_lock_prevents_duplicate_computation(
         self,
     ) -> None:
@@ -747,6 +816,21 @@ class TestSyncCachedLock:
 
         # Assert
         assert call_count == EXPECTED_CALL_COUNT_1
+
+    async def test_lock_true_per_key_promotes_existing_sync_lock(self) -> None:
+        """A repeated miss on the same key promotes its lock in LRU order."""
+        # Arrange
+        cache = _make_cache()
+
+        @cached(cache, lock=True)
+        def compute(x: int) -> int:
+            return x * 2
+
+        # Act: first miss creates the lock, then clear and miss again so the
+        # second call hits the existing-lock branch (move_to_end).
+        await asyncio.to_thread(lambda: compute(7))
+        await cache.clear()
+        await asyncio.to_thread(lambda: compute(7))
 
     async def test_custom_threading_lock_prevents_stampede(self) -> None:
         """A custom threading.Lock provides global stampede protection."""


### PR DESCRIPTION
## Summary

Closes R6 F1.

`@cached(lock=True)` stored per-key locks in an unbounded `dict`. Miss-heavy workloads with high key cardinality accumulated `asyncio.Lock` / `threading.Lock` objects for the lifetime of the decorator.

This PR replaces the storage with an `OrderedDict` and trims oldest unheld entries once the dictionary exceeds the per-decorator budget (1024 entries). Held locks are skipped so a concurrent stampede barrier is never silently dropped. Both the async wrapper and the sync wrapper use the same pattern:

- `_evict_idle_locks(locks)` for `asyncio.Lock` — uses `Lock.locked()`.
- `_evict_idle_locks_sync(locks)` for `threading.Lock` — probes with non-blocking `acquire` then `release`.

A repeated lookup of a key whose lock is still in the map calls `move_to_end` so the LRU order tracks recency.

Three new tests cover the bound trim, async held-lock preservation, sync held-lock preservation, plus a sync LRU-promotion path test. Coverage stays at 100%.

## Test plan

- [x] `uv run ty check`
- [x] `uv run pytest tests/cache/test_cached.py` (39 passed)
- [x] Pre-commit (unit + integration + coverage)