### PR TITLE
✅ Make the @cron tests deterministic by pinning the wall-clock seam

### DIFF
--- a/grelmicro/task/_cron.py
+++ b/grelmicro/task/_cron.py
@@ -27,6 +27,11 @@ if TYPE_CHECKING:
 
 logger = getLogger("grelmicro.task")
 
+# Wall-clock seam for the current time. Tests pin it to a fixed instant so
+# cron matching is deterministic and never straddles a real minute boundary.
+# Mirrors the `_now` seam in the cache.
+_now = datetime.now
+
 # Maximum number of years to search for the next matching datetime before
 # giving up. Covers Feb-29 schedules (every 4 years) with margin so an
 # impossible date such as ``30 2 31 2 *`` (Feb 31) raises instead of looping.
@@ -365,7 +370,7 @@ class CronTask(Task):
             # mode there is no past state, so startup is the baseline.
             await self._tick_guarded(catchup=True)
             while True:
-                now = datetime.now(self._tz)
+                now = _now(self._tz)
                 next_fire = self._expr.next_after(now)
                 delay = (next_fire - now).total_seconds()
                 # Wait until the next fire instant, waking early on stop.
@@ -405,7 +410,7 @@ class CronTask(Task):
         durable ``last_fired`` and runs only on a won claim, dropping coalesced
         or out-of-grace fires.
         """
-        now = datetime.now(self._tz)
+        now = _now(self._tz)
         due_dt = self._expr.previous_or_equal(now)
         if due_dt is None:  # pragma: no cover - schedule always has a past fire
             return

--- a/tests/task/test_cron_task.py
+++ b/tests/task/test_cron_task.py
@@ -75,7 +75,9 @@ def _run_fast(mocker: MockFixture) -> None:
     """Patch the loop sleep so every iteration runs almost immediately.
 
     Keeps a tiny real sleep so the loop yields to the event loop and never
-    starves the awaiting test coroutine.
+    starves the awaiting test coroutine. Also pins the cron wall clock to a
+    fixed instant so the spinning loop never straddles a real minute boundary,
+    which would otherwise add a second, legitimate fire and flake the count.
     """
 
     async def fast_sleep(seconds: float, stop: object) -> bool:
@@ -86,6 +88,11 @@ def _run_fast(mocker: MockFixture) -> None:
     mocker.patch(
         "grelmicro.task._cron.sleep_or_stop",
         side_effect=fast_sleep,
+    )
+    frozen = datetime.now(UTC).replace(second=30, microsecond=0)
+    mocker.patch(
+        "grelmicro.task._cron._now",
+        side_effect=frozen.astimezone,
     )
 
 


### PR DESCRIPTION
Fixes the intermittent `test_cron_task_replays_missed_fire` failure (`assert 2 == 1`) seen on CI this session.

### Root cause
`CronTask` matches the schedule against real `datetime.now(tz)`, and the test helper `_run_fast` makes the loop spin (a tiny real sleep per tick). Over the ~0.05s test window the loop re-reads the wall clock many times, so if a real minute boundary falls inside that window a second, legitimate fire happens and `execution_count` becomes 2.

### Fix
Add a small wall-clock seam `_now = datetime.now` in `grelmicro/task/_cron.py` (mirroring the existing `_now`/`_random` seams in the cache) and route both `datetime.now(self._tz)` sites through it. It is a no-op in production. The `_run_fast` test helper now pins `_now` to a fixed mid-minute instant, so the spinning loop can never straddle a minute boundary. Even if the helper and the pin straddle a boundary, the catch-up replay still fires exactly once and the now is frozen afterward, so the count is deterministic.

This also stabilizes the sibling timing tests (`misfire_grace`, `first_sight`, …) that share `_run_fast`.

Verified: ran the cron suite 5x with no flake, `ruff`/`ty` clean, full unit suite green (2545).