### PR TITLE
✨ Add Bulkhead uses= to scope Providers and Components onto an isolated pool

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@
 * ✨ Add `SQLiteProvider` and SQLite rate limiting. Use `RateLimiters(SQLiteProvider("app.db"))` for file-backed limits on a single host. Each acquire runs a read-modify-write inside a `BEGIN IMMEDIATE` transaction. Issue [#173](https://github.com/grelinfo/grelmicro/issues/173).
 * ✨ Add `PostgresCircuitBreakerAdapter` for fleet-wide circuit breaker state on Postgres, plus `PostgresProvider.breaker()` so `CircuitBreakers(postgres)` resolves it. Transitions run in PL/pgSQL functions guarded by `pg_advisory_xact_lock`.
 * ✨ Add `Bulkhead` resilience pattern to cap concurrent in-flight calls. `max_concurrent` bounds concurrency, `max_wait` lets callers queue briefly before a `BulkheadFullError` (default fails fast), and `max_workers` runs blocking work through `bulkhead.to_thread` on a dedicated pool. Async context manager and decorator forms. Issue [#168](https://github.com/grelinfo/grelmicro/issues/168).
+* ✨ Add `Bulkhead(uses=[...])` to scope Providers and Components to a bulkhead. Inside the scope, a Pattern resolving its default backend picks up the bulkhead's Component, isolating a business context onto its own pool. Explicit `backend=` still wins. Issue [#168](https://github.com/grelinfo/grelmicro/issues/168).
 
 ### Fixes
 

--- a/docs/resilience/bulkhead.md
+++ b/docs/resilience/bulkhead.md
@@ -26,6 +26,16 @@ The default fails fast: with no `max_wait`, a full bulkhead rejects immediately.
 --8<-- "resilience/bulkhead_to_thread.py"
 ```
 
+### Failure-domain isolation
+
+`uses=` scopes Providers and Components to the bulkhead, in the same shape as `Grelmicro(uses=[...])`. Inside the scope, a Pattern that resolves its *default* backend (a bare `Lock("k")`, a `cache.get(...)`, ...) picks up the bulkhead's Component instead of the app's. A Pattern with an explicit `backend=` is unaffected, so explicit choices always win. This isolates a business context (checkout, reporting) onto its own connection pool, so one context cannot exhaust another's.
+
+```python
+--8<-- "resilience/bulkhead_uses.py"
+```
+
+The bulkhead opens its `uses=` on first entry and closes them when the app shuts down, so an active `Grelmicro` app is required. List the Provider before the Component that borrows it, exactly as in `Grelmicro(uses=[...])`.
+
 ## Configuration
 
 `Bulkhead` follows the three-paths configuration contract.

--- a/docs/snippets/resilience/bulkhead_uses.py
+++ b/docs/snippets/resilience/bulkhead_uses.py
@@ -1,0 +1,22 @@
+from grelmicro.providers.redis import RedisProvider
+from grelmicro.resilience import Bulkhead
+from grelmicro.sync import Lock, Sync
+
+# A dedicated Redis for checkout, isolated from the app's default sync
+# backend. The bulkhead opens it on first entry and closes it at app
+# shutdown.
+checkout_redis = RedisProvider("redis://localhost:6379/1")
+checkout = Bulkhead(
+    "checkout",
+    max_concurrent=50,
+    uses=[checkout_redis, Sync(checkout_redis)],
+)
+
+cart_lock = Lock("cart")
+
+
+async def handle_checkout(cart_id: str) -> None:
+    # `cart_lock` has no explicit backend, so inside the scope it
+    # resolves to the bulkhead's dedicated Sync backend.
+    async with checkout, cart_lock:
+        ...

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -16,7 +16,7 @@ from grelmicro._component import Component
 from grelmicro.errors import GrelmicroError, OutOfContextError
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterable
+    from collections.abc import AsyncIterator, Iterable, Mapping
     from types import TracebackType
 
     from grelmicro.cache._component import Cache
@@ -34,6 +34,17 @@ else:
     Trace = Any
 
 _current_micro: ContextVar[Grelmicro] = ContextVar("grelmicro_current_app")
+
+_active_bulkhead: ContextVar[Mapping[tuple[str, str], Component]] = ContextVar(
+    "grelmicro_active_bulkhead"
+)
+"""Component overrides installed by the active `Bulkhead` scope, keyed by `(kind, name)`.
+
+`Grelmicro.get` consults this before its own registry so a Pattern resolving
+its default backend inside the scope picks up the bulkhead's `uses=`
+component. A Pattern with an explicit `backend=` never calls `get`, so
+explicit choices always win.
+"""
 
 
 class Grelmicro:
@@ -248,6 +259,11 @@ class Grelmicro:
         Raises:
             ComponentNotRegisteredError: If no component matches.
         """
+        overrides = _active_bulkhead.get(None)
+        if overrides is not None:
+            override = overrides.get((kind, name))
+            if override is not None:
+                return override
         try:
             return self._by_key[(kind, name)]
         except KeyError as exc:

--- a/grelmicro/resilience/bulkhead.py
+++ b/grelmicro/resilience/bulkhead.py
@@ -12,11 +12,15 @@ from typing import TYPE_CHECKING, Annotated, Any, Self
 from pydantic import BaseModel, NonNegativeFloat, PositiveInt
 from typing_extensions import Doc
 
+from grelmicro._app import Grelmicro, _active_bulkhead
+from grelmicro._component import Component
 from grelmicro._config import Reconfigurable, env_segment, resolve_config
 from grelmicro.resilience.errors import BulkheadFullError
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Iterable
+    from contextlib import AbstractAsyncContextManager
+    from contextvars import Token
     from types import TracebackType
 
 __all__ = [
@@ -120,6 +124,21 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
             PositiveInt | None,
             Doc("Private thread-pool size for `to_thread`."),
         ] = None,
+        uses: Annotated[
+            Iterable[AbstractAsyncContextManager[object]],
+            Doc(
+                """
+                Providers and Components, in the same shape as
+                `Grelmicro(uses=[...])`, scoped to this bulkhead. Inside
+                the scope, a Pattern that resolves its default backend
+                (a bare `Lock("k")`, `cache.get(...)`, ...) picks up the
+                matching Component here instead of the app's. A Pattern
+                with an explicit `backend=` is unaffected. The bulkhead
+                opens these on first entry and closes them when the app
+                shuts down, so an active `Grelmicro` app is required.
+                """
+            ),
+        ] = (),
         config: Annotated[
             BulkheadConfig | None,
             Doc(
@@ -154,8 +173,17 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
         )
         self._reconfigure_lock = asyncio.Lock()
         self._executor: ThreadPoolExecutor | None = None
-        self._permits: dict[
-            asyncio.Task[Any], list[asyncio.Semaphore | None]
+        self._uses = tuple(uses)
+        self._overrides: dict[tuple[str, str], Component] = {
+            (item.kind, item.name): item
+            for item in self._uses
+            if isinstance(item, Component)
+        }
+        self._opened = False
+        self._open_lock = asyncio.Lock()
+        self._scopes: dict[
+            asyncio.Task[Any],
+            list[tuple[asyncio.Semaphore | None, Token[Any] | None]],
         ] = {}
 
     @property
@@ -191,12 +219,24 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
                     name=self._name,
                     max_concurrent=state.config.max_concurrent,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
                 ) from None
+        if self._uses and not self._opened:
+            await self._open_uses()
+        token: Token[Any] | None = None
+        if self._overrides:
+            current = _active_bulkhead.get(None)
+            merged = (
+                {**current, **self._overrides}
+                if current
+                else dict(self._overrides)
+            )
+            token = _active_bulkhead.set(merged)
         task = _current_task()
-        stack = self._permits.get(task)
+        scope = (semaphore, token)
+        stack = self._scopes.get(task)
         if stack is None:
-            self._permits[task] = [semaphore]
+            self._scopes[task] = [scope]
         else:
-            stack.append(semaphore)
+            stack.append(scope)
         return self
 
     async def __aexit__(
@@ -205,15 +245,35 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> bool | None:
-        """Release the permit acquired by the matching `__aenter__`."""
+        """Release the permit and override scope from the matching `__aenter__`."""
         task = _current_task()
-        stack = self._permits[task]
-        semaphore = stack.pop()
+        stack = self._scopes[task]
+        semaphore, token = stack.pop()
         if not stack:
-            del self._permits[task]
+            del self._scopes[task]
+        if token is not None:
+            _active_bulkhead.reset(token)
         if semaphore is not None:
             semaphore.release()
         return None
+
+    async def _open_uses(self) -> None:
+        """Open the `uses=` providers and components once, on the app stack.
+
+        Entered in order so a Component borrows a provider opened just
+        before it. Registered on the active app's exit stack, so they
+        close when the app shuts down rather than per scope.
+        """
+        async with self._open_lock:
+            if self._opened:
+                return
+            exit_stack = Grelmicro.current()._exit_stack  # noqa: SLF001
+            if exit_stack is None:  # pragma: no cover
+                msg = "Bulkhead uses= requires an open Grelmicro app"
+                raise RuntimeError(msg)
+            for item in self._uses:
+                await exit_stack.enter_async_context(item)
+            self._opened = True
 
     def __call__(
         self, fn: Callable[..., Awaitable[Any]], /

--- a/tests/resilience/test_bulkhead.py
+++ b/tests/resilience/test_bulkhead.py
@@ -2,10 +2,18 @@
 
 import asyncio
 import threading
+from typing import Self
 
 import pytest
 
+from grelmicro import (
+    ComponentNotRegisteredError,
+    Grelmicro,
+    NoActiveAppError,
+)
 from grelmicro.resilience import Bulkhead, BulkheadConfig, BulkheadFullError
+from grelmicro.sync import Sync
+from grelmicro.sync.memory import MemorySyncAdapter
 
 pytestmark = [pytest.mark.timeout(5)]
 
@@ -269,3 +277,117 @@ async def test_reconfigure_rebuilds_executor() -> None:
     assert bulkhead._executor is None
     await bulkhead.to_thread(lambda: None)  # builds a fresh one
     assert bulkhead._executor is not first
+
+
+# --- uses= overrides ---
+
+
+async def test_uses_overrides_default_backend_in_scope() -> None:
+    """Inside the scope, a default lookup resolves to the bulkhead's component."""
+    default = MemorySyncAdapter()
+    dedicated = MemorySyncAdapter()
+    micro = Grelmicro(uses=[Sync(default)])
+    bulkhead = Bulkhead("checkout", uses=[Sync(dedicated)])
+
+    async with micro:
+        assert micro.get("sync", "default").backend is default
+        async with bulkhead:
+            assert micro.get("sync", "default").backend is dedicated
+        assert micro.get("sync", "default").backend is default
+
+
+async def test_uses_override_only_covers_registered_keys() -> None:
+    """A key the bulkhead does not override falls through to the registry."""
+    default = MemorySyncAdapter()
+    dedicated = MemorySyncAdapter()
+    micro = Grelmicro(uses=[Sync(default)])
+    bulkhead = Bulkhead("checkout", uses=[Sync(dedicated)])
+
+    async with micro, bulkhead:
+        assert micro.get("sync", "default").backend is dedicated
+        with pytest.raises(ComponentNotRegisteredError):
+            micro.get("sync", "analytics")
+
+
+async def test_uses_opens_once_and_closes_at_shutdown() -> None:
+    """`uses=` items open on first entry and close at app shutdown."""
+
+    class Track:
+        def __init__(self) -> None:
+            self.entered = 0
+            self.exited = 0
+
+        async def __aenter__(self) -> Self:
+            self.entered += 1
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            self.exited += 1
+
+    track = Track()
+    bulkhead = Bulkhead("reports", uses=[track])
+    micro = Grelmicro()
+
+    async with micro:
+        assert track.entered == 0
+        async with bulkhead:
+            pass
+        async with bulkhead:
+            pass
+        assert track.entered == 1  # opened once, not per entry
+        assert track.exited == 0
+    assert track.exited == 1  # closed at app shutdown
+
+
+async def test_uses_requires_active_app() -> None:
+    """Entering a `uses=` bulkhead without an app raises."""
+    bulkhead = Bulkhead("checkout", uses=[Sync(MemorySyncAdapter())])
+    with pytest.raises(NoActiveAppError):
+        async with bulkhead:
+            pass
+
+
+async def test_nested_bulkheads_merge_overrides() -> None:
+    """A nested bulkhead's overrides layer over the outer one's."""
+    default = MemorySyncAdapter()
+    outer_adapter = MemorySyncAdapter()
+    inner_adapter = MemorySyncAdapter()
+    micro = Grelmicro(uses=[Sync(default)])
+    outer = Bulkhead("outer", uses=[Sync(outer_adapter)])
+    inner = Bulkhead("inner", uses=[Sync(inner_adapter, name="analytics")])
+
+    async with micro, outer:
+        assert micro.get("sync", "default").backend is outer_adapter
+        async with inner:
+            assert micro.get("sync", "default").backend is outer_adapter
+            assert micro.get("sync", "analytics").backend is inner_adapter
+        assert micro.get("sync", "default").backend is outer_adapter
+    assert micro.get("sync", "default").backend is default
+
+
+async def test_uses_opens_once_under_concurrent_first_entry() -> None:
+    """Concurrent first entries open `uses=` exactly once."""
+
+    class Track:
+        def __init__(self) -> None:
+            self.entered = 0
+
+        async def __aenter__(self) -> Self:
+            await asyncio.sleep(0)  # yield so the second task races in
+            self.entered += 1
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            pass
+
+    track = Track()
+    bulkhead = Bulkhead("reports", uses=[track])
+    micro = Grelmicro()
+
+    async def worker() -> None:
+        async with bulkhead:
+            await asyncio.sleep(0.01)
+
+    async with micro:
+        await asyncio.gather(worker(), worker())
+        assert track.entered == 1


### PR DESCRIPTION
## Summary

Adds `Bulkhead(uses=[...])` for failure-domain isolation. Inside a bulkhead scope, a Pattern that resolves its *default* backend (a bare `Lock("k")`, `cache.get(...)`, ...) picks up the bulkhead's Component instead of the app's, isolating a business context (checkout, reporting) onto its own connection pool. A Pattern with an explicit `backend=` is unaffected, so explicit choices always win.

This closes the last open resilience-pattern gap from the road-to-1.0 review (r12 #5).

## Behavior

- `uses=` takes Providers and Components in the same shape as `Grelmicro(uses=[...])`.
- The bulkhead opens its `uses=` on first entry and closes them when the app shuts down, so an active `Grelmicro` app is required.
- Overrides are keyed by `(kind, name)` and consulted in `Grelmicro.get` before the app registry. Nested bulkheads layer their overrides over the outer scope.

## Tests

6 new tests cover default-backend override in scope, key fall-through, open-once/close-at-shutdown, active-app requirement, nested merge, and concurrent first-entry open-once.

Closes #168.
