### PR TITLE
✨ Add three-layer cache stampede menu: local, distributed, and early refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? S
 
 | Module | Summary |
 |---|---|
-| [**Cache**](docs/cache.md) | `@cached` decorator with per-key stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
+| [**Cache**](docs/cache.md) | `@cached` decorator with local, distributed, and early (XFetch) stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
 | [**Synchronization**](docs/sync.md) | Distributed `Lock`, `TaskLock`, `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
 | [**Task Scheduler**](docs/task.md) | Periodic task execution with optional distributed locking. Lightweight, not a Celery replacement. |
 | [**Resilience**](docs/resilience/index.md) | [Circuit Breaker](docs/resilience/circuit-breaker.md) and [Rate Limiter](docs/resilience/rate-limiter.md) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -165,15 +165,37 @@ async def get_user(user_id: int) -> dict:
 
 ### Stampede Protection
 
-Set `lock=True` to prevent multiple concurrent callers from recomputing the same cache entry on a cache miss. When enabled, only one caller executes the function while all others **block and wait** until the result is available:
+A cache stampede (or "dog-pile") happens when many callers miss the same key at once and all recompute it together. `@cached` ships a three-layer menu, opt-in by cost:
+
+| Layer | What it does | Cost | Use when |
+|---|---|---|---|
+| `stampede="local"` (default) | per-key in-process lock | free, no I/O | always, the cheap correct default |
+| `stampede="distributed"` | cross-replica lock via the `Sync` component | one backend acquire per cold miss | a hot key on many replicas |
+| `early=0.1` | probabilistic early refresh (XFetch) in the last 10% of the TTL | one background recompute per refresh | the hottest keys, where no caller should ever block |
+
+The layers compose. `stampede="distributed"` implies `"local"` (in-process dedup is free), and `early=` works with either.
 
 ```python
-@cached(cache, lock=True)
+@cached(cache)                          # default: stampede="local"
 async def get_user(user_id: int) -> dict:
     return await db.fetch_user(user_id)
+
+
+@cached(cache, stampede="distributed")  # cross-replica via the Sync component
+async def get_billing(user_id: int) -> dict:
+    return await billing.fetch(user_id)
+
+
+@cached(cache, early=0.1)               # refresh hot keys before they expire
+async def get_homepage_feed() -> dict:
+    return await build_feed()
 ```
 
-Locking is **per-key**: concurrent misses on different keys run in parallel. Only callers that request the same key wait in turn, so one slow computation does not block unrelated keys.
+`stampede="local"` is **per-key**: concurrent misses on different keys run in parallel. Only callers that request the same key wait in turn, so one slow computation does not block unrelated keys.
+
+`stampede="distributed"` resolves the `Sync` component from the active `Grelmicro` app, so it needs an app with a `Sync` backend. Set `stampede=None` to opt out entirely.
+
+`early=` returns the cached value immediately and recomputes in the background, so a hot key refreshes before it expires and no caller ever waits on a cold miss. It costs one extra recompute per refresh and stores a small sidecar entry next to the value so replicas coordinate the refresh window.
 
 **When to use:** your cached function is expensive (database query, API call, heavy computation) and may be called concurrently with the same arguments.
 
@@ -185,7 +207,8 @@ Locking is **per-key**: concurrent misses on different keys run in parallel. Onl
 | `key_maker` | `Callable` | `None` | Custom key generation function. Receives `(func, args, kwargs)`. |
 | `skip` | `Callable` | `None` | Predicate receiving the result. Returns `True` to skip caching. |
 | `typed` | `bool` | `False` | Cache arguments of different types separately. |
-| `lock` | `bool` or context manager | `None` | Stampede protection. `True` enables per-key locking. |
+| `stampede` | `"local"`, `"distributed"`, or `None` | `"local"` | Concurrent-miss protection. |
+| `early` | `float` in `[0, 1)` | `None` | Probabilistic early refresh in the late TTL window. |
 
 ## Redis Backend Configuration
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+### Breaking
+
+* 💥 Replace the `@cached(lock=...)` parameter with `@cached(stampede="local" | "distributed" | None)`. `lock=True` becomes `stampede="local"` (now the default), `lock=False` becomes `stampede=None`, and the custom-context-manager form is dropped in favor of the `"distributed"` cross-replica mode. Issue [#235](https://github.com/grelinfo/grelmicro/issues/235).
+
 ### Features
 
+* ✨ Add a three-layer cache stampede menu to `@cached`. `stampede="local"` (default) folds concurrent same-key misses to one in-process run, `stampede="distributed"` coordinates across replicas through the `Sync` component, and `early=` (XFetch) refreshes the hottest keys in the background before they expire so no caller blocks. Issue [#235](https://github.com/grelinfo/grelmicro/issues/235).
 * ✨ Add `LeaderElection.last_confirmation_age()` (seconds since the last backend response that confirmed local leadership, `None` until first acquisition and after confirmed loss) and `LeaderElection.is_leader_confirmed_within(max_age)` (stricter variant of `is_leader()` that requires a recent backend renewal). The `is_leader()` docstring now spells out the advisory uncertainty window during a backend partition.
 * ✨ Add `Grelmicro(strict=True)` to raise `LifecycleOrderError` instead of warning when a Component holds a Provider that is missing from `uses=` or listed after the dependent Component. The default `False` preserves the lenient warn-only behavior. `LifecycleOrderError` is exported from `grelmicro`.
 * ✨ Add `Shield` resilience pattern: per-attempt timeout, retry-budget-gated retries, CUBIC-style adaptive rate limiter, optional cache and fallback recovery paths. Three profiles (`internal`, `api`, `slow`) cover the common cases. Decorator (`@shield`, `@shield.api(...)`), class (`Shield.api("name")`), and imperative (`Shield.api("name").run(fn, ...)`) forms supported. Issue [#249](https://github.com/grelinfo/grelmicro/issues/249).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -24,7 +24,7 @@ A short decision tree before the detailed tables:
 
 | If you only need this | Use this | Pick grelmicro when you also need |
 |---|---|---|
-| Async cache decorator over Redis | [`aiocache`](https://github.com/aio-libs/aiocache) or [`fastapi-cache`](https://github.com/long2ice/fastapi-cache) | Opt-in per-key stampede protection (`lock=True`), type-safe `TTLCache[T]`, Postgres backend |
+| Async cache decorator over Redis | [`aiocache`](https://github.com/aio-libs/aiocache) or [`fastapi-cache`](https://github.com/long2ice/fastapi-cache) | Three-layer stampede menu (`stampede="local"`/`"distributed"`, `early=`), type-safe `TTLCache[T]`, Postgres backend |
 | FastAPI rate limiter | [`slowapi`](https://github.com/laurentS/slowapi) or [`fastapi-limiter`](https://github.com/long2ice/fastapi-limiter) | Sliding-window algorithm, structured `RateLimitResult` for retry-after headers, swap Memory and Redis with the same API |
 | Async circuit breaker | [`pybreaker`](https://github.com/danielfm/pybreaker) or [`aiobreaker`](https://github.com/arlyon/aiobreaker) | Reconfigurable thresholds, frozen Pydantic config, structured logging context, distributed backend (planned, see [#163](https://github.com/grelinfo/grelmicro/issues/163)) |
 | Retry with `@retry(stop=, wait=)` | [`tenacity`](https://github.com/jd/tenacity) | A `Retry` that shares the same config + reconfigure shape as the rest of grelmicro |
@@ -72,7 +72,7 @@ If you build microservices on FastAPI today, grelmicro is the missing batteries.
 | Backends | Memory, Redis, Memcached | Memory, Redis, Memcached, DynamoDB | Memory, Redis, Postgres |
 | Decorator | `@cached` | `@cache` | `@cached` |
 | Type-safe `Cache[T]` | no | no | yes (`TTLCache[T]` plus `PydanticSerializer(T)`) |
-| Per-key stampede protection | local lock via `lock_value` | none | opt-in via `lock=True` (off by default). Distributed lock planned (see [#235](https://github.com/grelinfo/grelmicro/issues/235)) |
+| Stampede protection | local lock via `lock_value` | none | three-layer menu: `stampede="local"` (default), `stampede="distributed"` (cross-replica), `early=` (XFetch refresh) |
 | Serializers | several built-in | json, binary | `JsonSerializer`, `PydanticSerializer`, `PickleSerializer` |
 | FastAPI integration | manual | first-class | works with any async framework, no FastAPI coupling |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? S
 
 | Module | Summary |
 |---|---|
-| [**Cache**](cache.md) | `@cached` decorator with per-key stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
+| [**Cache**](cache.md) | `@cached` decorator with local, distributed, and early (XFetch) stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
 | [**Synchronization**](sync.md) | Distributed `Lock`, `TaskLock`, `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
 | [**Task Scheduler**](task.md) | Periodic task execution with optional distributed locking. Lightweight, not a Celery replacement. |
 | [**Resilience**](resilience/index.md) | [Circuit Breaker](resilience/circuit-breaker.md) and [Rate Limiter](resilience/rate-limiter.md) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |

