### PR TITLE
✨ Add fencing tokens to the distributed Lock

### DIFF
--- a/docs/coordination.md
+++ b/docs/coordination.md
@@ -270,6 +270,43 @@ database round-trip, can keep using `Lock(name)` directly. Reach for
 - the deployment has `GREL_ENV_LOAD=true` and you want to skip the env path on
   per-request construction
 
+### Fencing tokens
+
+A fencing token is a strictly increasing integer the backend mints for a lock
+name. Each acquisition returns a `LockHandle` that carries it. Read it from the
+value the context manager binds:
+
+```python
+async with Lock("cart") as held:
+    print(held.fencing_token)
+```
+
+The token grows by one on every free-to-held transition: a new holder, or a
+takeover after the previous lease expired. It keeps climbing across release and
+re-acquire cycles, so a token is never reused for a name. The same holder
+renewing or extending its lease keeps the same token.
+
+`acquire()` and `acquire_nowait()` also return the `LockHandle`. The handle is
+per-acquisition, so a `Lock` shared by several tasks gives each holder its own
+handle with its own token.
+
+Every backend mints tokens that are strictly monotonic per name. Redis is
+strictly monotonic against its master.
+
+!!! warning "The resource enforces, grelmicro mints"
+    A fencing token only protects a resource that checks it. grelmicro hands you
+    the token. The resource you write to must record the highest token it has
+    accepted and reject any write that arrives with a lower or equal token.
+    Without that check on the resource, a paused or partitioned old holder can
+    still write after a new holder took over.
+
+    The pattern: read `held.fencing_token`, pass it to the resource on every
+    write, and have the resource compare it against its stored high-water mark.
+
+```python
+--8<-- "coordination/fencing.py"
+```
+
 ## Task Lock
 
 The Task Lock is a distributed lock for scheduled tasks. Unlike a regular Lock,

--- a/docs/snippets/coordination/fencing.py
+++ b/docs/snippets/coordination/fencing.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from grelmicro.coordination import Lock
+from grelmicro.coordination.memory import MemoryLockAdapter
+
+
+class Resource:
+    """A protected resource that records the highest fencing token it accepts."""
+
+    def __init__(self) -> None:
+        self.highest_token = 0
+
+    def write(self, *, fencing_token: int, value: str) -> bool:
+        """Accept the write only when its token beats every prior one."""
+        if fencing_token <= self.highest_token:
+            return False
+        self.highest_token = fencing_token
+        return True
+
+
+async def main() -> None:
+    resource = Resource()
+
+    async with MemoryLockAdapter() as backend:
+        lock = Lock("cart", backend=backend)
+
+        # A stale holder writes with an old token.
+        stale = await lock.acquire()
+        await lock.release()
+
+        # The new holder gets a strictly greater token.
+        async with lock as held:
+            assert resource.write(fencing_token=held.fencing_token, value="new")
+
+        # The stale token is now too low: the resource rejects it.
+        assert not resource.write(
+            fencing_token=stale.fencing_token, value="stale"
+        )
+
+
+asyncio.run(main())

--- a/grelmicro/coordination/__init__.py
+++ b/grelmicro/coordination/__init__.py
@@ -1,6 +1,7 @@
 """Coordination primitives for distributed locking and leader election."""
 
 from grelmicro.coordination._component import Coordination
+from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination.abc import (
     LeaderElectionBackend,
     LeaderRecord,
@@ -37,6 +38,7 @@ __all__ = [
     "LockAcquireError",
     "LockBackend",
     "LockBackendError",
+    "LockHandle",
     "LockLockedCheckError",
     "LockNotOwnedError",
     "LockOwnedCheckError",

--- a/grelmicro/coordination/_base.py
+++ b/grelmicro/coordination/_base.py
@@ -1,12 +1,13 @@
 """Lock Base Classes."""
 
 from types import TracebackType
-from typing import Annotated, Protocol, Self
+from typing import Annotated, Protocol
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Doc
 
+from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination._tokens import generate_worker_id
 from grelmicro.coordination.abc import LockPrimitive
 
@@ -30,8 +31,10 @@ class BaseLockConfig(BaseModel):
 class BaseLock(LockPrimitive, Protocol):
     """Base Lock Protocol."""
 
-    async def __aenter__(self) -> Self:
+    async def __aenter__(self) -> LockHandle:
         """Acquire the lock.
+
+        Returns the `LockHandle` for this acquisition.
 
         Raises:
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
@@ -59,8 +62,10 @@ class BaseLock(LockPrimitive, Protocol):
         """Return the config."""
         ...
 
-    async def acquire(self) -> None:
+    async def acquire(self) -> LockHandle:
         """Acquire the lock.
+
+        Returns the `LockHandle` for this acquisition.
 
         Raises:
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
@@ -69,9 +74,11 @@ class BaseLock(LockPrimitive, Protocol):
         """
         ...
 
-    async def acquire_nowait(self) -> None:
+    async def acquire_nowait(self) -> LockHandle:
         """
         Acquire the lock, without blocking.
+
+        Returns the `LockHandle` for this acquisition.
 
         Raises:
             LockReentrantError: If the lock is already acquired (nested usage is not supported).

--- a/grelmicro/coordination/_handle.py
+++ b/grelmicro/coordination/_handle.py
@@ -1,0 +1,42 @@
+"""Lock acquisition handle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated
+
+from typing_extensions import Doc
+
+
+@dataclass(frozen=True, slots=True)
+class LockHandle:
+    """The result of a successful lock acquisition.
+
+    Returned by `Lock.acquire`, `Lock.acquire_nowait`, and `Lock.__aenter__`.
+    Each acquisition produces its own handle, so a `Lock` shared by several
+    tasks gives each holder a distinct handle.
+    """
+
+    name: Annotated[
+        str,
+        Doc("The lock name, as passed to `Lock(name)`."),
+    ]
+    token: Annotated[
+        str,
+        Doc(
+            "The opaque ownership token the backend stored for this holder."
+            " The same token is passed to `release` and `owned`."
+        ),
+    ]
+    fencing_token: Annotated[
+        int,
+        Doc(
+            "A strictly increasing integer minted by the backend for this"
+            " lock name. It grows on every free-to-held transition (a new"
+            " holder or a takeover of an expired lock) and keeps climbing"
+            " across release and re-acquire cycles. A renewal by the same"
+            " holder keeps the same value. Pass it to the protected resource"
+            " so the resource can reject any write that carries a lower or"
+            " equal token."
+        ),
+    ]

--- a/grelmicro/coordination/abc.py
+++ b/grelmicro/coordination/abc.py
@@ -66,11 +66,17 @@ class LockBackend(Protocol):
                 " this elapses."
             ),
         ],
-    ) -> bool:
+    ) -> int | None:
         """Acquire the lock.
 
-        Returns `True` when the lock was granted, `False` when another
-        token already holds it.
+        Returns the fencing token when the lock was granted, `None` when
+        another token already holds it.
+
+        The fencing token is a strictly increasing integer per lock name.
+        It increments on every free-to-held transition (a fresh acquire by
+        a new holder, or a takeover of an expired lock) and keeps climbing
+        across release and re-acquire cycles. The same holder renewing or
+        extending its lease receives the same token.
         """
         ...
 
@@ -127,8 +133,12 @@ class LockBackend(Protocol):
 class LockPrimitive(Protocol):
     """Lock Primitive Protocol."""
 
-    async def __aenter__(self) -> Self:
-        """Enter the lock primitive."""
+    async def __aenter__(self) -> object:
+        """Enter the lock primitive.
+
+        Implementations return whatever the `async with` block binds. A
+        `Lock` binds a `LockHandle`, a `TaskLock` binds itself.
+        """
 
     async def __aexit__(
         self,

--- a/grelmicro/coordination/kubernetes.py
+++ b/grelmicro/coordination/kubernetes.py
@@ -105,6 +105,15 @@ class KubernetesLockAdapter(LockBackend):
     from Kubernetes optimistic concurrency: a Lease is read with its
     `resourceVersion` and written back with it, so a concurrent writer loses
     the race with a 409 Conflict.
+
+    Fencing tokens use the Lease `spec.leaseTransitions` counter. It is
+    incremented by one on every free-to-held transition (a fresh acquire or a
+    takeover of a vacated or expired Lease) and kept on a same-holder extend.
+    Release vacates the holder in place (clearing `holderIdentity`,
+    `acquireTime`, and `renewTime`) but keeps the Lease object and its
+    transitions counter, so fencing tokens are strictly monotonic per name
+    across release and re-acquire cycles. The Lease is never deleted while the
+    backend is open.
     """
 
     def __init__(
@@ -155,7 +164,12 @@ class KubernetesLockAdapter(LockBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the lock backend."""
+        """Close the lock backend.
+
+        Vacates the holder of any expired Lease in place rather than deleting
+        it, so the `leaseTransitions` fence counter survives for the next
+        acquire. A still-live Lease is left untouched.
+        """
         if self._client:  # pragma: no branch
             now = datetime.now(tz=UTC)
             async for lease in self._client.list(
@@ -164,23 +178,20 @@ class KubernetesLockAdapter(LockBackend):
                 labels={_LABEL_MANAGED_BY: _LABEL_MANAGED_BY_VALUE},
             ):
                 expire_at = _get_expire_at(lease)
-                if expire_at is not None and expire_at < now:
-                    assert lease.metadata  # noqa: S101
-                    assert lease.metadata.name  # noqa: S101
-                    try:
-                        await self._client.delete(
-                            Lease,
-                            name=lease.metadata.name,
-                            namespace=self._namespace,
-                        )
-                    except ApiError as e:
-                        if e.status.code != HTTPStatus.NOT_FOUND:
-                            raise
+                holder = lease.spec.holderIdentity if lease.spec else None
+                if (
+                    holder is not None
+                    and expire_at is not None
+                    and expire_at < now
+                ):
+                    await self._vacate_lease(lease)
             await self._client.close()
             self._client = None
 
-    async def acquire(self, *, name: str, token: str, duration: float) -> bool:
-        """Acquire a lock."""
+    async def acquire(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Acquire a lock, returning the fencing token or `None`."""
         if not self._client:
             raise OutOfContextError(self, "acquire")
 
@@ -198,18 +209,23 @@ class KubernetesLockAdapter(LockBackend):
 
         current_expire_at = _get_expire_at(lease)
         current_holder = lease.spec.holderIdentity if lease.spec else None
+        live = current_expire_at is not None and current_expire_at >= now
 
-        if (
-            current_expire_at is not None
-            and current_expire_at >= now
-            and current_holder != token
-        ):
-            return False
+        if live and current_holder != token:
+            return None
 
-        return await self._replace_lease(lease, token, duration)
+        return await self._replace_lease(
+            lease, token, duration, live=live, holder=current_holder
+        )
 
     async def release(self, *, name: str, token: str) -> bool:
-        """Release the lock."""
+        """Release the lock by vacating the holder in place.
+
+        Clears `holderIdentity`, `acquireTime`, and `renewTime` so the Lease
+        reads as free, while keeping the Lease object and its
+        `leaseTransitions` counter so fencing tokens keep climbing on the next
+        acquire.
+        """
         if not self._client:
             raise OutOfContextError(self, "release")
 
@@ -235,16 +251,7 @@ class KubernetesLockAdapter(LockBackend):
         ):
             return False
 
-        try:
-            await self._client.delete(
-                Lease, name=lease_name, namespace=self._namespace
-            )
-        except ApiError as e:
-            if e.status.code == HTTPStatus.NOT_FOUND:
-                return False
-            raise
-
-        return True
+        return await self._vacate_lease(lease)
 
     async def locked(self, *, name: str) -> bool:
         """Check if the lock is acquired."""
@@ -294,11 +301,12 @@ class KubernetesLockAdapter(LockBackend):
         lease_name: str,
         token: str,
         duration: float,
-    ) -> bool:
-        """Create a new Lease resource."""
+    ) -> int | None:
+        """Create a new Lease resource, returning fencing token `1`."""
         assert self._client  # noqa: S101
 
         now_dt = datetime.now(tz=UTC)
+        fence = 1
         lease = Lease(
             metadata=ObjectMeta(
                 name=lease_name,
@@ -312,6 +320,7 @@ class KubernetesLockAdapter(LockBackend):
                 leaseDurationSeconds=ceil(duration),
                 acquireTime=now_dt,
                 renewTime=now_dt,
+                leaseTransitions=fence,
             ),
         )
 
@@ -319,22 +328,41 @@ class KubernetesLockAdapter(LockBackend):
             await self._client.create(lease)
         except ApiError as e:
             if e.status.code == HTTPStatus.CONFLICT:
-                return False
+                return None
             raise
 
-        return True
+        return fence
 
     async def _replace_lease(
         self,
         existing_lease: Lease,
         token: str,
         duration: float,
-    ) -> bool:
-        """Replace an existing Lease resource using optimistic concurrency."""
+        *,
+        live: bool,
+        holder: str | None,
+    ) -> int | None:
+        """Replace an existing Lease using optimistic concurrency.
+
+        A live same-holder extend keeps `leaseTransitions`. A takeover of a
+        vacated or expired Lease bumps it by one. The new value is the fencing
+        token, written back under the read `resourceVersion`.
+        """
         assert self._client  # noqa: S101
         assert existing_lease.metadata  # noqa: S101
 
         now_dt = datetime.now(tz=UTC)
