### PR TITLE
✨ Add graceful shutdown with cooperative task draining and shutdown_timeout

### DIFF
--- a/docs/architecture/graceful-shutdown.md
+++ b/docs/architecture/graceful-shutdown.md
@@ -1,0 +1,41 @@
+# Graceful shutdown
+
+Container orchestrators (Kubernetes, ECS, systemd, Docker) stop a service by sending `SIGTERM` and then waiting a grace period (Kubernetes defaults to 30 seconds via `terminationGracePeriodSeconds`) before sending `SIGKILL`. A well-behaved service uses that window to:
+
+1. Stop accepting new work.
+2. Drain in-flight work.
+3. Release distributed resources so other replicas do not wait for a lease to expire.
+
+grelmicro stays library-shaped: the application owns the event loop and signal wiring. grelmicro gives you a clean way to translate a signal into shutdown and bounds how long draining takes.
+
+## Wire the signal to shutdown
+
+Translate `SIGTERM` and `SIGINT` into a future, then race it against the workload. Leaving the `Tasks` context drains the background tasks:
+
+```python
+--8<-- "task/graceful_shutdown.py"
+```
+
+When the host framework already owns the loop, let it do the wiring. Uvicorn and FastStream install their own signal handlers and exit the lifespan on `SIGTERM`, so a `Tasks` context entered inside the lifespan drains automatically. Add explicit handlers only for a plain `asyncio.run` or `uvloop.run` entry point.
+
+## Draining background tasks
+
+`Tasks(shutdown_timeout=...)` controls the drain. On exit, `Tasks` sets a stop signal that every `interval` task observes:
+
+- A task that is sleeping between runs wakes immediately and exits.
+- A task that is mid-run finishes its current iteration, then exits before the next one. In-flight work is never interrupted.
+- A task still running after `shutdown_timeout` seconds is force-cancelled.
+
+`shutdown_timeout` defaults to `30.0`, matching the Kubernetes grace period. Keep it at or below the pod `terminationGracePeriodSeconds` so draining finishes before `SIGKILL`. Set it to `0` to cancel immediately without draining.
+
+The stop signal only bounds shutdown for tasks that are stuck mid-iteration. Cooperative tasks exit as soon as their current run completes, so a healthy service shuts down well within the window regardless of the timeout.
+
+## Releasing distributed resources
+
+| Primitive | On graceful stop |
+|---|---|
+| `LeaderElection` | Breaks its loop after the current renew and releases the lock on the backend, so a standby replica takes over without waiting for the lease to expire. |
+| `Lock`, `TaskLock` | Released when the holder leaves `async with`. A task force-cancelled while holding the lease does not release it explicitly: the lease expires on the backend after its TTL. Keep `lease_duration` short enough that the worst-case takeover delay is acceptable. |
+| `RateLimiter`, `CircuitBreaker`, `HealthChecks` | Stateless across requests, so they have no shutdown obligation. |
+
+The lease-on-cancel contract is the reason to prefer cooperative draining: a task that finishes its iteration releases its locks through `async with`, while a force-cancel falls back to TTL expiry.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,10 +4,12 @@
 
 ### Breaking
 