--- a/docs/snippets/cache/postgres_basic.py
+++ b/docs/snippets/cache/postgres_basic.py
@@ -17,7 +17,7 @@ micro = Grelmicro(uses=[postgres, cache])
 ttl_cache = cache.ttl(ttl=300, serializer=PydanticSerializer(User))
 
 
-@cached(ttl_cache, lock=True)
+@cached(ttl_cache, stampede="local")
 async def get_user(user_id: int) -> User:
     return User(id=user_id, name="Alice")
 

--- a/docs/snippets/cache/redis_basic.py
+++ b/docs/snippets/cache/redis_basic.py
@@ -17,7 +17,7 @@ micro = Grelmicro(uses=[redis, cache])
 ttl_cache = cache.ttl(ttl=300, serializer=PydanticSerializer(User))
 
 
-@cached(ttl_cache, lock=True)
+@cached(ttl_cache, stampede="local")
 async def get_user(user_id: int) -> User:
     return User(id=user_id, name="Alice")
 

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -2,16 +2,21 @@
 
 import asyncio
 import functools
+import hashlib
+import json
+import math
+import random
 import threading
+import time
 from collections import OrderedDict
 from collections.abc import Callable
-from contextlib import AbstractAsyncContextManager, AbstractContextManager
-from typing import Annotated, Any, ParamSpec, TypeVar
+from typing import Annotated, Any, Literal, ParamSpec, TypeVar
 
 from typing_extensions import Doc
 
 from grelmicro.cache._key import make_cache_key
-from grelmicro.cache.ttl import TTLCache
+from grelmicro.cache.ttl import _CACHE_PREFIX, TTLCache
+from grelmicro.sync.lock import Lock
 
 # Decorator factories cannot use PEP 695 cleanly: the inner
 # ``decorator`` would inherit ``cached``'s type parameters instead
@@ -23,6 +28,15 @@ R = TypeVar("R")
 _SENTINEL = object()
 
 _PER_KEY_LOCK_BUDGET = 1024
