### PR TITLE
✅ Harden the three flaky tests and add a clock pytest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,23 @@
 """grelmicro Test Config."""
 
+from collections.abc import AsyncIterator
+
 import pytest
+
+from grelmicro.clock import VirtualClock
+
+
+@pytest.fixture
+async def clock() -> AsyncIterator[VirtualClock]:
+    """Install a `VirtualClock` for the test and yield it.
+
+    Time-dependent primitives read `grelmicro.clock.monotonic` and `sleep`
+    through the clock seam, so under this fixture they advance only when the
+    test calls `clock.advance(...)`, with no real waiting. Use it instead of
+    `async with VirtualClock() as clock:`.
+    """
+    async with VirtualClock() as virtual_clock:
+        yield virtual_clock
 
 
 @pytest.fixture(autouse=True)

--- a/tests/coordination/test_kubernetes.py
+++ b/tests/coordination/test_kubernetes.py
@@ -688,7 +688,13 @@ def _wait_for_k3s(
     """Wait for k3s to become ready."""
     start = time_module.time()
     while time_module.time() - start < timeout:
-        exit_code, _ = container.exec("kubectl get --raw /readyz")
+        try:
+            exit_code, _ = container.exec("kubectl get --raw /readyz")
+        except Exception:  # noqa: BLE001
+            # Right after start, the Docker daemon can reject the exec with
+            # 409 "container is not running" before the container is fully
+            # up. Treat any exec error as not-ready and keep polling.
+            exit_code = 1
         if exit_code == 0:
             return
         time_module.sleep(1)

--- a/tests/coordination/test_leaderelection.py
+++ b/tests/coordination/test_leaderelection.py
@@ -23,6 +23,8 @@ WORKERS = 4
 WORKER_1 = 0
 WORKER_2 = 1
 TEST_TIMEOUT = 1
+LEASE_DURATION = 0.02
+RENEW_DEADLINE = 0.015
 
 pytestmark = [pytest.mark.timeout(TEST_TIMEOUT)]
 
@@ -39,8 +41,8 @@ def configs() -> list[LeaderElectionConfig]:
     return [
         LeaderElectionConfig(
             worker=f"worker_{i}",
-            lease_duration=0.02,
-            renew_deadline=0.015,
+            lease_duration=LEASE_DURATION,
+            renew_deadline=RENEW_DEADLINE,
             retry_interval=0.005,
             error_interval=0.01,
             backend_timeout=0.005,
@@ -434,8 +436,14 @@ async def test_only_one_leader(leader_elections: list[LeaderElection]) -> None:
         for leader_election in leader_elections:
             await start_task(tg, leader_election)
         await wait_first_leader(leader_elections)
+        # Count confirmed leaders, not the advisory `is_leader()`. During a
+        # lease handoff a just-demoted worker still reports `is_leader()` True
+        # until its renew deadline elapses, so two could appear at once. A
+        # worker that lost the lease has a confirmation at least one
+        # `lease_duration` old, which `is_leader_confirmed_within` excludes.
         leaders_after_start = [
-            leader_election.is_leader() for leader_election in leader_elections
+            leader_election.is_leader_confirmed_within(RENEW_DEADLINE)
+            for leader_election in leader_elections
         ]
         cancel_group(tg)
     for leader_election in leader_elections:

--- a/tests/resilience/test_clock_driven.py
+++ b/tests/resilience/test_clock_driven.py
@@ -29,63 +29,62 @@ _BOOM = ValueError("boom")
 
 
 @pytest.mark.timeout(1)
-async def test_retry_backoff_driven_by_virtual_clock() -> None:
+async def test_retry_backoff_driven_by_virtual_clock(
+    clock: VirtualClock,
+) -> None:
     """A retry backoff is advanced instantly, with no real sleep."""
     calls = 0
 
-    async with VirtualClock() as clock:
+    @Retry.constant("clock_retry", when=ValueError, attempts=2, delay=_BACKOFF)
+    async def flaky() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _BOOM
+        return "ok"
 
-        @Retry.constant(
-            "clock_retry", when=ValueError, attempts=2, delay=_BACKOFF
-        )
-        async def flaky() -> str:
-            nonlocal calls
-            calls += 1
-            if calls == 1:
-                raise _BOOM
-            return "ok"
+    task = asyncio.create_task(flaky())  # ty: ignore[invalid-argument-type]
 
-        task = asyncio.create_task(flaky())  # ty: ignore[invalid-argument-type]
+    # Let the first attempt run, fail, and suspend on the backoff sleep.
+    await asyncio.sleep(0)
+    assert calls == 1
+    assert not task.done()
 
-        # Let the first attempt run, fail, and suspend on the backoff sleep.
-        await asyncio.sleep(0)
-        assert calls == 1
-        assert not task.done()
-
-        # Advance virtual time past the backoff: the second attempt runs.
-        await clock.advance(_BACKOFF)
-        assert await task == "ok"
-        assert calls == _EXPECTED_CALLS
+    # Advance virtual time past the backoff: the second attempt runs.
+    await clock.advance(_BACKOFF)
+    assert await task == "ok"
+    assert calls == _EXPECTED_CALLS
 
 
 @pytest.mark.timeout(1)
-async def test_circuit_breaker_half_open_driven_by_virtual_clock() -> None:
+async def test_circuit_breaker_half_open_driven_by_virtual_clock(
+    clock: VirtualClock,
+) -> None:
     """An open breaker moves to half-open after the cool-down elapses."""
-    async with VirtualClock() as clock:
-        backend = MemoryCircuitBreakerAdapter()
-        async with Grelmicro(uses=[CircuitBreakers(backend)]):
-            cb = CircuitBreaker.consecutive_count(
-                "clock_cb",
-                error_threshold=1,
-                success_threshold=2,
-                reset_timeout=_RESET_TIMEOUT,
-            )
+    backend = MemoryCircuitBreakerAdapter()
+    async with Grelmicro(uses=[CircuitBreakers(backend)]):
+        cb = CircuitBreaker.consecutive_count(
+            "clock_cb",
+            error_threshold=1,
+            success_threshold=2,
+            reset_timeout=_RESET_TIMEOUT,
+        )
 
-            # Trip the breaker open with one failure.
-            with pytest.raises(ValueError, match="boom"):
-                async with cb:
-                    raise _BOOM
-            assert cb.state == CircuitBreakerState.OPEN
+        # Trip the breaker open with one failure.
+        with pytest.raises(ValueError, match="boom"):
+            async with cb:
+                raise _BOOM
+        assert cb.state == CircuitBreakerState.OPEN
 
-            # Before the cool-down elapses the breaker stays open.
-            with pytest.raises(CircuitBreakerError):
-                async with cb:
-                    pass
-            assert cb.state == CircuitBreakerState.OPEN
-
-            # Advance virtual time past the cool-down: the next admission
-            # moves the breaker to half-open, no real waiting.
-            await clock.advance(_RESET_TIMEOUT)
+        # Before the cool-down elapses the breaker stays open.
+        with pytest.raises(CircuitBreakerError):
             async with cb:
                 pass
-            assert cb.state == CircuitBreakerState.HALF_OPEN
+        assert cb.state == CircuitBreakerState.OPEN
+
+        # Advance virtual time past the cool-down: the next admission
+        # moves the breaker to half-open, no real waiting.
+        await clock.advance(_RESET_TIMEOUT)
+        async with cb:
+            pass
+        assert cb.state == CircuitBreakerState.HALF_OPEN

--- a/tests/resilience/test_ratelimiter_properties.py
+++ b/tests/resilience/test_ratelimiter_properties.py
@@ -21,6 +21,7 @@ from hypothesis import strategies as st
 if TYPE_CHECKING:
     from collections.abc import Coroutine
 
+from grelmicro.clock import VirtualClock
 from grelmicro.resilience.ratelimiter.memory import (
     MemoryRateLimiterAdapter,
     MemoryTokenBucket,
@@ -173,23 +174,26 @@ def test_strategy_gcra_burst_never_exceeds_limit(
     """A fresh GCRA key allows exactly `limit` requests in a burst."""
 
     async def run() -> None:
-        adapter = MemoryRateLimiterAdapter()
-        async with adapter:
-            strategy = adapter.bind(
-                SlidingWindowConfig(limit=limit, window=window)
-            )
-            allowed = 0
-            for _ in range(limit + 5):
-                result = await strategy.acquire(key="k", cost=1)
-                if result.allowed:
-                    allowed += 1
-                    assert result.retry_after == 0
-                else:
-                    assert result.retry_after >= 0
-                    assert result.reset_after >= 0
-            # GCRA admits `limit` then denies; round-trip math may
-            # let one extra through depending on monotonic clock drift.
-            assert limit <= allowed <= limit + 1
+        # Freeze time so the whole burst lands at one instant. With a real
+        # clock, a wide window refills one emission interval mid-loop and
+        # admits an extra request, which made the bound flaky.
+        async with VirtualClock():
+            adapter = MemoryRateLimiterAdapter()
+            async with adapter:
+                strategy = adapter.bind(
+                    SlidingWindowConfig(limit=limit, window=window)
+                )
+                allowed = 0
+                for _ in range(limit + 5):
+                    result = await strategy.acquire(key="k", cost=1)
+                    if result.allowed:
+                        allowed += 1
+                        assert result.retry_after == 0
+                    else:
+                        assert result.retry_after >= 0
+                        assert result.reset_after >= 0
+                # A fresh GCRA key admits exactly `limit` in an instant burst.
+                assert allowed == limit
 
     _run(run())
 


### PR DESCRIPTION
Fixes the three CI flakes that forced re-runs on the 0.27.0 and #343 merges (roadmap section 3). Test-only — no library code or public API changes.

## Flakes fixed

- **`test_strategy_gcra_burst_never_exceeds_limit`** (Hypothesis `FlakyFailure`). A wide window let real-clock drift refill an emission interval mid-loop, admitting an extra request (`allowed=75` for `limit=73`). Now driven through `VirtualClock` so the burst lands at one instant — deterministic `allowed == limit`.
- **`test_only_one_leader`** (rare `assert 2 == 1`). `is_leader()` is advisory: a just-demoted worker still reads `True` until its renew deadline elapses, so two could appear during a handoff. Now counts `is_leader_confirmed_within(renew_deadline)`, which excludes a worker whose last backend confirmation is stale (a lost leader's confirmation is necessarily ≥ `lease_duration` old). Ran 15× locally, clean.
- **k3s testcontainer 409**. `_wait_for_k3s` called `container.exec()` immediately after start; during startup the daemon can reject the exec with 409 "container is not running", which crashed setup instead of being retried. Now any exec error is treated as not-ready and polling continues until the timeout.

## Bonus: `clock` pytest fixture

Added an async `clock` fixture in `tests/conftest.py` that installs a `VirtualClock` and yields it, so tests get virtual time without the `async with VirtualClock() as clock:` boilerplate. Refactored `test_clock_driven.py` to use it. (The GCRA property test keeps the inline context manager — Hypothesis runs its own event loop per example, which a fixture can't reach.)

## Verification
- 2371 unit tests pass; `ty check` (whole repo) and `ruff check` clean.
- The k3s fix is exercised only in the Docker integration job (CI), not locally.