### PR TITLE
✨ Add a built-in readiness check per provider with auto_health

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-* ✨ Add a built-in readiness check per provider. Every Provider ships a cheap `check()` probe (Redis and Valkey `PING`, Postgres and SQLite `SELECT 1`). Register it with `health.add_provider(redis)` as a critical `provider:redis` check, or register one for every active provider at once with `HealthChecks(auto_health=True)`. `Grelmicro.providers` lists the active providers.
+* ✨ Add a built-in readiness check per provider. Every connection provider ships a cheap `check()` probe (Redis and Valkey `PING`, Postgres and SQLite `SELECT 1`). Register it with `health.add_provider(redis)` as a critical `provider:redis` check, or register one for every active provider at once with `HealthChecks(auto_health=True)`. `Grelmicro.providers` lists the active providers.
 
 ## 1.0.0a1 - 2026-06-12
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+* ✨ Add a built-in readiness check per provider. Every Provider ships a cheap `check()` probe (Redis and Valkey `PING`, Postgres and SQLite `SELECT 1`). Register it with `health.add_provider(redis)` as a critical `provider:redis` check, or register one for every active provider at once with `HealthChecks(auto_health=True)`. `Grelmicro.providers` lists the active providers.
+
 ## 1.0.0a1 - 2026-06-12
 
 ### Breaking

