### PR TITLE
🔖 Release 0.26.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.26.0 - 2026-06-05
+
 ### Breaking
 
 * 💥 The `Task` protocol's `__call__` now takes a `stop: asyncio.Event | None = None` keyword used for graceful shutdown. Custom `Task` implementations must accept it. The built-in `interval` tasks and `LeaderElection` are unaffected. Issue [#187](https://github.com/grelinfo/grelmicro/issues/187).


### PR DESCRIPTION
Cuts the 0.26.0 release: moves the changelog `Unreleased` entries under `## 0.26.0 - 2026-06-05`.

Highlights this release:
- ✨ Three-layer cache stampede menu (`stampede=`, `early=` XFetch) — #235
- ✨ Graceful shutdown with `Tasks(shutdown_timeout=)` — #187
- ✨ Multi-app guard for process-global `Log`/`Trace` — #266
- ✨ Bare zero-arg classes in `uses=` — #263
- ✨ Bulkhead `uses=` failure-domain isolation — #168
- 📝 Runnable FastAPI demo + ConfigMap reconfigure example — #166, #169
- 🐛 FastAPI examples fixed to use explicit backends in handlers (#328 tracks the ambient follow-up)

**Breaking:** `@cached(lock=...)` → `@cached(stampede=...)`; `Task.__call__` gains a `stop=` keyword.

After merge, I'll publish the `0.26.0` GitHub Release to trigger PyPI + docs deploy.