### PR TITLE
✅ Stabilize flaky timing and log-capture tests on slow CI runners

### DIFF
--- a/tests/health/conftest.py
+++ b/tests/health/conftest.py
@@ -1,10 +1,45 @@
 """Shared test helpers for health checks."""
 
 import asyncio
-from collections.abc import Awaitable, Callable
+import logging
+from collections.abc import Awaitable, Callable, Iterator
 from typing import Any
 
+import pytest
+
 from grelmicro.health.errors import HealthError
+
+
+@pytest.fixture(autouse=True)
+def _isolate_health_logger() -> Iterator[None]:
+    """Give each test a pristine ``grelmicro.health`` logger.
+
+    The log-capture tests rely on `caplog` seeing records propagate to
+    the root logger. A co-resident test in the same xdist worker can
+    leave global logging state behind (a raised level, ``propagate``
+    turned off, a leaked filter or handler, or a ``logging.disable``)
+    that silently swallows those records. Reset the logger and the
+    global disable level around every test so capture is deterministic.
+    """
+    logger = logging.getLogger("grelmicro.health")
+    saved_level = logger.level
+    saved_propagate = logger.propagate
+    saved_filters = logger.filters[:]
+    saved_handlers = logger.handlers[:]
+    saved_disable = logging.root.manager.disable
+    logger.setLevel(logging.NOTSET)
+    logger.propagate = True
+    logger.filters.clear()
+    logger.handlers.clear()
+    logging.disable(logging.NOTSET)
+    try:
+        yield
+    finally:
+        logger.setLevel(saved_level)
+        logger.propagate = saved_propagate
+        logger.filters[:] = saved_filters
+        logger.handlers[:] = saved_handlers
+        logging.disable(saved_disable)
 
 
 def healthy() -> Callable[[], Awaitable[dict[str, Any] | None]]:

--- a/tests/resilience/test_memory_token_bucket.py
+++ b/tests/resilience/test_memory_token_bucket.py
@@ -78,8 +78,10 @@ def test_independent_keys() -> None:
 
 def test_cost() -> None:
     """Test cost consumes multiple tokens."""
-    # Arrange
-    bucket = MemoryTokenBucket(capacity=5, refill_rate=1)
+    # Arrange: a slow refill keeps `remaining` stable across the
+    # acquire/peek gap so the epsilon assertion is not clock-sensitive
+    # (matches test_peek_returns_tokens).
+    bucket = MemoryTokenBucket(capacity=5, refill_rate=0.01)
 
     # Act
     allowed = bucket.try_acquire(cost=3)


### PR DESCRIPTION
## Summary

Stabilize two pre-existing flaky tests that turned `main` red on the full CI matrix (the PR matrix runs Python 3.12 only, so both surfaced only after merge / on the 3.13/3.14 jobs). Neither is related to the resilience-backends feature work in #314.

## Fixes

1. **`test_memory_token_bucket.py::test_cost`** (failed on 3.14): asserted the post-acquire token count stayed within `0.001` of `2.0`, but at `refill_rate=1` the bucket refills ~0.0015 tokens in the millisecond gap between `try_acquire` and `peek`. Lowered the refill rate to `0.01`, matching `test_peek_returns_tokens` in the same file.

2. **`test_checks.py::test_generic_exception_logs_error`** (failed on 3.12): a `caplog` capture flake (`0` records despite a log being emitted). Pollution from a co-resident test in the same xdist worker (a raised level, `propagate` off, a leaked filter or handler, or `logging.disable`) can swallow the record. Added an autouse fixture in `tests/health/conftest.py` that resets the `grelmicro.health` logger and the global disable level around every test, so capture is deterministic.

## Validation

`ruff`, `ty`, full unit suite (run repeatedly), and the integration suite pass locally. The 3.13/3.14 fixes can only be confirmed by the full matrix that runs on push to `main`.