+        current_transitions = (
+            existing_lease.spec.leaseTransitions
+            if existing_lease.spec and existing_lease.spec.leaseTransitions
+            else 0
+        )
+        fence = (
+            current_transitions
+            if live and holder == token
+            else current_transitions + 1
+        )
+
         updated_lease = Lease(
             metadata=ObjectMeta(
                 name=existing_lease.metadata.name,
@@ -349,6 +377,7 @@ class KubernetesLockAdapter(LockBackend):
                 leaseDurationSeconds=ceil(duration),
                 acquireTime=now_dt,
                 renewTime=now_dt,
+                leaseTransitions=fence,
             ),
         )
 
@@ -356,6 +385,48 @@ class KubernetesLockAdapter(LockBackend):
             await self._client.replace(updated_lease)
         except ApiError as e:
             if e.status.code == HTTPStatus.CONFLICT:
+                return None
+            raise
+
+        return fence
+
+    async def _vacate_lease(self, existing_lease: Lease) -> bool:
+        """Clear the holder of a Lease in place, keeping its transitions.
+
+        Writes back under the read `resourceVersion`. Returns False on a 409
+        Conflict (a concurrent writer changed the Lease first) so the caller
+        sees the release as not applied.
+        """
+        assert self._client  # noqa: S101
+        assert existing_lease.metadata  # noqa: S101
+
+        transitions = (
+            existing_lease.spec.leaseTransitions
+            if existing_lease.spec and existing_lease.spec.leaseTransitions
+            else 0
+        )
+        vacated = Lease(
+            metadata=ObjectMeta(
+                name=existing_lease.metadata.name,
+                namespace=self._namespace,
+                resourceVersion=existing_lease.metadata.resourceVersion,
+                labels={
+                    _LABEL_MANAGED_BY: _LABEL_MANAGED_BY_VALUE,
+                },
+            ),
+            spec=LeaseSpec(
+                holderIdentity=None,
+                leaseDurationSeconds=None,
+                acquireTime=None,
+                renewTime=None,
+                leaseTransitions=transitions,
+            ),
+        )
+
+        try:
+            await self._client.replace(vacated)
+        except ApiError as e:
+            if e.status.code in (HTTPStatus.NOT_FOUND, HTTPStatus.CONFLICT):
                 return False
             raise
 

--- a/grelmicro/coordination/lock.py
+++ b/grelmicro/coordination/lock.py
@@ -14,6 +14,7 @@ from typing_extensions import Doc
 from grelmicro._app import Grelmicro
 from grelmicro._config import Reconfigurable, env_segment, resolve_config
 from grelmicro.coordination._base import BaseLock, BaseLockConfig
+from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination._tokens import generate_task_token
 from grelmicro.coordination.abc import LockBackend, Seconds
 from grelmicro.coordination.errors import (
@@ -287,15 +288,17 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         )
         return coordination.lock_backend
 
-    async def __aenter__(self) -> Self:
+    async def __aenter__(self) -> LockHandle:
         """Acquire the lock with the async context manager.
+
+        Returns the `LockHandle` for this acquisition so the body can read
+        `held.fencing_token`.
 
         Raises:
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
             LockAcquireError: If the lock cannot be acquired due to an error on the backend.
         """
