### PR TITLE
📝 Document comment convention and convert advisory-namespace blocks to docstrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,42 @@ The rules below are the ones the tooling can't check:
 - Keep `__init__` bodies thin. Attribute assignment only. Delegate
   validation to a frozen Pydantic config model.
 
+### Comments
+
+Document what a symbol is and why it exists **on the symbol**, the way
+FastAPI does, not in a block of `#` comments above it. A reader hovering
+the symbol in an IDE, and mkdocstrings, should see the explanation.
+
+- For parameters and fields, use `Annotated[type, Doc("...")]`.
+- For a class or function, use its docstring.
+- For a module constant or class attribute, use a `Doc(...)` annotation
+  on the annotated assignment, or an attribute docstring (a string
+  literal directly under the assignment).
+- Reserve `#` comments for short notes about non-obvious local logic
+  inside a function body. Do not use them to describe a public or
+  module-level symbol.
+
+Avoid (an explanatory `#` block describing a constant):
+
+```python
+# Advisory-lock namespace for the rate limiter. hashtextextended is
+# PG's 64-bit text hash with a configurable seed. A distinct seed
+# isolates rate-limiter keys from any other advisory lock.
+_RATE_LIMITER_ADVISORY_NAMESPACE = 0x67726C72_72746C6D
+```
+
+Prefer (an attribute docstring the symbol carries):
+
+```python
+_RATE_LIMITER_ADVISORY_NAMESPACE = 0x67726C72_72746C6D
+"""Advisory-lock namespace for the rate limiter.
+
+`hashtextextended` is Postgres's 64-bit text hash with a configurable
+seed. A distinct seed isolates rate-limiter keys from any other
+advisory lock in the same database.
+"""
+```
+
 ### Pydantic models
 
 - Every configuration class is

--- a/grelmicro/resilience/circuitbreaker/postgres.py
+++ b/grelmicro/resilience/circuitbreaker/postgres.py
@@ -26,12 +26,14 @@ if TYPE_CHECKING:
     )
 
 
-# Advisory-lock namespace for the circuit breaker. `hashtextextended`
-# is PG's 64-bit text hash with a configurable seed. A distinct seed
-# gives breaker names their own 64-bit lock id space, isolated from
-# the rate limiter and any other advisory lock in the same database.
-# The bigint value spells "grcb-cir" in ASCII bytes.
 _CIRCUIT_BREAKER_ADVISORY_NAMESPACE = 0x67726362_2D636972
+"""Advisory-lock namespace for the circuit breaker.
+
+`hashtextextended` is Postgres's 64-bit text hash with a configurable
+seed. A distinct seed gives breaker names their own 64-bit lock id
+space, isolated from the rate limiter and any other advisory lock in
+the same database.
+"""
 
 
 class PostgresCircuitBreakerAdapter(CircuitBreakerBackend):

--- a/grelmicro/resilience/ratelimiter/postgres.py
+++ b/grelmicro/resilience/ratelimiter/postgres.py
@@ -22,12 +22,13 @@ if TYPE_CHECKING:
     from asyncpg import Pool
 
 
-# Advisory-lock namespace for the rate limiter. `hashtextextended`
-# is PG's 64-bit text hash with a configurable seed; using a distinct
-# seed as the namespace gives rate-limiter keys their own 64-bit lock
-# id space and isolates them from any other advisory lock in the same
-# database. The bigint value spells "grlr-rate-limiter" in ASCII bytes.
 _RATE_LIMITER_ADVISORY_NAMESPACE = 0x67726C72_72746C6D
+"""Advisory-lock namespace for the rate limiter.
+
+`hashtextextended` is Postgres's 64-bit text hash with a configurable
+seed. A distinct seed gives rate-limiter keys their own 64-bit lock id
+space, isolated from any other advisory lock in the same database.
+"""
 
 
 class PostgresRateLimiterAdapter(RateLimiterBackend):


### PR DESCRIPTION
## Summary

Records a code-style convention and applies it to the code that prompted it.

Document a symbol's purpose **on the symbol** (a docstring or `Doc(...)` annotation, FastAPI-style) so IDE hover and mkdocstrings surface it, rather than in a block of `#` comments above it. `#` comments stay for short notes about non-obvious local logic.

## Changes

- `CONTRIBUTING.md`: new `### Comments` rule under Code style, with the advisory-namespace constant as the avoid/prefer example.
- `grelmicro/resilience/ratelimiter/postgres.py` and `circuitbreaker/postgres.py`: converted the `_*_ADVISORY_NAMESPACE` `#` blocks to attribute docstrings (also dropped a prose semicolon and the incidental "spells in ASCII" note).

No behavior change. `ruff`, `ty`, and the full pre-commit gate pass.