+
+_XFETCH_SUFFIX = "\x00xf"
+
+Stampede = Literal["local", "distributed"]
+
+# Seams rebound by tests for deterministic ``early`` behavior. ``_random``
+# rolls the XFetch die; ``_now`` is the wall clock that ages entries.
+_random = random.random
+_now = time.time
 
 
 def _evict_idle_locks(
@@ -63,12 +77,6 @@ def _evict_idle_locks_sync(
             return
 
 
-# Lock parameter: True auto-creates, or pass your own.
-_LockType = (
-    bool | AbstractContextManager[Any] | AbstractAsyncContextManager[Any] | None
-)
-
-
 def cached(
     cache: Annotated[
         TTLCache,
@@ -107,24 +115,39 @@ def cached(
             """,
         ),
     ] = False,
-    lock: Annotated[
-        _LockType,
+    stampede: Annotated[
+        Stampede | None,
         Doc(
             """
-            Protect against duplicate work on a cache miss. When
-            the cache does not have the value, only one caller
-            runs the function. The other callers wait for the
-            result.
+            Protect against duplicate work when many callers miss the
+            same key at once (the "dog-pile" effect).
 
-            Set to ``True`` for **per-key** locking. Misses on
-            different keys run in parallel. Misses on the same
-            key run one at a time. The right lock type is
-            created automatically (``asyncio.Lock`` for async,
-            ``threading.Lock`` for sync).
+            - ``"local"`` (default): per-key in-process lock. Misses on
+              the same key fold to one execution; the others wait and
+              reuse the result. Free, no I/O.
+            - ``"distributed"``: cross-replica lock via the `Sync`
+              component, resolved from the active `Grelmicro` app. One
+              short-lived backend acquire per cold miss folds misses
+              across replicas. Implies ``"local"`` (in-process dedup is
+              free). Requires an active app with a `Sync` backend.
+            - ``None``: no protection. Every concurrent miss runs the
+              function.
+            """,
+        ),
+    ] = "local",
+    early: Annotated[
+        float | None,
+        Doc(
+            """
+            Probabilistic early refresh (XFetch). A float in ``[0, 1)``.
+            When a cached entry is read inside the last ``early``
+            fraction of its TTL, the call may roll a die and, on success,
+            schedule a background recompute while still returning the
+            cached value. The hottest keys then refresh before they
+            expire, so no caller ever blocks on a cold miss.
 
-            You can also pass a custom context manager for
-            **global** locking. This uses a single lock shared
-            by all keys.
+            Costs one extra recompute per refresh. Leave ``None`` to
+            disable.
             """,
         ),
     ] = None,
@@ -138,16 +161,31 @@ def cached(
     ``cache_clear()`` helpers (matching ``functools.lru_cache``).
     ``cache_clear()`` is always a coroutine (must be awaited).
 
+    Raises:
+        ValueError: If ``stampede`` is not ``"local"``, ``"distributed"``,
+            or ``None``, if ``early`` is outside ``[0, 1)``, or if
+            ``stampede="distributed"`` is used on a sync function without
+            an active app.
+
     Returns:
         A decorator that caches function results.
     """
+    if stampede not in ("local", "distributed", None):
+        msg = (
+            f"Invalid stampede {stampede!r}: "
+            f"use 'local', 'distributed', or None."
+        )
+        raise ValueError(msg)
+    if early is not None and not 0 <= early < 1:
+        msg = f"Invalid early {early!r}: must be a float in [0, 1)."
+        raise ValueError(msg)
 
     def decorator(
         func: Callable[P, R],
     ) -> Callable[P, R]:
         is_async_func = asyncio.iscoroutinefunction(func)
-        per_key = lock is True
-        global_lock = _resolve_global_lock(lock)
+        per_key = stampede in ("local", "distributed")
+        distributed = stampede == "distributed"
 
         if is_async_func:
             wrapper = _build_async_wrapper(
@@ -156,8 +194,9 @@ def cached(
                 key_maker,
                 skip,
                 typed=typed,
-                global_lock=global_lock,
                 per_key=per_key,
+                distributed=distributed,
+                early=early,
             )
         else:
             wrapper = _build_sync_wrapper(
@@ -166,8 +205,9 @@ def cached(
                 key_maker,
                 skip,
                 typed=typed,
-                global_lock=global_lock,
                 per_key=per_key,
+                distributed=distributed,
+                early=early,
             )
         wrapper.cache_info = cache.cache_info
         wrapper.cache_clear = cache.clear
@@ -176,17 +216,69 @@ def cached(
     return decorator
 
 
-def _resolve_global_lock(
-    lock: _LockType,
-) -> AbstractContextManager[Any] | AbstractAsyncContextManager[Any] | None:
-    """Resolve the lock parameter to a global lock instance.
+# --- Stampede helpers ---
 
-    Returns None for ``True`` (per-key locks are handled in wrappers),
-    ``False``, and ``None``. Returns the custom instance as-is.
+
+def _stampede_lock_name(key: str) -> str:
+    """Build a backend-safe distributed lock name from a cache key.
+
+    Cache keys embed a function qualname that may contain characters
+    (``<locals>``, spaces) that the `Lock` name validator rejects, so we
+    hash the key into a fixed, always-valid name.
     """
-    if lock is True or lock is False or lock is None:
+    digest = hashlib.sha256(key.encode()).hexdigest()[:32]
+    return f"cache.stampede.{digest}"
+
+
+def _xfetch_should_refresh(remaining: float, delta: float) -> bool:
+    """Roll the Vattani XFetch die for an entry in its early window.
+
+    ``remaining`` is the seconds left before expiry and ``delta`` is the
+    last recompute duration. The entry refreshes when
+    ``delta * -ln(rand) >= remaining``, so a key whose recompute is
+    expensive relative to its remaining life refreshes sooner.
+    """
+    return delta * -math.log(_random()) >= remaining
+
+
+async def _read_meta(cache: TTLCache, key: str) -> tuple[float, float] | None:
+    """Return ``(written_epoch, delta)`` for an XFetch entry, or None."""
+    raw = await cache._get_backend().get(  # noqa: SLF001
+        key=f"{_CACHE_PREFIX}:{key}{_XFETCH_SUFFIX}"
+    )
+    if raw is None:
         return None
-    return lock
+    try:
+        data = json.loads(raw)
+        return float(data["w"]), float(data["d"])
+    except (ValueError, KeyError, TypeError):  # pragma: no cover - corrupt
+        return None
+
+
+async def _write_meta(
+    cache: TTLCache, key: str, written: float, delta: float
+) -> None:
+    """Store the XFetch ``(written, delta)`` sidecar next to a value."""
+    raw = json.dumps({"w": written, "d": delta}).encode()
+    await cache._get_backend().set(  # noqa: SLF001
+        key=f"{_CACHE_PREFIX}:{key}{_XFETCH_SUFFIX}",
+        value=raw,
+        ttl=cache.config.ttl,
+    )
+
+
+def _due_for_early_refresh(
+    meta: tuple[float, float] | None, ttl: float, early: float
+) -> bool:
+    """Decide whether a read should trigger a background refresh."""
+    if meta is None:
+        return False
+    written, delta = meta
+    remaining = written + ttl - _now()
+    if remaining <= 0 or remaining > early * ttl:
+        # Outside the early window (or already expired and refetched).
+        return False
+    return _xfetch_should_refresh(remaining, delta)
 
 
 # --- Async function ---
@@ -199,54 +291,108 @@ def _build_async_wrapper(
     skip: Any,  # noqa: ANN401
     *,
     typed: bool,
-    global_lock: Any,  # noqa: ANN401
     per_key: bool,
+    distributed: bool,
+    early: float | None,
 ) -> Any:  # noqa: ANN401
     """Build async wrapper for cached decorator."""
     key_locks: OrderedDict[str, asyncio.Lock] = OrderedDict()
     key_locks_guard = asyncio.Lock()
+
+    async def get_key_lock(key: str) -> asyncio.Lock:
+        async with key_locks_guard:
+            the_lock = key_locks.get(key)
+            if the_lock is None:
+                the_lock = asyncio.Lock()
+                key_locks[key] = the_lock
+                _evict_idle_locks(key_locks)
+            else:
+                key_locks.move_to_end(key)
+            return the_lock
 
     @functools.wraps(func)
     async def async_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         key = _make_key(func, args, kwargs, key_maker, typed=typed)
         result = await cache.get(key, _SENTINEL)
         if result is not _SENTINEL:
+            if early is not None:
+                await _maybe_refresh_async(
+                    func, args, kwargs, cache, key, skip, early, get_key_lock
+                )
             return result
 
-        if per_key:
-            async with key_locks_guard:
-                the_lock = key_locks.get(key)
-                if the_lock is None:
-                    the_lock = asyncio.Lock()
-                    key_locks[key] = the_lock
-                    _evict_idle_locks(key_locks)
-                else:
-                    key_locks.move_to_end(key)
-        else:
-            the_lock = global_lock
-        if the_lock is not None:
-            async with the_lock:
-                result = await cache.get(key, _SENTINEL)
-                if result is not _SENTINEL:
-                    return result
-                return await _compute_and_cache(
-                    func,
-                    args,
-                    kwargs,
-                    cache,
-                    key,
-                    skip,
+        if not per_key:
+            return await _compute_and_cache(
+                func, args, kwargs, cache, key, skip, early=early
+            )
+
+        the_lock = await get_key_lock(key)
+        async with the_lock:
+            result = await cache._peek(key, _SENTINEL)  # noqa: SLF001
+            if result is not _SENTINEL:
+                return result
+            if distributed:
+                return await _compute_distributed(
+                    func, args, kwargs, cache, key, skip, early=early
                 )
-        return await _compute_and_cache(
-            func,
-            args,
-            kwargs,
-            cache,
-            key,
-            skip,
-        )
+            return await _compute_and_cache(
+                func, args, kwargs, cache, key, skip, early=early
+            )
 
     return async_wrapper
+
+
+async def _compute_distributed(
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    cache: TTLCache,
+    key: str,
+    skip: Callable[[Any], bool] | None,
+    *,
+    early: float | None,
+) -> Any:  # noqa: ANN401
+    """Compute under a cross-replica `Sync` lock, re-checking inside it."""
+    async with Lock(_stampede_lock_name(key)):
+        result = await cache._peek(key, _SENTINEL)  # noqa: SLF001
+        if result is not _SENTINEL:
+            return result
+        return await _compute_and_cache(
+            func, args, kwargs, cache, key, skip, early=early
+        )
+
+
+async def _maybe_refresh_async(
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    cache: TTLCache,
+    key: str,
+    skip: Callable[[Any], bool] | None,
+    early: float,
+    get_key_lock: Callable[[str], Any],
+) -> None:
+    """Schedule a background recompute when an entry is due for refresh."""
+    meta = await _read_meta(cache, key)
+    if not _due_for_early_refresh(meta, cache.config.ttl, early):
+        return
+    the_lock = await get_key_lock(key)
+    if the_lock.locked():
+        # A refresh or cold miss is already computing this key.
+        return
+
+    async def refresh() -> None:
+        if the_lock.locked():  # pragma: no cover - raced lock
+            return
+        async with the_lock:
+            await _compute_and_cache(
+                func, args, kwargs, cache, key, skip, early=early
+            )
+
+    task = asyncio.create_task(refresh())
+    # Drop the lookup table reference once done; surfacing failures is
+    # the caller's job via the cache, not this best-effort refresh.
+    task.add_done_callback(lambda _: None)
 
 
 async def _compute_and_cache(
@@ -256,11 +402,17 @@ async def _compute_and_cache(
     cache: TTLCache,
     key: str,
     skip: Callable[[Any], bool] | None,
+    *,
+    early: float | None,
 ) -> Any:  # noqa: ANN401
     """Execute async function and store result in cache."""
+    started = time.perf_counter()
     result = await func(*args, **kwargs)
+    delta = time.perf_counter() - started
     if skip is None or not skip(result):
         await cache.set(key, result)
+        if early is not None:
+            await _write_meta(cache, key, _now(), delta)
     return result
 
 
@@ -274,8 +426,9 @@ def _build_sync_wrapper(
     skip: Any,  # noqa: ANN401
     *,
     typed: bool,
-    global_lock: Any,  # noqa: ANN401
     per_key: bool,
+    distributed: bool,
+    early: float | None,
 ) -> Any:  # noqa: ANN401
     """Build sync wrapper for cached decorator.
 
@@ -286,53 +439,125 @@ def _build_sync_wrapper(
     key_locks: OrderedDict[str, threading.Lock] = OrderedDict()
     key_locks_guard = threading.Lock()
 
+    def get_key_lock(key: str) -> threading.Lock:
+        with key_locks_guard:
+            the_lock = key_locks.get(key)
+            if the_lock is None:
+                the_lock = threading.Lock()
+                key_locks[key] = the_lock
+                _evict_idle_locks_sync(key_locks)
+            else:
+                key_locks.move_to_end(key)
+            return the_lock
+
     @functools.wraps(func)
     def sync_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         key = _make_key(func, args, kwargs, key_maker, typed=typed)
         loop = cache._get_backend()._loop  # noqa: SLF001  # ty: ignore[unresolved-attribute]
-        result = asyncio.run_coroutine_threadsafe(
-            cache.get(key, _SENTINEL), loop
-        ).result()
+        result = _run(cache.get(key, _SENTINEL), loop)
         if result is not _SENTINEL:
-            return result
-
-        if per_key:
-            with key_locks_guard:
-                the_lock = key_locks.get(key)
-                if the_lock is None:
-                    the_lock = threading.Lock()
-                    key_locks[key] = the_lock
-                    _evict_idle_locks_sync(key_locks)
-                else:
-                    key_locks.move_to_end(key)
-        else:
-            the_lock = global_lock
-
-        if the_lock is not None:
-            with the_lock:
-                result = asyncio.run_coroutine_threadsafe(
-                    cache.get(key, _SENTINEL), loop
-                ).result()
-                if result is not _SENTINEL:
-                    return result
-                return _compute_and_cache_sync(
+            if early is not None:
+                _maybe_refresh_sync(
                     func,
                     args,
                     kwargs,
                     cache,
                     key,
                     skip,
+                    early,
+                    loop,
+                    get_key_lock,
                 )
-        return _compute_and_cache_sync(
-            func,
-            args,
-            kwargs,
-            cache,
-            key,
-            skip,
-        )
+            return result
+
+        if not per_key:
+            return _compute_and_cache_sync(
+                func, args, kwargs, cache, key, skip, loop, early=early
+            )
+
+        the_lock = get_key_lock(key)
+        with the_lock:
+            result = _run(cache._peek(key, _SENTINEL), loop)  # noqa: SLF001
+            if result is not _SENTINEL:
+                return result
+            if distributed:
+                return _run(
+                    _distributed_orchestrate(
+                        func, args, kwargs, cache, key, skip, loop, early=early
+                    ),
+                    loop,
+                )
+            return _compute_and_cache_sync(
+                func, args, kwargs, cache, key, skip, loop, early=early
+            )
 
     return sync_wrapper
+
+
+def _run(coro: Any, loop: Any) -> Any:  # noqa: ANN401
+    """Run a coroutine on the cache's event loop from a worker thread."""
+    return asyncio.run_coroutine_threadsafe(coro, loop).result()
+
+
+async def _distributed_orchestrate(
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    cache: TTLCache,
+    key: str,
+    skip: Callable[[Any], bool] | None,
+    loop: Any,  # noqa: ANN401
+    *,
+    early: float | None,
+) -> Any:  # noqa: ANN401
+    """Hold the cross-replica lock and recompute, all in one loop task.
+
+    The blocking function runs in an executor so it does not stall the
+    loop, while the `Lock` acquire and release stay on the same task so
+    ownership holds.
+    """
+    async with Lock(_stampede_lock_name(key)):
+        result = await cache._peek(key, _SENTINEL)  # noqa: SLF001
+        if result is not _SENTINEL:
+            return result
+        started = time.perf_counter()
+        result = await loop.run_in_executor(None, lambda: func(*args, **kwargs))
+        delta = time.perf_counter() - started
+        if skip is None or not skip(result):
+            await cache.set(key, result)
+            if early is not None:
+                await _write_meta(cache, key, _now(), delta)
+        return result
+
+
+def _maybe_refresh_sync(
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    cache: TTLCache,
+    key: str,
+    skip: Callable[[Any], bool] | None,
+    early: float,
+    loop: Any,  # noqa: ANN401
+    get_key_lock: Callable[[str], threading.Lock],
+) -> None:
+    """Schedule a background recompute for a sync entry due for refresh."""
+    meta = _run(_read_meta(cache, key), loop)
+    if not _due_for_early_refresh(meta, cache.config.ttl, early):
+        return
+    the_lock = get_key_lock(key)
+    if not the_lock.acquire(blocking=False):
+        return
+
+    def refresh() -> None:
+        try:
+            _compute_and_cache_sync(
+                func, args, kwargs, cache, key, skip, loop, early=early
+            )
+        finally:
+            the_lock.release()
+
+    threading.Thread(target=refresh, daemon=True).start()
 
 
 def _compute_and_cache_sync(
@@ -342,14 +567,18 @@ def _compute_and_cache_sync(
     cache: TTLCache,
     key: str,
     skip: Callable[[Any], bool] | None,
+    loop: Any,  # noqa: ANN401
+    *,
+    early: float | None,
 ) -> Any:  # noqa: ANN401
     """Execute sync function and store result in async cache."""
+    started = time.perf_counter()
     result = func(*args, **kwargs)
+    delta = time.perf_counter() - started
     if skip is None or not skip(result):
-        asyncio.run_coroutine_threadsafe(
-            cache.set(key, result),
-            cache._get_backend()._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
-        ).result()
+        _run(cache.set(key, result), loop)
+        if early is not None:
+            _run(_write_meta(cache, key, _now(), delta), loop)
     return result
 
 

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -214,6 +214,17 @@ class TTLCache(Generic[T]):
             self._promote(key)
         return self._deserialize(raw)
 
+    async def _peek(self, key: str, default: T | None = None) -> T | None:
+        """Read a key without recording hit/miss stats or LRU promotion.
+
+        Used for the double-checked recheck inside stampede locks, where
+        the lookup is part of an in-flight miss rather than a new access.
+        """
+        raw = await self._get_backend().get(key=f"{_CACHE_PREFIX}:{key}")
+        if raw is None:
+            return default
+        return self._deserialize(raw)
+
     async def set(
         self,
         key: Annotated[str, Doc("The cache key.")],

--- a/tests/cache/test_cache_backends.py
+++ b/tests/cache/test_cache_backends.py
@@ -215,7 +215,7 @@ async def test_cached_end_to_end_with_postgres() -> None:
             )
             call_count = 0
 
-            @cached(cache, lock=True)
+            @cached(cache, stampede="local")
             async def fetch_user(user_id: int) -> dict:
                 nonlocal call_count
                 call_count += 1

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -7,10 +7,13 @@ from contextlib import suppress
 
 import pytest
 
+from grelmicro import Grelmicro
 from grelmicro.cache.cached import cached
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.serializers import PickleSerializer
 from grelmicro.cache.ttl import TTLCache
+from grelmicro.sync import Sync
+from grelmicro.sync.memory import MemorySyncAdapter
 
 pytestmark = [pytest.mark.timeout(10)]
 
@@ -350,17 +353,17 @@ class TestAsyncCachedKeyMaker:
         assert call_count == EXPECTED_CALL_COUNT_1
 
 
-class TestAsyncCachedLock:
-    """Test @cached with lock-based stampede protection on async functions."""
+class TestAsyncCachedStampede:
+    """Test @cached stampede protection on async functions."""
 
     async def test_lock_true_prevents_duplicate_computation(self) -> None:
-        """lock=True ensures only one coroutine computes on concurrent miss."""
+        """stampede='local' ensures only one coroutine computes on concurrent miss."""
         # Arrange
         cache = _make_cache()
         call_count = 0
         barrier = asyncio.Event()
 
-        @cached(cache, lock=True)
+        @cached(cache, stampede="local")
         async def slow_fetch(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -383,14 +386,14 @@ class TestAsyncCachedLock:
     async def test_lock_true_per_key_allows_parallel_different_keys(
         self,
     ) -> None:
-        """lock=True uses per-key locks: different keys run in parallel."""
+        """stampede='local' uses per-key locks: different keys run in parallel."""
         # Arrange
         cache = _make_cache()
         order: list[str] = []
         barrier_a = asyncio.Event()
         barrier_b = asyncio.Event()
 
-        @cached(cache, lock=True)
+        @cached(cache, stampede="local")
         async def fetch(key: str) -> str:
             if key == "a":
                 order.append("a:start")
@@ -492,16 +495,14 @@ class TestAsyncCachedLock:
         finally:
             held.release()
 
-    async def test_custom_asyncio_lock_prevents_duplicate_computation(
-        self,
-    ) -> None:
-        """A custom asyncio.Lock provides global stampede protection."""
+    async def test_stampede_none_allows_duplicate_computation(self) -> None:
+        """stampede=None runs the function for every concurrent miss."""
         # Arrange
         cache = _make_cache()
         call_count = 0
         barrier = asyncio.Event()
 
-        @cached(cache, lock=asyncio.Lock())
+        @cached(cache, stampede=None)
         async def slow_fetch(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -516,15 +517,15 @@ class TestAsyncCachedLock:
         await task1
         await task2
 
-        # Assert: global lock serializes concurrent same-key misses
-        assert call_count == EXPECTED_CALL_COUNT_1
+        # Assert: no dedup, both concurrent misses computed
+        assert call_count == EXPECTED_CALL_COUNT_2
 
     async def test_lock_true_cache_hit_does_not_acquire_lock(self) -> None:
-        """A cache hit returns immediately without touching the lock."""
+        """A cache hit returns immediately without acquiring the per-key lock."""
         # Arrange
         cache = _make_cache()
 
-        @cached(cache, lock=True)
+        @cached(cache, stampede="local")
         async def fetch(x: int) -> int:
             return x
 
@@ -539,12 +540,12 @@ class TestAsyncCachedLock:
         assert cache.cache_info().hits == EXPECTED_HITS_1
 
     async def test_lock_false_disables_protection(self) -> None:
-        """lock=False behaves like lock=None (no protection but still caches)."""
+        """stampede=None disables protection but still caches."""
         # Arrange
         cache = _make_cache()
         call_count = 0
 
-        @cached(cache, lock=False)
+        @cached(cache, stampede=None)
         async def fetch(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -795,16 +796,16 @@ class TestSyncCachedKeyMaker:
         assert call_count == EXPECTED_CALL_COUNT_1
 
 
-class TestSyncCachedLock:
-    """Test @cached with lock-based stampede protection on sync functions."""
+class TestSyncCachedStampede:
+    """Test @cached stampede protection on sync functions."""
 
     async def test_lock_true_prevents_duplicate_computation(self) -> None:
-        """lock=True with threading.Lock prevents redundant computation."""
+        """stampede='local' with threading.Lock prevents redundant computation."""
         # Arrange
         cache = _make_cache()
         call_count = 0
 
-        @cached(cache, lock=True)
+        @cached(cache, stampede="local")
         def compute(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -822,7 +823,7 @@ class TestSyncCachedLock:
         # Arrange
         cache = _make_cache()
 
-        @cached(cache, lock=True)
+        @cached(cache, stampede="local")
         def compute(x: int) -> int:
             return x * 2
 
@@ -832,15 +833,15 @@ class TestSyncCachedLock:
         await cache.clear()
         await asyncio.to_thread(lambda: compute(7))
 
-    async def test_custom_threading_lock_prevents_stampede(self) -> None:
-        """A custom threading.Lock provides global stampede protection."""
+    async def test_local_prevents_stampede_under_concurrency(self) -> None:
+        """stampede='local' folds concurrent same-key sync misses to one run."""
         # Arrange
         cache = _make_cache()
         call_count = 0
         # started is set the first time slow_compute begins executing
         started = threading.Event()
 
-        @cached(cache, lock=threading.Lock())
+        @cached(cache, stampede="local")
         def slow_compute(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -868,12 +869,12 @@ class TestSyncCachedLock:
         assert sorted(results) == [EXPECTED_DOUBLE_5, EXPECTED_DOUBLE_5]
 
     async def test_lock_true_per_key_sync(self) -> None:
-        """lock=True uses per-key threading.Lock: same key serialized, different keys not."""
+        """stampede='local' uses per-key threading.Lock: same key serialized, different keys not."""
         # Arrange
         cache = _make_cache()
         call_count = 0
 
-        @cached(cache, lock=True)
+        @cached(cache, stampede="local")
         def compute(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -890,12 +891,12 @@ class TestSyncCachedLock:
         assert call_count == EXPECTED_CALL_COUNT_2  # 5 once, 6 once
 
     async def test_lock_false_still_caches(self) -> None:
-        """lock=False behaves like lock=None (no protection but still caches)."""
+        """stampede=None disables protection but still caches."""
         # Arrange
         cache = _make_cache()
         call_count = 0
 
-        @cached(cache, lock=False)
+        @cached(cache, stampede=None)
         def compute(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -908,3 +909,407 @@ class TestSyncCachedLock:
         # Assert
         assert call_count == EXPECTED_CALL_COUNT_1
         assert cache.cache_info().hits == EXPECTED_HITS_1
+
+
+# ---------------------------------------------------------------------------
+# Distributed stampede tests
+# ---------------------------------------------------------------------------
+# A distributed miss serializes through the Sync component's lock. Two
+# separate decorations of the SAME function share the cache key and the
+# distributed lock but keep independent in-process locks, so they model
+# two replicas folding onto one execution.
+
+
+def _shared_cache(loop: asyncio.AbstractEventLoop) -> TTLCache:
+    backend = MemoryCacheAdapter()
+    backend._loop = loop
+    return TTLCache(backend=backend, serializer=PickleSerializer())
+
+
+class TestDistributedStampede:
+    """Test @cached(stampede="distributed") across simulated replicas."""
+
+    async def test_two_replicas_fold_to_one_execution(self) -> None:
+        """Concurrent distributed misses on the same key run once."""
+        loop = asyncio.get_running_loop()
+        cache = _shared_cache(loop)
+        micro = Grelmicro(uses=[Sync(MemorySyncAdapter())])
+        call_count = 0
+        barrier = asyncio.Event()
+
+        def impl_factory():  # noqa: ANN202
+            async def impl(x: int) -> int:
+                nonlocal call_count
+                call_count += 1
+                await barrier.wait()
+                return x * 2
+
+            return impl
+
+        impl = impl_factory()
+        replica_a = cached(cache, stampede="distributed")(impl)
+        replica_b = cached(cache, stampede="distributed")(impl)
+
+        async with micro:
+            task_a = asyncio.create_task(replica_a(5))
+            task_b = asyncio.create_task(replica_b(5))
+            await asyncio.sleep(0.02)  # let the first acquire the lock
+            barrier.set()
+            result_a = await task_a
+            result_b = await task_b
+
+        assert result_a == EXPECTED_DOUBLE_5
+        assert result_b == EXPECTED_DOUBLE_5
+        assert call_count == EXPECTED_CALL_COUNT_1
+
+    async def test_distributed_sync_function_folds(self) -> None:
+        """Distributed protection drives the lock from a sync worker thread."""
+        loop = asyncio.get_running_loop()
+        cache = _shared_cache(loop)
+        micro = Grelmicro(uses=[Sync(MemorySyncAdapter())])
+        call_count = 0
+
+        def impl(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            time.sleep(0.03)
+            return x * 2
+
+        replica_a = cached(cache, stampede="distributed")(impl)
+        replica_b = cached(cache, stampede="distributed")(impl)
+
+        async with micro:
+            results: list[int] = []
+
+            async def run(fn) -> None:  # noqa: ANN001
+                results.append(await asyncio.to_thread(lambda: fn(5)))
+
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(run(replica_a))
+                await asyncio.sleep(0.01)
+                tg.create_task(run(replica_b))
+
+        assert call_count == EXPECTED_CALL_COUNT_1
+        assert sorted(results) == [EXPECTED_DOUBLE_5, EXPECTED_DOUBLE_5]
+
+
+# ---------------------------------------------------------------------------
+# Early (XFetch) refresh tests
+# ---------------------------------------------------------------------------
+
+
+class _Clock:
+    """Mutable wall clock standing in for ``cached._now``."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+
+class TestEarlyRefresh:
+    """Test @cached(early=...) probabilistic XFetch refresh."""
+
+    async def test_invalid_early_rejected(self) -> None:
+        """Early outside [0, 1) raises at decoration time."""
+        cache = _make_cache()
+        with pytest.raises(ValueError, match="early"):
+            cached(cache, early=1.0)
+        with pytest.raises(ValueError, match="early"):
+            cached(cache, early=-0.1)
+
+    async def test_invalid_stampede_rejected(self) -> None:
+        """An unknown stampede value raises at decoration time."""
+        cache = _make_cache()
+        with pytest.raises(ValueError, match="stampede"):
+            cached(cache, stampede="global")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    async def test_early_outside_window_does_not_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fresh entry read early in its TTL is not refreshed."""
+        import sys  # noqa: PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+        call_count = 0
+
+        @cached(cache, early=0.5)
+        async def fetch(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return x * 2
+
+        await fetch(5)  # miss, writes meta at t=1000
+        clock.t = 1010  # remaining 50s > 30s window
+        await fetch(5)  # hit, not due
+        await asyncio.sleep(0.02)
+        assert call_count == EXPECTED_CALL_COUNT_1
+
+    async def test_early_in_window_schedules_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An entry inside the early window refreshes when the die rolls true."""
+        import sys  # noqa: PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+        call_count = 0
+
+        @cached(cache, early=0.5)
+        async def fetch(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return x * 2
+
+        await fetch(5)  # miss at t=1000
+        clock.t = 1040  # remaining 20s <= 30s window
+        result = await fetch(5)  # hit, schedules background refresh
+        assert result == EXPECTED_DOUBLE_5
+        # Wait for the background refresh task to recompute.
+        for _ in range(50):
+            await asyncio.sleep(0.005)
+            if call_count == EXPECTED_CALL_COUNT_2:
+                break
+        assert call_count == EXPECTED_CALL_COUNT_2
+
+    async def test_early_die_rolls_false_no_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In the window but the die rolls false: no refresh."""
+        import sys  # noqa: PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: False
+        )
+        cache = _make_cache(ttl=60)
+        call_count = 0
+
+        @cached(cache, early=0.5)
+        async def fetch(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return x * 2
+
+        await fetch(5)
+        clock.t = 1040
+        await fetch(5)
+        await asyncio.sleep(0.02)
+        assert call_count == EXPECTED_CALL_COUNT_1
+
+    async def test_early_no_meta_no_refresh(self) -> None:
+        """Early hit with no stored metadata falls through to normal expiry."""
+        cache = _make_cache(ttl=60)
+        call_count = 0
+
+        from grelmicro.cache.cached import _make_key  # noqa: PLC0415
+
+        async def impl(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return x * 2
+
+        fetch = cached(cache, early=0.5)(impl)
+        # Seed the value directly so no XFetch meta exists for the key.
+        key = _make_key(impl, (5,), {}, None, typed=False)
+        await cache.set(key, 10)
+        await fetch(5)  # hit, meta is None
+        await asyncio.sleep(0.02)
+        assert call_count == 0
+
+    async def test_early_sync_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sync entry in the early window refreshes on a daemon thread."""
+        import sys  # noqa: PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+        call_count = 0
+
+        @cached(cache, early=0.5)
+        def compute(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return x * 2
+
+        await asyncio.to_thread(lambda: compute(5))  # miss at t=1000
+        clock.t = 1040
+        await asyncio.to_thread(lambda: compute(5))  # hit, schedules refresh
+        for _ in range(50):
+            await asyncio.sleep(0.005)
+            if call_count == EXPECTED_CALL_COUNT_2:
+                break
+        assert call_count == EXPECTED_CALL_COUNT_2
+
+    async def test_xfetch_formula(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Vattani die fires once delta*-ln(rand) crosses remaining."""
+        import sys  # noqa: PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+
+        # -ln(rand) ~ 0 -> never refresh, even with a costly delta.
+        monkeypatch.setattr(cached_mod, "_random", lambda: 1.0)
+        assert (
+            cached_mod._xfetch_should_refresh(remaining=1.0, delta=10.0)
+            is False
+        )
+        # A large -ln(rand) and a costly delta clear a small remaining.
+        monkeypatch.setattr(cached_mod, "_random", lambda: 0.01)  # -ln ~ 4.6
+        assert (
+            cached_mod._xfetch_should_refresh(remaining=1.0, delta=10.0) is True
+        )
+
+    async def test_early_refresh_skipped_when_lock_held(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A read does not start a second refresh while one is in flight."""
+        import sys  # noqa: PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+        gate = asyncio.Event()
+        call_count = 0
+
+        @cached(cache, early=0.5)
+        async def fetch(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= EXPECTED_CALL_COUNT_2:  # the refresh recompute
+                await gate.wait()
+            return x * 2
+
+        await fetch(5)  # miss at t=1000
+        clock.t = 1040  # in window
+        await fetch(5)  # hit -> schedules refresh that holds the lock
+        await asyncio.sleep(0.02)  # let the refresh task acquire the lock
+        await fetch(5)  # hit -> refresh skipped, lock already held
+        gate.set()
+        await asyncio.sleep(0.02)
+        assert call_count == EXPECTED_CALL_COUNT_2  # only one refresh ran
+
+    async def test_early_sync_outside_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sync hit early in the TTL is not refreshed."""
+        import sys  # noqa: PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        cache = _make_cache(ttl=60)
+        call_count = 0
+
+        @cached(cache, early=0.5)
+        def compute(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return x * 2
+
+        await asyncio.to_thread(lambda: compute(5))  # miss at t=1000
+        clock.t = 1010  # remaining 50s > 30s window
+        await asyncio.to_thread(lambda: compute(5))  # hit, not due
+        await asyncio.sleep(0.02)
+        assert call_count == EXPECTED_CALL_COUNT_1
+
+    async def test_distributed_sync_early_writes_meta(self) -> None:
+        """A sync distributed cold miss with early= stores XFetch metadata."""
+        from grelmicro.cache.cached import (  # noqa: PLC0415
+            _make_key,
+            _read_meta,
+        )
+
+        loop = asyncio.get_running_loop()
+        cache = _shared_cache(loop)
+        micro = Grelmicro(uses=[Sync(MemorySyncAdapter())])
+
+        def impl(x: int) -> int:
+            return x * 2
+
+        fetch = cached(cache, stampede="distributed", early=0.5)(impl)
+        async with micro:
+            await asyncio.to_thread(lambda: fetch(5))
+            key = _make_key(impl, (5,), {}, None, typed=False)
+            meta = await _read_meta(cache, key)
+        assert meta is not None
+
+    async def test_distributed_sync_skip_not_cached(self) -> None:
+        """A sync distributed miss whose result is skipped is not cached."""
+        loop = asyncio.get_running_loop()
+        cache = _shared_cache(loop)
+        micro = Grelmicro(uses=[Sync(MemorySyncAdapter())])
+        call_count = 0
+
+        def impl(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return x * 2
+
+        fetch = cached(cache, stampede="distributed", skip=lambda _: True)(impl)
+        async with micro:
+            await asyncio.to_thread(lambda: fetch(5))
+            await asyncio.to_thread(lambda: fetch(5))
+        assert call_count == EXPECTED_CALL_COUNT_2
+
+    async def test_early_sync_refresh_skipped_when_lock_held(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sync read does not start a second refresh while one is in flight."""
+        import sys  # noqa: PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+        gate = threading.Event()
+        call_count = 0
+
+        @cached(cache, early=0.5)
+        def compute(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= EXPECTED_CALL_COUNT_2:  # the refresh recompute
+                gate.wait()
+            return x * 2
+
+        await asyncio.to_thread(lambda: compute(5))  # miss at t=1000
+        clock.t = 1040  # in window
+        await asyncio.to_thread(lambda: compute(5))  # hit -> refresh holds lock
+        await asyncio.sleep(0.05)  # let the refresh thread acquire the lock
+        await asyncio.to_thread(lambda: compute(5))  # hit -> refresh skipped
+        gate.set()
+        await asyncio.sleep(0.05)
+        assert call_count == EXPECTED_CALL_COUNT_2  # only one refresh ran


### PR DESCRIPTION
## Summary

Replaces the `@cached(lock=...)` parameter with a three-layer, opt-in stampede protection menu (closes #235):

| Layer | What it does | Cost |
|---|---|---|
| `stampede="local"` (default) | per-key in-process lock | free, no I/O |
| `stampede="distributed"` | cross-replica lock via the `Sync` component | one backend acquire per cold miss |
| `early=0.1` | probabilistic XFetch refresh in the late TTL window | one background recompute per refresh |

Layers compose. `distributed` implies `local`; `early` works with either.

## Breaking change

`@cached(lock=...)` is removed (0.x clean cut, no shim):
- `lock=True` → `stampede="local"` (now the **default**)
- `lock=False` → `stampede=None`
- custom-context-manager form → dropped in favor of `stampede="distributed"`

## Design notes

- **XFetch metadata** is stored in a sidecar cache key (`{key}\x00xf` → `{written, delta}`) so the early-refresh window is shared across replicas, matching cashews/Vattani rather than an in-process-only map. Value serialization is untouched.
- **Distributed on sync functions** drives the `Sync` `Lock` from a single loop task (acquire → executor compute → release) so lease ownership holds.
- In-lock rechecks use a new stats-free `TTLCache._peek` so single-flight does not distort hit/miss counters.

## Tests

Local/distributed/early across async and sync, deterministic XFetch via `_now`/`_xfetch_should_refresh` seams, two-replica fold, validation, and lock-held refresh guards. 100% coverage on `cached.py` and `ttl.py`.

Closes #235.