-        await self.acquire()
-        return self
+        return await self.acquire()
 
     async def __aexit__(
         self,
@@ -327,8 +330,11 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             raise RuntimeError(msg)
         return task
 
-    async def acquire(self) -> None:
+    async def acquire(self) -> LockHandle:
         """Acquire the lock.
+
+        Returns the `LockHandle` for this acquisition, carrying the ownership
+        `token` and the strictly increasing `fencing_token`.
 
         Raises:
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
@@ -341,12 +347,22 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             raise LockReentrantError(name=self._name)
         token = generate_task_token(config.worker)
         duration = config.lease_duration
-        while not await self.do_acquire(token=token, duration=duration):  # noqa: ASYNC110 // Polling is intentional
+        fencing_token = await self.do_acquire(token=token, duration=duration)
+        while fencing_token is None:
             await asyncio.sleep(config.retry_interval)
+            fencing_token = await self.do_acquire(
+                token=token, duration=duration
+            )
         self._held_by_tasks.add(task)
+        return LockHandle(
+            name=self._name, token=token, fencing_token=fencing_token
+        )
 
-    async def acquire_nowait(self) -> None:
+    async def acquire_nowait(self) -> LockHandle:
         """Acquire the lock, without blocking.
+
+        Returns the `LockHandle` for this acquisition, carrying the ownership
+        `token` and the strictly increasing `fencing_token`.
 
         Raises:
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
@@ -358,12 +374,16 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         if task in self._held_by_tasks:
             raise LockReentrantError(name=self._name)
         token = generate_task_token(config.worker)
-        if not await self.do_acquire(
+        fencing_token = await self.do_acquire(
             token=token, duration=config.lease_duration
-        ):
+        )
+        if fencing_token is None:
             msg = f"Lock not acquired: name={self._name}, token={token}"
             raise WouldBlockError(msg)
         self._held_by_tasks.add(task)
+        return LockHandle(
+            name=self._name, token=token, fencing_token=fencing_token
+        )
 
     async def release(self) -> None:
         """Release the lock.
@@ -403,7 +423,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         """
         return await self.do_owned(generate_task_token(self._config.worker))
 
-    async def do_acquire(self, token: str, *, duration: Seconds) -> bool:
+    async def do_acquire(self, token: str, *, duration: Seconds) -> int | None:
         """Acquire the lock.
 
         This method should not be called directly. Use `acquire` instead.
@@ -417,7 +437,8 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
                 runs concurrently.
 
         Returns:
-            bool: True if the lock was acquired, False if the lock was not acquired.
+            int | None: The fencing token if the lock was acquired, None if
+                the lock was not acquired.
 
         Raises:
             LockAcquireError: If the lock cannot be acquired due to an error on the backend.
@@ -480,7 +501,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         """Build a thread token from a worker identity and the given thread ID."""
         return f"{worker}:thread:{thread_id}"
 
-    async def do_thread_acquire(self, thread_id: int) -> None:
+    async def do_thread_acquire(self, thread_id: int) -> LockHandle:
         """Acquire the lock from a worker thread (blocking).
 
         Runs on the event loop so the reentrant check and backend acquire
@@ -495,11 +516,18 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             raise LockReentrantError(name=self._name)
         token = self._thread_token(thread_id, config.worker)
         duration = config.lease_duration
-        while not await self.do_acquire(token=token, duration=duration):  # noqa: ASYNC110 // Polling is intentional
+        fencing_token = await self.do_acquire(token=token, duration=duration)
+        while fencing_token is None:
             await asyncio.sleep(config.retry_interval)
+            fencing_token = await self.do_acquire(
+                token=token, duration=duration
+            )
         self._held_by_threads.add(thread_id)
+        return LockHandle(
+            name=self._name, token=token, fencing_token=fencing_token
+        )
 
-    async def do_thread_acquire_nowait(self, thread_id: int) -> None:
+    async def do_thread_acquire_nowait(self, thread_id: int) -> LockHandle:
         """Acquire the lock from a worker thread (non-blocking).
 
         Runs on the event loop so the reentrant check and backend acquire
@@ -514,12 +542,16 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         if thread_id in self._held_by_threads:
             raise LockReentrantError(name=self._name)
         token = self._thread_token(thread_id, config.worker)
-        if not await self.do_acquire(
+        fencing_token = await self.do_acquire(
             token=token, duration=config.lease_duration
-        ):
+        )
+        if fencing_token is None:
             msg = f"Lock not acquired: name={self._name}, token={token}"
             raise WouldBlockError(msg)
         self._held_by_threads.add(thread_id)
+        return LockHandle(
+            name=self._name, token=token, fencing_token=fencing_token
+        )
 
     async def do_thread_release(self, thread_id: int) -> None:
         """Release the lock from a worker thread.
@@ -550,15 +582,17 @@ class ThreadLockAdapter:
         """Initialize the lock adapter."""
         self._lock = lock
 
-    def __enter__(self) -> Self:
+    def __enter__(self) -> LockHandle:
         """Acquire the lock with the context manager.
+
+        Returns the `LockHandle` for this acquisition so the body can read
+        `held.fencing_token`.
 
         Raises:
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
             LockAcquireError: Cannot acquire the lock due to backend error.
         """
-        self.acquire()
-        return self
+        return self.acquire()
 
     def __exit__(
         self,
@@ -569,27 +603,33 @@ class ThreadLockAdapter:
         """Release the lock with the context manager."""
         self.release()
 
-    def acquire(self) -> None:
+    def acquire(self) -> LockHandle:
         """Acquire the lock.
+
+        Returns the `LockHandle` for this acquisition, carrying the ownership
+        `token` and the strictly increasing `fencing_token`.
 
         Raises:
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
             LockAcquireError: Cannot acquire the lock due to backend error.
         """
-        asyncio.run_coroutine_threadsafe(
+        return asyncio.run_coroutine_threadsafe(
             self._lock.do_thread_acquire(get_ident()),
             self._lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
         ).result()
 
-    def acquire_nowait(self) -> None:
+    def acquire_nowait(self) -> LockHandle:
         """Acquire the lock, without blocking.
+
+        Returns the `LockHandle` for this acquisition, carrying the ownership
+        `token` and the strictly increasing `fencing_token`.
 
         Raises:
             LockReentrantError: If the lock is already acquired (nested usage is not supported).
             LockAcquireError: Cannot acquire the lock due to backend error.
             WouldBlockError: If the lock cannot be acquired without blocking.
         """
-        asyncio.run_coroutine_threadsafe(
+        return asyncio.run_coroutine_threadsafe(
             self._lock.do_thread_acquire_nowait(get_ident()),
             self._lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
         ).result()

--- a/grelmicro/coordination/memory.py
+++ b/grelmicro/coordination/memory.py
@@ -25,6 +25,7 @@ class MemoryLockAdapter(LockBackend):
     def __init__(self) -> None:
         """Initialize the lock backend."""
         self._locks: dict[str, tuple[str | None, float]] = {}
+        self._fences: dict[str, int] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
 
     async def __aenter__(self) -> Self:
@@ -40,18 +41,24 @@ class MemoryLockAdapter(LockBackend):
     ) -> None:
         """Close the lock backend."""
         self._locks.clear()
+        self._fences.clear()
 
-    async def acquire(self, *, name: str, token: str, duration: float) -> bool:
-        """Acquire the lock."""
+    async def acquire(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Acquire the lock, returning the fencing token or `None`."""
         current_token, expire_at = self._locks.get(name, (None, 0))
-        if (
-            current_token is None
-            or current_token == token
-            or expire_at < monotonic()
-        ):
+        free = current_token is None or expire_at < monotonic()
+        if free or current_token == token:
+            if free:
+                # Free-to-held transition: a new holder or a takeover of an
+                # expired lock bumps the per-name high-water counter. The
+                # counter persists for the adapter lifetime, even across
+                # release, so re-acquire keeps climbing.
+                self._fences[name] = self._fences.get(name, 0) + 1
             self._locks[name] = (token, monotonic() + duration)
-            return True
-        return False
+            return self._fences[name]
+        return None
 
     async def release(self, *, name: str, token: str) -> bool:
         """Release the lock."""

--- a/grelmicro/coordination/postgres.py
+++ b/grelmicro/coordination/postgres.py
@@ -23,39 +23,62 @@ class PostgresLockAdapter(LockBackend):
     for distributed locks. Pass an explicit `provider=` to share a pool
     with other components, or rely on the default `env_prefix=` to build
     one from environment variables.
+
+    Fencing tokens live in a `fence BIGINT` column. The acquire statement
+    bumps the fence on every free-to-held transition and keeps it on a
+    same-holder extend, returning the value with `RETURNING fence`. Release
+    clears the holder and expiry but keeps the row and its fence, so the
+    fence is strictly monotonic per name across release and re-acquire cycles.
     """
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """
                 CREATE TABLE IF NOT EXISTS {table_name} (
                     name TEXT PRIMARY KEY,
-                    token TEXT NOT NULL,
-                    expire_at TIMESTAMP NOT NULL
+                    token TEXT,
+                    expire_at TIMESTAMP,
+                    fence BIGINT NOT NULL DEFAULT 0
                 );
+                ALTER TABLE {table_name}
+                    ADD COLUMN IF NOT EXISTS fence BIGINT NOT NULL DEFAULT 0;
+                ALTER TABLE {table_name} ALTER COLUMN token DROP NOT NULL;
+                ALTER TABLE {table_name} ALTER COLUMN expire_at DROP NOT NULL;
                 """
 
     _SQL_ACQUIRE_OR_EXTEND = """
-                INSERT INTO {table_name} (name, token, expire_at)
-                VALUES ($1, $2, NOW() + make_interval(secs => $3))
+                INSERT INTO {table_name} (name, token, expire_at, fence)
+                VALUES ($1, $2, NOW() + make_interval(secs => $3), 1)
                 ON CONFLICT (name) DO UPDATE
-                SET token = EXCLUDED.token, expire_at = EXCLUDED.expire_at
-                WHERE {table_name}.token = EXCLUDED.token OR {table_name}.expire_at < NOW()
-                RETURNING 1;
+                SET token = EXCLUDED.token,
+                    expire_at = EXCLUDED.expire_at,
+                    fence = CASE
+                        WHEN {table_name}.token = EXCLUDED.token
+                             AND {table_name}.expire_at >= NOW()
+                        THEN {table_name}.fence
+                        ELSE {table_name}.fence + 1
+                    END
+                WHERE {table_name}.token = EXCLUDED.token
+                   OR {table_name}.token IS NULL
+                   OR {table_name}.expire_at IS NULL
+                   OR {table_name}.expire_at < NOW()
+                RETURNING fence;
                 """
 
     _SQL_RELEASE = """
-            DELETE FROM {table_name}
+            UPDATE {table_name}
+            SET token = NULL, expire_at = NULL
             WHERE name = $1 AND token = $2 AND expire_at >= NOW()
             RETURNING 1;
             """
 
     _SQL_RELEASE_ALL_EXPIRED = """
-        DELETE FROM {table_name}
+        UPDATE {table_name}
+        SET token = NULL, expire_at = NULL
         WHERE expire_at < NOW();
         """
 
     _SQL_LOCKED = """
         SELECT 1 FROM {table_name}
-        WHERE name = $1 AND expire_at >= NOW();
+        WHERE name = $1 AND token IS NOT NULL AND expire_at >= NOW();
         """
 
     _SQL_OWNED = """
@@ -144,13 +167,14 @@ class PostgresLockAdapter(LockBackend):
         if self._owns_provider:
             await self._provider.__aexit__(exc_type, exc_value, traceback)
 
-    async def acquire(self, *, name: str, token: str, duration: float) -> bool:
-        """Acquire a lock."""
-        return bool(
-            await self._provider.client.fetchval(
-                self._acquire_sql, name, token, duration
-            )
+    async def acquire(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Acquire a lock, returning the fencing token or `None`."""
+        fence = await self._provider.client.fetchval(
+            self._acquire_sql, name, token, duration
         )
+        return int(fence) if fence is not None else None
 
     async def release(self, *, name: str, token: str) -> bool:
         """Release the lock."""

--- a/grelmicro/coordination/redis.py
+++ b/grelmicro/coordination/redis.py
@@ -24,23 +24,47 @@ class RedisLockAdapter(LockBackend):
     for distributed locks. Pass an explicit `provider=` to share a
     pool with other components, or rely on the default `env_prefix=`
     to build one from environment variables.
+
+    Fencing tokens come from a Redis `INCR` on a per-name counter key,
+    bumped inside the acquire Lua script only on a free-to-held transition.
+    The lock value stores the token's fence so an extend by the same holder
+    returns the same token. The counter key is never deleted on release, so
+    re-acquire keeps climbing. Tokens are strictly monotonic against a single
+    Redis master.
     """
 
     _LUA_ACQUIRE_OR_EXTEND = """
-        local token = redis.call('get', KEYS[1])
-        if not token then
-            redis.call('set', KEYS[1], ARGV[1], 'px', ARGV[2])
-            return 1
+        -- KEYS[1] = lock key, KEYS[2] = fence counter key
+        -- ARGV[1] = token, ARGV[2] = duration in ms
+        -- The lock value is stored as "<fence>:<token>". The fence counter
+        -- key is INCR'd only on a free-to-held transition and never deleted,
+        -- so fencing tokens stay strictly monotonic across release cycles.
+        local stored = redis.call('get', KEYS[1])
+        if not stored then
+            local fence = redis.call('incr', KEYS[2])
+            redis.call(
+                'set', KEYS[1], fence .. ':' .. ARGV[1], 'px', ARGV[2]
+            )
+            return fence
         end
+        local sep = string.find(stored, ':', 1, true)
+        local fence = tonumber(string.sub(stored, 1, sep - 1))
+        local token = string.sub(stored, sep + 1)
         if token == ARGV[1] then
             redis.call('pexpire', KEYS[1], ARGV[2])
-            return 1
+            return fence
         end
-        return 0
+        return nil
     """
     _LUA_RELEASE = """
-        local token = redis.call('get', KEYS[1])
-        if not token or token ~= ARGV[1] then
+        -- The fence counter key is left untouched so re-acquire keeps climbing.
+        local stored = redis.call('get', KEYS[1])
+        if not stored then
+            return 0
+        end
+        local sep = string.find(stored, ':', 1, true)
+        local token = string.sub(stored, sep + 1)
+        if token ~= ARGV[1] then
             return 0
         end
         redis.call('del', KEYS[1])
@@ -121,15 +145,20 @@ class RedisLockAdapter(LockBackend):
         if self._owns_provider:
             await self._provider.__aexit__(exc_type, exc_value, traceback)
 
-    async def acquire(self, *, name: str, token: str, duration: float) -> bool:
-        """Acquire the lock."""
-        return bool(
-            await self._lua_acquire(
-                keys=[f"{self._key_prefix}{name}"],
-                args=[token, int(duration * 1000)],
-                client=self._provider.client,
-            )
+    def _fence_key(self, name: str) -> str:
+        """Return the persistent fence counter key for a lock name."""
+        return f"{self._key_prefix}fence:{name}"
+
+    async def acquire(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Acquire the lock, returning the fencing token or `None`."""
+        fence = await self._lua_acquire(
+            keys=[f"{self._key_prefix}{name}", self._fence_key(name)],
+            args=[token, int(duration * 1000)],
+            client=self._provider.client,
         )
+        return int(fence) if fence is not None else None
 
     async def release(self, *, name: str, token: str) -> bool:
         """Release the lock."""
@@ -149,9 +178,12 @@ class RedisLockAdapter(LockBackend):
 
     async def owned(self, *, name: str, token: str) -> bool:
         """Check if the lock is owned."""
-        return (
-            await self._provider.client.get(f"{self._key_prefix}{name}")
-        ) == token.encode()
+        stored = await self._provider.client.get(f"{self._key_prefix}{name}")
+        if stored is None:
+            return False
+        value = stored.decode() if isinstance(stored, bytes) else stored
+        _fence, sep, holder = value.partition(":")
+        return sep == ":" and holder == token
 
 
 class RedisLeaderElectionBackend:

--- a/grelmicro/coordination/sqlite.py
+++ b/grelmicro/coordination/sqlite.py
@@ -38,40 +38,62 @@ def _get_sqlite_path() -> str:
 
 
 class SQLiteLockAdapter(LockBackend):
-    """SQLite Lock Adapter."""
+    """SQLite Lock Adapter.
+
+    Fencing tokens live in a `fence` column on the lock row. Acquire runs
+    inside a `BEGIN IMMEDIATE` transaction, bumps the fence on every
+    free-to-held transition, keeps it on a same-holder extend, and returns it
+    with `RETURNING fence`. Release clears the holder and expiry but keeps the
+    row and its fence, so the fence is strictly monotonic per name across
+    release and re-acquire cycles.
+    """
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """
                 CREATE TABLE IF NOT EXISTS {table_name} (
                     name TEXT PRIMARY KEY,
-                    token TEXT NOT NULL,
-                    expire_at TEXT NOT NULL
+                    token TEXT,
+                    expire_at TEXT,
+                    fence INTEGER NOT NULL DEFAULT 0
                 );
                 """
 
     _SQL_ACQUIRE_OR_EXTEND = """
-                INSERT INTO {table_name} (name, token, expire_at)
-                VALUES (?, ?, datetime('now', '+' || ? || ' seconds'))
+                INSERT INTO {table_name} (name, token, expire_at, fence)
+                VALUES (
+                    ?, ?, datetime('now', '+' || ? || ' seconds'), 1
+                )
                 ON CONFLICT (name) DO UPDATE
-                SET token = EXCLUDED.token, expire_at = EXCLUDED.expire_at
+                SET token = EXCLUDED.token,
+                    expire_at = EXCLUDED.expire_at,
+                    fence = CASE
+                        WHEN {table_name}.token = EXCLUDED.token
+                             AND {table_name}.expire_at >= datetime('now')
+                        THEN {table_name}.fence
+                        ELSE {table_name}.fence + 1
+                    END
                 WHERE {table_name}.token = EXCLUDED.token
+                   OR {table_name}.token IS NULL
+                   OR {table_name}.expire_at IS NULL
                    OR {table_name}.expire_at < datetime('now')
-                RETURNING 1;
+                RETURNING fence;
                 """
 
     _SQL_RELEASE = """
-            DELETE FROM {table_name}
+            UPDATE {table_name}
+            SET token = NULL, expire_at = NULL
             WHERE name = ? AND token = ? AND expire_at >= datetime('now')
             RETURNING 1;
             """
 
     _SQL_RELEASE_ALL_EXPIRED = """
-        DELETE FROM {table_name}
+        UPDATE {table_name}
+        SET token = NULL, expire_at = NULL
         WHERE expire_at < datetime('now');
         """
 
     _SQL_LOCKED = """
         SELECT 1 FROM {table_name}
-        WHERE name = ? AND expire_at >= datetime('now');
+        WHERE name = ? AND token IS NOT NULL AND expire_at >= datetime('now');
         """
 
     _SQL_OWNED = """
@@ -140,17 +162,28 @@ class SQLiteLockAdapter(LockBackend):
             await self._conn.close()
             self._conn = None
 
-    async def acquire(self, *, name: str, token: str, duration: float) -> bool:
-        """Acquire a lock."""
+    async def acquire(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Acquire a lock, returning the fencing token or `None`.
+
+        Runs the read-modify-write inside a `BEGIN IMMEDIATE` transaction so
+        the fence high-water update is serialized against concurrent writers.
+        """
         if not self._conn:
             raise OutOfContextError(self, "acquire")
 
-        async with self._conn.execute(
-            self._acquire_sql, (name, token, ceil(duration))
-        ) as cursor:
-            result = await cursor.fetchone()
+        await self._conn.execute("BEGIN IMMEDIATE;")
+        try:
+            async with self._conn.execute(
+                self._acquire_sql, (name, token, ceil(duration))
+            ) as cursor:
+                result = await cursor.fetchone()
+        except BaseException:
+            await self._conn.rollback()
+            raise
         await self._conn.commit()
-        return result is not None
+        return int(result[0]) if result is not None else None
 
     async def release(self, *, name: str, token: str) -> bool:
         """Release the lock."""

--- a/grelmicro/coordination/tasklock.py
+++ b/grelmicro/coordination/tasklock.py
@@ -357,13 +357,16 @@ class TaskLock(Reconfigurable[TaskLockConfig], LockPrimitive):
         """
         backend = self.backend
         try:
-            acquired = await backend.acquire(
+            # TaskLock does not surface the fencing token. A non-None result
+            # means the lock was acquired.
+            fencing_token = await backend.acquire(
                 name=self._lock_name,
                 token=token,
                 duration=duration,
             )
         except Exception as exc:
             raise LockAcquireError(name=self._name) from exc
+        acquired = fencing_token is not None
         if acquired:
             self._acquired_at = monotonic()
         return acquired
@@ -398,11 +401,15 @@ class TaskLock(Reconfigurable[TaskLockConfig], LockPrimitive):
         """
         backend = self.backend
         try:
-            return await backend.acquire(
-                name=self._lock_name,
-                token=token,
-                duration=duration,
-            )
+            # TaskLock does not surface the fencing token. A non-None result
+            # means the lock was re-acquired.
+            return (
+                await backend.acquire(
+                    name=self._lock_name,
+                    token=token,
+                    duration=duration,
+                )
+            ) is not None
         except Exception as exc:
             raise LockReleaseError(name=self._name) from exc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,9 @@ ignore = ["COM812", "ISC001"] # Ignore rules conflicting with the formatter.
 ]
 "docs/snippets/*" = [
     "ARG001",
+    "ARG002",
+    "D107",
+    "S101",
     "ANN001",
     "ANN201",
     "D100",
@@ -218,6 +221,8 @@ ignore = ["COM812", "ISC001"] # Ignore rules conflicting with the formatter.
 "docs/snippets/task/router.py" = ["I001", "E402"]
 "tests/*" = [
     "S101",
+    "S105",
+    "S106",
     "SLF001",
     "RUF029",  # async test helpers may be coroutine-only without awaits
 ]

--- a/tests/coordination/test_handle.py
+++ b/tests/coordination/test_handle.py
@@ -23,7 +23,7 @@ def test_handle_is_frozen() -> None:
     handle = LockHandle(name="cart", token="worker-1", fencing_token=1)
 
     with pytest.raises(dataclasses.FrozenInstanceError):
-        handle.fencing_token = 2  # type: ignore[misc]
+        handle.fencing_token = 2  # type: ignore[misc]  # ty: ignore[invalid-assignment]
 
 
 def test_handle_uses_slots() -> None:

--- a/tests/coordination/test_handle.py
+++ b/tests/coordination/test_handle.py
@@ -1,0 +1,34 @@
+"""Tests for the LockHandle dataclass."""
+
+import dataclasses
+
+import pytest
+
+from grelmicro.coordination import LockHandle
+
+pytestmark = [pytest.mark.timeout(1)]
+
+
+def test_handle_carries_fields() -> None:
+    """The handle exposes name, token, and fencing_token."""
+    handle = LockHandle(name="cart", token="worker-1", fencing_token=7)
+
+    assert handle.name == "cart"
+    assert handle.token == "worker-1"
+    assert handle.fencing_token == 7  # noqa: PLR2004
+
+
+def test_handle_is_frozen() -> None:
+    """The handle is immutable."""
+    handle = LockHandle(name="cart", token="worker-1", fencing_token=1)
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        handle.fencing_token = 2  # type: ignore[misc]
+
+
+def test_handle_uses_slots() -> None:
+    """The handle uses slots, so it carries no instance __dict__."""
+    handle = LockHandle(name="cart", token="worker-1", fencing_token=1)
+
+    assert not hasattr(handle, "__dict__")
+    assert LockHandle.__slots__ == ("name", "token", "fencing_token")

--- a/tests/coordination/test_kubernetes.py
+++ b/tests/coordination/test_kubernetes.py
@@ -26,7 +26,7 @@ from grelmicro.coordination.kubernetes import (
 )
 from grelmicro.errors import OutOfContextError, SettingsValidationError
 
-TOKEN = "test-token"  # noqa: S105
+TOKEN = "test-token"
 OTHER = "other-token"
 
 # Named values keep ruff's magic-value rule quiet in assertions.

--- a/tests/coordination/test_kubernetes_lock.py
+++ b/tests/coordination/test_kubernetes_lock.py
@@ -33,10 +33,11 @@ def _make_api_error(code: int) -> ApiError:
 
 def _make_lease(
     name: str = "test",
-    holder: str = TOKEN,
+    holder: str | None = TOKEN,
     *,
     expired: bool = False,
     resource_version: str = "1",
+    transitions: int = 1,
 ) -> Lease:
     """Create a Lease for testing."""
     if expired:
@@ -55,6 +56,7 @@ def _make_lease(
             holderIdentity=holder,
             leaseDurationSeconds=duration_seconds,
             renewTime=renew_time,
+            leaseTransitions=transitions,
         ),
     )
 
@@ -230,37 +232,92 @@ async def test_aenter_sets_client(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 async def test_acquire_creates_when_not_found() -> None:
-    """Test acquire creates a new lease when none exists."""
+    """Test acquire creates a new lease when none exists, fence starts at 1."""
     # Arrange
+    create = AsyncMock()
     backend = _make_mocked_backend(
         get=AsyncMock(side_effect=_make_api_error(404)),
-        create=AsyncMock(),
+        create=create,
     )
 
     # Act
     result = await backend.acquire(name="lock", token=TOKEN, duration=1)
 
     # Assert
-    assert result is True
+    assert result == 1
+    created = create.await_args.args[0]
+    assert created.spec.leaseTransitions == 1
+    assert created.spec.holderIdentity == TOKEN
 
 
-async def test_acquire_replaces_expired_lease() -> None:
-    """Test acquire replaces an expired lease."""
+async def test_acquire_replaces_expired_lease_bumps_transitions() -> None:
+    """Test acquire takes over an expired lease and bumps transitions."""
     # Arrange
+    replace = AsyncMock()
     backend = _make_mocked_backend(
-        get=AsyncMock(return_value=_make_lease(expired=True)),
-        replace=AsyncMock(),
+        get=AsyncMock(
+            return_value=_make_lease(
+                holder="other-token", expired=True, transitions=4
+            )
+        ),
+        replace=replace,
     )
 
     # Act
     result = await backend.acquire(name="lock", token=TOKEN, duration=1)
 
     # Assert
-    assert result is True
+    assert result == 5  # noqa: PLR2004
+    written = replace.await_args.args[0]
+    assert written.spec.leaseTransitions == 5  # noqa: PLR2004
+    assert written.spec.holderIdentity == TOKEN
 
 
-async def test_acquire_returns_false_when_held_by_other() -> None:
-    """Test acquire returns False when held by another token."""
+async def test_acquire_extend_same_holder_keeps_transitions() -> None:
+    """Test a same-holder live extend keeps the fencing token."""
+    # Arrange
+    replace = AsyncMock()
+    backend = _make_mocked_backend(
+        get=AsyncMock(return_value=_make_lease(holder=TOKEN, transitions=3)),
+        replace=replace,
+    )
+
+    # Act
+    result = await backend.acquire(name="lock", token=TOKEN, duration=1)
+
+    # Assert
+    assert result == 3  # noqa: PLR2004
+    written = replace.await_args.args[0]
+    assert written.spec.leaseTransitions == 3  # noqa: PLR2004
+
+
+async def test_acquire_takeover_vacated_lease_bumps_transitions() -> None:
+    """Test acquire takes over a vacated (released) lease and bumps the fence."""
+    # Arrange
+    vacated = Lease(
+        metadata=ObjectMeta(
+            name="lock", namespace="default", resourceVersion="9"
+        ),
+        spec=LeaseSpec(leaseTransitions=2),
+    )
+    replace = AsyncMock()
+    backend = _make_mocked_backend(
+        get=AsyncMock(return_value=vacated),
+        replace=replace,
+    )
+
+    # Act
+    result = await backend.acquire(name="lock", token=TOKEN, duration=1)
+
+    # Assert
+    assert result == 3  # noqa: PLR2004
+    written = replace.await_args.args[0]
+    assert written.spec.leaseTransitions == 3  # noqa: PLR2004
+    assert written.spec.holderIdentity == TOKEN
+
+
+async def test_acquire_returns_none_when_held_by_other() -> None:
+    """Test acquire returns None when held by another token."""
     # Arrange
     other_token = "other-token"  # noqa: S105
     backend = _make_mocked_backend(
@@ -271,15 +328,18 @@ async def test_acquire_returns_false_when_held_by_other() -> None:
     result = await backend.acquire(name="lock", token=TOKEN, duration=1)
 
     # Assert
-    assert result is False
+    assert result is None
 
 
-async def test_release_succeeds() -> None:
-    """Test release succeeds when token matches and not expired."""
+async def test_release_vacates_in_place_keeping_transitions() -> None:
+    """Test release clears the holder in place and keeps leaseTransitions."""
     # Arrange
+    replace = AsyncMock()
+    delete = AsyncMock()
     backend = _make_mocked_backend(
-        get=AsyncMock(return_value=_make_lease(holder=TOKEN)),
-        delete=AsyncMock(),
+        get=AsyncMock(return_value=_make_lease(holder=TOKEN, transitions=7)),
+        replace=replace,
+        delete=delete,
     )
 
     # Act
@@ -287,6 +347,13 @@ async def test_release_succeeds() -> None:
 
     # Assert
     assert result is True
+    delete.assert_not_called()
+    replace.assert_awaited_once()
+    written = replace.await_args.args[0]
+    assert written.spec.holderIdentity is None
+    assert written.spec.renewTime is None
+    assert written.spec.acquireTime is None
+    assert written.spec.leaseTransitions == 7  # noqa: PLR2004
 
 
 async def test_release_not_found() -> None:
@@ -417,7 +484,7 @@ async def test_raises_on_non_404_get_error(
 
 
 async def test_acquire_conflict_on_create() -> None:
-    """Test acquire returns False on 409 Conflict during CREATE."""
+    """Test acquire returns None on 409 Conflict during CREATE."""
     # Arrange
     backend = _make_mocked_backend(
         get=AsyncMock(side_effect=_make_api_error(404)),
@@ -428,7 +495,7 @@ async def test_acquire_conflict_on_create() -> None:
     result = await backend.acquire(name="lock", token=TOKEN, duration=1)
 
     # Assert
-    assert result is False
+    assert result is None
 
 
 async def test_acquire_raises_on_create_non_409() -> None:
@@ -445,7 +512,7 @@ async def test_acquire_raises_on_create_non_409() -> None:
 
 
 async def test_acquire_conflict_on_replace() -> None:
-    """Test acquire returns False on 409 Conflict during REPLACE."""
+    """Test acquire returns None on 409 Conflict during REPLACE."""
     # Arrange
     backend = _make_mocked_backend(
         get=AsyncMock(return_value=_make_lease(expired=True)),
@@ -456,7 +523,7 @@ async def test_acquire_conflict_on_replace() -> None:
     result = await backend.acquire(name="lock", token=TOKEN, duration=1)
 
     # Assert
-    assert result is False
+    assert result is None
 
 
 async def test_acquire_raises_on_replace_non_409() -> None:
@@ -472,12 +539,13 @@ async def test_acquire_raises_on_replace_non_409() -> None:
         await backend.acquire(name="lock", token=TOKEN, duration=1)
 
 
-async def test_release_delete_404_race() -> None:
-    """Test release returns False when DELETE gets 404 (race)."""
+@pytest.mark.parametrize("code", [404, 409])
+async def test_release_vacate_conflict_returns_false(code: int) -> None:
+    """Test release returns False when the vacate write loses the race."""
     # Arrange
     backend = _make_mocked_backend(
         get=AsyncMock(return_value=_make_lease(holder=TOKEN)),
-        delete=AsyncMock(side_effect=_make_api_error(404)),
+        replace=AsyncMock(side_effect=_make_api_error(code)),
     )
 
     # Act
@@ -487,12 +555,12 @@ async def test_release_delete_404_race() -> None:
     assert result is False
 
 
-async def test_release_raises_on_delete_non_404() -> None:
-    """Test release re-raises non-404 API errors on DELETE."""
+async def test_release_raises_on_vacate_non_conflict() -> None:
+    """Test release re-raises non-conflict API errors on the vacate write."""
     # Arrange
     backend = _make_mocked_backend(
         get=AsyncMock(return_value=_make_lease(holder=TOKEN)),
-        delete=AsyncMock(side_effect=_make_api_error(500)),
+        replace=AsyncMock(side_effect=_make_api_error(500)),
     )
 
     # Act / Assert
@@ -503,26 +571,53 @@ async def test_release_raises_on_delete_non_404() -> None:
 # --- __aexit__ cleanup ---
 
 
+async def test_aexit_vacates_expired_lease_keeping_transitions() -> None:
+    """Cleanup vacates an expired lease in place and keeps its transitions."""
+    # Arrange
+    backend = KubernetesLockAdapter(namespace="default")
+    expired_lease = _make_lease(holder=TOKEN, expired=True, transitions=6)
+    replace = AsyncMock()
+    delete = AsyncMock()
+    mock_client = AsyncMock()
+    mock_client.list = MagicMock(return_value=_async_iter([expired_lease]))
+    mock_client.replace = replace
+    mock_client.delete = delete
+    mock_client.close = AsyncMock()
+    backend._client = mock_client
+
+    # Act
+    await backend.__aexit__(None, None, None)
+
+    # Assert
+    delete.assert_not_called()
+    replace.assert_awaited_once()
+    written = replace.await_args.args[0]
+    assert written.spec.holderIdentity is None
+    assert written.spec.leaseTransitions == 6  # noqa: PLR2004
+    assert backend._client is None
+
+
 @pytest.mark.parametrize(
-    ("delete_side_effect", "should_raise"),
+    ("replace_side_effect", "should_raise"),
     [
         (_make_api_error(404), False),
+        (_make_api_error(409), False),
         (_make_api_error(500), True),
     ],
-    ids=["404-ignored", "500-raises"],
+    ids=["404-ignored", "409-ignored", "500-raises"],
 )
-async def test_aexit_cleanup_delete_errors(
-    delete_side_effect: ApiError,
+async def test_aexit_cleanup_vacate_errors(
+    replace_side_effect: ApiError,
     *,
     should_raise: bool,
 ) -> None:
-    """Test __aexit__ error handling during cleanup delete."""
+    """Test __aexit__ error handling during the cleanup vacate write."""
     # Arrange
     backend = KubernetesLockAdapter(namespace="default")
-    expired_lease = _make_lease(expired=True)
+    expired_lease = _make_lease(holder=TOKEN, expired=True)
     mock_client = AsyncMock()
     mock_client.list = MagicMock(return_value=_async_iter([expired_lease]))
-    mock_client.delete = AsyncMock(side_effect=delete_side_effect)
+    mock_client.replace = AsyncMock(side_effect=replace_side_effect)
     mock_client.close = AsyncMock()
     backend._client = mock_client
 
@@ -536,13 +631,13 @@ async def test_aexit_cleanup_delete_errors(
 
 
 async def test_aexit_skips_live_lease() -> None:
-    """Cleanup leaves a still-live lease in place and does not delete it."""
+    """Cleanup leaves a still-live lease in place and does not vacate it."""
     # Arrange
     backend = KubernetesLockAdapter(namespace="default")
-    live_lease = _make_lease(expired=False)
+    live_lease = _make_lease(holder=TOKEN, expired=False)
     mock_client = AsyncMock()
     mock_client.list = MagicMock(return_value=_async_iter([live_lease]))
-    mock_client.delete = AsyncMock()
+    mock_client.replace = AsyncMock()
     mock_client.close = AsyncMock()
     backend._client = mock_client
 
@@ -550,5 +645,27 @@ async def test_aexit_skips_live_lease() -> None:
     await backend.__aexit__(None, None, None)
 
     # Assert
-    mock_client.delete.assert_not_called()
+    mock_client.replace.assert_not_called()
+    assert backend._client is None
+
+
+async def test_aexit_skips_already_vacated_lease() -> None:
+    """Cleanup leaves an already-vacated (no holder) lease untouched."""
+    # Arrange
+    backend = KubernetesLockAdapter(namespace="default")
+    vacated = Lease(
+        metadata=ObjectMeta(name="test", namespace="default"),
+        spec=LeaseSpec(leaseTransitions=2),
+    )
+    mock_client = AsyncMock()
+    mock_client.list = MagicMock(return_value=_async_iter([vacated]))
+    mock_client.replace = AsyncMock()
+    mock_client.close = AsyncMock()
+    backend._client = mock_client
+
+    # Act
+    await backend.__aexit__(None, None, None)
+
+    # Assert
+    mock_client.replace.assert_not_called()
     assert backend._client is None

--- a/tests/coordination/test_kubernetes_lock.py
+++ b/tests/coordination/test_kubernetes_lock.py
@@ -21,7 +21,7 @@ from grelmicro.errors import OutOfContextError
 
 pytestmark = [pytest.mark.timeout(1)]
 
-TOKEN = "test-token"  # noqa: S105
+TOKEN = "test-token"
 
 
 def _make_api_error(code: int) -> ApiError:
@@ -245,6 +245,7 @@ async def test_acquire_creates_when_not_found() -> None:
 
     # Assert
     assert result == 1
+    assert create.await_args is not None
     created = create.await_args.args[0]
     assert created.spec.leaseTransitions == 1
     assert created.spec.holderIdentity == TOKEN
@@ -268,6 +269,7 @@ async def test_acquire_replaces_expired_lease_bumps_transitions() -> None:
 
     # Assert
     assert result == 5  # noqa: PLR2004
+    assert replace.await_args is not None
     written = replace.await_args.args[0]
     assert written.spec.leaseTransitions == 5  # noqa: PLR2004
     assert written.spec.holderIdentity == TOKEN
@@ -287,6 +289,7 @@ async def test_acquire_extend_same_holder_keeps_transitions() -> None:
 
     # Assert
     assert result == 3  # noqa: PLR2004
+    assert replace.await_args is not None
     written = replace.await_args.args[0]
     assert written.spec.leaseTransitions == 3  # noqa: PLR2004
 
@@ -311,6 +314,7 @@ async def test_acquire_takeover_vacated_lease_bumps_transitions() -> None:
 
     # Assert
     assert result == 3  # noqa: PLR2004
+    assert replace.await_args is not None
     written = replace.await_args.args[0]
     assert written.spec.leaseTransitions == 3  # noqa: PLR2004
     assert written.spec.holderIdentity == TOKEN
@@ -319,7 +323,7 @@ async def test_acquire_takeover_vacated_lease_bumps_transitions() -> None:
 async def test_acquire_returns_none_when_held_by_other() -> None:
     """Test acquire returns None when held by another token."""
     # Arrange
-    other_token = "other-token"  # noqa: S105
+    other_token = "other-token"
     backend = _make_mocked_backend(
         get=AsyncMock(return_value=_make_lease(holder=other_token)),
     )
@@ -349,6 +353,7 @@ async def test_release_vacates_in_place_keeping_transitions() -> None:
     assert result is True
     delete.assert_not_called()
     replace.assert_awaited_once()
+    assert replace.await_args is not None
     written = replace.await_args.args[0]
     assert written.spec.holderIdentity is None
     assert written.spec.renewTime is None
@@ -373,7 +378,7 @@ async def test_release_not_found() -> None:
 async def test_release_wrong_token() -> None:
     """Test release returns False when token doesn't match."""
     # Arrange
-    other_token = "other-token"  # noqa: S105
+    other_token = "other-token"
     backend = _make_mocked_backend(
         get=AsyncMock(return_value=_make_lease(holder=other_token)),
     )
@@ -444,7 +449,7 @@ async def test_owned_active() -> None:
 async def test_owned_wrong_token() -> None:
     """Test owned returns False when lease is held by another."""
     # Arrange
-    other_token = "other-token"  # noqa: S105
+    other_token = "other-token"
     backend = _make_mocked_backend(
         get=AsyncMock(return_value=_make_lease(holder=other_token)),
     )
@@ -591,6 +596,7 @@ async def test_aexit_vacates_expired_lease_keeping_transitions() -> None:
     # Assert
     delete.assert_not_called()
     replace.assert_awaited_once()
+    assert replace.await_args is not None
     written = replace.await_args.args[0]
     assert written.spec.holderIdentity is None
     assert written.spec.leaseTransitions == 6  # noqa: PLR2004

--- a/tests/coordination/test_leaderelection.py
+++ b/tests/coordination/test_leaderelection.py
@@ -699,7 +699,7 @@ async def test_leader_election_stops_gracefully_on_stop_event(
     # Leadership was released on the backend, so another worker can take it.
     record = await backend.acquire_or_renew(
         name=leader_election._lock_name,
-        token="other",  # noqa: S106
+        token="other",
         duration=1,
     )
     assert record.holder == "other"

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -17,6 +17,7 @@ from grelmicro.coordination.errors import (
     LockReentrantError,
     LockReleaseError,
 )
+from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination.lock import Lock
 from grelmicro.coordination.memory import MemoryLockAdapter
 from grelmicro.errors import WouldBlockError as WouldBlock
@@ -541,6 +542,92 @@ async def test_lock_locked_backend_error(
     # Act / Assert
     with pytest.raises(LockLockedCheckError):
         await lock.locked()
+
+
+# --- Fencing tokens ---
+
+
+async def test_acquire_returns_handle(lock: Lock) -> None:
+    """`acquire` returns a LockHandle with name, token, and fencing token."""
+    handle = await lock.acquire()
+
+    assert isinstance(handle, LockHandle)
+    assert handle.name == LOCK_NAME
+    assert handle.token
+    assert handle.fencing_token >= 1
+
+
+async def test_acquire_nowait_returns_handle(lock: Lock) -> None:
+    """`acquire_nowait` returns a LockHandle."""
+    handle = await lock.acquire_nowait()
+
+    assert isinstance(handle, LockHandle)
+    assert handle.fencing_token >= 1
+
+
+async def test_context_manager_binds_handle(lock: Lock) -> None:
+    """`async with lock as held` binds the LockHandle."""
+    async with lock as held:
+        assert isinstance(held, LockHandle)
+        assert held.fencing_token >= 1
+
+
+async def test_from_thread_acquire_returns_handle(lock: Lock) -> None:
+    """`from_thread.acquire` returns a LockHandle."""
+    handles: list[LockHandle] = []
+
+    def sync() -> None:
+        handles.append(lock.from_thread.acquire())
+
+    await asyncio.to_thread(sync)
+
+    assert isinstance(handles[0], LockHandle)
+    assert handles[0].fencing_token >= 1
+
+
+async def test_from_thread_acquire_nowait_returns_handle(lock: Lock) -> None:
+    """`from_thread.acquire_nowait` returns a LockHandle."""
+    handles: list[LockHandle] = []
+
+    def sync() -> None:
+        handles.append(lock.from_thread.acquire_nowait())
+
+    await asyncio.to_thread(sync)
+
+    assert isinstance(handles[0], LockHandle)
+
+
+async def test_from_thread_context_manager_binds_handle(lock: Lock) -> None:
+    """`with lock.from_thread as held` binds the LockHandle."""
+    handles: list[LockHandle] = []
+
+    def sync() -> None:
+        with lock.from_thread as held:
+            handles.append(held)
+
+    await asyncio.to_thread(sync)
+
+    assert isinstance(handles[0], LockHandle)
+
+
+async def test_fencing_token_climbs_across_reacquire(lock: Lock) -> None:
+    """Releasing and re-acquiring mints a strictly greater fencing token."""
+    first = await lock.acquire()
+    await lock.release()
+    second = await lock.acquire()
+
+    assert second.fencing_token > first.fencing_token
+
+
+async def test_blocked_acquire_then_takeover_climbs(
+    locks: list[Lock],
+) -> None:
+    """A waiter that takes over after expiry gets a greater fencing token."""
+    first = await locks[WORKER_1].acquire()
+    # worker 2 blocks until worker 1's short lease expires, then takes over.
+    second = await locks[WORKER_2].acquire()
+
+    assert second.fencing_token > first.fencing_token
 
 
 # --- Non-reentrant (nested usage rejected) tests ---

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncGenerator
 import pytest
 from pytest_mock import MockerFixture
 
+from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination.abc import LockBackend
 from grelmicro.coordination.errors import (
     LockAcquireError,
@@ -17,7 +18,6 @@ from grelmicro.coordination.errors import (
     LockReentrantError,
     LockReleaseError,
 )
-from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination.lock import Lock
 from grelmicro.coordination.memory import MemoryLockAdapter
 from grelmicro.errors import WouldBlockError as WouldBlock

--- a/tests/coordination/test_lock_backends.py
+++ b/tests/coordination/test_lock_backends.py
@@ -384,6 +384,98 @@ async def test_owned(backend: LockBackend) -> None:
     assert owned_after is True
 
 
+async def test_acquire_returns_fencing_token(backend: LockBackend) -> None:
+    """A fresh acquire returns a positive fencing token."""
+    # Arrange
+    name = "test_fence_fresh" + uuid4().hex
+    token = uuid4().hex
+
+    # Act
+    fence = await backend.acquire(name=name, token=token, duration=60)
+
+    # Assert
+    assert fence is not None
+    assert fence >= 1
+
+
+async def test_not_acquired_returns_none(backend: LockBackend) -> None:
+    """A blocked acquire returns None, not a fencing token."""
+    # Arrange
+    name = "test_fence_blocked" + uuid4().hex
+    token1 = uuid4().hex
+    token2 = uuid4().hex
+
+    # Act
+    fence1 = await backend.acquire(name=name, token=token1, duration=60)
+    fence2 = await backend.acquire(name=name, token=token2, duration=60)
+
+    # Assert
+    assert fence1 is not None
+    assert fence2 is None
+
+
+async def test_extend_keeps_same_fencing_token(backend: LockBackend) -> None:
+    """The same holder extending the lease keeps its fencing token."""
+    # Arrange
+    name = "test_fence_extend" + uuid4().hex
+    token = uuid4().hex
+
+    # Act
+    fence1 = await backend.acquire(name=name, token=token, duration=60)
+    fence2 = await backend.acquire(name=name, token=token, duration=60)
+
+    # Assert
+    assert fence1 is not None
+    assert fence2 == fence1
+
+
+async def test_takeover_after_expiry_bumps_fencing_token(
+    backend: LockBackend, expire_duration: float, expire_wait: float
+) -> None:
+    """A takeover after expiry returns a strictly greater fencing token."""
+    # Arrange
+    name = "test_fence_takeover" + uuid4().hex
+    token1 = uuid4().hex
+    token2 = uuid4().hex
+
+    # Act
+    fence1 = await backend.acquire(
+        name=name, token=token1, duration=expire_duration
+    )
+    await sleep(expire_wait)
+    fence2 = await backend.acquire(
+        name=name, token=token2, duration=expire_duration
+    )
+
+    # Assert
+    assert fence1 is not None
+    assert fence2 is not None
+    assert fence2 > fence1
+
+
+async def test_reacquire_after_release_keeps_climbing(
+    backend: LockBackend,
+) -> None:
+    """Release then re-acquire returns a strictly greater fencing token.
+
+    The per-name high-water counter survives release on every backend, so
+    fencing tokens never repeat across release and re-acquire cycles.
+    """
+    # Arrange
+    name = "test_fence_reacquire" + uuid4().hex
+    token = uuid4().hex
+
+    # Act
+    fence1 = await backend.acquire(name=name, token=token, duration=60)
+    await backend.release(name=name, token=token)
+    fence2 = await backend.acquire(name=name, token=token, duration=60)
+
+    # Assert
+    assert fence1 is not None
+    assert fence2 is not None
+    assert fence2 > fence1
+
+
 async def test_owned_another(backend: LockBackend) -> None:
     """Test owned another."""
     # Arrange

--- a/tests/coordination/test_postgres.py
+++ b/tests/coordination/test_postgres.py
@@ -47,7 +47,7 @@ async def test_out_of_context_errors() -> None:
     """Backend methods raise when called outside the context manager."""
     backend = PostgresLeaderElectionBackend(provider=PostgresProvider(URL))
     name = "election"
-    token = "token"  # noqa: S105
+    token = "token"
 
     with pytest.raises(OutOfContextError):
         await backend.acquire_or_renew(name=name, token=token, duration=1)

--- a/tests/coordination/test_postgres_lock.py
+++ b/tests/coordination/test_postgres_lock.py
@@ -38,7 +38,7 @@ async def test_out_of_context_errors() -> None:
     """Adapter methods raise when called outside the context manager."""
     backend = PostgresLockAdapter(provider=PostgresProvider(URL))
     name = "lock"
-    token = "token"  # noqa: S105
+    token = "token"
 
     with pytest.raises(OutOfContextError):
         await backend.acquire(name=name, token=token, duration=1)

--- a/tests/coordination/test_tasklock.py
+++ b/tests/coordination/test_tasklock.py
@@ -397,7 +397,7 @@ async def test_tasklock_reacquire_backend_error(
 
     async def fail_on_reacquire(
         *, name: str, token: str, duration: float
-    ) -> bool:
+    ) -> int | None:
         # Let initial acquire succeed, fail on re-acquire (shorter duration)
         if duration < max_lock_seconds:
             msg = "Backend Error"
@@ -435,7 +435,7 @@ async def test_tasklock_state_cleaned_up_after_failed_reacquire(
 
     async def fail_on_reacquire(
         *, name: str, token: str, duration: float
-    ) -> bool:
+    ) -> int | None:
         # Let initial acquire succeed, fail on re-acquire (shorter duration)
         if duration < max_lock_seconds:
             msg = "Transient backend error"
@@ -631,7 +631,7 @@ async def test_tasklock_from_thread_reacquire_backend_error(
 
     async def fail_on_reacquire(
         *, name: str, token: str, duration: float
-    ) -> bool:
+    ) -> int | None:
         if duration < max_lock_seconds:
             msg = "Backend Error"
             raise Exception(msg)  # noqa: TRY002

--- a/tests/coordination/test_tasklock.py
+++ b/tests/coordination/test_tasklock.py
@@ -472,10 +472,10 @@ async def test_tasklock_reacquire_lost_raises(
 
     async def reject_reacquire(
         *, name: str, token: str, duration: float
-    ) -> bool:
-        # Let initial acquire succeed, return False on re-acquire
+    ) -> int | None:
+        # Let initial acquire succeed, return None (not acquired) on re-acquire
         if duration < max_lock_seconds:
-            return False
+            return None
         return await original_acquire(name=name, token=token, duration=duration)
 
     mocker.patch.object(backend, "acquire", side_effect=reject_reacquire)

--- a/tests/providers/test_postgres_provider.py
+++ b/tests/providers/test_postgres_provider.py
@@ -43,7 +43,7 @@ class TestConstruction:
             port=1234,
             database="test_db",
             user="test_user",
-            password="test_password",  # noqa: S106
+            password="test_password",
         )
         assert provider.url == URL
 
@@ -138,7 +138,7 @@ class TestFromConfig:
             port=4321,
             database="cfg_db",
             user="cfg_user",
-            password="cfg_pw",  # noqa: S106
+            password="cfg_pw",
         )
 
         provider = PostgresProvider.from_config(cfg)

--- a/tests/providers/test_redis_provider.py
+++ b/tests/providers/test_redis_provider.py
@@ -41,7 +41,7 @@ class TestConstruction:
             host="test_host",
             port=1234,
             db=0,
-            password="test_password",  # noqa: S106
+            password="test_password",
         )
         assert provider.url == URL
 
@@ -131,7 +131,7 @@ class TestFromConfig:
             host="cfg_host",
             port=4321,
             db=2,
-            password="cfg_pw",  # noqa: S106
+            password="cfg_pw",
         )
 
         provider = RedisProvider.from_config(cfg)


### PR DESCRIPTION
Adds strictly-monotonic fencing tokens to `Lock`, closing the top coordination correctness gap from the market analysis (Kleppmann's fencing-token argument).

## API
```python
async with Lock("account:42") as held:
    fence = held.fencing_token          # strictly increasing int per lock name
    await db.write(data, fence=fence)   # the resource rejects a lower token
```
`acquire()` / `acquire_nowait()` now return a frozen `LockHandle(name, token, fencing_token)`. `LockBackend.acquire(...) -> int | None` returns the granted fence. The fence increments only on a free->held transition and stays the same on same-holder renewal (Hazelcast rule).

## Backends (all strictly monotonic, no compromise)
- memory: per-name high-water counter that survives release
- Redis: `INCR` in the acquire Lua, fence persists across release
- Postgres / SQLite: `fence BIGINT` high-water column, survives release, `RETURNING fence`
- Kubernetes: `leaseTransitions` as the fence, with release reworked to **expire-in-place** (vacate the holder, keep the Lease object) so the counter never resets

## Docs
New "Fencing tokens" section in `docs/coordination.md` plus a runnable snippet, with the key caveat that the protected resource must reject lower-or-equal tokens.

Local: 2203 tests pass, ruff/ty clean, mkdocs --strict builds. Integration tests assert the fence on every backend (100% on CI).