### PR TITLE
🐛 Pass explicit backends to FastAPI request-handler patterns in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,12 @@ from grelmicro.log import configure as configure_logging
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience import (
     CircuitBreaker,
+    CircuitBreakers,
     RateLimitExceededError,
     RateLimiter,
     RateLimiters,
 )
+from grelmicro.resilience.circuitbreaker.memory import MemoryCircuitBreakerAdapter
 from grelmicro.sync import LeaderElection, Lock, Sync
 from grelmicro.task import Tasks
 
@@ -182,20 +184,31 @@ tasks.add_task(leader)
 
 redis = RedisProvider("redis://localhost:6379/0")
 
+# Patterns used inside FastAPI request handlers take an explicit backend:
+# handlers run in their own task, outside the app's ambient scope. Background
+# tasks run inside that scope, so they resolve their backend ambiently.
+sync_backend = redis.sync()
+cache_backend = redis.cache()
+ratelimiter_backend = redis.ratelimiter()
+breaker_backend = MemoryCircuitBreakerAdapter()
+
 micro = Grelmicro(uses=[
     redis,
-    Sync(redis),
-    Cache(redis),
-    RateLimiters(redis),
+    Sync(sync_backend),
+    Cache(cache_backend),
+    RateLimiters(ratelimiter_backend),
+    CircuitBreakers(breaker_backend),
     tasks,
     health,
 ])
 
-# === Patterns declared once at module load, resolved at use time ===
-ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer())
-lock = Lock("shared-resource")
-cb = CircuitBreaker("my-service")
-api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
+# === Patterns declared once at module load ===
+ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer(), backend=cache_backend)
+lock = Lock("shared-resource", backend=sync_backend)
+cb = CircuitBreaker("my-service", backend=breaker_backend)
+api_limiter = RateLimiter.sliding_window(
+    "api", limit=100, window=60, backend=ratelimiter_backend
+)
 
 
 # === FastAPI lifespan ===

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,7 @@
 
 ### Fixes
 
+* 🐛 The README and `simple_fastapi_app.py` FastAPI examples now pass an explicit `backend=` to patterns used inside request handlers. Request handlers run outside the app's ambient `Grelmicro.current()` scope, so the previous ambient form raised `NoActiveAppError` (locks, cache) or silently fell back to an in-memory backend (rate limiter, circuit breaker) at runtime. Background `Tasks` keep using ambient resolution. Ambient resolution in handlers is tracked in [#328](https://github.com/grelinfo/grelmicro/issues/328).
 * 🔒 `SettingsValidationError` no longer echoes the offending input value. Env-loaded credentials (DSNs, tokens) no longer surface in error messages.
 * 🚨 `ComponentNotRegisteredError` from `Grelmicro.get(kind, name)` now lists every registered `(kind, name)` pair (or states that none are registered). Agents and developers see what is available without inspecting the container.
 * 🚨 `HealthChecks.add` invalid-name errors now include valid examples (`'redis'`, `'db-primary'`, `'weather:circuitbreaker'`) alongside the regex.

--- a/docs/index.md
+++ b/docs/index.md
@@ -165,10 +165,12 @@ from grelmicro.log import configure as configure_logging
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience import (
     CircuitBreaker,
+    CircuitBreakers,
     RateLimitExceededError,
     RateLimiter,
     RateLimiters,
 )
+from grelmicro.resilience.circuitbreaker.memory import MemoryCircuitBreakerAdapter
 from grelmicro.sync import LeaderElection, Lock, Sync
 from grelmicro.task import Tasks
 
@@ -182,20 +184,31 @@ tasks.add_task(leader)
 
 redis = RedisProvider("redis://localhost:6379/0")
 
+# Patterns used inside FastAPI request handlers take an explicit backend:
+# handlers run in their own task, outside the app's ambient scope. Background
+# tasks run inside that scope, so they resolve their backend ambiently.
+sync_backend = redis.sync()
+cache_backend = redis.cache()
+ratelimiter_backend = redis.ratelimiter()
+breaker_backend = MemoryCircuitBreakerAdapter()
+
 micro = Grelmicro(uses=[
     redis,
-    Sync(redis),
-    Cache(redis),
-    RateLimiters(redis),
+    Sync(sync_backend),
+    Cache(cache_backend),
+    RateLimiters(ratelimiter_backend),
+    CircuitBreakers(breaker_backend),
     tasks,
     health,
 ])
 
-# === Patterns declared once at module load, resolved at use time ===
-ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer())
-lock = Lock("shared-resource")
-cb = CircuitBreaker("my-service")
-api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
+# === Patterns declared once at module load ===
+ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer(), backend=cache_backend)
+lock = Lock("shared-resource", backend=sync_backend)
+cb = CircuitBreaker("my-service", backend=breaker_backend)
+api_limiter = RateLimiter.sliding_window(
+    "api", limit=100, window=60, backend=ratelimiter_backend
+)
 
 
 # === FastAPI lifespan ===

--- a/docs/snippets/simple_fastapi_app.py
+++ b/docs/snippets/simple_fastapi_app.py
@@ -22,11 +22,17 @@ tasks.add_task(leader_election)
 
 redis = RedisProvider("redis://localhost:6379/0")
 
+# Patterns used inside FastAPI request handlers take an explicit backend:
+# handlers run in their own task, outside the app's ambient scope. Background
+# tasks run inside that scope, so they resolve their backend ambiently.
+sync_backend = redis.sync()
+breaker_backend = MemoryCircuitBreakerAdapter()
+
 micro = Grelmicro(
     uses=[
         redis,
-        Sync(redis),
-        CircuitBreakers(MemoryCircuitBreakerAdapter()),
+        Sync(sync_backend),
+        CircuitBreakers(breaker_backend),
         tasks,
     ]
 )
@@ -44,7 +50,7 @@ app = FastAPI(lifespan=lifespan)
 
 
 # --- Circuit Breaker: protect calls to an unreliable service ---
-cb = CircuitBreaker("my-service")
+cb = CircuitBreaker("my-service", backend=breaker_backend)
 
 
 @app.get("/")
@@ -54,7 +60,7 @@ async def read_root():
 
 
 # --- Distributed Lock: synchronize access to a shared resource ---
-lock = Lock("shared-resource")
+lock = Lock("shared-resource", backend=sync_backend)
 
 
 @app.get("/protected")


### PR DESCRIPTION
## Problem

The README front-door example and `simple_fastapi_app.py` declared patterns (`Lock`, `TTLCache`, `CircuitBreaker`, `RateLimiter`) without an explicit backend and used them inside FastAPI request handlers. Request handlers run in their own asyncio task, outside the app's ambient `Grelmicro.current()` scope, so at runtime:

- `Lock` / `TTLCache` raise `NoActiveAppError`.
- `RateLimiter` / `CircuitBreaker` silently fall back to an in-memory backend.

Snippet/README tests only import the modules, so this never surfaced in CI. It was found while building the FastAPI demo (#166).

## Fix

Pass an explicit `backend=` to the patterns used in handlers (shared with the registered Component), matching the working demo. Background `Tasks` keep ambient resolution (they run inside the lifespan scope). The README example also gains the missing `CircuitBreakers` component.

Making ambient resolution work in handlers is the proper follow-up, tracked in #328.

Refs #328.