+* 💥 The `Task` protocol's `__call__` now takes a `stop: asyncio.Event | None = None` keyword used for graceful shutdown. Custom `Task` implementations must accept it. The built-in `interval` tasks and `LeaderElection` are unaffected. Issue [#187](https://github.com/grelinfo/grelmicro/issues/187).
 * 💥 Replace the `@cached(lock=...)` parameter with `@cached(stampede="local" | "distributed" | None)`. `lock=True` becomes `stampede="local"` (now the default), `lock=False` becomes `stampede=None`, and the custom-context-manager form is dropped in favor of the `"distributed"` cross-replica mode. Issue [#235](https://github.com/grelinfo/grelmicro/issues/235).
 
 ### Features
 
+* ✨ Add `Tasks(shutdown_timeout=...)` for graceful shutdown. On exit, `Tasks` signals every `interval` task to finish its current run and stop, force-cancelling only stragglers that outlast the timeout. The default `30.0` matches Kubernetes' `terminationGracePeriodSeconds`, and `LeaderElection` releases leadership on the same signal. New `docs/architecture/graceful-shutdown.md` covers signal wiring. Issue [#187](https://github.com/grelinfo/grelmicro/issues/187).
 * ✨ Add a three-layer cache stampede menu to `@cached`. `stampede="local"` (default) folds concurrent same-key misses to one in-process run, `stampede="distributed"` coordinates across replicas through the `Sync` component, and `early=` (XFetch) refreshes the hottest keys in the background before they expire so no caller blocks. Issue [#235](https://github.com/grelinfo/grelmicro/issues/235).
 * ✨ Add `LeaderElection.last_confirmation_age()` (seconds since the last backend response that confirmed local leadership, `None` until first acquisition and after confirmed loss) and `LeaderElection.is_leader_confirmed_within(max_age)` (stricter variant of `is_leader()` that requires a recent backend renewal). The `is_leader()` docstring now spells out the advisory uncertainty window during a backend partition.
 * ✨ Add `Grelmicro(strict=True)` to raise `LifecycleOrderError` instead of warning when a Component holds a Provider that is missing from `uses=` or listed after the dependent Component. The default `False` preserves the lenient warn-only behavior. `LifecycleOrderError` is exported from `grelmicro`.

--- a/docs/snippets/task/graceful_shutdown.py
+++ b/docs/snippets/task/graceful_shutdown.py
@@ -1,0 +1,35 @@
+import asyncio
+import signal
+
+from grelmicro.task import Tasks
+
+# Keep shutdown_timeout at or below the Kubernetes
+# terminationGracePeriodSeconds (default 30s) so draining finishes
+# before the pod receives SIGKILL.
+tasks = Tasks(shutdown_timeout=25)
+
+
+@tasks.interval(seconds=5)
+async def heartbeat() -> None:
+    """Run periodic work; finishes the current run before shutdown."""
+
+
+def _request_stop(stop: asyncio.Future[None]) -> None:
+    """Resolve the stop future the first time a signal arrives."""
+    if not stop.done():
+        stop.set_result(None)
+
+
+async def main() -> None:
+    loop = asyncio.get_running_loop()
+    stop = loop.create_future()
+    # Translate the orchestrator's signals into a future, then race it
+    # against the workload. Leaving `async with tasks` drains the tasks.
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _request_stop, stop)
+    async with tasks:
+        await stop
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/grelmicro/_async.py
+++ b/grelmicro/_async.py
@@ -2,9 +2,31 @@
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import inspect
 from typing import Any
+
+
+async def sleep_or_stop(seconds: float, stop: asyncio.Event | None) -> bool:
+    """Sleep up to ``seconds``, waking early when ``stop`` is set.
+
+    Returns ``True`` when a stop was requested (either already set or
+    raised during the wait), so a background loop can break and unwind
+    cleanly. Returns ``False`` when the full interval elapsed and the
+    loop should run again. With ``stop`` of ``None`` this is a plain
+    ``asyncio.sleep`` that always returns ``False``.
+    """
+    if stop is None:
+        await asyncio.sleep(seconds)
+        return False
+    if stop.is_set():
+        return True
+    try:
+        await asyncio.wait_for(stop.wait(), timeout=seconds)
+    except TimeoutError:
+        return False
+    return True
 
 
 def is_async_callable(obj: Any) -> bool:  # noqa: ANN401

--- a/grelmicro/sync/leaderelection.py
+++ b/grelmicro/sync/leaderelection.py
@@ -11,6 +11,7 @@ from pydantic import model_validator
 from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro
+from grelmicro._async import sleep_or_stop
 from grelmicro._config import Reconfigurable, env_segment, resolve_config
 from grelmicro.errors import WouldBlockError
 from grelmicro.sync._base import BaseLockConfig
@@ -427,7 +428,10 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
                 pass
 
     async def __call__(
-        self, *, ready: asyncio.Future[None] | None = None
+        self,
+        *,
+        ready: asyncio.Future[None] | None = None,
+        stop: asyncio.Event | None = None,
     ) -> None:
         """Run polling loop service to acquire or renew the distributed lock."""
         if ready is not None and not ready.done():  # pragma: no branch
@@ -441,7 +445,10 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], SyncPrimitive, Task):
             while True:
                 config = self._config
                 await self._try_acquire_or_renew(config)
