### PR TITLE
✨ Add Bulkhead concurrency-isolation pattern (#168)

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -24,7 +24,7 @@ See [Backends and Adapters](architecture/backends.md) for the full model.
 | `RateLimiter`       | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | N/A        |
 | `CircuitBreaker`    | ✅                                                             | ✅                                                             | ✅                                                             | Future                                                         | N/A        |
 | `Retry`             | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
-| `Bulkhead`          | [#168](https://github.com/grelinfo/grelmicro/issues/168)       | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
+| `Bulkhead`          | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
 | `Fallback`          | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
 | `Timeout`           | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
 
@@ -41,7 +41,7 @@ Closing every gap above that links to an issue. Anything marked `Future` is out 
 
 ## Picking an Adapter
 
-- **Memory** for tests, single-process apps, and `Retry`, `Fallback`, and `Timeout` (in-process Patterns that ship today). `Bulkhead` will join this group at `1.0.0`.
+- **Memory** for tests, single-process apps, and `Retry`, `Fallback`, `Timeout`, and `Bulkhead` (in-process Patterns).
 - **Redis** when you already run Redis and want the lowest-latency distributed option.
 - **Postgres** when Postgres is your only stateful dependency and you want one fewer service to run.
 - **SQLite** for single-host deployments that still need durability across restarts.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 * ✨ Add `TracingConfig.shutdown_timeout` (default `5.0` seconds). `Trace.__aexit__` now runs `TracerProvider.shutdown()` in a thread with this deadline so a slow or broken exporter no longer hangs application shutdown.
 * ✨ Add `SQLiteProvider` and SQLite rate limiting. Use `RateLimiters(SQLiteProvider("app.db"))` for file-backed limits on a single host. Each acquire runs a read-modify-write inside a `BEGIN IMMEDIATE` transaction. Issue [#173](https://github.com/grelinfo/grelmicro/issues/173).
 * ✨ Add `PostgresCircuitBreakerAdapter` for fleet-wide circuit breaker state on Postgres, plus `PostgresProvider.breaker()` so `CircuitBreakers(postgres)` resolves it. Transitions run in PL/pgSQL functions guarded by `pg_advisory_xact_lock`.
+* ✨ Add `Bulkhead` resilience pattern to cap concurrent in-flight calls. `max_concurrent` bounds concurrency, `max_wait` lets callers queue briefly before a `BulkheadFullError` (default fails fast), and `max_workers` runs blocking work through `bulkhead.to_thread` on a dedicated pool. Async context manager and decorator forms. Issue [#168](https://github.com/grelinfo/grelmicro/issues/168).
 
 ### Fixes
 

--- a/docs/reference/resilience.md
+++ b/docs/reference/resilience.md
@@ -8,6 +8,9 @@
     options:
       show_submodules: true
       members:
+        - Bulkhead
+        - BulkheadConfig
+        - BulkheadFullError
         - CircuitBreakers
         - CircuitBreaker
         - CircuitBreakerBackend

--- a/docs/resilience/bulkhead.md
+++ b/docs/resilience/bulkhead.md
@@ -1,0 +1,53 @@
+# Bulkhead
+
+A **Bulkhead** caps how many calls run at once. Rate limiting bounds requests per unit time. A bulkhead bounds *concurrent in-flight* work, so one slow dependency cannot consume every worker and starve the rest of the app.
+
+**Why**
+
+- Bound concurrent in-flight business operations.
+- Fail fast when saturated instead of queueing unboundedly.
+- Keep blocking work on a dedicated thread pool, off the event loop and off the shared executor.
+
+## Usage
+
+`Bulkhead` works as an async context manager and as a decorator on async functions. When the limit is reached, a caller waits up to `max_wait` seconds for a permit, then is rejected with `BulkheadFullError`.
+
+```python
+--8<-- "resilience/bulkhead.py"
+```
+
+The default fails fast: with no `max_wait`, a full bulkhead rejects immediately. Set `max_wait` to let callers queue briefly for a permit.
+
+### Bounded blocking work
+
+`to_thread` runs a blocking function on the bulkhead's own thread pool when `max_workers` is set, otherwise on the event loop's shared executor.
+
+```python
+--8<-- "resilience/bulkhead_to_thread.py"
+```
+
+## Configuration
+
+`Bulkhead` follows the three-paths configuration contract.
+
+### Environmental
+
+Prefix: `GREL_BULKHEAD_{NAME_UPPER}_`
+
+| Env var | Field | Type | Default |
+|---|---|---|---|
+| `GREL_BULKHEAD_{NAME_UPPER}_MAX_CONCURRENT` | `max_concurrent` | `PositiveInt` | unbounded |
+| `GREL_BULKHEAD_{NAME_UPPER}_MAX_WAIT` | `max_wait` | `NonNegativeFloat` | fail fast |
+| `GREL_BULKHEAD_{NAME_UPPER}_MAX_WORKERS` | `max_workers` | `PositiveInt` | shared executor |
+
+## Composition
+
+The recommended outside-in order is **Fallback → Retry → CircuitBreaker → Bulkhead → Timeout → call**. Read more in [Composing patterns](composition.md). Placing the bulkhead above the timeout caps concurrency before a call enters its timeout window.
+
+## Live reconfiguration
+
+`Bulkhead` inherits `Reconfigurable[BulkheadConfig]`. Calling `bulkhead.reconfigure(new_config)` applies a new `max_concurrent` to calls admitted after the swap. Calls already inside keep their permit. Changing `max_workers` rebuilds the private thread pool. See [Live reconfiguration](../architecture/reconfigure.md).
+
+## Reference
+
+See the [API reference](../reference/resilience.md#grelmicro.resilience.Bulkhead) for every option.

--- a/docs/resilience/index.md
+++ b/docs/resilience/index.md
@@ -8,6 +8,7 @@ The `resilience` package provides primitives that help your services handle fail
 - [**Rate Limiter**](rate-limiter.md): cap how many requests a client can make per window. Pluggable algorithm (`TokenBucketConfig` or `SlidingWindowConfig`), pluggable backend (`Memory` or `Redis`), with a result shape that maps directly to HTTP rate limit headers.
 - [**Retry**](retry.md): repeat a failing call with backoff and jitter. Pluggable algorithm (`ExponentialBackoff`, `ConstantBackoff`, `LinearBackoff`, `FibonacciBackoff`, `RandomBackoff`), required exception filter, decorator and block forms.
 - [**Timeout**](timeout.md): bound how long an async call may run. Reconfigurable deadline, async context manager and decorator forms. Wraps `asyncio.timeout`.
+- [**Bulkhead**](bulkhead.md): cap concurrent in-flight calls and fail fast when saturated. Optional bounded wait for a permit and a dedicated thread pool for blocking work. Async context manager and decorator forms.
 
 See [Composing patterns](composition.md) for the recommended outside-in order when stacking decorators.
 
@@ -21,6 +22,7 @@ See [Composing patterns](composition.md) for the recommended outside-in order wh
 | **Rate Limiter** | You need to throttle *your own* endpoint, worker, or background job to protect the downstream side or enforce fair usage. |
 | **Retry** | A call fails for transient reasons (network blip, brief overload) and is safe to repeat. |
 | **Timeout** | An async call may stall and you need a hard deadline on it. |
+| **Bulkhead** | A dependency can saturate your workers and you want to cap concurrent calls and fail fast instead of queueing unboundedly. |
 
 For synchronous, in-process token-bucket rate limiting on a performance-critical sync path (the main example is the logging pipeline), see [`MemoryTokenBucket`](rate-limiter.md#standalone-memorytokenbucket). It powers `grelmicro.log.RateLimitFilter`.
 

--- a/docs/snippets/resilience/bulkhead.py
+++ b/docs/snippets/resilience/bulkhead.py
@@ -1,0 +1,18 @@
+from grelmicro.resilience import Bulkhead, BulkheadFullError
+
+
+async def process(order_id: str) -> str:
+    return order_id
+
+
+# Bound concurrent checkouts to 50. A caller waits up to 2s for a free
+# permit, then is rejected.
+checkout = Bulkhead("checkout", max_concurrent=50, max_wait=2.0)
+
+
+async def handle(order_id: str) -> str:
+    try:
+        async with checkout:
+            return await process(order_id)
+    except BulkheadFullError:
+        return "busy"

--- a/docs/snippets/resilience/bulkhead_to_thread.py
+++ b/docs/snippets/resilience/bulkhead_to_thread.py
@@ -1,0 +1,17 @@
+import time
+
+from grelmicro.resilience import Bulkhead
+
+# A dedicated 4-thread pool keeps blocking work off the event loop and
+# off the default executor shared by the rest of the app.
+reports = Bulkhead("reports", max_workers=4)
+
+
+def render_pdf(report_id: str) -> bytes:
+    time.sleep(0.1)  # blocking work
+    return report_id.encode()
+
+
+@reports
+async def build_report(report_id: str) -> bytes:
+    return await reports.to_thread(render_pdf, report_id)

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -14,6 +14,8 @@ Pick the front door first, the algorithm second, the backend third.
 * `Fallback("name", when=..., default=...)` or the `@fallback(...)`
   / `falling_back(...)` decorator and block form.
 * `Timeout("name", seconds=...)` for deadlines.
+* `Bulkhead("name", max_concurrent=...)` or the `@bulkhead`
+  decorator to cap concurrent in-flight calls.
 * `Shield("name")` or the `@shield(...)` decorator for the bundled
   timeout + retry + adaptive rate-limit + cache + fallback profile.
 
@@ -34,8 +36,8 @@ users rarely name these directly. The Components do.
 **Configs** (frozen Pydantic models, accept env vars):
 `TokenBucketConfig`, `SlidingWindowConfig`,
 `CircuitBreakerConfig`, `RetryConfig`, `FallbackConfig`,
-`TimeoutConfig`, `ShieldConfig`. One per pattern, plus backoff
-configs (`ExponentialBackoff`, `LinearBackoff`, ...).
+`TimeoutConfig`, `BulkheadConfig`, `ShieldConfig`. One per pattern,
+plus backoff configs (`ExponentialBackoff`, `LinearBackoff`, ...).
 
 **Loading**: top-level re-exports are PEP 562 lazy. Importing this
 package loads `_components`, `_match`, `_outcome`, `_protocol`,
@@ -67,6 +69,7 @@ from grelmicro.resilience._protocol import (
     RetryStrategy,
 )
 from grelmicro.resilience.errors import (
+    BulkheadFullError,
     CircuitBreakerError,
     RateLimitExceededError,
     ResilienceError,
@@ -100,6 +103,7 @@ if TYPE_CHECKING:
         RandomBackoff,
         RetryBackoffConfig,
     )
+    from grelmicro.resilience.bulkhead import Bulkhead, BulkheadConfig
     from grelmicro.resilience.circuitbreaker import (
         CircuitBreaker,
         CircuitBreakerConfig,
@@ -160,6 +164,9 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ApiShieldConfig",
+    "Bulkhead",
+    "BulkheadConfig",
+    "BulkheadFullError",
     "CircuitBreaker",
     "CircuitBreakerBackend",
     "CircuitBreakerConfig",
@@ -222,6 +229,9 @@ __all__ = [
 # (attribute -> (module, attribute)). The module is loaded lazily on
 # first access. Adding a new Pattern means adding one row per export.
 _LAZY: dict[str, tuple[str, str]] = {
+    # Bulkhead
+    "Bulkhead": ("grelmicro.resilience.bulkhead", "Bulkhead"),
+    "BulkheadConfig": ("grelmicro.resilience.bulkhead", "BulkheadConfig"),
     # Circuit breaker
     "CircuitBreaker": ("grelmicro.resilience.circuitbreaker", "CircuitBreaker"),
     "CircuitBreakerConfig": (

--- a/grelmicro/resilience/bulkhead.py
+++ b/grelmicro/resilience/bulkhead.py
@@ -1,0 +1,287 @@
+"""Bulkhead."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from inspect import iscoroutinefunction
+from typing import TYPE_CHECKING, Annotated, Any, Self
+
+from pydantic import BaseModel, NonNegativeFloat, PositiveInt
+from typing_extensions import Doc
+
+from grelmicro._config import Reconfigurable, env_segment, resolve_config
+from grelmicro.resilience.errors import BulkheadFullError
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from types import TracebackType
+
+__all__ = [
+    "Bulkhead",
+    "BulkheadConfig",
+]
+
+
+def _current_task() -> asyncio.Task[Any]:
+    """Return the current asyncio task or raise if none is running."""
+    task = asyncio.current_task()
+    if task is None:  # pragma: no cover
+        msg = "Bulkhead requires a running asyncio task"
+        raise RuntimeError(msg)
+    return task
+
+
+class BulkheadConfig(BaseModel, frozen=True, extra="forbid"):
+    """Bulkhead policy configuration.
+
+    Frozen Pydantic data class. Three-paths configuration: kwargs,
+    instance, or env vars.
+
+    Read more in the [Bulkhead](../resilience/bulkhead.md) docs.
+    """
+
+    max_concurrent: Annotated[
+        PositiveInt | None,
+        Doc(
+            "Maximum concurrent calls admitted to the bulkhead. `None` "
+            "(the default) leaves concurrency unbounded."
+        ),
+    ] = None
+
+    max_wait: Annotated[
+        NonNegativeFloat | None,
+        Doc(
+            "Seconds a caller waits for a free permit before the "
+            "bulkhead rejects it with `BulkheadFullError`. `None` (the "
+            "default) and `0` reject immediately (fail fast). Ignored "
+            "when `max_concurrent` is `None`."
+        ),
+    ] = None
+
+    max_workers: Annotated[
+        PositiveInt | None,
+        Doc(
+            "Size of the private thread pool backing `to_thread`. `None` "
+            "(the default) uses the event loop's shared executor."
+        ),
+    ] = None
+
+
+@dataclass(frozen=True, slots=True)
+class _State:
+    """Read-side snapshot bundling the config with its bound semaphore."""
+
+    config: BulkheadConfig
+    semaphore: asyncio.Semaphore | None
+
+
+class Bulkhead(Reconfigurable[BulkheadConfig]):
+    """Bulkhead policy.
+
+    A named, reusable concurrency limiter with three-paths
+    configuration and live reconfiguration. Use it as an async context
+    manager or as a decorator on async functions to bound the number of
+    in-flight calls, and `to_thread` to run blocking work on a bounded
+    private thread pool.
+
+    When the bulkhead is full, a caller waits up to `max_wait` seconds
+    for a permit, then is rejected with
+    [`BulkheadFullError`][grelmicro.resilience.BulkheadFullError]. The
+    default fails fast (no wait).
+
+    Read more in the [Bulkhead](../resilience/bulkhead.md) docs.
+    """
+
+    def __init__(
+        self,
+        name: Annotated[
+            str,
+            Doc(
+                "The name of the bulkhead. Used as the env namespace, "
+                "the rejection error label, and the thread-name prefix."
+            ),
+        ],
+        *,
+        max_concurrent: Annotated[
+            PositiveInt | None,
+            Doc("Maximum concurrent calls. `None` leaves it unbounded."),
+        ] = None,
+        max_wait: Annotated[
+            NonNegativeFloat | None,
+            Doc(
+                "Seconds to wait for a permit before rejecting. `None` "
+                "or `0` fails fast."
+            ),
+        ] = None,
+        max_workers: Annotated[
+            PositiveInt | None,
+            Doc("Private thread-pool size for `to_thread`."),
+        ] = None,
+        config: Annotated[
+            BulkheadConfig | None,
+            Doc(
+                "A pre-built [`BulkheadConfig`][grelmicro.resilience.BulkheadConfig]. "
+                "Mutually exclusive with the per-field kwargs."
+            ),
+        ] = None,
+        env_load: Annotated[
+            bool | None,
+            Doc(
+                "Whether to read environment variables. Defaults to the "
+                "process-wide `GREL_ENV_LOAD` flag."
+            ),
+        ] = None,
+    ) -> None:
+        """Initialize the bulkhead."""
+        self._name = name
+        resolved = resolve_config(
+            BulkheadConfig,
+            explicit=config,
+            kwargs={
+                "max_concurrent": max_concurrent,
+                "max_wait": max_wait,
+                "max_workers": max_workers,
+            },
+            env_prefix=f"GREL_BULKHEAD_{env_segment(name)}_",
+            env_load=env_load,
+        )
+        self._config = resolved
+        self._state = _State(
+            config=resolved, semaphore=_build_semaphore(resolved)
+        )
+        self._reconfigure_lock = asyncio.Lock()
+        self._executor: ThreadPoolExecutor | None = None
+        self._permits: dict[
+            asyncio.Task[Any], list[asyncio.Semaphore | None]
+        ] = {}
+
+    @property
+    def name(self) -> str:
+        """Return the bulkhead identity."""
+        return self._name
+
+    @classmethod
+    def from_config(
+        cls,
+        name: Annotated[str, Doc("The name of the bulkhead.")],
+        config: Annotated[
+            BulkheadConfig,
+            Doc("The pre-built bulkhead configuration."),
+        ],
+    ) -> Self:
+        """Construct a `Bulkhead` from a name and a pre-built `BulkheadConfig`."""
+        return cls(name, config=config)
+
+    async def __aenter__(self) -> Self:
+        """Admit the current task, waiting up to `max_wait` for a permit."""
+        state = self._state
+        semaphore = state.semaphore
+        if semaphore is not None:
+            wait = state.config.max_wait or 0.0
+            try:
+                async with asyncio.timeout(wait):
+                    await semaphore.acquire()
+            except TimeoutError:
+                # A semaphore exists only when `max_concurrent` is set,
+                # so the value is never `None` on this branch.
+                raise BulkheadFullError(
+                    name=self._name,
+                    max_concurrent=state.config.max_concurrent,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+                ) from None
+        task = _current_task()
+        stack = self._permits.get(task)
+        if stack is None:
+            self._permits[task] = [semaphore]
+        else:
+            stack.append(semaphore)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        """Release the permit acquired by the matching `__aenter__`."""
+        task = _current_task()
+        stack = self._permits[task]
+        semaphore = stack.pop()
+        if not stack:
+            del self._permits[task]
+        if semaphore is not None:
+            semaphore.release()
+        return None
+
+    def __call__(
+        self, fn: Callable[..., Awaitable[Any]], /
+    ) -> Callable[..., Awaitable[Any]]:
+        """Decorate ``fn`` so each call runs under this bulkhead."""
+        if not iscoroutinefunction(fn):
+            msg = (
+                "Bulkhead only decorates async functions. Use "
+                f"`bulkhead.to_thread(...)` for blocking work, got {fn!r}."
+            )
+            raise TypeError(msg)
+
+        @functools.wraps(fn)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            async with self:
+                return await fn(*args, **kwargs)
+
+        return async_wrapper
+
+    async def to_thread(
+        self,
+        func: Annotated[
+            Callable[..., Any],
+            Doc("Blocking callable to run off the event loop."),
+        ],
+        /,
+        *args: Any,  # noqa: ANN401
+        **kwargs: Any,  # noqa: ANN401
+    ) -> Any:  # noqa: ANN401
+        """Run ``func`` in a worker thread, bounded by `max_workers`.
+
+        Routes through the bulkhead's private `ThreadPoolExecutor` when
+        `max_workers` is set, otherwise the event loop's shared executor
+        (`asyncio.to_thread`).
+        """
+        max_workers = self._state.config.max_workers
+        if max_workers is None:
+            return await asyncio.to_thread(func, *args, **kwargs)
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(
+                max_workers=max_workers,
+                thread_name_prefix=f"bulkhead-{self._name}",
+            )
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor, functools.partial(func, *args, **kwargs)
+        )
+
+    async def _apply_reconfigure(self, new_config: BulkheadConfig) -> None:
+        """Publish a fresh snapshot. In-flight calls keep their permit.
+
+        A changed `max_concurrent` builds a new semaphore for calls that
+        enter after the swap. A changed `max_workers` discards the
+        private executor so the next `to_thread` rebuilds it.
+        """
+        if (
+            self._executor is not None
+            and new_config.max_workers != self._state.config.max_workers
+        ):
+            self._executor.shutdown(wait=False)
+            self._executor = None
+        self._state = _State(
+            config=new_config, semaphore=_build_semaphore(new_config)
+        )
+
+
+def _build_semaphore(config: BulkheadConfig) -> asyncio.Semaphore | None:
+    """Build a semaphore for the configured concurrency, or `None`."""
+    if config.max_concurrent is None:
+        return None
+    return asyncio.Semaphore(config.max_concurrent)

--- a/grelmicro/resilience/errors.py
+++ b/grelmicro/resilience/errors.py
@@ -19,6 +19,27 @@ class ResilienceSettingsValidationError(
     """Resilience Settings Validation Error."""
 
 
+class BulkheadFullError(ResilienceError):
+    """Bulkhead full error.
+
+    Raised when a bulkhead has no free permit and the caller's
+    `max_wait` elapsed (or was zero, the fail-fast default).
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        max_concurrent: int,
+    ) -> None:
+        """Initialize the error."""
+        self.name = name
+        self.max_concurrent = max_concurrent
+        super().__init__(
+            f"Bulkhead '{name}' is full ({max_concurrent} concurrent calls)"
+        )
+
+
 class RateLimitExceededError(ResilienceError):
     """Rate limit exceeded error.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
     - Resilience:
         - resilience/index.md
         - resilience/shield.md
+        - resilience/bulkhead.md
         - resilience/circuit-breaker.md
         - resilience/fallback.md
         - resilience/rate-limiter.md

--- a/tests/resilience/test_bulkhead.py
+++ b/tests/resilience/test_bulkhead.py
@@ -1,0 +1,271 @@
+"""Tests for the Bulkhead concurrency-isolation pattern."""
+
+import asyncio
+import threading
+
+import pytest
+
+from grelmicro.resilience import Bulkhead, BulkheadConfig, BulkheadFullError
+
+pytestmark = [pytest.mark.timeout(5)]
+
+LIMIT = 2
+WORKERS = 6
+UNBOUNDED_WORKERS = 5
+ENV_LIMIT = 7
+FROM_CONFIG_LIMIT = 4
+CONFIG_CONCURRENT = 3
+CONFIG_WAIT = 0.5
+CONFIG_WORKERS = 2
+ADD_RESULT = 42
+KWARGS_SUM = 5
+
+
+# --- Construction & configuration ---
+
+
+def test_config_property() -> None:
+    """`config` exposes the resolved configuration."""
+    bulkhead = Bulkhead(
+        "api",
+        max_concurrent=CONFIG_CONCURRENT,
+        max_wait=CONFIG_WAIT,
+        max_workers=CONFIG_WORKERS,
+    )
+    assert bulkhead.name == "api"
+    assert isinstance(bulkhead.config, BulkheadConfig)
+    assert bulkhead.config.max_concurrent == CONFIG_CONCURRENT
+    assert bulkhead.config.max_wait == CONFIG_WAIT
+    assert bulkhead.config.max_workers == CONFIG_WORKERS
+
+
+def test_from_config() -> None:
+    """`from_config` builds a bulkhead from a pre-built config."""
+    bulkhead = Bulkhead.from_config(
+        "api", BulkheadConfig(max_concurrent=FROM_CONFIG_LIMIT)
+    )
+    assert bulkhead.config.max_concurrent == FROM_CONFIG_LIMIT
+
+
+def test_env_vars_fill_unset_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset fields resolve from `GREL_BULKHEAD_{NAME}_*`."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "true")
+    monkeypatch.setenv("GREL_BULKHEAD_CHECKOUT_MAX_CONCURRENT", str(ENV_LIMIT))
+
+    bulkhead = Bulkhead("checkout")
+
+    assert bulkhead.config.max_concurrent == ENV_LIMIT
+
+
+# --- Concurrency enforcement ---
+
+
+async def test_max_concurrent_caps_in_flight_calls() -> None:
+    """No more than `max_concurrent` calls run inside the scope at once."""
+    bulkhead = Bulkhead("api", max_concurrent=LIMIT, max_wait=2.0)
+    active = 0
+    peak = 0
+
+    async def worker() -> None:
+        nonlocal active, peak
+        async with bulkhead:
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0.02)
+            active -= 1
+
+    await asyncio.gather(*(worker() for _ in range(WORKERS)))
+
+    assert peak == LIMIT
+
+
+async def test_unbounded_admits_everyone() -> None:
+    """With `max_concurrent=None` there is no permit and no limit."""
+    bulkhead = Bulkhead("api")
+    active = 0
+    peak = 0
+
+    async def worker() -> None:
+        nonlocal active, peak
+        async with bulkhead:
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+
+    await asyncio.gather(*(worker() for _ in range(UNBOUNDED_WORKERS)))
+
+    assert peak == UNBOUNDED_WORKERS
+
+
+async def test_fail_fast_rejects_when_full() -> None:
+    """The default (no `max_wait`) rejects immediately when full."""
+    bulkhead = Bulkhead("api", max_concurrent=1)
+    released = asyncio.Event()
+
+    async def holder() -> None:
+        async with bulkhead:
+            await released.wait()
+
+    task = asyncio.create_task(holder())
+    await asyncio.sleep(0.01)  # let the holder take the only permit
+
+    with pytest.raises(BulkheadFullError) as exc:
+        async with bulkhead:
+            pass
+
+    assert exc.value.name == "api"
+    assert exc.value.max_concurrent == 1
+    released.set()
+    await task
+
+
+async def test_max_wait_acquires_when_permit_frees() -> None:
+    """A waiter within `max_wait` gets the permit once it frees."""
+    bulkhead = Bulkhead("api", max_concurrent=1, max_wait=1.0)
+    admitted = False
+
+    async def holder() -> None:
+        async with bulkhead:
+            await asyncio.sleep(0.05)
+
+    async def waiter() -> None:
+        nonlocal admitted
+        async with bulkhead:
+            admitted = True
+
+    await asyncio.gather(holder(), waiter())
+
+    assert admitted is True
+
+
+async def test_max_wait_rejects_after_timeout() -> None:
+    """A waiter past `max_wait` is rejected."""
+    bulkhead = Bulkhead("api", max_concurrent=1, max_wait=0.05)
+    released = asyncio.Event()
+
+    async def holder() -> None:
+        async with bulkhead:
+            await released.wait()
+
+    task = asyncio.create_task(holder())
+    await asyncio.sleep(0.01)
+
+    with pytest.raises(BulkheadFullError):
+        async with bulkhead:
+            pass
+
+    released.set()
+    await task
+
+
+async def test_nested_scopes_consume_permits() -> None:
+    """Nested entries in one task each take and release a permit."""
+    bulkhead = Bulkhead("api", max_concurrent=LIMIT)
+    async with bulkhead, bulkhead:
+        # Both permits are held; a third concurrent entry fails fast.
+        with pytest.raises(BulkheadFullError):
+            async with bulkhead:
+                pass
+    # Both released: a fresh entry succeeds.
+    async with bulkhead:
+        pass
+
+
+# --- Decorator ---
+
+
+async def test_decorator_enforces_limit() -> None:
+    """`@bulkhead` admits calls under the limit."""
+    bulkhead = Bulkhead("api", max_concurrent=1)
+
+    @bulkhead
+    async def handler() -> str:
+        return "ok"
+
+    assert await handler() == "ok"
+
+
+def test_decorator_rejects_sync_function() -> None:
+    """`@bulkhead` on a sync function raises `TypeError`."""
+    bulkhead = Bulkhead("api", max_concurrent=1)
+
+    with pytest.raises(TypeError, match="only decorates async functions"):
+
+        @bulkhead  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        def handler() -> None: ...
+
+
+# --- to_thread ---
+
+
+async def test_to_thread_default_executor() -> None:
+    """Without `max_workers`, `to_thread` runs on the shared executor."""
+    bulkhead = Bulkhead("api")
+
+    result = await bulkhead.to_thread(lambda x: x + 1, 41)
+
+    assert result == ADD_RESULT
+
+
+async def test_to_thread_private_executor() -> None:
+    """With `max_workers`, `to_thread` runs on the bulkhead's own pool."""
+    bulkhead = Bulkhead("checkout", max_workers=2)
+
+    name = await bulkhead.to_thread(lambda: threading.current_thread().name)
+    # A second call reuses the already-built private executor.
+    again = await bulkhead.to_thread(lambda: threading.current_thread().name)
+
+    assert name.startswith("bulkhead-checkout")
+    assert again.startswith("bulkhead-checkout")
+
+
+async def test_to_thread_passes_kwargs() -> None:
+    """`to_thread` forwards positional and keyword arguments."""
+    bulkhead = Bulkhead("api", max_workers=1)
+
+    def add(a: int, *, b: int) -> int:
+        return a + b
+
+    assert await bulkhead.to_thread(add, 2, b=3) == KWARGS_SUM
+
+
+# --- Reconfigure ---
+
+
+async def test_reconfigure_changes_concurrency() -> None:
+    """A reconfigured `max_concurrent` applies to new entries."""
+    bulkhead = Bulkhead("api", max_concurrent=1, max_wait=2.0)
+    await bulkhead.reconfigure(
+        bulkhead.config.model_copy(update={"max_concurrent": LIMIT})
+    )
+
+    active = 0
+    peak = 0
+
+    async def worker() -> None:
+        nonlocal active, peak
+        async with bulkhead:
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0.02)
+            active -= 1
+
+    await asyncio.gather(*(worker() for _ in range(FROM_CONFIG_LIMIT)))
+
+    assert peak == LIMIT
+
+
+async def test_reconfigure_rebuilds_executor() -> None:
+    """Changing `max_workers` discards the private executor."""
+    bulkhead = Bulkhead("api", max_workers=1)
+    await bulkhead.to_thread(lambda: None)  # builds the executor
+    first = bulkhead._executor
+
+    await bulkhead.reconfigure(
+        bulkhead.config.model_copy(update={"max_workers": 2})
+    )
+
+    assert bulkhead._executor is None
+    await bulkhead.to_thread(lambda: None)  # builds a fresh one
+    assert bulkhead._executor is not first

--- a/tests/resilience/test_errors.py
+++ b/tests/resilience/test_errors.py
@@ -33,6 +33,9 @@ def test_resilience_module_exports() -> None:
     """Test resilience module __all__ contains expected symbols."""
     expected = {
         "ApiShieldConfig",
+        "Bulkhead",
+        "BulkheadConfig",
+        "BulkheadFullError",
         "CircuitBreakers",
         "CircuitBreaker",
         "CircuitBreakerBackend",


### PR DESCRIPTION
## Summary

Add the **Bulkhead** resilience pattern (issue #168): cap concurrent in-flight calls, fail fast when saturated, and run blocking work on a dedicated thread pool. This is the first of two PRs. It delivers the two self-contained axes; the `uses=` Component-override axis follows in PR B (it needs core resolution and provider-lifecycle wiring).

## What it does

- `Bulkhead("name", max_concurrent=N)` admits at most `N` concurrent calls as an async context manager or `@bulkhead` decorator.
- `max_wait` (seconds) lets a caller queue briefly for a permit, then raises `BulkheadFullError`. The default (`None`) fails fast, matching the resilience4j semaphore-bulkhead model.
- `max_workers` plus `bulkhead.to_thread(fn, *args, **kwargs)` runs blocking work on the bulkhead's own `ThreadPoolExecutor`, off the event loop and off the shared executor.
- Three-paths config (`BulkheadConfig`, env prefix `GREL_BULKHEAD_{NAME}_`) and live `reconfigure`.

## Why `uses=` is deferred to PR B

`uses=` re-points a Pattern's *default* backend to a dedicated Component while inside the scope, via an ambient `ContextVar` that `Grelmicro.get` consults. Wiring it correctly also requires opening the providers behind those components (a `Sync(provider)` component does not retain its provider), which is real lifecycle work best reviewed on its own.

## Validation

100% coverage on the new module (16 tests). `ruff`, `ty`, `mkdocs build --strict`, and the full unit + integration gate pass. Docs: reference page, two executable snippets (run by `test_snippets.py`), capability matrix, resilience landing page, changelog.
