### PR TITLE
✨ Add a time-based stop to Retry with max_seconds=

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@
 
 ### Features
 
+* ✨ Add a time-based stop to `Retry` with `max_seconds=`. Retrying stops as soon as either `attempts` is reached or the wall-clock budget elapses, whichever comes first (`attempts` still defaults to 3). Available on the `Retry.exponential`/`Retry.constant` factories, the constructor, and `RetryConfig` (env var `GREL_RETRY_{NAME}_MAX_SECONDS`). The budget reads the clock seam, so `VirtualClock` drives it in tests. PR [#347](https://github.com/grelinfo/grelmicro/pull/347).
 * ✨ Re-export `FunctionTypeError` and `TaskAddOperationError` from `grelmicro.task`, so the task errors users catch live next to `TaskError` instead of only in `grelmicro.task.errors`. PR [#343](https://github.com/grelinfo/grelmicro/pull/343).
 * ✨ Export the catch-all base `GrelmicroError` and the cross-cutting `DependencyNotFoundError`, `OutOfContextError`, and `SettingsValidationError` from the top-level `grelmicro` package, so `except GrelmicroError` catches any library error from one import. Re-export `WouldBlockError` and `CoordinationBackendError` from `grelmicro.coordination` (the latter moved into `grelmicro.coordination.errors`). PR [#343](https://github.com/grelinfo/grelmicro/pull/343).
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -113,7 +113,7 @@ Decorator and async context manager with stop / wait / retry conditions.
 
 | Axis | [`tenacity`](https://github.com/jd/tenacity) | [`backoff`](https://github.com/litl/backoff) | grelmicro `Retry` |
 |---|---|---|---|
-| Stop conditions | rich (`stop_after_attempt`, `stop_after_delay`, ...) | basic | `attempts=` (count). Time-based stop planned. |
+| Stop conditions | rich (`stop_after_attempt`, `stop_after_delay`, ...) | basic | `attempts=` (count) and `max_seconds=` (time budget), whichever comes first. |
 | Wait strategies | rich (`wait_exponential`, `wait_chain`, ...) | exponential, fibonacci, constant | exponential, constant, linear, fibonacci, random |
 | Retry condition | `retry_if_*` factories, `\|`/`&` operators | exception type or predicate | `Match.exception(...)`, `Match.result(...)`, `Match.exception_message(...)`, `Match.exception_cause(...)`, plus `not_*` twins, `\|`/`&` operators |
 | Async support | yes | yes | yes |

--- a/docs/resilience/retry.md
+++ b/docs/resilience/retry.md
@@ -45,6 +45,14 @@ policy = Retry.exponential("payments", when=httpx.HTTPError, attempts=5)
 polling = Retry.constant("wait_job", when=NotReady, attempts=20, delay=1.0)
 ```
 
+Add `max_seconds=` to cap the total time spent retrying. Retrying stops when
+either `attempts` or the time budget is reached, whichever comes first:
+
+```python
+# Up to 5 attempts, but never more than 30 seconds in total.
+policy = Retry.exponential("payments", when=httpx.HTTPError, max_seconds=30.0)
+```
+
 ??? note "How backoff and jitter work"
 
     **Exponential.** The raw wait before retry `N` is `min(base_delay * 2 ** (N - 1), max_delay)`. It doubles each attempt until it reaches the cap. With the defaults (`base_delay=0.1`, `max_delay=30.0`), the raw wait is `0.1s`, `0.2s`, `0.4s`, `0.8s`, `1.6s`, ..., capped at `30.0s`.

--- a/grelmicro/resilience/retry.py
+++ b/grelmicro/resilience/retry.py
@@ -145,6 +145,17 @@ class RetryConfig(BaseModel, frozen=True, extra="forbid"):
         ),
     ] = 3
 
+    max_seconds: Annotated[
+        PositiveFloat | None,
+        Doc(
+            "Optional wall-clock budget in seconds, measured from the "
+            "first attempt. Retrying stops as soon as either ``attempts`` "
+            "is reached or this budget elapses, whichever comes first. The "
+            "budget is checked between attempts, so one backoff may run "
+            "slightly past it. ``None`` (default) means no time limit."
+        ),
+    ] = None
+
     when: Annotated[
         Match,
         Doc(
@@ -236,6 +247,7 @@ class RetryAttempt:
         "_attempts",
         "_loop",
         "_matcher",
+        "_max_seconds",
         "_started_at",
         "delay_before",
         "number",
@@ -250,6 +262,7 @@ class RetryAttempt:
         matcher: Matcher,
         loop: _AttemptLoop,
         started_at: float,
+        max_seconds: float | None,
     ) -> None:
         """Initialize one retry attempt."""
         self.number = number
@@ -262,6 +275,7 @@ class RetryAttempt:
         self._matcher = matcher
         self._loop = loop
         self._started_at = started_at
+        self._max_seconds = max_seconds
 
     async def __aenter__(self) -> Self:
         """Enter the attempt context."""
@@ -300,13 +314,24 @@ class RetryAttempt:
             return False
         if not self._matcher(Outcome.from_exception(exc)):
             return False
-        if self.number >= self._attempts:
-            elapsed = clock_monotonic() - self._started_at
+        elapsed = clock_monotonic() - self._started_at
+        attempts_done = self.number >= self._attempts
+        time_done = (
+            self._max_seconds is not None and elapsed >= self._max_seconds
+        )
+        if attempts_done or time_done:
             backoff_name = self._loop.backoff_name
-            exc.add_note(
-                f"retry: {self._attempts}/{self._attempts} attempts "
-                f"exhausted in {elapsed:.2f}s ({backoff_name} backoff)"
-            )
+            if attempts_done:
+                exc.add_note(
+                    f"retry: {self._attempts}/{self._attempts} attempts "
+                    f"exhausted in {elapsed:.2f}s ({backoff_name} backoff)"
+                )
+            else:
+                exc.add_note(
+                    f"retry: {self._max_seconds}s budget elapsed after "
+                    f"{self.number} attempt(s) in {elapsed:.2f}s "
+                    f"({backoff_name} backoff)"
+                )
             return False
         return True
 
@@ -352,6 +377,7 @@ async def _async_iter(
             matcher=matcher,
             loop=loop,
             started_at=started_at,
+            max_seconds=config.max_seconds,
         )
         if loop.done:
             return
@@ -377,6 +403,7 @@ def _sync_iter(
             matcher=matcher,
             loop=loop,
             started_at=started_at,
+            max_seconds=config.max_seconds,
         )
         if loop.done:
             return
@@ -424,12 +451,24 @@ async def _run_async(
         except Exception as exc:
             if not matcher(Outcome.from_exception(exc)):
                 raise
-            if number >= config.attempts:
-                exc.add_note(
-                    f"retry: {config.attempts}/{config.attempts} attempts "
-                    f"exhausted in {clock_monotonic() - started_at:.2f}s "
-                    f"({backoff_name} backoff)"
-                )
+            elapsed = clock_monotonic() - started_at
+            attempts_done = number >= config.attempts
+            time_done = (
+                config.max_seconds is not None and elapsed >= config.max_seconds
+            )
+            if attempts_done or time_done:
+                if attempts_done:
+                    exc.add_note(
+                        f"retry: {config.attempts}/{config.attempts} "
+                        f"attempts exhausted in {elapsed:.2f}s "
+                        f"({backoff_name} backoff)"
+                    )
+                else:
+                    exc.add_note(
+                        f"retry: {config.max_seconds}s budget elapsed "
+                        f"after {number} attempt(s) in {elapsed:.2f}s "
+                        f"({backoff_name} backoff)"
+                    )
                 _emit_retry(name, started_at=started_at, outcome="error")
                 raise
             delay = strategy.delay(number)
@@ -438,7 +477,10 @@ async def _run_async(
             _emit_retry(name, started_at=started_at, outcome="success")
             return result
         last_result = result
-        if number >= config.attempts:
+        if number >= config.attempts or (
+            config.max_seconds is not None
+            and clock_monotonic() - started_at >= config.max_seconds
+        ):
             _emit_retry(name, started_at=started_at, outcome="error")
             return last_result
         delay = strategy.delay(number)
@@ -467,12 +509,24 @@ def _run_sync(
         except Exception as exc:
             if not matcher(Outcome.from_exception(exc)):
                 raise
-            if number >= config.attempts:
-                exc.add_note(
-                    f"retry: {config.attempts}/{config.attempts} attempts "
-                    f"exhausted in {clock_monotonic() - started_at:.2f}s "
-                    f"({backoff_name} backoff)"
-                )
+            elapsed = clock_monotonic() - started_at
+            attempts_done = number >= config.attempts
+            time_done = (
+                config.max_seconds is not None and elapsed >= config.max_seconds
+            )
+            if attempts_done or time_done:
+                if attempts_done:
+                    exc.add_note(
+                        f"retry: {config.attempts}/{config.attempts} "
+                        f"attempts exhausted in {elapsed:.2f}s "
+                        f"({backoff_name} backoff)"
+                    )
+                else:
+                    exc.add_note(
+                        f"retry: {config.max_seconds}s budget elapsed "
+                        f"after {number} attempt(s) in {elapsed:.2f}s "
+                        f"({backoff_name} backoff)"
+                    )
                 _emit_retry(name, started_at=started_at, outcome="error")
                 raise
             delay = strategy.delay(number)
@@ -481,7 +535,10 @@ def _run_sync(
             _emit_retry(name, started_at=started_at, outcome="success")
             return result
         last_result = result
-        if number >= config.attempts:
+        if number >= config.attempts or (
+            config.max_seconds is not None
+            and clock_monotonic() - started_at >= config.max_seconds
+        ):
             _emit_retry(name, started_at=started_at, outcome="error")
             return last_result
         delay = strategy.delay(number)
@@ -533,6 +590,14 @@ class Retry(Reconfigurable[RetryConfig]):
             PositiveInt | None,
             Doc("Total calls including the first. Default ``3``."),
         ] = None,
+        max_seconds: Annotated[
+            PositiveFloat | None,
+            Doc(
+                "Optional wall-clock budget in seconds. Retrying stops "
+                "when either ``attempts`` or this budget is reached, "
+                "whichever comes first. Default no time limit."
+            ),
+        ] = None,
         config: Annotated[
             RetryConfig | None,
             Doc(
@@ -552,6 +617,7 @@ class Retry(Reconfigurable[RetryConfig]):
         self._name = name
         kwargs: dict[str, object | None] = {
             "attempts": attempts,
+            "max_seconds": max_seconds,
             "when": when,
             "backoff": backoff,
         }
@@ -607,6 +673,13 @@ class Retry(Reconfigurable[RetryConfig]):
             PositiveInt,
             Doc("Total calls including the first."),
         ] = 3,
+        max_seconds: Annotated[
+            PositiveFloat | None,
+            Doc(
+                "Optional wall-clock budget in seconds, whichever comes "
+                "first with ``attempts``."
+            ),
+        ] = None,
         base_delay: Annotated[
             PositiveFloat,
             Doc("Initial delay in seconds before the first retry."),
@@ -638,6 +711,7 @@ class Retry(Reconfigurable[RetryConfig]):
             backoff,
             when=when,
             attempts=attempts,
+            max_seconds=max_seconds,
             env_load=env_load,
         )
 
@@ -654,6 +728,13 @@ class Retry(Reconfigurable[RetryConfig]):
             PositiveInt,
             Doc("Total calls including the first."),
         ] = 3,
+        max_seconds: Annotated[
+            PositiveFloat | None,
+            Doc(
+                "Optional wall-clock budget in seconds, whichever comes "
+                "first with ``attempts``."
+            ),
+        ] = None,
         delay: Annotated[
             PositiveFloat,
             Doc("Fixed delay in seconds between retries."),
@@ -675,6 +756,7 @@ class Retry(Reconfigurable[RetryConfig]):
             backoff,
             when=when,
             attempts=attempts,
+            max_seconds=max_seconds,
             env_load=env_load,
         )
 

--- a/tests/resilience/test_clock_driven.py
+++ b/tests/resilience/test_clock_driven.py
@@ -25,6 +25,10 @@ _BACKOFF = 5.0
 _RESET_TIMEOUT = 30.0
 _EXPECTED_CALLS = 2
 
+_BUDGET = 25.0
+_STEP = 10.0
+_CALLS_BEFORE_BUDGET = 4
+
 _BOOM = ValueError("boom")
 
 
@@ -54,6 +58,47 @@ async def test_retry_backoff_driven_by_virtual_clock(
     await clock.advance(_BACKOFF)
     assert await task == "ok"
     assert calls == _EXPECTED_CALLS
+
+
+@pytest.mark.timeout(1)
+async def test_retry_max_seconds_stops_on_time_budget(
+    clock: VirtualClock,
+) -> None:
+    """Retrying stops once the `max_seconds` budget elapses, before attempts."""
+    calls = 0
+
+    # attempts is deliberately high so the time budget is the limiting factor.
+    @Retry.constant(
+        "clock_budget",
+        when=ValueError,
+        attempts=100,
+        max_seconds=_BUDGET,
+        delay=_STEP,
+    )
+    async def always_fails() -> None:
+        nonlocal calls
+        calls += 1
+        raise _BOOM
+
+    task = asyncio.create_task(always_fails())  # ty: ignore[invalid-argument-type]
+
+    # Attempt 1 runs at t=0.
+    await asyncio.sleep(0)
+    assert calls == 1
+
+    # Each advance unblocks one backoff and runs the next attempt. By t=30 the
+    # elapsed time (30s) has passed the 25s budget, so the 4th attempt is the
+    # last and the error is re-raised.
+    for expected in (2, 3, _CALLS_BEFORE_BUDGET):
+        await clock.advance(_STEP)
+        await asyncio.sleep(0)
+        assert calls == expected
+
+    with pytest.raises(ValueError, match="boom") as info:
+        await task
+    notes = getattr(info.value, "__notes__", [])
+    assert any("budget elapsed" in note for note in notes)
+    assert calls == _CALLS_BEFORE_BUDGET
 
 
 @pytest.mark.timeout(1)

--- a/tests/resilience/test_retry.py
+++ b/tests/resilience/test_retry.py
@@ -82,6 +82,26 @@ def test_retry_constructs_with_class_filter(
     assert policy.config.attempts == _THREE
 
 
+def test_max_seconds_defaults_to_none() -> None:
+    """No time budget is set by default."""
+    policy = Retry.constant("svc", when=ValueError)
+    assert policy.config.max_seconds is None
+
+
+def test_max_seconds_flows_through_factories() -> None:
+    """`max_seconds=` reaches the resolved config from both factories."""
+    assert (
+        Retry.exponential(
+            "a", when=ValueError, max_seconds=5.0
+        ).config.max_seconds
+        == _FIVE
+    )
+    assert (
+        Retry.constant("b", when=ValueError, max_seconds=5.0).config.max_seconds
+        == _FIVE
+    )
+
+
 def test_retry_normalizes_single_class_to_match(
     fast_constant: ConstantBackoff,
 ) -> None:


### PR DESCRIPTION
Ships the retry time-based stop from roadmap section 4 (the cheapest 1.0 item). Removes the "Time-based stop planned" caveat from the comparison page. API approved up front.

## What

A flat `max_seconds=` on `Retry` — the constructor, `Retry.exponential`/`Retry.constant` factories, and `RetryConfig`:

```python
# Up to 5 attempts, but never more than 30 seconds total.
policy = Retry.exponential("payments", when=httpx.HTTPError, max_seconds=30.0)
```

## Semantics (approved)

- **First limit wins:** retrying stops as soon as either `attempts` is reached OR the wall-clock budget elapses. `attempts` keeps its default of 3. To go time-dominant, raise `attempts`. Matches tenacity's `stop_after_attempt | stop_after_delay`.
- The budget is measured from the first attempt and checked between attempts, so one backoff may run slightly past it (same as tenacity).
- Default `max_seconds=None` → no time limit (fully backward compatible).
- Reads the clock seam, so `VirtualClock` drives it deterministically in tests.
- Env: `GREL_RETRY_{NAME}_MAX_SECONDS` (flows through the existing config path).
- Distinct exhaustion note per reason: the existing `"N/N attempts exhausted"` for the attempt cap, a new `"…s budget elapsed after N attempt(s)"` for the time cap.

## Tests

- `test_retry_max_seconds_stops_on_time_budget` (in `test_clock_driven.py`) drives a 100-attempt policy under `VirtualClock` and asserts it stops at the 4th attempt when the 25s budget passes, with the budget note.
- Config round-trip tests for both factories + the `None` default.

## Verification
- 2374 unit tests pass; `ty check` (whole repo), `ruff check`, and `ruff format --check` clean.