### PR TITLE
🐛 Fix the @cron Feb-29 crash and correct docs (Copilot review)

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -20,15 +20,15 @@ Users construct **Providers**, attach **Components** that share each Provider, a
 
 ## Distribution model
 
-Not every Pattern needs a backend, and the ones that do not all need the same kind. Three tiers decide whether you register a Component at all.
+Not every Pattern needs a backend, and the ones that do behave differently when one is missing. What a Pattern does without a registered backend sorts it into three tiers.
 
-**Distributed-mandatory.** `Lock`, `TaskLock`, `LeaderElection`, and the `@cron` schedule only mean something against a shared store: a lock that is local to one process is not a lock. They have no local fallback, so using one without a registered `Coordination` backend raises. Because every coordination Pattern runs on the same store, one `Coordination(provider)` wires the whole domain at once.
+**Backend required.** `Lock`, `TaskLock`, and `LeaderElection` only mean something against a shared store: a lock local to one process is not a lock. They have no safe local fallback, so using one without a registered `Coordination` backend raises.
 
-**Local-first, shared-optional.** `CircuitBreaker` and `RateLimiter` work per process out of the box and fall back to an in-process backend when nothing is registered. A circuit breaker is local by default on purpose: each replica trips on the failures it sees. Sharing is a deliberate opt-in, and the safe default differs per Pattern, so each has its own Component (`CircuitBreakers`, `RateLimiters`). Register `CircuitBreakers(redis)` only when one replica's open circuit should short-circuit the fleet, and `RateLimiters(redis)` only when the quota is global. Keeping them separate means opting rate limiting into a shared store does not also distribute your circuit breakers.
+**Backend optional, degrades safely.** `CircuitBreaker`, `RateLimiter`, and the `@cron` schedule all run without a backend, they just stop coordinating across replicas. A circuit breaker trips per replica, a rate limiter counts per replica, and a `@cron` task runs on every worker instead of once across the fleet. Sharing is a deliberate opt-in, and the safe default differs per Pattern: a circuit breaker is best left local (each replica reacts to what it sees), a rate limiter is often global, and a cron task usually wants the schedule backend so it fires once. Resilience keeps `CircuitBreakers` and `RateLimiters` as separate Components so opting rate limiting into a shared store does not also distribute your circuit breakers.
 
 **Purely local.** `Retry`, `Timeout`, `Bulkhead`, `Shield`, and `Fallback` hold no shared state and never take a backend. Construct and use them directly.
 
-This is why `Coordination` is a single component for its whole domain while resilience exposes one component per shared Pattern: coordination has one mandatory backend decision, resilience has independent per-Pattern ones.
+`Coordination` groups the coordination backends (lock, leader election, schedule) under one Component because they belong to one domain, though you can still wire each to a different backend (`Coordination(lock=..., election=..., schedule=...)`). Resilience instead exposes one Component per shared Pattern, because each carries an independent sharing decision.
 
 ## Construction vs registration
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -302,7 +302,9 @@ async def get_homepage_feed() -> dict:
 Set `stale_ttl` to keep serving the last good value when a recompute fails. Each result is also kept as a fallback copy for `ttl + stale_ttl` seconds. After the TTL, the next miss recomputes as usual, but if that recompute raises, the most recent value is served instead of propagating the error, for up to `stale_ttl` seconds past the TTL.
 
 ```python
-@cached(cache, ttl=60, stale_ttl=600)
+cache = TTLCache(ttl=60)
+
+@cached(cache, stale_ttl=600)
 async def get_exchange_rates() -> dict:
     return await rates_api.fetch()   # a flaky external call
 ```

--- a/grelmicro/task/_cron.py
+++ b/grelmicro/task/_cron.py
@@ -190,7 +190,9 @@ class CronExpression:
         """
         # Start at the next whole minute strictly after dt.
         candidate = dt.replace(second=0, microsecond=0) + timedelta(minutes=1)
-        limit = candidate.replace(year=candidate.year + _MAX_SEARCH_YEARS)
+        # A timedelta bound, not `replace(year=...)`, so a Feb 29 candidate
+        # never lands on a non-leap year and raises.
+        limit = candidate + timedelta(days=_MAX_SEARCH_YEARS * 366)
 
         while candidate <= limit:
             if candidate.month not in self._months:
@@ -224,7 +226,9 @@ class CronExpression:
         within five years before ``dt``.
         """
         candidate = dt.replace(second=0, microsecond=0)
-        limit = candidate.replace(year=candidate.year - _MAX_SEARCH_YEARS)
+        # A timedelta bound, not `replace(year=...)`, so a Feb 29 candidate
+        # never lands on a non-leap year and raises.
+        limit = candidate - timedelta(days=_MAX_SEARCH_YEARS * 366)
 
         while candidate >= limit:
             if candidate.month not in self._months:

--- a/tests/task/test_cron.py
+++ b/tests/task/test_cron.py
@@ -135,6 +135,19 @@ def test_leap_year_feb_29() -> None:
     assert expr.next_after(dt(2027, 1, 1)) == dt(2028, 2, 29)
 
 
+def test_next_after_from_feb_29_does_not_crash() -> None:
+    """A Feb 29 starting point must not crash the search-window bound."""
+    expr = CronExpression("0 0 * * *")
+    # The window bound must not land on a non-leap year (2028 + 5 = 2033).
+    assert expr.next_after(dt(2028, 2, 29, 12)) == dt(2028, 3, 1)
+
+
+def test_previous_or_equal_from_feb_29_does_not_crash() -> None:
+    """A Feb 29 starting point must not crash the backward search bound."""
+    expr = CronExpression("0 0 * * *")
+    assert expr.previous_or_equal(dt(2028, 2, 29, 12)) == dt(2028, 2, 29)
+
+
 @pytest.mark.parametrize(
     "expr",
     [


### PR DESCRIPTION
Fixes three valid findings surfaced by re-checking Copilot reviews on recently merged PRs. All are corrections to **unreleased** work, so no changelog entry is needed.

### 🐛 `@cron` crash on a Feb 29 start (from #348)
`CronExpression.next_after()` / `previous_or_equal()` computed their search-window bound with `candidate.replace(year=candidate.year ± 5)`. When `candidate` falls on Feb 29 and the target year is not a leap year (e.g. 2028 + 5 = 2033), that raises `ValueError: day is out of range for month` — so cron crashed for **any** call made on Feb 29. Replaced the bound with a `timedelta`-based one. Added regression tests for both directions from a Feb 29 start. (Copilot flagged this on #348; the existing leap-year test started from Jan 1, so it never hit the trigger.)

### 📝 Cache stale example (from #350)
`docs/cache.md` showed `@cached(cache, ttl=60, stale_ttl=600)`, but `cached()` has no `ttl=` parameter (TTL lives on the `TTLCache`), so the example would raise `TypeError`. Corrected to set `ttl` on the cache and pass only `stale_ttl` to the decorator.

### 📝 Backend distribution model (from #351)
The new distribution-model section put `@cron` in the "backend required, raises without one" tier, but cron actually **runs on every worker** without a schedule backend (it degrades, it does not raise). Moved cron into the "backend optional, degrades safely" tier alongside `CircuitBreaker`/`RateLimiter`, and corrected the claim that `Coordination` is "one backend decision" (it groups lock/election/schedule under one Component but each can use a different backend).