### PR TITLE
🐛 Fix remaining Copilot-flagged issues (cache tags, SQLite pragma, docs)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+* 🐛 Reconcile cache tags on every Redis `set` and `set_many`, even with no tags. Re-setting a previously tagged key without tags now drops its stale tag membership, so a later `delete_tags` no longer wrongly removes it. PR [#353](https://github.com/grelinfo/grelmicro/pull/353).
 * 🐛 Store the cache sidecar entries (the `early=` refresh metadata, and the new stale reserve) under a `\x1f` separator instead of `\x00`, so they are valid Postgres text keys. `@cached(early=...)` previously raised on a Postgres cache backend. PR [#350](https://github.com/grelinfo/grelmicro/pull/350).
 
 ### Features

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -11,7 +11,7 @@ The `metrics` module records OpenTelemetry metrics for your app. Add one `Metric
 `Metrics()` installs an OpenTelemetry `MeterProvider` for the app's lifetime. The provider is installed on enter and restored to the prior global on exit, so sequential apps in tests do not stack providers.
 
 !!! tip "Install"
-    Metrics need the `opentelemetry` extra: `pip install "grelmicro[opentelemetry]"`. See the [installation guide](installation.md) for `uv` and `poetry`. Without the extra, every metric call is a no-op and your app still runs.
+    Metrics need the `opentelemetry` extra: `pip install "grelmicro[opentelemetry]"`. See the [installation guide](installation.md) for `uv` and `poetry`. Without the extra, the metric calls built into every component are no-ops, so an app that does not register `Metrics()` runs normally. Registering a `Metrics()` component does require the extra: it raises `DependencyNotFoundError` at startup when OpenTelemetry is missing.
 
 ## Exporters
 

--- a/grelmicro/cache/redis.py
+++ b/grelmicro/cache/redis.py
@@ -190,9 +190,9 @@ class RedisCacheAdapter:
         """Store raw bytes with a TTL in seconds and optional tags."""
         full_key = self._full(key)
         px = int(ttl * 1000)
-        if not tags:
-            await self._provider.client.set(full_key, value, px=px)
-            return
+        # Always reconcile tags, even when empty, so re-setting a previously
+        # tagged key drops its stale tag membership. The script handles the
+        # no-tag case (it clears the old reverse-tag set and adds nothing).
         await self._run_script(
             _SET_WITH_TAGS_SCRIPT,
             2,
@@ -229,12 +229,9 @@ class RedisCacheAdapter:
             return
         px = int(ttl * 1000)
         tag_keys = [self._tag_key(tag) for tag in tags]
-        if not tag_keys:
-            pipe = self._provider.client.pipeline(transaction=False)
-            for key, value in items.items():
-                pipe.set(self._full(key), value, px=px)
-            await pipe.execute()
-            return
+        # Reconcile tags per key, even when empty, so re-setting a previously
+        # tagged key without tags drops its stale membership. The script
+        # clears the old reverse-tag set and adds only the new tags.
         for key, value in items.items():
             await self._run_script(
                 _SET_WITH_TAGS_SCRIPT,

--- a/grelmicro/cache/sqlite.py
+++ b/grelmicro/cache/sqlite.py
@@ -32,10 +32,10 @@ class SQLiteCacheAdapter:
     whenever the key row goes away, so deleting by tag, by key, or by
     janitor never leaves an orphan tag row behind.
 
-    Reads and writes run inside a `BEGIN IMMEDIATE` transaction. The
-    provider's lock serializes the single connection within the process,
-    and the transaction's write lock serializes across processes sharing
-    the same file. State survives process restarts.
+    Writes run inside a `BEGIN IMMEDIATE` transaction (reads are a plain
+    `SELECT`). The provider's lock serializes the single connection within
+    the process, and the transaction's write lock serializes across
+    processes sharing the same file. State survives process restarts.
 
     Pass an explicit `provider=` to share a connection with other
     components, or rely on the default `env_prefix=` to build one from
@@ -218,8 +218,11 @@ class SQLiteCacheAdapter:
         if self._owns_provider:
             await self._provider.__aenter__()
         self._loop = asyncio.get_running_loop()
+        # `foreign_keys` is a per-connection setting, so it must be on whether
+        # or not we own the schema. Otherwise the tag rows' `ON DELETE CASCADE`
+        # is silently inert when `auto_migrate=False`.
+        await self._provider.client.execute("PRAGMA foreign_keys=ON;")
         if self._auto_migrate:
-            await self._provider.client.execute("PRAGMA foreign_keys=ON;")
             await self._provider.client.executescript(
                 self._SQL_CREATE_TABLE.format(table_name=self._table_name)
             )

--- a/grelmicro/coordination/_component.py
+++ b/grelmicro/coordination/_component.py
@@ -27,7 +27,7 @@ class Coordination:
     """Coordination component: wraps backends and exposes coordination primitives.
 
     Registered as `micro.coordination` after `Grelmicro.use(Coordination(...))`.
-    Exposes `lock(...)`, `task_lock(...)`, and `leader_election(...)` so users do
+    Exposes `lock(...)`, `tasklock(...)`, and `leaderelection(...)` so users do
     not need to pass `backend=` on every primitive.
 
     A single positional `Provider` resolves every primitive: the component calls

--- a/tests/cache/test_cache_backends.py
+++ b/tests/cache/test_cache_backends.py
@@ -286,6 +286,19 @@ async def test_overwrite_replaces_tags(backend: CacheBackend) -> None:
     assert await backend.get(key="rt_k") is None
 
 
+async def test_overwrite_with_empty_tags_clears_tags(
+    backend: CacheBackend,
+) -> None:
+    """Re-setting a tagged key with no tags drops the old tag link."""
+    await backend.set(key="et_k", value=b"v", ttl=60, tags=["old"])
+    await backend.set(key="et_k", value=b"v2", ttl=60)  # no tags
+
+    await backend.delete_tags(tags=["old"])
+
+    # The key carries no tags now, so deleting "old" must not remove it.
+    assert await backend.get(key="et_k") == b"v2"
+
+
 async def test_clear_sweeps_tags(backend: CacheBackend) -> None:
     """Test that clear removes tagged entries and their tag bookkeeping."""
     await backend.set(key="ct_a", value=b"a", ttl=60, tags=["g"])

--- a/tests/cache/test_redis.py
+++ b/tests/cache/test_redis.py
@@ -95,31 +95,38 @@ class TestRedisCacheAdapterAsyncMethods:
         client.get.assert_awaited_once_with("ns:k")
 
     async def test_set_passes_key_value_ttl(self) -> None:
-        """`set` forwards the prefixed key, value, and TTL."""
+        """`set` runs the reconcile script with the prefixed key, value, TTL."""
         backend, client = _build(prefix="p:")
-        client.set = AsyncMock()
+        client.eval = AsyncMock()
 
         await backend.set(key="key", value=b"value", ttl=30)
 
-        client.set.assert_awaited_once_with("p:key", b"value", px=30000)
+        # script, numkeys, value key, reverse-tag set, value, px.
+        client.eval.assert_awaited_once_with(
+            ANY, 2, "p:key", "p:cache:rtag:key", b"value", "30000"
+        )
 
     async def test_set_without_prefix(self) -> None:
         """`set` uses the bare key when no prefix is configured."""
         backend, client = _build()
-        client.set = AsyncMock()
+        client.eval = AsyncMock()
 
         await backend.set(key="bare", value=b"data", ttl=60)
 
-        client.set.assert_awaited_once_with("bare", b"data", px=60000)
+        client.eval.assert_awaited_once_with(
+            ANY, 2, "bare", "cache:rtag:bare", b"data", "60000"
+        )
 
     async def test_set_float_ttl(self) -> None:
         """`set` passes fractional TTL values through to Redis."""
         backend, client = _build()
-        client.set = AsyncMock()
+        client.eval = AsyncMock()
 
         await backend.set(key="k", value=b"v", ttl=0.5)
 
-        client.set.assert_awaited_once_with("k", b"v", px=500)
+        client.eval.assert_awaited_once_with(
+            ANY, 2, "k", "cache:rtag:k", b"v", "500"
+        )
 
     async def test_delete(self) -> None:
         """`delete` runs the delete-with-tags script on the prefixed key."""


### PR DESCRIPTION
Resolves the rest of the Copilot review audit. Each finding was verified against current code.

### 🐛 Redis cache tags — stale membership on empty-tags re-set (#342)
`set`/`set_many` had a no-tags fast-path (plain `SET`) that skipped tag reconciliation, so re-setting a previously tagged key **without** tags left its old tag membership behind — a later `delete_tags` could then wrongly remove it. Both now always run the reconcile script (which clears the old reverse-tag set and adds only the new tags). Added a conformance test (`test_overwrite_with_empty_tags_clears_tags`) across all backends; SQLite/Postgres/Memory were already correct.

### 🐛 SQLite `foreign_keys` pragma (#349)
`PRAGMA foreign_keys=ON` was set only when `auto_migrate=True`. It's a per-connection setting, so with a user-managed schema (`auto_migrate=False`) the tag rows' `ON DELETE CASCADE` was silently inert. Now set on every connection. Also corrected the class docstring ("reads run in `BEGIN IMMEDIATE`" → reads are a plain `SELECT`).

### 📝 Docs (#344, #340)
- `Coordination` class docstring advertised the old method names `task_lock(...)`/`leader_election(...)` → corrected to `tasklock`/`leaderelection`.
- metrics.md clarified: emission no-ops without the extra, but registering a `Metrics()` component requires it (raises `DependencyNotFoundError` otherwise).

### Dismissed after review
- #343 (`_app.py` singleton order) — not a real bug: singleton-ness is a per-kind class attribute, so the second registration always trips the check regardless of order.
- #339 (lock fencing legacy format) — moot pre-1.0 (no stable persisted-format guarantee; locks are TTL'd).