### PR TITLE
✨ Simplify the API surface: default limiter key, zero-object @cached, one OutOfContextError

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,46 @@
+name: OpenSSF Scorecard
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 1 * * 1"
+  workflow_dispatch: {}
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and create a badge.
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        with:
+          sarif_file: results.sarif

--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -53,3 +53,122 @@ asciinema rec demo.cast
 ```
 
 Upload the cast (asciinema.org or an SVG via `svg-term`) and add it to the top of `examples/fastapi-demo/README.md` and the main README "Run the demo" section. A GIF works too; keep it under ~2 MB so GitHub renders it inline.
+
+## Launch post drafts (#172)
+
+Ready-to-post copy for each channel. Adjust the version number and demo link before publishing. Do not cross-post the same text verbatim.
+
+---
+
+### Show HN
+
+**Title (79 chars):** `Show HN: grelmicro 1.0 - async microservice toolkit for Python`
+
+**First comment (from the author, post within 5 minutes):**
+
+> I kept re-implementing the same five patterns across every async Python service at work: a distributed lock, a rate limiter, a circuit breaker, a cache with stampede protection, and health check endpoints. Each one pulled in a separate library with its own config format, its own backend client, its own lifecycle hooks.
+>
+> grelmicro bundles them all behind one unified API. One `Grelmicro(uses=[...])` container manages the lifecycle. One Redis client is shared by the cache, the lock, the rate limiter, and the circuit breaker. One `reconfigure(new_config)` call changes thresholds at runtime without a restart.
+>
+> It is not a task queue and not a web framework. It is the layer between "I picked FastAPI" and "I need distributed coordination."
+>
+> Backends: Redis, PostgreSQL, SQLite, Kubernetes Lease, and in-memory (for tests). Patterns: Lock, TaskLock, LeaderElection, Cache, RateLimiter, CircuitBreaker, Retry, Bulkhead, Fallback, Timeout, HealthChecks, scheduled tasks (interval and cron).
+>
+> The [FastAPI demo](https://github.com/grelinfo/grelmicro/tree/main/examples/fastapi-demo) starts with `docker compose up --wait` and shows every pattern running against real Redis and Postgres.
+>
+> Happy to answer questions about design decisions, especially the backend-agnostic protocol model and the ambient resolution pattern.
+
+---
+
+### r/Python
+
+**Title:** `grelmicro 1.0: one async toolkit for distributed locks, rate limits, circuit breakers, cache, cron, and health checks`
+
+**Body:**
+
+grelmicro 1.0 is out. It is an async Python toolkit that ships the microservice patterns you keep reimplementing, behind a unified API.
+
+What it covers: distributed locks and leader election, cache with stampede protection and serve-stale-on-error, rate limiting (token bucket and sliding window), circuit breakers with live reconfiguration, idempotency keys, interval and cron scheduled tasks, structured JSON logging, OpenTelemetry tracing, and health check endpoints (`/livez`, `/readyz`, `/healthz`).
+
+Backends for each pattern: Redis, PostgreSQL, SQLite, Kubernetes Lease, and in-memory for tests. Swap the backend without changing application code.
+
+Why not separate libraries? If you only need one pattern, a focused library is often the right pick. The comparison page names the right one per domain. When you need two or more in the same service, grelmicro removes four or five separate config dialects and replaces them with one lifecycle (`async with micro:`) and one shared backend client.
+
+- Repo: https://github.com/grelinfo/grelmicro
+- Docs: https://grelinfo.github.io/grelmicro/
+- Demo: https://github.com/grelinfo/grelmicro/tree/main/examples/fastapi-demo
+- Comparison: https://grelinfo.github.io/grelmicro/comparison/
+
+`pip install grelmicro`
+
+---
+
+### r/FastAPI
+
+**Title:** `grelmicro 1.0: locks, rate limits, circuit breakers, cache, and health checks for FastAPI - one toolkit, one lifespan`
+
+**Body:**
+
+grelmicro 1.0 is a toolkit built for FastAPI and any asyncio app that needs distributed coordination.
+
+The FastAPI integration is three lines: wire `Grelmicro(uses=[...])` into your lifespan and add `GrelmicroMiddleware`. After that, `Lock("cart")`, `RateLimiter.sliding_window(...)`, and `@cached(ttl_cache)` resolve ambiently in request handlers with no explicit `backend=` argument.
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    async with micro:
+        yield
+
+app = FastAPI(lifespan=lifespan)
+app.add_middleware(GrelmicroMiddleware, micro=micro)
+```
+
+Health checks are a FastAPI router you include with one line. It exposes the orchestrator-grade triple your Kubernetes deployment expects: `/livez` (shallow), `/readyz` (deep, concurrent checks, per-check timeout and TTL cache), and `/healthz` (aggregate).
+
+The [FastAPI demo](https://github.com/grelinfo/grelmicro/tree/main/examples/fastapi-demo) shows every pattern in one `app.py`: cached endpoint, rate-limited endpoint, circuit-breaker-protected endpoint, distributed lock, leader-gated task, and health probes. Start it with `docker compose up --wait`.
+
+What it is not: not a task queue (reach for Celery, Dramatiq, or taskiq), not a web framework (it plugs into FastAPI, not next to it).
+
+- Repo: https://github.com/grelinfo/grelmicro
+- Docs: https://grelinfo.github.io/grelmicro/
+- Demo: https://github.com/grelinfo/grelmicro/tree/main/examples/fastapi-demo
+
+`pip install grelmicro`
+
+---
+
+### dev.to
+
+**Title:** `What "distributed" actually means in a FastAPI app`
+
+**Tags:** `python, fastapi, microservices, opensource`
+
+**Outline:**
+
+1. The problem: four separate libraries, four config formats, four backend clients
+2. What grelmicro ships (one-paragraph overview of each pattern group)
+3. The FastAPI wiring pattern (lifespan + middleware, code snippet)
+4. Cache with serve-stale-on-error (real problem, real code)
+5. Rate limiting with retry-after headers (real code)
+6. Distributed lock across replicas (real code)
+7. Health check triple for Kubernetes
+8. "When not to use grelmicro" (task queues, single-pattern use cases)
+9. Getting started
+
+**Intro paragraphs:**
+
+Every FastAPI service past a certain size ends up with the same gap. You have a web framework for routing, a database driver for storage, and then a pile of small distributed coordination problems: rate limiting per user, a shared cache that does not stampede under load, a lock so two workers do not process the same job, and a circuit breaker so one slow downstream does not take down the rest.
+
+Most teams reach for a separate library for each one. That works until you have four of them. At that point you are managing four config formats, four backend clients, and four different startup and shutdown sequences.
+
+grelmicro is one async Python toolkit that covers all of these patterns behind a uniform API. One container manages the lifecycle. One Redis connection is shared by the cache, the lock, and the rate limiter. One `reconfigure(new_config)` call changes thresholds at runtime without a restart.
+
+In this article I will show what the wiring looks like in a real FastAPI app and where grelmicro earns its place, including the honest "when not to use it" section.
+
+**Honest "when not to use it" one-liners:**
+
+- Use `tenacity` if retry is the only pattern you need.
+- Use `aiocache` or `fastapi-cache` if cache is the only pattern you need.
+- Use `slowapi` if per-route rate limiting with a wide backend choice is the only thing missing.
+- Reach for `aioredlock` if you want Redlock specifically.
+- Pick grelmicro when you need two or more of these in the same service and want one config and lifecycle story across all of them.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/astral-sh/uv"><img alt="uv" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json"></a>
   <a href="https://github.com/astral-sh/ruff"><img alt="Ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
   <a href="https://github.com/astral-sh/ty"><img alt="ty" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/grelinfo/grelmicro"><img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/grelinfo/grelmicro/badge"></a>
 </p>
 
 > **Project status: Active development.** grelmicro is pre-1.0. The public API is not yet stable. Breaking changes are allowed on `MINOR` bumps (`0.14.0` → `0.15.0`) and never on `PATCH`. Pin the minor: `grelmicro>=0.14.0,<0.15.0`. After `1.0.0`, standard semver applies. See the [versioning policy](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#about-grelmicro-versions).
@@ -105,7 +106,7 @@ api_limiter = RateLimiter.sliding_window(
 @app.get("/ping")
 async def ping() -> dict[str, str]:
     try:
-        await api_limiter.acquire_or_raise(key="global")
+        await api_limiter.acquire_or_raise()
     except RateLimitExceededError:
         return {"status": "throttled"}
     return {"status": "ok"}
@@ -150,7 +151,7 @@ app.add_middleware(GrelmicroMiddleware, micro=micro)
 @app.get("/ping")
 async def ping() -> dict[str, str]:
     try:
-        await api_limiter.acquire_or_raise(key="global")
+        await api_limiter.acquire_or_raise()
     except RateLimitExceededError:
         return {"status": "throttled"}
     return {"status": "ok"}

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -250,6 +250,18 @@ Literal tags with no `{...}` pass through unchanged. Tags work the same across M
 
 The `@cached` decorator automatically caches function results. It works with both sync and async functions.
 
+For the plain "memoize this function for N seconds" case, pass `ttl=` and nothing else. The decorator builds a private process-local cache for this function alone:
+
+```python
+from grelmicro.cache import cached
+
+@cached(ttl=30)
+async def get_rates() -> dict:
+    return await fetch_rates()
+```
+
+That private cache lives only in this process and is never shared across replicas. To share results across replicas, invalidate by tag, or reuse one store across functions, pass a `TTLCache` instead:
+
 ```python
 from grelmicro.cache import JsonSerializer, TTLCache, cached
 
@@ -259,6 +271,8 @@ cache = TTLCache(ttl=300, serializer=JsonSerializer())
 async def get_user(user_id: int) -> dict:
     return await db.fetch_user(user_id)
 ```
+
+Passing both `cache` and `ttl`, or neither, raises `TypeError`.
 
 ### Stampede Protection
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 Raise `OutOfContextError` with an actionable message on every ambient backend miss: `Lock`, `TaskLock`, `LeaderElection`, `TTLCache`, `@cached`, the cron schedule resolution, and `Idempotency` now match `CircuitBreaker` and `RateLimiter`. `NoActiveAppError` stays the low-level error raised by `Grelmicro.current()` itself.
 * 💥 Remove the implicit memory fallback on `CircuitBreaker` and `RateLimiter`. Backend resolution is now one rule on every pattern: explicit `backend=` wins, else the active app's component, else `OutOfContextError`. For a per-process limiter or breaker without an app, pass `backend=MemoryRateLimiterAdapter()` or `backend=MemoryCircuitBreakerAdapter()`. Inside FastAPI handlers, add `GrelmicroMiddleware` so ambient resolution works there. `RateLimiter.reconfigure` now publishes the config and rebinds the strategy lazily on the next call, matching `CircuitBreaker`.
 * 💥 Add positional argument capture to `grelmicro.testing`: `Call` is now `Call(method, args=..., kwargs=...)` and `CallLog.count` matches positional arguments too. Update direct `Call(...)` constructions.
 * 💥 Align the leader election and task lock env var prefixes with their single-token names: `GREL_LEADER_ELECTION_{NAME}_` becomes `GREL_LEADERELECTION_{NAME}_` and `GREL_TASK_LOCK_{NAME}_` becomes `GREL_TASKLOCK_{NAME}_`. Update any environment variables set for these components. PR [#346](https://github.com/grelinfo/grelmicro/pull/346).
@@ -19,6 +20,9 @@
 
 ### Features
 
+* ✨ Default the rate limiter `key` to `"default"` on `acquire`, `acquire_or_raise`, `allow`, `peek`, and `reset`, so the single-bucket case is `await limiter.allow()`. The limiter `name` already namespaces the backend key.
+* ✨ Add the zero-object `@cached(ttl=30)` form for plain memoization: it binds a private process-local `TTLCache` at decoration, never resolves the active app, and never shares across replicas. Pass a `TTLCache` for shared state. Passing both `cache` and `ttl` raises `TypeError`.
+* ✨ Add the OpenSSF Scorecard workflow and badge.
 * ✨ Make `Grelmicro(uses=[...])` and `micro.use(...)` forgiving: a bare Component class is constructed for you, a bare adapter (class or instance) is wrapped in its matching Component, and a bare Provider with no Components auto-registers one default Component per kind it serves. The explicit form always wins, so any explicit Component turns provider auto-registration off entirely.
 * ✨ Add `AmbiguousProviderError`, raised when `uses=[...]` lists two bare Providers with no Components, so the default Component for a shared kind would be ambiguous. Wrap each Provider in the Components it should serve to resolve it.
 * ✨ Add the Idempotency pattern: a new `grelmicro.idempotency` module with an `Idempotency` primitive and `@idempotent` decorator. A caller-provided key (an `Idempotency-Key` header) executes the operation once, stores the response for `ttl` seconds, and replays it on repeats. Duplicates arriving mid-flight fold into the first execution, across replicas when a Coordination lock backend is configured. A failure stores nothing, so a retry executes fresh. An optional `fingerprint=` rejects a reused key with a different payload via `IdempotencyConflictError`. Storage rides the cache layer (`cache=` or the active app's `Cache` component).

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/astral-sh/uv"><img alt="uv" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json"></a>
   <a href="https://github.com/astral-sh/ruff"><img alt="Ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
   <a href="https://github.com/astral-sh/ty"><img alt="ty" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/grelinfo/grelmicro"><img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/grelinfo/grelmicro/badge"></a>
 </p>
 
 > **Project status: Active development.** grelmicro is pre-1.0. The public API is not yet stable. Breaking changes are allowed on `MINOR` bumps (`0.14.0` → `0.15.0`) and never on `PATCH`. Pin the minor: `grelmicro>=0.14.0,<0.15.0`. After `1.0.0`, standard semver applies. See the [versioning policy](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#about-grelmicro-versions).
@@ -105,7 +106,7 @@ api_limiter = RateLimiter.sliding_window(
 @app.get("/ping")
 async def ping() -> dict[str, str]:
     try:
-        await api_limiter.acquire_or_raise(key="global")
+        await api_limiter.acquire_or_raise()
     except RateLimitExceededError:
         return {"status": "throttled"}
     return {"status": "ok"}
@@ -150,7 +151,7 @@ app.add_middleware(GrelmicroMiddleware, micro=micro)
 @app.get("/ping")
 async def ping() -> dict[str, str]:
     try:
-        await api_limiter.acquire_or_raise(key="global")
+        await api_limiter.acquire_or_raise()
     except RateLimitExceededError:
         return {"status": "throttled"}
     return {"status": "ok"}

--- a/docs/resilience/rate-limiter.md
+++ b/docs/resilience/rate-limiter.md
@@ -40,6 +40,20 @@ if not result:
 
 Use `acquire_or_raise` when a surrounding layer should turn the rejection into a response: it raises `RateLimitExceededError`, which is an `AdmissionError` (the shared base, exported from the top-level `grelmicro` package for every "turned away" rejection: rate limiter, bulkhead, open circuit breaker, non-blocking lock), so one `except AdmissionError` catches them all.
 
+### One fleet-wide limit
+
+When the limiter protects a service with one shared budget (no per-user or per-IP split), omit `key`. It defaults to `"default"`, and the limiter's own `name` already namespaces the bucket on the backend:
+
+```python
+api_limiter = RateLimiter.token_bucket("api", capacity=5, refill_rate=1)
+
+await api_limiter.acquire()             # one fleet-wide bucket
+await api_limiter.allow()
+await api_limiter.acquire_or_raise()
+
+await api_limiter.acquire(key=user_id)  # per-subject stays explicit
+```
+
 The factory classmethods keep the call site explicit and short:
 
 ```python

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,3 +11,7 @@ Post-1.0 items planned for future releases. All are purely additive. No dates ar
 - **Observability depth**: provider pool metrics, lock acquire latency, optional provider health auto-registration, metric exemplars.
 - **More backends**: MySQL/MariaDB, MongoDB, etcd/ZooKeeper.
 - **Multi-window rate limits and task pause/resume**: additive features with lower urgency.
+- **Uniform admission guard**: a `@guard(on_reject=...)` decorator over the shared `AdmissionError` base (was issue #356).
+- **Saga and transactional outbox helpers**: docs-first recipes on `Tasks` plus `TaskLock`, then a helper if demand shows (was issue #175).
+- **RFC 9457 problem-detail responses**: error-to-response mapping for the FastAPI integration (was issue #78).
+- **Project starter template**: a `copier` or `cookiecutter` starter wiring one provider, health, and one pattern (was issue #179).

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -21,6 +21,8 @@ from grelmicro.cache._stampede import (
     _stampede_lock_name,
     compute_with_stampede,
 )
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache.serializers import PickleSerializer
 from grelmicro.cache.ttl import _CACHE_PREFIX, TTLCache
 from grelmicro.coordination.lock import Lock
 from grelmicro.metrics import _emit
@@ -91,16 +93,98 @@ def _evict_idle_locks_sync(
             return
 
 
+class _PrivateMemoryCacheAdapter(MemoryCacheAdapter):
+    """Memory backend for a private `@cached(ttl=...)` cache.
+
+    The cache is built at decoration without an app or an explicit
+    `async with`, so the running event loop is captured on the first
+    async access instead. `_loop` lets the sync `@cached` wrapper
+    dispatch coroutines back into that loop, so a sync function reaches
+    a private cache only after one async access has primed the loop.
+    """
+
+    async def get(self, *, key: str) -> bytes | None:
+        """Capture the running loop on first read, then read by key."""
+        if self._loop is None:
+            self._loop = asyncio.get_running_loop()
+        return await super().get(key=key)
+
+
+def _resolve_cache(
+    cache: TTLCache | None, ttl: float | None, maxsize: int
+) -> TTLCache:
+    """Return the cache to use, building a private one for `ttl=`.
+
+    Passing both `cache` and `ttl`, or neither, raises `TypeError`.
+    """
+    if cache is not None:
+        if ttl is not None:
+            msg = (
+                "cached() takes either a cache or ttl=, not both. Pass a "
+                "TTLCache to share a store, or ttl= for a private "
+                "process-local cache."
+            )
+            raise TypeError(msg)
+        return cache
+    if ttl is None:
+        msg = (
+            "cached() needs a cache or a ttl=. Pass a TTLCache, or "
+            "ttl= for a private process-local cache (e.g. "
+            "@cached(ttl=30))."
+        )
+        raise TypeError(msg)
+    return TTLCache(
+        maxsize=maxsize,
+        ttl=ttl,
+        backend=_PrivateMemoryCacheAdapter(),
+        serializer=PickleSerializer(),
+    )
+
+
 def cached(
     cache: Annotated[
-        TTLCache,
+        TTLCache | None,
         Doc(
             """
             The TTLCache instance to store results in.
+
+            Omit it and pass `ttl=` instead for the plain memoize case.
+            The decorator then builds a private process-local
+            `TTLCache` on a `MemoryCacheAdapter` owned by this
+            function. That private cache never resolves the active app,
+            so its entries live only in this process and are not shared
+            across replicas. Pass a `TTLCache` when you want a shared
+            backend, tag invalidation, or to reuse one cache across
+            functions.
             """,
         ),
-    ],
+    ] = None,
     *,
+    ttl: Annotated[
+        float | None,
+        Doc(
+            """
+            TTL in seconds for the private process-local cache.
+
+            Only valid when `cache` is omitted. It builds a private
+            `TTLCache(maxsize=maxsize, ttl=ttl)` on a
+            `MemoryCacheAdapter` for plain in-process memoization
+            (the `functools.lru_cache` case). To share results across
+            replicas, pass a `TTLCache` instead. Passing both `cache`
+            and `ttl` raises `TypeError`.
+            """,
+        ),
+    ] = None,
+    maxsize: Annotated[
+        int,
+        Doc(
+            """
+            Maximum number of entries in the private process-local
+            cache. `0` (the default) means unlimited. Only used when
+            `cache` is omitted and `ttl` is given.
+            """,
+        ),
+    ] = 0,
     key_maker: Annotated[
         Callable[[Callable[..., Any], tuple[Any, ...], dict[str, Any]], str]
         | None,
@@ -206,7 +290,15 @@ def cached(
     ``cache_clear()`` helpers (matching ``functools.lru_cache``).
     ``cache_clear()`` is always a coroutine (must be awaited).
 
+    Pass a ``TTLCache`` as ``cache`` to share one store across
+    functions, invalidate by tag, or override it in tests. For the
+    plain memoize case, omit ``cache`` and pass ``ttl=`` instead. The
+    decorator then builds a private process-local cache for this
+    function alone.
+
     Raises:
+        TypeError: If both ``cache`` and ``ttl`` are given, or if
+            neither is given.
         ValueError: If ``lock`` is not ``True``, ``False``, or ``"local"``,
             if ``early`` is outside ``[0, 1)``, or if ``stale_ttl`` is not
             positive.
@@ -214,6 +306,7 @@ def cached(
     Returns:
         A decorator that caches function results.
     """
+    cache = _resolve_cache(cache, ttl, maxsize)
     if lock not in (True, False, "local"):
         msg = f"Invalid lock {lock!r}: use True, False, or 'local'."
         raise ValueError(msg)

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -306,6 +306,7 @@ def cached(
     Returns:
         A decorator that caches function results.
     """
+    is_private_cache = cache is None
     cache = _resolve_cache(cache, ttl, maxsize)
     if lock not in (True, False, "local"):
         msg = f"Invalid lock {lock!r}: use True, False, or 'local'."
@@ -321,6 +322,14 @@ def cached(
         func: Callable[P, R],
     ) -> Callable[P, R]:
         is_async_func = asyncio.iscoroutinefunction(func)
+        if is_private_cache and not is_async_func:
+            msg = (
+                "@cached(ttl=...) supports async functions only: the "
+                "private cache has no event loop for a sync wrapper. "
+                "Pass a TTLCache opened by the app, or use "
+                "functools.lru_cache for pure sync memoization."
+            )
+            raise TypeError(msg)
         per_key = lock is not False
         auto_distributed = lock is True
         tag_spec = _TagSpec(tags, inspect.signature(func) if tags else None)

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -186,10 +186,32 @@ class TTLCache(Generic[T]):
         always returned. Otherwise the active `Grelmicro` app is
         consulted via `Grelmicro.current()` so that
         `micro.override(Cache(...))` blocks take effect.
+
+        Raises:
+            OutOfContextError: No backend resolved in this scope. Pass
+                `backend=` (a `MemoryCacheAdapter()` for a per-process
+                cache), register a `Cache` Component, or run the call
+                under the app context (for FastAPI, add
+                `GrelmicroMiddleware`).
         """
         if self._backend is not None:
             return self._backend
-        cache = Grelmicro.current().get("cache", "default")
+        from grelmicro._app import (  # noqa: PLC0415
+            ComponentNotRegisteredError,
+            NoActiveAppError,
+        )
+        from grelmicro.errors import OutOfContextError  # noqa: PLC0415
+
+        try:
+            cache = Grelmicro.current().get("cache", "default")
+        except (NoActiveAppError, ComponentNotRegisteredError):
+            msg = (
+                "TTLCache resolved no backend. Pass backend= "
+                "(MemoryCacheAdapter() for a per-process cache), register "
+                "a Cache component, or run the call under the app context "
+                "(for FastAPI add GrelmicroMiddleware)."
+            )
+            raise OutOfContextError(msg) from None
         return cache.backend
 
     def _serialize(self, value: T) -> bytes:

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -420,12 +420,35 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
         `micro.override(Coordination(...))` blocks take effect. The
         backend comes from the `Coordination` component, whose election
         backend can point at a different vendor than its lock backend.
+
+        Raises:
+            OutOfContextError: No backend resolved in this scope. Pass
+                `backend=` (a `MemoryLeaderElectionBackend()` for a
+                per-process election), register a `Coordination`
+                Component, or run the call under the app context (for
+                FastAPI, add `GrelmicroMiddleware`).
         """
         if self._backend is not None:
             return self._backend
-        coordination = Grelmicro.current().get(
-            "coordination", self._backend_name or "default"
+        from grelmicro._app import (  # noqa: PLC0415
+            ComponentNotRegisteredError,
+            NoActiveAppError,
         )
+        from grelmicro.errors import OutOfContextError  # noqa: PLC0415
+
+        try:
+            coordination = Grelmicro.current().get(
+                "coordination", self._backend_name or "default"
+            )
+        except (NoActiveAppError, ComponentNotRegisteredError):
+            msg = (
+                f"LeaderElection({self._name!r}) resolved no backend. Pass "
+                f"backend= (MemoryLeaderElectionBackend() for a per-process "
+                f"election), register a Coordination component, or run the "
+                f"call under the app context (for FastAPI add "
+                f"GrelmicroMiddleware)."
+            )
+            raise OutOfContextError(msg) from None
         return coordination.election_backend
 
     def is_running(self) -> bool:

--- a/grelmicro/coordination/lock.py
+++ b/grelmicro/coordination/lock.py
@@ -317,12 +317,34 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         always returned. Otherwise the active `Grelmicro` app is
         consulted via `Grelmicro.current()` on every access so that
         `micro.override(Coordination(...))` blocks take effect.
+
+        Raises:
+            OutOfContextError: No backend resolved in this scope. Pass
+                `backend=` (a `MemoryLockAdapter()` for a per-process
+                lock), register a `Coordination` Component, or run the
+                call under the app context (for FastAPI, add
+                `GrelmicroMiddleware`).
         """
         if self._backend is not None:
             return self._backend
-        coordination = Grelmicro.current().get(
-            "coordination", self._backend_name or "default"
+        from grelmicro._app import (  # noqa: PLC0415
+            ComponentNotRegisteredError,
+            NoActiveAppError,
         )
+        from grelmicro.errors import OutOfContextError  # noqa: PLC0415
+
+        try:
+            coordination = Grelmicro.current().get(
+                "coordination", self._backend_name or "default"
+            )
+        except (NoActiveAppError, ComponentNotRegisteredError):
+            msg = (
+                f"Lock({self._name!r}) resolved no backend. Pass backend= "
+                f"(MemoryLockAdapter() for a per-process lock), register a "
+                f"Coordination component, or run the call under the app "
+                f"context (for FastAPI add GrelmicroMiddleware)."
+            )
+            raise OutOfContextError(msg) from None
         return coordination.lock_backend
 
     async def __aenter__(self) -> LockHandle:

--- a/grelmicro/coordination/tasklock.py
+++ b/grelmicro/coordination/tasklock.py
@@ -276,12 +276,34 @@ class TaskLock(Reconfigurable[TaskLockConfig], LockPrimitive):
         always returned. Otherwise the active `Grelmicro` app is
         consulted via `Grelmicro.current()` on every access so that
         `micro.override(Coordination(...))` blocks take effect.
+
+        Raises:
+            OutOfContextError: No backend resolved in this scope. Pass
+                `backend=` (a `MemoryLockAdapter()` for a per-process
+                lock), register a `Coordination` Component, or run the
+                call under the app context (for FastAPI, add
+                `GrelmicroMiddleware`).
         """
         if self._backend is not None:
             return self._backend
-        coordination = Grelmicro.current().get(
-            "coordination", self._backend_name or "default"
+        from grelmicro._app import (  # noqa: PLC0415
+            ComponentNotRegisteredError,
+            NoActiveAppError,
         )
+        from grelmicro.errors import OutOfContextError  # noqa: PLC0415
+
+        try:
+            coordination = Grelmicro.current().get(
+                "coordination", self._backend_name or "default"
+            )
+        except (NoActiveAppError, ComponentNotRegisteredError):
+            msg = (
+                f"TaskLock({self._name!r}) resolved no backend. Pass "
+                f"backend= (MemoryLockAdapter() for a per-process lock), "
+                f"register a Coordination component, or run the call under "
+                f"the app context (for FastAPI add GrelmicroMiddleware)."
+            )
+            raise OutOfContextError(msg) from None
         return coordination.lock_backend
 
     async def __aenter__(self) -> Self:

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -123,7 +123,11 @@ class _Block(Generic[T]):
             replay = await self._idempotency._replay(  # noqa: SLF001
                 self._key, self._fingerprint
             )
-        except (NoActiveAppError, ComponentNotRegisteredError):
+        except (
+            NoActiveAppError,
+            ComponentNotRegisteredError,
+            OutOfContextError,
+        ):
             msg = (
                 f"Idempotency({self._idempotency.name!r}) resolved no "
                 f"cache backend. Pass cache=, register a Cache "

--- a/grelmicro/resilience/ratelimiter/__init__.py
+++ b/grelmicro/resilience/ratelimiter/__init__.py
@@ -379,8 +379,11 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
             Doc(
                 "Identifier for rate limiting"
                 " (e.g. IP address, user ID, session)."
+                " Defaults to `default` for the single-bucket case."
+                " The limiter's `name` already namespaces the backend"
+                " key, so the default bucket is `name:default`."
             ),
-        ],
+        ] = "default",
         cost: Annotated[
             int,
             Doc("Number of tokens to consume."),
@@ -424,8 +427,11 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
             Doc(
                 "Identifier for rate limiting"
                 " (e.g. IP address, user ID, session)."
+                " Defaults to `default` for the single-bucket case."
+                " The limiter's `name` already namespaces the backend"
+                " key, so the default bucket is `name:default`."
             ),
-        ],
+        ] = "default",
         cost: Annotated[
             int,
             Doc("Number of tokens to consume."),
@@ -455,8 +461,11 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
             Doc(
                 "Identifier for rate limiting"
                 " (e.g. IP address, user ID, session)."
+                " Defaults to `default` for the single-bucket case."
+                " The limiter's `name` already namespaces the backend"
+                " key, so the default bucket is `name:default`."
             ),
-        ],
+        ] = "default",
         cost: Annotated[
             int,
             Doc("Number of tokens to consume."),
@@ -486,8 +495,11 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
             Doc(
                 "Identifier for rate limiting"
                 " (e.g. IP address, user ID, session)."
+                " Defaults to `default` for the single-bucket case."
+                " The limiter's `name` already namespaces the backend"
+                " key, so the default bucket is `name:default`."
             ),
-        ],
+        ] = "default",
     ) -> RateLimitResult:
         """Check rate limit state without consuming tokens.
 
@@ -515,8 +527,11 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
             Doc(
                 "Identifier for rate limiting"
                 " (e.g. IP address, user ID, session)."
+                " Defaults to `default` for the single-bucket case."
+                " The limiter's `name` already namespaces the backend"
+                " key, so the default bucket is `name:default`."
             ),
-        ],
+        ] = "default",
     ) -> None:
         """Delete rate limit state for a key, restoring full quota.
 

--- a/grelmicro/task/_cron.py
+++ b/grelmicro/task/_cron.py
@@ -358,19 +358,36 @@ class CronTask(Task):
         `Grelmicro.current()` so that `micro.override(Coordination(...))`
         blocks take effect. Returns `None` when no app is running and no
         backend was passed, which runs the body on every worker.
+
+        Raises:
+            OutOfContextError: An app is running but no `Coordination`
+                component is registered. Pass `backend=`, register a
+                `Coordination` Component, or run the call under the app
+                context (for FastAPI, add `GrelmicroMiddleware`).
         """
         if self._backend is not None:
             return self._backend
         from grelmicro._app import (  # noqa: PLC0415
+            ComponentNotRegisteredError,
             Grelmicro,
             NoActiveAppError,
         )
+        from grelmicro.errors import OutOfContextError  # noqa: PLC0415
 
         try:
             app = Grelmicro.current()
         except NoActiveAppError:
             return None
-        coordination = app.get("coordination", "default")
+        try:
+            coordination = app.get("coordination", "default")
+        except ComponentNotRegisteredError:
+            msg = (
+                f"Cron task {self.name!r} resolved no schedule backend. "
+                f"Pass backend=, register a Coordination component, or run "
+                f"the call under the app context (for FastAPI add "
+                f"GrelmicroMiddleware)."
+            )
+            raise OutOfContextError(msg) from None
         return coordination.schedule_backend
 
     async def __call__(

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -39,7 +39,7 @@
   "grelmicro.cache": {
     "Cache": {
       "()": "(source, *, name=...)",
-      ".cached": "(cache, *, key_maker=..., skip=..., typed=..., lock=..., early=..., stale_ttl=..., tags=...)"
+      ".cached": "(cache=..., *, ttl=..., maxsize=..., key_maker=..., skip=..., typed=..., lock=..., early=..., stale_ttl=..., tags=...)"
     },
     "CacheBackend": {
       "()": "(*args, **kwargs)"
@@ -70,7 +70,7 @@
       "()": "(*, maxsize=..., ttl=...)"
     },
     "cached": {
-      "()": "(cache, *, key_maker=..., skip=..., typed=..., lock=..., early=..., stale_ttl=..., tags=...)"
+      "()": "(cache=..., *, ttl=..., maxsize=..., key_maker=..., skip=..., typed=..., lock=..., early=..., stale_ttl=..., tags=...)"
     }
   },
   "grelmicro.clock": {

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -1639,3 +1639,73 @@ class TestSyncCachedNoLoop:
 
         with pytest.raises(RuntimeError, match="async with"):
             compute(5)
+
+
+# ---------------------------------------------------------------------------
+# Zero-object @cached(ttl=...) private-cache form
+# ---------------------------------------------------------------------------
+
+
+class TestPrivateCacheForm:
+    """Test @cached(ttl=...) building a private process-local cache."""
+
+    async def test_async_memoizes_with_ttl(self) -> None:
+        """@cached(ttl=...) on an async function memoizes results."""
+        call_count = 0
+
+        @cached(ttl=30)
+        async def get_rates() -> dict:
+            nonlocal call_count
+            call_count += 1
+            return {"usd": 1.0}
+
+        assert await get_rates() == {"usd": 1.0}
+        assert await get_rates() == {"usd": 1.0}
+        assert call_count == EXPECTED_CALL_COUNT_1
+
+    async def test_private_cache_exposes_helpers(self) -> None:
+        """The private form still exposes cache_info and cache_clear."""
+        expected_value = 7
+
+        @cached(ttl=30)
+        async def get_value() -> int:
+            return expected_value
+
+        assert await get_value() == expected_value
+        info = get_value.cache_info()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        assert info.hits == 0
+        assert info.misses == EXPECTED_MISSES_1
+        await get_value.cache_clear()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+    async def test_maxsize_bounds_private_cache(self) -> None:
+        """maxsize= bounds the private cache and evicts the oldest entry."""
+        call_count = 0
+        expected_calls = 3
+
+        @cached(ttl=30, maxsize=1)
+        async def square(n: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return n * n
+
+        assert await square(2) == 2 * 2
+        assert await square(3) == 3 * 3
+        # The first entry was evicted, so recomputing it counts a third call.
+        assert await square(2) == 2 * 2
+        assert call_count == expected_calls
+
+    def test_both_cache_and_ttl_raises(self) -> None:
+        """Passing both cache and ttl raises TypeError."""
+        with pytest.raises(TypeError, match="not both"):
+
+            @cached(TTLCache(ttl=5), ttl=5)
+            async def f() -> int:
+                return 1
+
+    def test_neither_cache_nor_ttl_raises(self) -> None:
+        """Bare @cached() with neither cache nor ttl raises TypeError."""
+        with pytest.raises(TypeError, match="needs a cache or a ttl="):
+
+            @cached()
+            async def f() -> int:
+                return 1

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -1709,3 +1709,12 @@ class TestPrivateCacheForm:
             @cached()
             async def f() -> int:
                 return 1
+
+
+def test_private_cache_rejects_sync_function() -> None:
+    """The zero-object form raises at decoration on a sync function."""
+    with pytest.raises(TypeError, match="async functions only"):
+
+        @cached(ttl=30)
+        def sync_fn() -> int:
+            return 1

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -14,6 +14,7 @@ from grelmicro.cache import Cache, TTLCacheConfig
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.serializers import JsonSerializer, PickleSerializer
 from grelmicro.cache.ttl import CacheInfo, TTLCache
+from grelmicro.errors import OutOfContextError
 
 pytestmark = [pytest.mark.timeout(10)]
 
@@ -106,6 +107,12 @@ class TestInit:
             result = await cache.get("app_test")
 
         assert result == b"works"
+
+    async def test_backend_out_of_context(self) -> None:
+        """A miss with no backend and no active app raises `OutOfContextError`."""
+        cache = TTLCache(maxsize=0, ttl=60)
+        with pytest.raises(OutOfContextError, match="TTLCache resolved"):
+            await cache.get("missing")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/coordination/test_leaderelection.py
+++ b/tests/coordination/test_leaderelection.py
@@ -14,6 +14,7 @@ from grelmicro.coordination.leaderelection import (
     LeaderElectionConfig,
 )
 from grelmicro.coordination.memory import MemoryLeaderElectionBackend
+from grelmicro.errors import OutOfContextError
 from grelmicro.errors import WouldBlockError as WouldBlock
 from tests.task._helpers import cancel_group, start_task
 
@@ -740,3 +741,12 @@ async def test_leader_election_without_jitter(
 
     # Assert
     assert is_leader_inside is True
+
+
+async def test_leaderelection_backend_out_of_context() -> None:
+    """A `LeaderElection` with no backend and no active app raises `OutOfContextError`."""
+    election = LeaderElection("out-of-context", worker="worker")
+    with pytest.raises(
+        OutOfContextError, match="LeaderElection\\('out-of-context'\\)"
+    ):
+        _ = election.backend

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -21,6 +21,7 @@ from grelmicro.coordination.errors import (
 )
 from grelmicro.coordination.lock import Lock
 from grelmicro.coordination.memory import MemoryLockAdapter
+from grelmicro.errors import OutOfContextError
 from grelmicro.errors import WouldBlockError as WouldBlock
 from tests._faults import cancel_midflight
 
@@ -1147,3 +1148,9 @@ async def test_from_thread_extend_lost_lease(
             lock.from_thread.extend()
 
     await asyncio.to_thread(sync)
+
+
+async def test_lock_backend_out_of_context() -> None:
+    """A `Lock` with no backend and no active app raises `OutOfContextError`."""
+    with pytest.raises(OutOfContextError, match="Lock\\('out-of-context'\\)"):
+        _ = Lock("out-of-context").backend

--- a/tests/coordination/test_tasklock.py
+++ b/tests/coordination/test_tasklock.py
@@ -22,6 +22,7 @@ from grelmicro.coordination.errors import (
 from grelmicro.coordination.lock import Lock, LockConfig
 from grelmicro.coordination.memory import MemoryLockAdapter
 from grelmicro.coordination.tasklock import TaskLock, TaskLockConfig
+from grelmicro.errors import OutOfContextError
 from grelmicro.errors import WouldBlockError as WouldBlock
 
 pytestmark = [pytest.mark.timeout(10)]
@@ -854,3 +855,17 @@ async def test_tasklock_refresh_lease_lost_raises(
 
     with pytest.raises(LockNotOwnedError):
         await task_lock.refresh()
+
+
+async def test_tasklock_backend_out_of_context() -> None:
+    """A `TaskLock` with no backend and no active app raises `OutOfContextError`."""
+    task_lock = TaskLock(
+        "out-of-context",
+        worker=WORKER_1,
+        min_lock_seconds=1,
+        max_lock_seconds=10,
+    )
+    with pytest.raises(
+        OutOfContextError, match="TaskLock\\('out-of-context'\\)"
+    ):
+        _ = task_lock.backend

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -135,6 +135,41 @@ async def test_bind_called_once_on_first_use() -> None:
 
 
 @pytest.mark.usefixtures("_backend")
+async def test_acquire_defaults_to_single_bucket(
+    limiter: RateLimiter,
+) -> None:
+    """`acquire`, `allow`, `peek`, and `reset` default `key` to the single bucket."""
+    # Act: the single-bucket path needs no explicit key.
+    result = await limiter.acquire()
+    peeked = await limiter.peek()
+    allowed = await limiter.allow()
+    await limiter.reset()
+
+    # Assert: the default bucket is namespaced by the limiter name.
+    assert result.allowed is True
+    assert peeked.allowed is True
+    assert allowed is True
+    full_key = limiter._full_key("default")
+    assert full_key == f"{limiter.name}:default"
+
+
+@pytest.mark.usefixtures("_backend")
+async def test_acquire_or_raise_defaults_to_single_bucket(
+    limiter: RateLimiter,
+) -> None:
+    """`acquire_or_raise` defaults `key` to the single bucket."""
+    # Act & Assert: no key needed, and the deny branch carries the default key.
+    result = await limiter.acquire_or_raise()
+    assert result.allowed is True
+
+    for _ in range(LIMIT - 1):
+        await limiter.acquire()
+    with pytest.raises(RateLimitExceededError) as exc:
+        await limiter.acquire_or_raise()
+    assert exc.value.key == "default"
+
+
+@pytest.mark.usefixtures("_backend")
 async def test_acquire_allowed(limiter: RateLimiter) -> None:
     """Test acquire returns allowed result within limit."""
     # Act

--- a/tests/task/test_cron_task.py
+++ b/tests/task/test_cron_task.py
@@ -14,6 +14,7 @@ from grelmicro.coordination import Coordination
 from grelmicro.coordination.abc import LockPrimitive
 from grelmicro.coordination.errors import LockNotOwnedError
 from grelmicro.coordination.memory import MemoryScheduleAdapter
+from grelmicro.errors import OutOfContextError
 from grelmicro.task._cron import CronTask, FireInfo
 from grelmicro.task.errors import CronError
 from tests.task import samples
@@ -535,3 +536,19 @@ async def test_cron_task_resolves_backend_from_active_app() -> None:
 
     async with micro:
         assert task.backend is schedule
+
+
+async def test_cron_task_backend_none_without_app() -> None:
+    """With no app and no explicit backend, the task runs on every worker."""
+    task = CronTask(expr=EVERY_MINUTE, function=count_execution)
+    assert task.backend is None
+
+
+async def test_cron_task_backend_out_of_context_without_coordination() -> None:
+    """An app without a `Coordination` component raises `OutOfContextError`."""
+    micro = Grelmicro()
+    task = CronTask(expr=EVERY_MINUTE, function=count_execution)
+
+    async with micro:
+        with pytest.raises(OutOfContextError, match="Cron task"):
+            _ = task.backend

--- a/tests/test_external_config.py
+++ b/tests/test_external_config.py
@@ -413,3 +413,14 @@ async def test_poll_loop_applies_on_each_interval() -> None:
                 break
         assert isinstance(rl.config, SlidingWindowConfig)
         assert rl.config.limit > 1
+
+
+def test_resolve_config_from_mapping_ignores_unprefixed_keys() -> None:
+    """A key outside the prefix is skipped without logging or validation."""
+    cfg = TokenBucketConfig(capacity=5, refill_rate=1.0)
+    out = resolve_config_from_mapping(
+        cfg,
+        env_prefix="GREL_RATELIMITER_API_",
+        mapping={"OTHER_PREFIX_CAPACITY": "9"},
+    )
+    assert out is cfg


### PR DESCRIPTION
## What this ships

The DX audit follow-up plus the supply-chain and launch prep.

### API simplifications
- **Default `key="default"`** on `RateLimiter.acquire/acquire_or_raise/allow/peek/reset`. The single-bucket case is `await limiter.allow()`. The limiter `name` already namespaces the backend key.
- **Zero-object `@cached(ttl=30)`**: plain process-local memoization with no `TTLCache` ceremony. It binds a private memory cache at decoration and never resolves the active app. Pass a `TTLCache` for shared state.
- **One error for every ambient miss (breaking)**: `Lock`, `TaskLock`, `LeaderElection`, `TTLCache`, `@cached`, cron schedule resolution, and `Idempotency` now raise `OutOfContextError` with an actionable message, matching `CircuitBreaker` and `RateLimiter`. `NoActiveAppError` stays the low-level `Grelmicro.current()` error.

### Supply chain and launch
- OpenSSF Scorecard workflow (SHA-pinned, zizmor-clean) and badge. PEP 740 attestations were already enabled on release, verified.
- Launch post drafts (Show HN, r/Python, r/FastAPI, dev.to) in `LAUNCH_CHECKLIST.md`.
- Roadmap consolidation: issues #356, #175, #78, #179 migrate to `docs/roadmap.md` lines.

Combined coverage gate at 100 percent, ruff, ty clean.

Fixes #177