-                await asyncio.sleep(config.retry_interval)
+                # On a graceful stop, break and let the finally block
+                # release leadership on the backend before unwinding.
+                if await sleep_or_stop(config.retry_interval, stop):
+                    break
         except asyncio.CancelledError:
             logger.info("Leader Election stopped: %s", self.name)
             raise

--- a/grelmicro/task/_interval.py
+++ b/grelmicro/task/_interval.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from fast_depends import inject
 
-from grelmicro._async import is_async_callable
+from grelmicro._async import is_async_callable, sleep_or_stop
 from grelmicro.errors import WouldBlockError
 from grelmicro.sync.abc import SyncBackend, SyncPrimitive
 from grelmicro.sync.errors import LockNotOwnedError
@@ -118,7 +118,10 @@ class IntervalTask(Task):
         return self._name
 
     async def __call__(
-        self, *, ready: asyncio.Future[None] | None = None
+        self,
+        *,
+        ready: asyncio.Future[None] | None = None,
+        stop: asyncio.Event | None = None,
     ) -> None:
         """Run the repeated task loop."""
         logger.info(
@@ -150,7 +153,11 @@ class IntervalTask(Task):
                 if task is not None and task.cancelling():
                     task.uncancel()
                     raise asyncio.CancelledError
-                await asyncio.sleep(self._seconds)
+                # The current iteration finished. Break here on a graceful
+                # stop so in-flight work is never interrupted; otherwise
+                # sleep until the next interval (waking early on stop).
+                if await sleep_or_stop(self._seconds, stop):
+                    break
         finally:
             logger.info("Task stopped: %s", self.name)
 

--- a/grelmicro/task/_tasks.py
+++ b/grelmicro/task/_tasks.py
@@ -41,17 +41,45 @@ class Tasks(TaskRouter):
                 """,
             ),
         ] = None,
+        shutdown_timeout: Annotated[
+            float,
+            Doc(
+                """
+                Seconds to let running tasks finish their current unit of
+                work on shutdown before they are force-cancelled. On exit
+                a stop signal is raised so tasks unwind as soon as their
+                in-flight work completes; this only bounds how long a task
+                stuck mid-work delays shutdown.
+
+                Defaults to `30.0`, matching Kubernetes'
+                `terminationGracePeriodSeconds`. Keep it at or below the
+                pod grace period so draining finishes before `SIGKILL`.
+                Set to `0` to cancel immediately without draining.
+                """,
+            ),
+        ] = 30.0,
     ) -> None:
-        """Initialize Tasks."""
+        """Initialize Tasks.
+
+        Raises:
+            ValueError: If `shutdown_timeout` is negative.
+        """
         TaskRouter.__init__(self, tasks=tasks)
 
+        if shutdown_timeout < 0:
+            msg = "shutdown_timeout must be greater than or equal to 0"
+            raise ValueError(msg)
+
         self._auto_start = auto_start
+        self._shutdown_timeout = shutdown_timeout
         self._task_group: asyncio.TaskGroup | None = None
         self._task_handles: list[asyncio.Task[None]] = []
+        self._stop = asyncio.Event()
 
     async def __aenter__(self) -> Self:
         """Enter the context manager."""
         self._exit_stack = AsyncExitStack()
+        self._stop = asyncio.Event()
         await self._exit_stack.__aenter__()
         self._task_group = await self._exit_stack.enter_async_context(
             asyncio.TaskGroup(),
@@ -66,13 +94,30 @@ class Tasks(TaskRouter):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> bool | None:
-        """Exit the context manager."""
+        """Exit the context manager, draining tasks before forcing cancel."""
         if not self._task_group or not self._exit_stack:
             raise OutOfContextError(self, "__aexit__")
-        for handle in self._task_handles:
+        await self._drain()
+        return await self._exit_stack.__aexit__(exc_type, exc_value, traceback)
+
+    async def _drain(self) -> None:
+        """Stop tasks gracefully, force-cancelling stragglers after the timeout.
+
+        Sets the shared stop signal so each task breaks once its current
+        iteration finishes, then waits up to `shutdown_timeout`. Tasks
+        still running at the deadline are cancelled.
+        """
+        self._stop.set()
+        handles = self._task_handles
+        if handles and self._shutdown_timeout > 0:
+            _, pending = await asyncio.wait(
+                handles, timeout=self._shutdown_timeout
+            )
+        else:
+            pending = set(handles)
+        for handle in pending:
             handle.cancel()
         self._task_handles.clear()
-        return await self._exit_stack.__aexit__(exc_type, exc_value, traceback)
 
     async def start(self) -> None:
         """Start all tasks manually."""
@@ -88,7 +133,7 @@ class Tasks(TaskRouter):
         for task in self.tasks:
             ready: asyncio.Future[None] = loop.create_future()
             handle = self._task_group.create_task(
-                task(ready=ready), name=task.name
+                task(ready=ready, stop=self._stop), name=task.name
             )
             self._task_handles.append(handle)
             # Wait for the task to signal readiness, but surface its

--- a/grelmicro/task/abc.py
+++ b/grelmicro/task/abc.py
@@ -20,12 +20,18 @@ class Task(Protocol):
         self,
         *,
         ready: asyncio.Future[None] | None = None,
+        stop: asyncio.Event | None = None,
     ) -> None:
         """Run the task.
 
         ``ready`` is a Future the task should resolve once it has reached
         a steady state. The parent uses it to know when start-up has
         finished. ``None`` means the parent does not wait.
+
+        ``stop`` is an Event the parent sets to request a graceful
+        shutdown. A long-running task should finish its current unit of
+        work, then break and unwind instead of waiting for a forced
+        cancellation. ``None`` means the parent only stops via cancel.
 
         This is the entry point of the task to be run in the async event loop.
         """

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
     - architecture/imports.md
     - architecture/sync-from-thread.md
     - architecture/sync.md
+    - architecture/graceful-shutdown.md
     - architecture/kubernetes.md
     - architecture/sqlite.md
     - architecture/tracing.md

--- a/tests/sync/test_leaderelection.py
+++ b/tests/sync/test_leaderelection.py
@@ -669,3 +669,28 @@ async def test_leader_reconfigure_takes_effect_on_next_iteration(
         assert leader_election.config.error_interval == new_error_interval
 
         cancel_group(tg)
+
+
+async def test_leader_election_stops_gracefully_on_stop_event(
+    leader_election: LeaderElection,
+    backend: SyncBackend,
+) -> None:
+    """Setting the stop event breaks the loop and releases leadership."""
+    stop = Event()
+    async with asyncio.TaskGroup() as tg:
+        handle = await start_task(tg, leader_election, stop=stop)
+        await leader_election.wait_for_leader()
+        assert leader_election.is_leader() is True
+        stop.set()  # request graceful shutdown
+    # The loop broke on its own, without a cancellation.
+    assert handle.done()
+    assert not handle.cancelled()
+    # Leadership was released on the backend, so another worker can take it.
+    assert (
+        await backend.acquire(
+            name=leader_election._lock_name,
+            token="other",  # noqa: S106
+            duration=1,
+        )
+        is True
+    )

--- a/tests/task/samples.py
+++ b/tests/task/samples.py
@@ -102,9 +102,13 @@ class EventTask(Task):
         return "event_task"
 
     async def __call__(
-        self, *, ready: asyncio.Future[None] | None = None
+        self,
+        *,
+        ready: asyncio.Future[None] | None = None,
+        stop: asyncio.Event | None = None,
     ) -> None:
         """Run the task that sets the event."""
+        del stop
         if ready is not None and not ready.done():
             ready.set_result(None)
         self._event.set()

--- a/tests/task/test_tasks.py
+++ b/tests/task/test_tasks.py
@@ -11,6 +11,27 @@ from tests.task.samples import EventTask
 
 pytestmark = [pytest.mark.timeout(10)]
 
+# Module-level interval task functions (the interval decorator rejects
+# nested functions). `_drain_events` records whether the running
+# iteration was interrupted by a cancellation.
+_drain_events: list[str] = []
+
+
+async def _drain_work() -> None:
+    """Append a marker, yielding once to model in-flight work."""
+    import asyncio  # noqa: PLC0415
+
+    try:
+        _drain_events.append("run")
+        await asyncio.sleep(0)
+    except asyncio.CancelledError:  # pragma: no cover - drain should avoid this
+        _drain_events.append("cancelled")
+        raise
+
+
+async def _noop_work() -> None:
+    """Do nothing; used to exercise the interruptible interval sleep."""
+
 
 def test_tasks_init() -> None:
     """Test Tasks Initialization."""
@@ -79,9 +100,12 @@ async def test_tasks_start_surfaces_early_task_failure() -> None:
             return "boom"
 
         async def __call__(
-            self, *, ready: asyncio.Future[None] | None = None
+            self,
+            *,
+            ready: asyncio.Future[None] | None = None,
+            stop: asyncio.Event | None = None,
         ) -> None:
-            del ready
+            del ready, stop
             msg = "early failure"
             raise RuntimeError(msg)
 
@@ -107,9 +131,12 @@ async def test_tasks_start_surfaces_early_clean_exit() -> None:
             return "silent"
 
         async def __call__(
-            self, *, ready: asyncio.Future[None] | None = None
+            self,
+            *,
+            ready: asyncio.Future[None] | None = None,
+            stop: asyncio.Event | None = None,
         ) -> None:
-            del ready
+            del ready, stop
 
     app = Tasks(auto_start=False, tasks=[SilentTask()])
 
@@ -130,13 +157,19 @@ async def test_tasks_cancels_running_tasks_on_exit() -> None:
     cancelled = asyncio.Event()
 
     class LongRunningTask:
+        """A task that ignores the stop signal, so it must be force-cancelled."""
+
         @property
         def name(self) -> str:
             return "long"
 
         async def __call__(
-            self, *, ready: asyncio.Future[None] | None = None
+            self,
+            *,
+            ready: asyncio.Future[None] | None = None,
+            stop: asyncio.Event | None = None,
         ) -> None:
+            del stop
             if ready is not None:
                 ready.set_result(None)
             try:
@@ -145,7 +178,9 @@ async def test_tasks_cancels_running_tasks_on_exit() -> None:
                 cancelled.set()
                 raise
 
-    async with Tasks(tasks=[LongRunningTask()]):
+    # The task never observes the stop signal, so it is force-cancelled
+    # once the short drain window elapses.
+    async with Tasks(tasks=[LongRunningTask()], shutdown_timeout=0.05):
         pass
 
     assert cancelled.is_set()
@@ -162,3 +197,42 @@ async def test_tasks_out_of_context_errors() -> None:
 
     with pytest.raises(OutOfContextError):
         await app.__aexit__(None, None, None)
+
+
+async def test_tasks_shutdown_timeout_negative_rejected() -> None:
+    """A negative shutdown_timeout is rejected at construction."""
+    with pytest.raises(ValueError, match="shutdown_timeout"):
+        Tasks(shutdown_timeout=-1)
+
+
+async def test_tasks_drains_cooperative_task_without_cancel() -> None:
+    """An interval task finishes its iteration on stop and is not cancelled."""
+    import asyncio  # noqa: PLC0415
+
+    _drain_events.clear()
+    tasks = Tasks(auto_start=False, shutdown_timeout=5)
+    tasks.interval(seconds=0.01)(_drain_work)
+
+    async with tasks:
+        await tasks.start()
+        await asyncio.sleep(0.05)  # let it run a few iterations
+
+    # Exited well under shutdown_timeout, and the running iteration was
+    # never interrupted by a cancellation.
+    assert "run" in _drain_events
+    assert "cancelled" not in _drain_events
+
+
+async def test_tasks_interval_wakes_promptly_on_stop() -> None:
+    """A task sleeping on a long interval breaks immediately on shutdown."""
+    import asyncio  # noqa: PLC0415
+
+    tasks = Tasks(auto_start=False, shutdown_timeout=5)
+    tasks.interval(seconds=3600)(_noop_work)  # would otherwise sleep an hour
+
+    async with asyncio.timeout(
+        2
+    ):  # fails loudly if the sleep is not interruptible
+        async with tasks:
+            await tasks.start()
+            await asyncio.sleep(0.02)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,5 +1,6 @@
 """Tests for grelmicro._async utilities."""
 
+import asyncio
 import functools
 
 from grelmicro._async import is_async_callable
@@ -59,3 +60,42 @@ def test_nested_partial_of_async_is_async() -> None:
 def test_partial_of_sync_is_sync() -> None:
     """``functools.partial`` of a sync function stays sync."""
     assert is_async_callable(functools.partial(_sync_fn)) is False
+
+
+async def test_sleep_or_stop_returns_false_on_timeout() -> None:
+    """With no stop set, the full interval elapses and returns False."""
+    from grelmicro._async import sleep_or_stop  # noqa: PLC0415
+
+    assert await sleep_or_stop(0.01, asyncio.Event()) is False
+
+
+async def test_sleep_or_stop_returns_true_when_already_set() -> None:
+    """A stop already set returns True without sleeping."""
+    from grelmicro._async import sleep_or_stop  # noqa: PLC0415
+
+    stop = asyncio.Event()
+    stop.set()
+    assert await sleep_or_stop(60, stop) is True
+
+
+async def test_sleep_or_stop_wakes_on_stop_during_wait() -> None:
+    """A stop set during the wait wakes early and returns True."""
+    from grelmicro._async import sleep_or_stop  # noqa: PLC0415
+
+    stop = asyncio.Event()
+
+    async def trip() -> None:
+        await asyncio.sleep(0.01)
+        stop.set()
+
+    async with asyncio.timeout(2):
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(trip())
+            assert await sleep_or_stop(60, stop) is True
+
+
+async def test_sleep_or_stop_none_is_plain_sleep() -> None:
+    """A None stop behaves like asyncio.sleep and returns False."""
+    from grelmicro._async import sleep_or_stop  # noqa: PLC0415
+
+    assert await sleep_or_stop(0.01, None) is False


### PR DESCRIPTION
## Summary

Adds graceful shutdown for background tasks (closes #187). `Tasks(shutdown_timeout=...)` signals every `interval` task to finish its current run and stop, force-cancelling only stragglers that outlast the timeout.

## Behavior

- On exit, `Tasks` sets a shared stop signal. A task sleeping between runs wakes immediately; a task mid-run finishes its current iteration, then exits before the next. In-flight work is never interrupted.
- A task still running after `shutdown_timeout` seconds is force-cancelled.
- Default `shutdown_timeout=30.0` matches Kubernetes `terminationGracePeriodSeconds`. `0` cancels immediately.
- `LeaderElection` breaks its loop on the same signal and releases leadership on the backend, so a standby takes over without waiting for the lease TTL.

## Design

- New `grelmicro._async.sleep_or_stop(seconds, stop)`: an interruptible interval sleep shared by `IntervalTask` and `LeaderElection`.
- The `Task` protocol's `__call__` gains `stop: asyncio.Event | None = None` (**breaking** for custom `Task` implementations).
- New `docs/architecture/graceful-shutdown.md` documents signal wiring (SIGTERM/SIGINT → future), the drain contract, and the Lock/TaskLock lease-on-cancel behavior, with a runnable snippet.

## Tests

Cooperative drain without cancel, prompt wake on long intervals, force-cancel of a non-cooperative task after the timeout, `sleep_or_stop` unit cases, `LeaderElection` graceful release, and `shutdown_timeout` validation. 100% coverage.

Closes #187.
