### PR TITLE
📝 Refine backend positioning and document the distribution model

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? S
 
 | Module | Summary |
 |---|---|
-| [**Cache**](docs/cache.md) | `@cached` decorator with local, distributed, and early (XFetch) stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
+| [**Cache**](docs/cache.md) | `@cached` decorator with local and distributed stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
 | [**Coordination**](docs/coordination.md) | Distributed `Lock`, `TaskLock`, and `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
 | [**Task Scheduler**](docs/task.md) | Interval and cron tasks with durable, distributed at-most-once execution. A modern, lightweight alternative to APScheduler and Celery beat. |
 | [**Resilience**](docs/resilience/index.md) | [Circuit Breaker](docs/resilience/circuit-breaker.md) and [Rate Limiter](docs/resilience/rate-limiter.md) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It is built for any Python application that coordinates work across processes, w
 - **Backend-agnostic**: each primitive is a protocol. Swap Redis for PostgreSQL or SQLite without touching application code.
 - **Railguarded**: fully tested, type-checked, and validated. Pre-1.0 the API may change on a minor release. `1.x` follows standard semver.
 
-grelmicro is **not** a task queue (reach for Celery, Dramatiq, or taskiq), **not** a web framework (it plugs into FastAPI, Starlette, or Litestar), and **not** a multi-node lock service (reach for ZooKeeper or etcd). It fills the gap between the web framework you picked and the infrastructure you run.
+grelmicro is **not** a task queue (reach for Celery, Dramatiq, or taskiq) and **not** a web framework (it plugs into FastAPI, Starlette, or Litestar). It fills the gap between the web framework you picked and the infrastructure you run.
 
 Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? See the [comparison page](docs/comparison.md) for a per-domain breakdown.
 

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -18,6 +18,18 @@ Every backend uses **async** methods because it performs network or disk I/O (Re
 
 Users construct **Providers**, attach **Components** that share each Provider, and import **Patterns** at module level. Adapter classes rarely appear in user code.
 
+## Distribution model
+
+Not every Pattern needs a backend, and the ones that do not all need the same kind. Three tiers decide whether you register a Component at all.
+
+**Distributed-mandatory.** `Lock`, `TaskLock`, `LeaderElection`, and the `@cron` schedule only mean something against a shared store: a lock that is local to one process is not a lock. They have no local fallback, so using one without a registered `Coordination` backend raises. Because every coordination Pattern runs on the same store, one `Coordination(provider)` wires the whole domain at once.
+
+**Local-first, shared-optional.** `CircuitBreaker` and `RateLimiter` work per process out of the box and fall back to an in-process backend when nothing is registered. A circuit breaker is local by default on purpose: each replica trips on the failures it sees. Sharing is a deliberate opt-in, and the safe default differs per Pattern, so each has its own Component (`CircuitBreakers`, `RateLimiters`). Register `CircuitBreakers(redis)` only when one replica's open circuit should short-circuit the fleet, and `RateLimiters(redis)` only when the quota is global. Keeping them separate means opting rate limiting into a shared store does not also distribute your circuit breakers.
+
+**Purely local.** `Retry`, `Timeout`, `Bulkhead`, `Shield`, and `Fallback` hold no shared state and never take a backend. Construct and use them directly.
+
+This is why `Coordination` is a single component for its whole domain while resilience exposes one component per shared Pattern: coordination has one mandatory backend decision, resilience has independent per-Pattern ones.
+
 ## Construction vs registration
 
 Construction and registration are two distinct steps. `__init__` validates configuration and binds locals. It performs no registry writes and no I/O. Registration happens when the Component is attached to a `Grelmicro` app.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? S
 
 | Module | Summary |
 |---|---|
-| [**Cache**](cache.md) | `@cached` decorator with local, distributed, and early (XFetch) stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
+| [**Cache**](cache.md) | `@cached` decorator with local and distributed stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
 | [**Coordination**](coordination.md) | Distributed `Lock`, `TaskLock`, and `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
 | [**Task Scheduler**](task.md) | Interval and cron tasks with durable, distributed at-most-once execution. A modern, lightweight alternative to APScheduler and Celery beat. |
 | [**Resilience**](resilience/index.md) | [Circuit Breaker](resilience/circuit-breaker.md) and [Rate Limiter](resilience/rate-limiter.md) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ It is built for any Python application that coordinates work across processes, w
 - **Backend-agnostic**: each primitive is a protocol. Swap Redis for PostgreSQL or SQLite without touching application code.
 - **Railguarded**: fully tested, type-checked, and validated. Pre-1.0 the API may change on a minor release. `1.x` follows standard semver.
 
-grelmicro is **not** a task queue (reach for Celery, Dramatiq, or taskiq), **not** a web framework (it plugs into FastAPI, Starlette, or Litestar), and **not** a multi-node lock service (reach for ZooKeeper or etcd). It fills the gap between the web framework you picked and the infrastructure you run.
+grelmicro is **not** a task queue (reach for Celery, Dramatiq, or taskiq) and **not** a web framework (it plugs into FastAPI, Starlette, or Litestar). It fills the gap between the web framework you picked and the infrastructure you run.
 
 Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? See the [comparison page](comparison.md) for a per-domain breakdown.
 


### PR DESCRIPTION
Landing/architecture docs cleanup ahead of 1.0.

### Distribution model (`docs/architecture/backends.md`)
A new **Distribution model** section covering the three tiers of backend coupling, so it is clear when a Component must be registered:
- **Distributed-mandatory** (`Lock`, `TaskLock`, `LeaderElection`, `@cron` schedule): no local fallback, one aggregate `Coordination` wires the domain.
- **Local-first, shared-optional** (`CircuitBreaker`, `RateLimiter`): local by default, sharing is a deliberate per-Pattern opt-in.
- **Purely local** (`Retry`, `Timeout`, `Bulkhead`, `Shield`, `Fallback`): no backend.

### Positioning (`README.md`, `docs/index.md`)
- Drop the "not a multi-node lock service (reach for ZooKeeper or etcd)" clause. grelmicro *does* provide distributed locks, and ZooKeeper/etcd are candidate future backends, not alternatives.
- Drop the "early (XFetch)" jargon from the Cache feature row. The feature stays (with full docs in `docs/cache.md`); it just does not belong in the landing one-liner.