--- a/docs/health.md
+++ b/docs/health.md
@@ -107,6 +107,26 @@ Raise `HealthError(message, details=...)` to attach a diagnostic payload to a fa
 --8<-- "health/error_details.py"
 ```
 
+## Provider Readiness Checks
+
+Every connection provider ships a built-in readiness probe. Redis and Valkey run `PING`, Postgres and SQLite run `SELECT 1`. These are cheaper and more honest than a borrowed lock round trip, and you no longer hand-write one check per backend.
+
+Register a provider's check with `add_provider`. It registers under `provider:{short_name}`, for example `provider:redis`:
+
+```python
+--8<-- "health/provider_check.py"
+```
+
+The check is **critical** by default, so an unreachable backend fails `/readyz`. Pass `critical=False` for a degradable dependency such as a cache. Pass `name=` to disambiguate two providers of the same vendor, which registers `provider:{name}` instead.
+
+To register a check for every provider on the app at once, build the `HealthChecks` with `auto_health=True`:
+
+```python
+--8<-- "health/auto_health.py"
+```
+
+On startup this discovers every active provider, including ones a Component borrows without listing, and registers a critical `provider:{short_name}` check for each. It is off by default, so checks appear only when you ask for them. When two providers share a `short_name`, the second is skipped with a warning: register it explicitly with `add_provider(provider, name=...)` to give it a distinct name.
+
 ## FastAPI Integration
 
 Add health endpoints to your FastAPI app:

--- a/docs/health.md
+++ b/docs/health.md
@@ -125,7 +125,7 @@ To register a check for every provider on the app at once, build the `HealthChec
 --8<-- "health/auto_health.py"
 ```
 
-On startup this discovers every active provider, including ones a Component borrows without listing, and registers a critical `provider:{short_name}` check for each. It is off by default, so checks appear only when you ask for them. When two providers share a `short_name`, the second is skipped with a warning: register it explicitly with `add_provider(provider, name=...)` to give it a distinct name.
+On startup this discovers every active provider, including ones a Component borrows without listing, and registers a critical `provider:{short_name}` check for each. A provider with no built-in probe is skipped. It is off by default, so checks appear only when you ask for them. When two providers share a `short_name`, the second is skipped with a warning: register it explicitly with `add_provider(provider, name=...)` to give it a distinct name.
 
 ## FastAPI Integration
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -232,6 +232,14 @@ Factories that do not apply raise `NotImplementedError` with a message
 pointing to the right alternative. `Coordination(provider)`, `Cache(provider)`,
 `RateLimiters(provider)`, and `CircuitBreakers(provider)` call these factories.
 
+## Readiness check
+
+Every Provider ships a built-in `check()` readiness probe: Redis and Valkey run
+`PING`, Postgres and SQLite run `SELECT 1`. A `HealthChecks` registers it as a
+`provider:{short_name}` check, one provider at a time with
+`health.add_provider(provider)` or for the whole app with
+`HealthChecks(auto_health=True)`. See [Health Checks](health.md#provider-readiness-checks).
+
 ## Valkey
 
 `ValkeyProvider` is a subclass of `RedisProvider`. It connects to a

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -234,8 +234,8 @@ pointing to the right alternative. `Coordination(provider)`, `Cache(provider)`,
 
 ## Readiness check
 
-Every Provider ships a built-in `check()` readiness probe: Redis and Valkey run
-`PING`, Postgres and SQLite run `SELECT 1`. A `HealthChecks` registers it as a
+Every connection provider ships a built-in `check()` readiness probe: Redis and
+Valkey run `PING`, Postgres and SQLite run `SELECT 1`. A `HealthChecks` registers it as a
 `provider:{short_name}` check, one provider at a time with
 `health.add_provider(provider)` or for the whole app with
 `HealthChecks(auto_health=True)`. See [Health Checks](health.md#provider-readiness-checks).

--- a/docs/snippets/health/auto_health.py
+++ b/docs/snippets/health/auto_health.py
@@ -1,0 +1,10 @@
+from grelmicro import Grelmicro
+from grelmicro.health import HealthChecks
+from grelmicro.providers.postgres import PostgresProvider
+from grelmicro.providers.redis import RedisProvider
+
+redis = RedisProvider("redis://localhost:6379")
+postgres = PostgresProvider("postgresql://localhost:5432/app")
+
+# Registers "provider:redis" and "provider:postgres" critical checks on startup.
+micro = Grelmicro(uses=[redis, postgres, HealthChecks(auto_health=True)])

--- a/docs/snippets/health/provider_check.py
+++ b/docs/snippets/health/provider_check.py
@@ -1,0 +1,13 @@
+from grelmicro.health import HealthChecks
+from grelmicro.providers.redis import RedisProvider
+
+store = RedisProvider("redis://localhost:6379")
+cache = RedisProvider("redis://localhost:6379/1")
+
+health = HealthChecks()
+
+# Register the provider's built-in readiness check as "provider:redis".
+health.add_provider(store)
+
+# A degradable dependency: visible in /healthz, never fails /readyz.
+health.add_provider(cache, name="cache", critical=False)

--- a/examples/fastapi-demo/app.py
+++ b/examples/fastapi-demo/app.py
@@ -17,7 +17,7 @@ from grelmicro.cache.cached import cached
 from grelmicro.cache.serializers import JsonSerializer
 from grelmicro.coordination import Coordination, LeaderElection, Lock
 from grelmicro.fastapi import GrelmicroMiddleware
-from grelmicro.health import HealthChecks, HealthDetails
+from grelmicro.health import HealthChecks
 from grelmicro.health.fastapi import health_router
 from grelmicro.log import configure
 from grelmicro.providers.postgres import PostgresProvider
@@ -48,7 +48,9 @@ tasks = Tasks()
 leader = LeaderElection("demo-leader")
 tasks.add_task(leader)
 
-health = HealthChecks()
+# auto_health registers a provider:{short_name} readiness check for every
+# active provider, so /readyz probes Redis and Postgres with no boilerplate.
+health = HealthChecks(auto_health=True)
 
 micro = Grelmicro(
     uses=[
@@ -60,13 +62,6 @@ micro = Grelmicro(
         tasks,
     ]
 )
-
-
-@health.check("redis")
-async def check_redis() -> HealthDetails | None:
-    # Readiness probe: a lock round-trip proves Redis is reachable.
-    await Lock("healthz").locked()
-    return None
 
 
 @asynccontextmanager

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -493,6 +493,22 @@ class Grelmicro:
         return tuple(self._by_key.values())
 
     @property
+    def providers(self) -> tuple[Provider, ...]:
+        """Active `Provider` instances, in registration order, deduped by identity.
+
+        Includes Providers listed in `uses=` and those adopted from
+        Components that borrow them (see `_discover_shared_providers`). One
+        Provider feeding several Components appears once. Useful for
+        introspection and for `HealthChecks(auto_health=True)`, which
+        registers a `provider:{short_name}` check per entry.
+        """
+        seen: dict[int, Provider] = {}
+        for item in self._items:
+            if isinstance(item, Provider) and id(item) not in seen:
+                seen[id(item)] = item
+        return tuple(seen.values())
+
+    @property
     def coordination(self) -> Coordination:
         """The registered `Coordination` component.
 

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -222,10 +222,17 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
             str,
             Doc("Registration name. Defaults to `'default'`."),
         ] = "default",
+        auto_health: Annotated[
+            bool,
+            Doc(
+                "Register a `provider:{short_name}` readiness check for "
+                "every active `Provider` on startup. Off by default."
+            ),
+        ] = False,
     ) -> Self:
         """Construct a `HealthChecks` from a pre-built `HealthChecksConfig`."""
         instance = cls.__new__(cls)
-        instance._setup(config, name=name)  # noqa: SLF001
+        instance._setup(config, name=name, auto_health=auto_health)  # noqa: SLF001
         return instance
 
     def _setup(
@@ -411,12 +418,13 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
         """Register a critical check for every Provider active on the app.
 
         Called from `__aenter__` when `auto_health` is on. A provider with
-        no readiness check is skipped. A name already bound to this same
-        provider (an explicit `add_provider`, or a second `__aenter__`) is
+        no readiness check is skipped. A provider already registered under
+        any name (an explicit `add_provider`, or a second `__aenter__`) is
         left untouched, so the explicit registration wins and re-entry is
-        idempotent. A name held by a different check (two providers of the
-        same vendor) is skipped with a warning, pointing at the explicit
-        `add_provider(provider, name=...)` form.
+        idempotent. A `provider:{short_name}` name held by a different
+        provider (two providers of the same vendor) is skipped with a
+        warning, pointing at the explicit `add_provider(provider, name=...)`
+        form.
         """
         from grelmicro._app import Grelmicro  # noqa: PLC0415
         from grelmicro.providers._base import Provider  # noqa: PLC0415
@@ -424,20 +432,21 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
         for provider in Grelmicro.current().providers:
             if type(provider).check is Provider.check:
                 continue
-            check_name = f"provider:{provider.short_name}"
-            existing = self._entries.get(check_name)
-            if existing is not None:
-                if existing.func != provider.check:
-                    logger.warning(
-                        "auto_health: %r is already registered, skipping "
-                        "%r. Register it with "
-                        "health.add_provider(provider, name=...) to give "
-                        "it a distinct name.",
-                        check_name,
-                        provider,
-                    )
+            check = provider.check
+            if any(entry.func == check for entry in self._entries.values()):
                 continue
-            self.add(check_name, provider.check, critical=True)
+            check_name = f"provider:{provider.short_name}"
+            if check_name in self._entries:
+                logger.warning(
+                    "auto_health: %r is already registered, skipping %r. "
+                    "Register it with "
+                    "health.add_provider(provider, name=...) to give it a "
+                    "distinct name.",
+                    check_name,
+                    provider,
+                )
+                continue
+            self.add(check_name, check, critical=True)
 
     async def run(
         self,

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from logging import getLogger
 from types import TracebackType
-from typing import Annotated, ClassVar, Self
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self
 
 from pydantic import BaseModel, NonNegativeFloat, PositiveFloat
 from typing_extensions import Doc
@@ -26,6 +26,9 @@ from grelmicro.health._types import (
 )
 from grelmicro.health.errors import HealthError
 from grelmicro.metrics import _emit
+
+if TYPE_CHECKING:
+    from grelmicro.providers._base import Provider
 
 logger = getLogger("grelmicro.health")
 
@@ -174,6 +177,18 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
                 """
             ),
         ] = None,
+        auto_health: Annotated[
+            bool,
+            Doc(
+                """
+                Register a `provider:{short_name}` readiness check for
+                every `Provider` active on the app, on startup. Off by
+                default. Each registered check is critical, so an
+                unreachable backend fails `/readyz`. For finer control,
+                leave this off and call `add_provider` per provider.
+                """
+            ),
+        ] = False,
     ) -> None:
         """Initialize the health checks."""
         config = resolve_config(
@@ -183,7 +198,7 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
             env_prefix=env_prefix or "GREL_HEALTH_",
             env_load=env_load,
         )
-        self._setup(config, name=name)
+        self._setup(config, name=name, auto_health=auto_health)
 
     @classmethod
     def from_config(
@@ -214,11 +229,16 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
         return instance
 
     def _setup(
-        self, config: HealthChecksConfig, *, name: str = "default"
+        self,
+        config: HealthChecksConfig,
+        *,
+        name: str = "default",
+        auto_health: bool = False,
     ) -> None:
         """Wire the validated config and runtime deps onto the instance."""
         self._name = name
         self._config = config
+        self._auto_health = auto_health
         self._reconfigure_lock = asyncio.Lock()
         self._entries: dict[str, _Entry] = {}
 
@@ -228,7 +248,13 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
         return self._name
 
     async def __aenter__(self) -> Self:
-        """Open the health checks."""
+        """Open the health checks.
+
+        When `auto_health` is on, register one `provider:{short_name}`
+        check per Provider active on the app.
+        """
+        if self._auto_health:
+            self._register_active_providers()
         return self
 
     async def __aexit__(
@@ -328,6 +354,90 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
             return func
 
         return decorator
+
+    def add_provider(
+        self,
+        provider: Annotated[
+            "Provider",
+            Doc("The provider whose built-in readiness check to register."),
+        ],
+        *,
+        name: Annotated[
+            str | None,
+            Doc(
+                "Check name suffix. Defaults to the provider's "
+                "``short_name``, so the check is ``provider:redis``. "
+                "Pass an explicit name to disambiguate two providers of "
+                "the same vendor, e.g. ``name='sessions'`` registers "
+                "``provider:sessions``."
+            ),
+        ] = None,
+        critical: Annotated[
+            bool,
+            Doc(
+                "Whether the check affects ``/readyz``. Critical by "
+                "default: an unreachable backend fails readiness. Pass "
+                "``critical=False`` for a degradable dependency such as "
+                "a cache."
+            ),
+        ] = True,
+        timeout: Annotated[
+            PositiveFloat | None,
+            Doc("Per-check timeout override. Falls back to the default."),
+        ] = None,
+    ) -> None:
+        """Register a provider's built-in readiness check as ``provider:{name}``.
+
+        Raises:
+            ValueError: If the provider ships no readiness check, or the
+                resulting name is already registered.
+        """
+        from grelmicro.providers._base import Provider  # noqa: PLC0415
+
+        if type(provider).check is Provider.check:
+            msg = (
+                f"{type(provider).__name__} ships no readiness check. "
+                f"Register a custom check with health.check(...) instead."
+            )
+            raise ValueError(msg)
+        self.add(
+            f"provider:{name or provider.short_name}",
+            provider.check,
+            critical=critical,
+            timeout=timeout,
+        )
+
+    def _register_active_providers(self) -> None:
+        """Register a critical check for every Provider active on the app.
+
+        Called from `__aenter__` when `auto_health` is on. A provider with
+        no readiness check is skipped. A name already bound to this same
+        provider (an explicit `add_provider`, or a second `__aenter__`) is
+        left untouched, so the explicit registration wins and re-entry is
+        idempotent. A name held by a different check (two providers of the
+        same vendor) is skipped with a warning, pointing at the explicit
+        `add_provider(provider, name=...)` form.
+        """
+        from grelmicro._app import Grelmicro  # noqa: PLC0415
+        from grelmicro.providers._base import Provider  # noqa: PLC0415
+
+        for provider in Grelmicro.current().providers:
+            if type(provider).check is Provider.check:
+                continue
+            check_name = f"provider:{provider.short_name}"
+            existing = self._entries.get(check_name)
+            if existing is not None:
+                if existing.func != provider.check:
+                    logger.warning(
+                        "auto_health: %r is already registered, skipping "
+                        "%r. Register it with "
+                        "health.add_provider(provider, name=...) to give "
+                        "it a distinct name.",
+                        check_name,
+                        provider,
+                    )
+                continue
+            self.add(check_name, provider.check, critical=True)
 
     async def run(
         self,

--- a/grelmicro/providers/_base.py
+++ b/grelmicro/providers/_base.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
         LockBackend,
         ScheduleBackend,
     )
+    from grelmicro.health._types import HealthDetails
     from grelmicro.resilience._protocol import (
         CircuitBreakerBackend,
         RateLimiterBackend,
@@ -121,5 +122,22 @@ class Provider(AbstractAsyncContextManager["Provider"]):
         msg = (
             f"{type(self).__name__} has no circuit breaker adapter. "
             f"Pass a CircuitBreakerBackend instance to CircuitBreakers(...) directly."
+        )
+        raise NotImplementedError(msg)
+
+    async def check(self) -> HealthDetails | None:
+        """Run a cheap readiness probe against the backend.
+
+        A `HealthChecks` registers this as a `provider:{short_name}` check
+        via `add_provider` or `auto_health`. Returns `None` on success.
+        Raises on failure: the exception surfaces in the health report and
+        flips the check to `error`.
+
+        Raises:
+            NotImplementedError: If this Provider has no backend to probe.
+        """
+        msg = (
+            f"{type(self).__name__} has no readiness check. "
+            f"Register a custom check with health.check(...) instead."
         )
         raise NotImplementedError(msg)

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -302,6 +302,10 @@ class PostgresProvider(Provider):
 
         return PostgresCircuitBreakerAdapter(provider=self, **kwargs)
 
+    async def check(self) -> None:
+        """Run `SELECT 1` to prove the pool can serve a connection."""
+        await self.client.fetchval("SELECT 1")
+
     async def __aenter__(self) -> Self:
         """Open the asyncpg pool when the provider owns it."""
         if self._pool is None:

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -442,6 +442,10 @@ class RedisProvider(Provider):
 
         return RedisCircuitBreakerAdapter(provider=self, **kwargs)
 
+    async def check(self) -> None:
+        """`PING` Redis to prove the connection is reachable."""
+        await self._client.ping()
+
     async def __aenter__(self) -> Self:
         """Open the provider. The client is already constructed eagerly."""
         return self

--- a/grelmicro/providers/sqlite.py
+++ b/grelmicro/providers/sqlite.py
@@ -248,6 +248,11 @@ class SQLiteProvider(Provider):
 
         return SQLiteCircuitBreakerAdapter(provider=self, **kwargs)
 
+    async def check(self) -> None:
+        """Run `SELECT 1` to prove the connection is open."""
+        async with self._lock, self.client.execute("SELECT 1"):
+            pass
+
     async def __aenter__(self) -> Self:
         """Open the connection when the provider owns it."""
         if self._conn is None:

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -174,7 +174,7 @@
     "HealthCheckFunc": null,
     "HealthChecks": {
       "()": "(*, name=..., timeout=..., cache_ttl=..., env_prefix=..., env_load=..., auto_health=...)",
-      ".from_config": "(config, *, name=...)"
+      ".from_config": "(config, *, name=..., auto_health=...)"
     },
     "HealthChecksConfig": {
       "()": "(*, timeout=..., cache_ttl=...)"

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -173,7 +173,7 @@
     "CheckResult": null,
     "HealthCheckFunc": null,
     "HealthChecks": {
-      "()": "(*, name=..., timeout=..., cache_ttl=..., env_prefix=..., env_load=...)",
+      "()": "(*, name=..., timeout=..., cache_ttl=..., env_prefix=..., env_load=..., auto_health=...)",
       ".from_config": "(config, *, name=...)"
     },
     "HealthChecksConfig": {

--- a/tests/health/test_provider_checks.py
+++ b/tests/health/test_provider_checks.py
@@ -1,0 +1,216 @@
+"""Tests for provider readiness checks (`add_provider`, `auto_health`)."""
+
+from typing import Self
+
+import pytest
+
+from grelmicro import Grelmicro
+from grelmicro.health._checks import HealthChecks
+from grelmicro.health._models import HealthStatus
+from grelmicro.providers._base import Provider
+
+pytestmark = [pytest.mark.timeout(1)]
+
+
+class FakeProvider(Provider):
+    """Minimal provider with a stub readiness check, no real backend."""
+
+    def __init__(
+        self, short_name: str = "fake", *, healthy: bool = True
+    ) -> None:
+        """Record the vendor name and the desired check outcome."""
+        self.short_name = short_name  # type: ignore[misc]  # ty: ignore[invalid-attribute-access]
+        self._healthy = healthy
+        self.calls = 0
+
+    async def check(self) -> None:
+        """Count the call and raise when configured unhealthy."""
+        self.calls += 1
+        if not self._healthy:
+            msg = "backend down"
+            raise ConnectionError(msg)
+
+    async def __aenter__(self) -> Self:
+        """Open the provider (no-op)."""
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        """Close the provider (no-op)."""
+
+
+class NoCheckProvider(Provider):
+    """Provider without a readiness check, like a backend-less provider."""
+
+    short_name = "nocheck"
+
+    async def __aenter__(self) -> Self:
+        """Open the provider (no-op)."""
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        """Close the provider (no-op)."""
+
+
+class TestAddProvider:
+    """Tests for `HealthChecks.add_provider`."""
+
+    async def test_registers_provider_short_name(self) -> None:
+        """The check is registered under `provider:{short_name}`."""
+        health = HealthChecks(cache_ttl=0)
+        provider = FakeProvider("redis")
+
+        health.add_provider(provider)
+
+        report = await health.run()
+        assert "provider:redis" in report["checks"]
+        assert report["checks"]["provider:redis"]["status"] == HealthStatus.OK
+        assert provider.calls == 1
+
+    async def test_critical_by_default(self) -> None:
+        """An unreachable provider flips the aggregate to error."""
+        health = HealthChecks(cache_ttl=0)
+        health.add_provider(FakeProvider("redis", healthy=False))
+
+        report = await health.run()
+        assert report["checks"]["provider:redis"]["critical"] is True
+        assert report["status"] == HealthStatus.ERROR
+
+    async def test_critical_false_does_not_flip_aggregate(self) -> None:
+        """A non-critical provider failure stays out of the aggregate."""
+        health = HealthChecks(cache_ttl=0)
+        health.add_provider(
+            FakeProvider("cache", healthy=False), critical=False
+        )
+
+        report = await health.run()
+        assert report["checks"]["provider:cache"]["critical"] is False
+        assert report["status"] == HealthStatus.OK
+
+    async def test_name_override(self) -> None:
+        """An explicit name registers `provider:{name}` instead."""
+        health = HealthChecks(cache_ttl=0)
+        health.add_provider(FakeProvider("redis"), name="sessions")
+
+        report = await health.run()
+        assert "provider:sessions" in report["checks"]
+        assert "provider:redis" not in report["checks"]
+
+    async def test_timeout_override(self) -> None:
+        """An explicit timeout is applied to the registered check."""
+        timeout = 2.0
+        health = HealthChecks(cache_ttl=0)
+        health.add_provider(FakeProvider("redis"), timeout=timeout)
+
+        assert health._entries["provider:redis"].timeout == timeout
+
+    def test_provider_without_check_raises(self) -> None:
+        """A provider that ships no readiness check raises ValueError."""
+        health = HealthChecks()
+        with pytest.raises(ValueError, match="no readiness check"):
+            health.add_provider(NoCheckProvider())
+
+    async def test_base_check_raises_not_implemented(self) -> None:
+        """The base `Provider.check` raises `NotImplementedError`."""
+        with pytest.raises(NotImplementedError, match="no readiness check"):
+            await NoCheckProvider().check()
+
+    def test_duplicate_name_raises(self) -> None:
+        """Registering the same provider name twice raises."""
+        health = HealthChecks()
+        health.add_provider(FakeProvider("redis"))
+        with pytest.raises(ValueError, match="already registered"):
+            health.add_provider(FakeProvider("redis"))
+
+
+class TestAutoHealth:
+    """Tests for `HealthChecks(auto_health=True)`."""
+
+    async def test_registers_every_active_provider(self) -> None:
+        """Every active provider gets a critical `provider:{short_name}` check."""
+        redis = FakeProvider("redis")
+        postgres = FakeProvider("postgres")
+        health = HealthChecks(cache_ttl=0, auto_health=True)
+        micro = Grelmicro(uses=[redis, postgres, health])
+
+        async with micro:
+            report = await health.run()
+
+        assert set(report["checks"]) == {"provider:redis", "provider:postgres"}
+        assert all(c["critical"] for c in report["checks"].values())
+        assert redis.calls == 1
+        assert postgres.calls == 1
+
+    async def test_off_by_default(self) -> None:
+        """Without the flag, no provider checks are registered."""
+        health = HealthChecks(cache_ttl=0)
+        micro = Grelmicro(uses=[FakeProvider("redis"), health])
+
+        async with micro:
+            report = await health.run()
+
+        assert report["checks"] == {}
+
+    async def test_skips_provider_without_check(self) -> None:
+        """A provider with no readiness check is skipped, not an error."""
+        health = HealthChecks(cache_ttl=0, auto_health=True)
+        micro = Grelmicro(
+            uses=[NoCheckProvider(), FakeProvider("redis"), health]
+        )
+
+        async with micro:
+            report = await health.run()
+
+        assert set(report["checks"]) == {"provider:redis"}
+
+    async def test_duplicate_vendor_skipped_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A second provider of the same vendor is skipped with a warning."""
+        health = HealthChecks(cache_ttl=0, auto_health=True)
+        micro = Grelmicro(
+            uses=[FakeProvider("redis"), FakeProvider("redis"), health]
+        )
+
+        with caplog.at_level("WARNING", logger="grelmicro.health"):
+            async with micro:
+                report = await health.run()
+
+        assert set(report["checks"]) == {"provider:redis"}
+        assert "already registered" in caplog.text
+
+    async def test_explicit_registration_wins_without_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An explicit add_provider keeps its settings and warns nothing."""
+        redis = FakeProvider("redis")
+        health = HealthChecks(cache_ttl=0, auto_health=True)
+        health.add_provider(redis, critical=False)
+        micro = Grelmicro(uses=[redis, health])
+
+        with caplog.at_level("WARNING", logger="grelmicro.health"):
+            async with micro:
+                report = await health.run()
+
+        assert report["checks"]["provider:redis"]["critical"] is False
+        assert "already registered" not in caplog.text
+
+
+class TestProvidersProperty:
+    """Tests for `Grelmicro.providers`."""
+
+    def test_lists_providers_deduped_by_identity(self) -> None:
+        """Listed providers appear once, in registration order.
+
+        A `HealthChecks` component is present so the bare providers are
+        lifecycle-only (no default-component registration).
+        """
+        redis = FakeProvider("redis")
+        postgres = FakeProvider("postgres")
+        micro = Grelmicro(uses=[redis, postgres, redis, HealthChecks()])
+
+        assert micro.providers == (redis, postgres)
+
+    def test_empty_when_no_providers(self) -> None:
+        """An app with no providers reports an empty tuple."""
+        micro = Grelmicro(uses=[HealthChecks()])
+        assert micro.providers == ()

--- a/tests/health/test_provider_checks.py
+++ b/tests/health/test_provider_checks.py
@@ -194,6 +194,22 @@ class TestAutoHealth:
         assert report["checks"]["provider:redis"]["critical"] is False
         assert "already registered" not in caplog.text
 
+    async def test_explicit_custom_name_suppresses_auto_check(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An explicit custom name skips the auto `provider:{short_name}` check."""
+        redis = FakeProvider("redis")
+        health = HealthChecks(cache_ttl=0, auto_health=True)
+        health.add_provider(redis, name="cache", critical=False)
+        micro = Grelmicro(uses=[redis, health])
+
+        with caplog.at_level("WARNING", logger="grelmicro.health"):
+            async with micro:
+                report = await health.run()
+
+        assert set(report["checks"]) == {"provider:cache"}
+        assert "already registered" not in caplog.text
+
 
 class TestProvidersProperty:
     """Tests for `Grelmicro.providers`."""

--- a/tests/providers/test_postgres_provider.py
+++ b/tests/providers/test_postgres_provider.py
@@ -183,6 +183,28 @@ class TestFromClient:
         pool.close.assert_awaited_once()
 
 
+class TestCheck:
+    """Tests for `PostgresProvider.check` readiness probe."""
+
+    async def test_check_selects_one(self) -> None:
+        """`check` runs `SELECT 1` on the pool and returns None."""
+        pool = MagicMock()
+        pool.fetchval = AsyncMock(return_value=1)
+
+        provider = PostgresProvider.from_client(pool)
+        assert await provider.check() is None
+        pool.fetchval.assert_awaited_once_with("SELECT 1")
+
+    async def test_check_propagates_failure(self) -> None:
+        """A query failure surfaces from `check`."""
+        pool = MagicMock()
+        pool.fetchval = AsyncMock(side_effect=ConnectionError("down"))
+
+        provider = PostgresProvider.from_client(pool)
+        with pytest.raises(ConnectionError):
+            await provider.check()
+
+
 class TestSafeUrl:
     """`safe_url` and `repr` must redact passwords."""
 

--- a/tests/providers/test_redis_provider.py
+++ b/tests/providers/test_redis_provider.py
@@ -181,6 +181,28 @@ class TestFromClient:
         client.aclose.assert_awaited_once()
 
 
+class TestCheck:
+    """Tests for `RedisProvider.check` readiness probe."""
+
+    async def test_check_pings(self) -> None:
+        """`check` pings the client and returns None on success."""
+        client = MagicMock()
+        client.ping = AsyncMock()
+
+        provider = RedisProvider.from_client(client)
+        assert await provider.check() is None
+        client.ping.assert_awaited_once()
+
+    async def test_check_propagates_failure(self) -> None:
+        """A ping failure surfaces from `check`."""
+        client = MagicMock()
+        client.ping = AsyncMock(side_effect=ConnectionError("down"))
+
+        provider = RedisProvider.from_client(client)
+        with pytest.raises(ConnectionError):
+            await provider.check()
+
+
 class TestSafeUrl:
     """`safe_url` and `repr` must redact passwords."""
 

--- a/tests/providers/test_sqlite_provider.py
+++ b/tests/providers/test_sqlite_provider.py
@@ -107,3 +107,20 @@ async def test_from_client_owns_when_requested(tmp_path: Path) -> None:
     # Owned: closed on exit, so the client is no longer available.
     with pytest.raises(OutOfContextError):
         _ = provider.client
+
+
+async def test_check_runs_select_one(tmp_path: Path) -> None:
+    """`check` runs `SELECT 1` on the connection and returns None."""
+    provider = SQLiteProvider(tmp_path / "check.db")
+    async with provider:
+        assert await provider.check() is None
+
+
+async def test_check_propagates_failure(tmp_path: Path) -> None:
+    """A query failure on the connection surfaces from `check`."""
+    conn = await aiosqlite.connect(tmp_path / "byo.db", isolation_level=None)
+    provider = SQLiteProvider.from_client(conn)  # not owned: we close it
+    async with provider:
+        await conn.close()  # force the next query to fail
+        with pytest.raises(Exception, match=r"(?i)connection"):
+            await provider.check()

--- a/tests/providers/test_valkey_provider.py
+++ b/tests/providers/test_valkey_provider.py
@@ -202,6 +202,19 @@ class TestFromClient:
         client.aclose.assert_awaited_once()
 
 
+class TestCheck:
+    """`ValkeyProvider` inherits the Redis `PING` readiness probe."""
+
+    async def test_check_pings(self) -> None:
+        """`check` pings the client and returns None on success."""
+        client = MagicMock()
+        client.ping = AsyncMock()
+
+        provider = ValkeyProvider.from_client(client)
+        assert await provider.check() is None
+        client.ping.assert_awaited_once()
+
+
 class TestSafeUrl:
     """`safe_url` and `repr` must redact passwords."""
 


### PR DESCRIPTION
Closes #363.

Every grelmicro app that exposes `/readyz` wants to answer "can I reach my backends?" Today the user hand-rolls one check per provider. The demo proved the friction by probing Redis with a borrowed `Lock("healthz").locked()` round trip, which is neither the cheapest nor the most honest readiness signal for a connection pool.

## What this adds

* `Provider.check()`: an async readiness probe on every connection provider. Redis and Valkey run `PING`, Postgres and SQLite run `SELECT 1`. The base method raises `NotImplementedError`, so a provider with no backend opts out.
* `HealthChecks.add_provider(provider, *, name=None, critical=True, timeout=None)`: registers the probe as a `provider:{short_name}` check. Critical by default, so an unreachable backend fails `/readyz`. Pass `critical=False` for a degradable dependency such as a cache, or `name=` to disambiguate two providers of the same vendor.
* `HealthChecks(auto_health=True)`: off by default. On startup it discovers every active provider (including ones a Component borrows without listing) and registers a critical `provider:{short_name}` check for each. An explicit `add_provider` wins, and re-entry is idempotent. A second provider of the same vendor is skipped with a warning.
* `Grelmicro.providers`: lists active providers, deduped by identity.

## Settled decisions

* `auto_health` defaults to **off** (explicit opt-in, no-magic stance).
* Provider checks default to **critical** (matches the demo they replace and the `/readyz` framing).

## Demo

The FastAPI demo drops its hand-rolled `check_redis` for `HealthChecks(auto_health=True)`, which now probes both Redis and Postgres with no boilerplate.

## Tests and docs

Per-provider `check()` tests, full `add_provider` and `auto_health` coverage, a `Grelmicro.providers` test, a new "Provider Readiness Checks" docs section with runnable snippets, a `providers.md` note, and a changelog entry. The public-API snapshot is updated for the new `auto_health` parameter.