### PR TITLE
📝 Fix verified docs drift across provider matrix, lock cleanup, and stale claims

### DIFF
--- a/docs/architecture/coordination.md
+++ b/docs/architecture/coordination.md
@@ -52,14 +52,14 @@ This prevents accidental collisions between different primitive types sharing th
 Expired locks are never actively removed during normal operation. Instead, all backends use a **lazy filtering** strategy combined with **cleanup on exit**:
 
 1. **Lazy filtering**: Every `locked()`, `owned()`, and `acquire()` call includes an expiry check (`expire_at >= now`), so expired locks are simply ignored without requiring deletion.
-2. **Cleanup on exit**: When the backend context manager exits (`__aexit__`), all expired locks are deleted in bulk. This keeps storage clean across graceful restarts.
+2. **Cleanup on exit**: When the backend context manager exits (`__aexit__`), expired locks are vacated in place. This keeps storage clean across graceful restarts.
 
 If the process crashes without exiting the context manager, expired locks remain in storage but are harmless: they will be filtered out by all subsequent operations and cleaned up on the next graceful shutdown.
 
 ### Backend-specific cleanup
 
-- **SQLite / PostgreSQL**: A single bulk `DELETE ... WHERE expire_at < now` removes all stale rows before closing the connection.
-- **Kubernetes**: Lists all Lease resources labeled `app.kubernetes.io/managed-by: grelmicro` and deletes each expired lease individually. The Kubernetes API does not support bulk conditional deletion. `NOT_FOUND` errors are silently ignored to handle concurrent deletions.
+- **SQLite / PostgreSQL**: A single bulk `UPDATE ... SET token = NULL, expire_at = NULL WHERE expire_at < now` clears all stale rows before closing the connection. The row is kept so the fence counter survives across restart cycles.
+- **Kubernetes**: Lists all Lease resources labeled `app.kubernetes.io/managed-by: grelmicro` and vacates each expired lease in place by clearing `holderIdentity`, `acquireTime`, and `renewTime` via a REPLACE. The Lease object is never deleted, so `spec.leaseTransitions` survives across release and re-acquire cycles. `NOT_FOUND` errors are silently ignored.
 
 ## Fencing token guarantees
 

--- a/docs/architecture/kubernetes.md
+++ b/docs/architecture/kubernetes.md
@@ -19,7 +19,7 @@ The backend uses **Lease** resources from the `coordination.k8s.io/v1` API group
 The backend uses Kubernetes **resourceVersion** for optimistic concurrency control:
 
 - **Acquire**: GET the Lease. If 404 → CREATE. If expired or same token → REPLACE (with resourceVersion). If held by another → return `False`. On 409 Conflict → return `False`.
-- **Release**: GET the Lease. If token matches and not expired → DELETE. Otherwise `False`.
+- **Release**: GET the Lease. If token matches and not expired → REPLACE clearing `holderIdentity`, `acquireTime`, and `renewTime` (vacate in place, never DELETE). Otherwise `False`.
 - **Locked**: GET the Lease. Check `renewTime + leaseDurationSeconds >= now`.
 - **Owned**: GET the Lease. Check `holderIdentity == token` and `renewTime + leaseDurationSeconds >= now`.
 

--- a/docs/architecture/multiple-apps.md
+++ b/docs/architecture/multiple-apps.md
@@ -6,11 +6,11 @@ A `Grelmicro` app is a plain async context manager, so you can construct as many
 
 Most components keep their state on the instance: `Coordination`, `Cache`, `RateLimiters`, `CircuitBreakers`, and `HealthChecks` all hold their own backend, so two overlapping apps never touch each other. They run concurrently with no special handling, the same way a web framework lets you instantiate two `App` objects.
 
-`Log`, `Trace`, and `Metrics` are different. They configure **process-global** state (the stdlib root logger, the OpenTelemetry tracer and meter providers) and restore the previous value on exit. Within one app the exit stack restores in reverse order, so nesting is safe. Across two overlapping apps there is no such ordering guarantee: the first to exit would restore the global and clobber the second app's configuration.
+`Log` and `Trace` are different. They configure **process-global** state (the stdlib root logger and the OpenTelemetry tracer provider) and restore the previous value on exit. Within one app the exit stack restores in reverse order, so nesting is safe. Across two overlapping apps there is no such ordering guarantee: the first to exit would restore the global and clobber the second app's configuration.
 
-Because they own a single global, these components are singletons: registering a second `Log` (or `Trace`, or `Metrics`) on the same app raises `ComponentAlreadyRegisteredError`, even under a different name. There is only one root logger to configure, so a second instance has nothing of its own to own.
+Because they own a single global, these components are singletons: registering a second `Log` (or `Trace`) on the same app raises `ComponentAlreadyRegisteredError`, even under a different name. There is only one root logger to configure, so a second instance has nothing of its own to own.
 
-So grelmicro also blocks the cross-app case that is unsafe: opening a second app that owns `Log`, `Trace`, or `Metrics` while another app that owns one is still active raises `MultipleActiveAppsError`. Apps without those components overlap freely.
+So grelmicro also blocks the cross-app case that is unsafe: opening a second app that owns `Log` or `Trace` while another app that owns one is still active raises `MultipleActiveAppsError`. Apps without those components overlap freely.
 
 ```python
 # Fine: neither app owns process-global state.

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -16,7 +16,7 @@ A Provider covers the vendor axis: one Provider per vendor. An Adapter covers
 the algorithm axis within a kind, so several adapters can share one Provider
 (a Redis lock and a Redis cache both run on `RedisProvider`).
 
-The component kinds are `coordination`, `coordination.election`, `cache`,
+The component kinds are `coordination`, `coordination.election`, `coordination.schedule`, `cache`,
 `ratelimiter`, and `circuitbreaker`.
 
 ## Publish a third-party adapter

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -71,7 +71,7 @@ into a `Grelmicro` app via the `Cache` component. For Redis, pass the
     from grelmicro.providers.sqlite import SQLiteProvider
 
     sqlite = SQLiteProvider("app.db")
-    micro = Grelmicro(uses=[sqlite, Cache(sqlite)])
+    micro = Grelmicro(uses=[Cache(sqlite)])
     ```
 
 `async with micro:` opens the provider and the cache backend together.
@@ -329,9 +329,13 @@ A flaky upstream then degrades to slightly stale data instead of an error storm.
 
 ### Decorator Parameters
 
+`cache` and `ttl` are mutually exclusive. Pass one or the other, not both.
+
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `cache` | `TTLCache` | required | The cache instance to store results in. |
+| `cache` | `TTLCache` | `None` | The cache instance to store results in. Mutually exclusive with `ttl`. |
+| `ttl` | `float` | `None` | TTL in seconds for a private per-function cache. Mutually exclusive with `cache`. |
+| `maxsize` | `int` | `128` | Maximum number of entries in the private per-function cache (used only when `ttl` is set). |
 | `key_maker` | `Callable` | `None` | Custom key generation function. Receives `(func, args, kwargs)`. |
 | `skip` | `Callable` | `None` | Predicate receiving the result. Returns `True` to skip caching. |
 | `typed` | `bool` | `False` | Cache arguments of different types separately. |

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -335,7 +335,7 @@ A flaky upstream then degrades to slightly stale data instead of an error storm.
 |---|---|---|---|
 | `cache` | `TTLCache` | `None` | The cache instance to store results in. Mutually exclusive with `ttl`. |
 | `ttl` | `float` | `None` | TTL in seconds for a private per-function cache. Mutually exclusive with `cache`. |
-| `maxsize` | `int` | `128` | Maximum number of entries in the private per-function cache (used only when `ttl` is set). |
+| `maxsize` | `int` | `0` | Max entries in the private per-function cache, `0` means unlimited (used only when `ttl` is set). |
 | `key_maker` | `Callable` | `None` | Custom key generation function. Receives `(func, args, kwargs)`. |
 | `skip` | `Callable` | `None` | Predicate receiving the result. Returns `True` to skip caching. |
 | `typed` | `bool` | `False` | Cache arguments of different types separately. |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -19,7 +19,7 @@ See [Backends and Adapters](architecture/backends.md) for the full model.
 | ------------------- | :------------------------------------------------------------: | :------------------------------------------------------------: | :------------------------------------------------------------: | :------------------------------------------------------------: | :--------: |
 | `Lock`              | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | ✅         |
 | `TaskLock`          | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | ✅         |
-| `LeaderElection`    | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | ✅         |
+| `LeaderElection`    | ✅                                                             | ✅                                                             | ✅                                                             | N/A                                                            | ✅         |
 | `Schedule` (cron)   | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | N/A        |
 | `TTLCache`          | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | N/A        |
 | `RateLimiter`       | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | N/A        |
@@ -32,7 +32,7 @@ See [Backends and Adapters](architecture/backends.md) for the full model.
 Legend:
 
 - ✅ ships today.
-- `N/A` does not apply. `Retry`, `Bulkhead`, `Fallback`, and `Timeout` are in-process Patterns with no remote state to share. For `Schedule` (cron), Kubernetes has no Adapter on purpose: run a native [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) instead.
+- `N/A` does not apply. `Retry`, `Bulkhead`, `Fallback`, and `Timeout` are in-process Patterns with no remote state to share. For `Schedule` (cron), Kubernetes has no Adapter on purpose: run a native [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) instead. For `LeaderElection`, SQLite has no adapter: leader election is meaningful only across multiple nodes, and SQLite does not coordinate across nodes.
 
 ## Picking an Adapter
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -38,7 +38,7 @@ What you get from a single import:
 | Pattern | grelmicro class | Backends |
 |---|---|---|
 | Distributed lock | `Lock` | Redis, PostgreSQL, SQLite, Kubernetes Lease, Memory |
-| Leader election | `LeaderElection` | same as `Lock` |
+| Leader election | `LeaderElection` | Redis, PostgreSQL, Kubernetes Lease, Memory (no SQLite) |
 | Scheduled-task lock | `TaskLock` | same as `Lock` |
 | Cache decorator + TTL store | `Cache`, `TTLCache[T]`, `@cached` | Redis, Memory, Postgres, SQLite |
 | Rate limiter | `RateLimiter` (token bucket, sliding window) | Redis, Memory, Postgres, SQLite |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -40,9 +40,9 @@ What you get from a single import:
 | Distributed lock | `Lock` | Redis, PostgreSQL, SQLite, Kubernetes Lease, Memory |
 | Leader election | `LeaderElection` | same as `Lock` |
 | Scheduled-task lock | `TaskLock` | same as `Lock` |
-| Cache decorator + TTL store | `Cache`, `TTLCache[T]`, `@cached` | Redis, Memory, Postgres |
+| Cache decorator + TTL store | `Cache`, `TTLCache[T]`, `@cached` | Redis, Memory, Postgres, SQLite |
 | Rate limiter | `RateLimiter` (token bucket, sliding window) | Redis, Memory, Postgres, SQLite |
-| Circuit breaker | `CircuitBreaker` | Redis, Memory, Postgres |
+| Circuit breaker | `CircuitBreaker` | Redis, Memory, Postgres, SQLite |
 | Retry | `Retry`, `@retry` | n/a (in-process) |
 | Health checks | `HealthChecks` + `/livez` `/readyz` `/healthz` router | n/a |
 | Scheduled tasks | `Tasks`, `TaskRouter`, `@interval`, `@cron` | n/a |
@@ -67,7 +67,7 @@ If you build microservices on FastAPI today, grelmicro is the missing batteries.
 
 | Axis | [`aiocache`](https://github.com/aio-libs/aiocache) | [`fastapi-cache`](https://github.com/long2ice/fastapi-cache) | grelmicro `Cache` |
 |---|---|---|---|
-| Backends | Memory, Redis, Memcached | Memory, Redis, Memcached, DynamoDB | Memory, Redis, Postgres |
+| Backends | Memory, Redis, Memcached | Memory, Redis, Memcached, DynamoDB | Memory, Redis, Postgres, SQLite |
 | Decorator | `@cached` | `@cache` | `@cached` |
 | Type-safe `Cache[T]` | no | no | yes (`TTLCache[T]` plus `PydanticSerializer(T)`) |
 | Stampede protection | local lock via `lock_value` | none | `lock=True` (folds across replicas when a `Coordination` backend is set), `lock="local"` (in-process only), `early=` (XFetch refresh) |
@@ -98,7 +98,7 @@ Half-open / open / closed states, with thresholds and ignore lists.
 | Axis | [`pybreaker`](https://github.com/danielfm/pybreaker) | [`aiobreaker`](https://github.com/arlyon/aiobreaker) | grelmicro `CircuitBreaker` |
 |---|---|---|---|
 | Async-first | sync-first, has async wrapper | yes | yes |
-| Storage | in-memory, Redis (via plugin) | in-memory | in-memory, Redis, Postgres (fleet-wide state) |
+| Storage | in-memory, Redis (via plugin) | in-memory | in-memory, Redis, Postgres, SQLite (fleet-wide state on Redis or Postgres) |
 | Decorator + async CM | decorator + sync CM | decorator + async CM | decorator + async CM |
 | Frozen Pydantic config | no | no | yes (`CircuitBreakerConfig`) |
 | Live reconfigure | no | no | yes (`reconfigure(new_config)`) |

--- a/docs/coordination.md
+++ b/docs/coordination.md
@@ -134,7 +134,7 @@ The lock supports the following features:
 - **Non-reentrant**: a nested acquire from the same task or thread raises
   `LockReentrantError`. Use separate instances if you need independent locks.
 - **Idempotent backend**: the backend lets the same token re-acquire the lock,
-  which extends the lease. Call `do_acquire` directly if you need to extend the
+  which extends the lease. Call `extend()` if you need to extend the
   lease explicitly.
 - **Expiring**: the lock has a timeout that auto-releases the lock to prevent
   deadlocks.
@@ -400,7 +400,7 @@ directly inside an `asyncio.TaskGroup`:
 Build `LeaderElection` with keyword arguments. The lease timing fields
 (`lease_duration`, `renew_deadline`, `retry_interval`, `retry_jitter`,
 `backend_timeout`, `error_interval`) tune in deployment from
-`GREL_LEADERELECTION_{NAME}_*` environment variables. See
+`GREL_LEADERELECTION_{NAME_UPPER}_*` environment variables. See
 [Configuration](config.md) for the deployment story.
 
 !!! tip "Advanced"

--- a/docs/health.md
+++ b/docs/health.md
@@ -26,7 +26,7 @@ A health check is a function returning `None` (healthy) or a `HealthDetails` dic
 - Return `None`: healthy, no details.
 - Return a `HealthDetails` dict: healthy, with details. Values can be primitives, `datetime`, nested dicts, lists, or tuples.
 - Raise `HealthError`: unhealthy. The exception message appears in the `error` field.
-- Raise any other exception: unhealthy, with a generic `"Health check failed"` message. The traceback is logged server-side to avoid leaking internal information.
+- Raise any other exception: unhealthy, with an `error` field formatted as `"{ExceptionType}: {message}"` (for example `"ValueError: bad input"`). The traceback is logged server-side to avoid leaking internal information.
 
 `HealthDetails` is a type alias for `dict[str, JSONEncodable]`. Both sync and async check functions are supported. Sync functions run in a worker thread via `asyncio.to_thread` so they never block the event loop.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,7 +54,7 @@ async def checkout(cart_id: str) -> None:
 
 - `<name>.duration`: a histogram of seconds.
 - `<name>.calls`: a counter with an `outcome` attribute set to `success` or `error`. On failure an `error.type` attribute carries the exception class name.
-- `<name>.active`: an in-flight gauge that rises while the function runs. Only when `record_in_flight=True`.
+- `<name>.active`: an up_down_counter that rises while the function runs and falls when it returns. Only when `record_in_flight=True`.
 
 Every metric is a no-op when no `Metrics` component is active, so a decorated function is safe to ship even when metrics are off.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -109,7 +109,7 @@ from grelmicro.providers.redis import RedisProvider
 client = redis.Redis(host="prod.cache", socket_timeout=5)
 redis_provider = RedisProvider.from_client(client)  # caller owns the client
 
-micro = Grelmicro(uses=[redis_provider, Cache(redis_provider)])
+micro = Grelmicro(uses=[Cache(redis_provider)])
 ```
 
 Pass `own=True` to hand ownership to the provider. It will close the
@@ -224,9 +224,9 @@ Each Provider exposes factory methods that return its matching adapter:
 |----------------------------|-------------------------------|:-------------:|:--------------:|:----------------:|:--------------:|
 | `.lock(**kwargs)`           | `LockBackend` implementation  |       ✓        |       ✓        |        ✓         |       ✓        |
 | `.leaderelection(**kwargs)` | `LeaderElectionBackend` impl  |       ✓        |       ✓        |        ✓         |      N/A       |
-| `.cache(**kwargs)`          | `CacheBackend` implementation |       ✓        |       ✓        |        ✓         |      N/A       |
+| `.cache(**kwargs)`          | `CacheBackend` implementation |       ✓        |       ✓        |        ✓         |       ✓        |
 | `.ratelimiter(**kwargs)`    | `RateLimiterBackend` impl     |       ✓        |       ✓        |        ✓         |       ✓        |
-| `.circuitbreaker(**kwargs)` | `CircuitBreakerBackend` impl  |       ✓        |       ✓        |        ✓         |      N/A       |
+| `.circuitbreaker(**kwargs)` | `CircuitBreakerBackend` impl  |       ✓        |       ✓        |        ✓         |       ✓        |
 
 Factories that do not apply raise `NotImplementedError` with a message
 pointing to the right alternative. `Coordination(provider)`, `Cache(provider)`,
@@ -293,7 +293,7 @@ same way.
 
 ## Postgres
 
-`PostgresProvider` ships the `.lock()` and `.leaderelection()` factories. The
+`PostgresProvider` ships all factory methods: `.lock()`, `.leaderelection()`, `.cache()`, `.ratelimiter()`, and `.circuitbreaker()`. The
 provider wraps an `asyncpg.Pool` and opens it lazily on `__aenter__`.
 
 ```python
@@ -340,7 +340,7 @@ PostgresProvider.from_client(pool)              # bring-your-own pool
 
 ## SQLite
 
-`SQLiteProvider` ships the `.lock()` and `.ratelimiter()` factories. The
+`SQLiteProvider` ships the `.lock()`, `.ratelimiter()`, `.cache()`, and `.circuitbreaker()` factories. The
 provider owns one `aiosqlite` connection (autocommit, WAL) and a shared
 lock that adapters borrow.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -223,6 +223,7 @@ Each Provider exposes factory methods that return its matching adapter:
 | Method                      | Returns                       | RedisProvider | ValkeyProvider | PostgresProvider | SQLiteProvider |
 |----------------------------|-------------------------------|:-------------:|:--------------:|:----------------:|:--------------:|
 | `.lock(**kwargs)`           | `LockBackend` implementation  |       ✓        |       ✓        |        ✓         |       ✓        |
+| `.schedule(**kwargs)`       | `ScheduleBackend` impl        |       ✓        |       ✓        |        ✓         |       ✓        |
 | `.leaderelection(**kwargs)` | `LeaderElectionBackend` impl  |       ✓        |       ✓        |        ✓         |      N/A       |
 | `.cache(**kwargs)`          | `CacheBackend` implementation |       ✓        |       ✓        |        ✓         |       ✓        |
 | `.ratelimiter(**kwargs)`    | `RateLimiterBackend` impl     |       ✓        |       ✓        |        ✓         |       ✓        |
@@ -293,7 +294,7 @@ same way.
 
 ## Postgres
 
-`PostgresProvider` ships all factory methods: `.lock()`, `.leaderelection()`, `.cache()`, `.ratelimiter()`, and `.circuitbreaker()`. The
+`PostgresProvider` ships all factory methods: `.lock()`, `.leaderelection()`, `.cache()`, `.ratelimiter()`, `.circuitbreaker()`, and `.schedule()`. The
 provider wraps an `asyncpg.Pool` and opens it lazily on `__aenter__`.
 
 ```python
@@ -340,7 +341,7 @@ PostgresProvider.from_client(pool)              # bring-your-own pool
 
 ## SQLite
 
-`SQLiteProvider` ships the `.lock()`, `.ratelimiter()`, `.cache()`, and `.circuitbreaker()` factories. The
+`SQLiteProvider` ships the `.lock()`, `.ratelimiter()`, `.cache()`, `.circuitbreaker()`, and `.schedule()` factories. The
 provider owns one `aiosqlite` connection (autocommit, WAL) and a shared
 lock that adapters borrow.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,6 @@ Post-1.0 items planned for future releases. All are purely additive. No dates ar
 - **Adaptive `Bulkhead`**: the CUBIC machinery inside Shield, exposed as `Bulkhead.adaptive()`.
 - **Deadline propagation**: a contextvar deadline that `Timeout`, `Retry`, and `Shield` respect.
 - **Framework depth**: `Depends()` helpers, an ASGI per-route rate-limit middleware, Litestar and FastStream integration.
-- **Built-in health check per provider**: each provider ships a readiness probe (Redis and Valkey ping, Postgres `SELECT 1`, SQLite quick check), auto-registered by `HealthChecks`. Memory and Kubernetes need none, they own no provider to probe. ([#363](https://github.com/grelinfo/grelmicro/issues/363))
 - **Observability depth**: provider pool metrics, lock acquire latency, metric exemplars.
 - **More backends**: MySQL/MariaDB, MongoDB, etcd/ZooKeeper.
 - **Multi-window rate limits and task pause/resume**: additive features with lower urgency.

--- a/docs/snippets/health/checker.py
+++ b/docs/snippets/health/checker.py
@@ -20,6 +20,6 @@ async def check_redis() -> HealthDetails | None:
 @health.check("external-api", critical=False)
 async def check_external_api() -> HealthDetails | None:
     # Raise HealthError to expose a specific message in the error field.
-    # Other exceptions produce a generic "Health check failed" message.
+    # Other exceptions produce an error formatted as "{ExceptionType}: {message}".
     msg = "Connection refused"
     raise HealthError(msg)

--- a/docs/task.md
+++ b/docs/task.md
@@ -203,7 +203,7 @@ Each task exposes two read-only properties for observability:
   or `None` when the task has not started yet. For interval tasks, this is
   computed from the last loop instant. For cron tasks, it comes from the
   parsed expression.
-- **`last_fire`**: a `FireInfo` with the started time, outcome
+- **`last_fire`**: a `FireInfo` with the `started_at` timestamp, outcome
   (`"success"`, `"error"`, or `"skipped"`), and duration in seconds. `None`
   before the first fire.
 

--- a/todo.md
+++ b/todo.md
@@ -1,9 +1,0 @@
-❯ 1. Mutation-test resilience
-     Run a mutmut campaign on the resilience module (circuit breaker, rate limiter, retry, shield) and close the genuine assertion gaps with verified killing tests, same proven flow as coordination. Highest robustness leverage before 1.0, the headline feature, never mutation-tested.
-  2. Mutation-test cache
-     Same campaign on the cache module (TTLCache, @cached, stampede, stale_ttl, tags). Complex, concurrency-heavy, never mutation-tested. Slightly lower stakes than resilience but real gaps likely.
-  3. Finish coordination gaps
-     Close the remaining ~7 mutation clusters from the original report (backend_timeout enforcement, metadata forwarding, last_confirmation_age sign, memory fencing-start). Completes what we started, smaller scope, diminishing returns.
-  4. Launch-readiness sweep
-     Audit LAUNCH_CHECKLIST.md and the comparison/capabilities pages for 1.0-final accuracy, verify every doc example runs against the published artifact, refresh any stale 'why not X' claims. Forward-looking toward 1.0 final and the launch.
-  5. Type something.

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,9 @@
+❯ 1. Mutation-test resilience
+     Run a mutmut campaign on the resilience module (circuit breaker, rate limiter, retry, shield) and close the genuine assertion gaps with verified killing tests, same proven flow as coordination. Highest robustness leverage before 1.0, the headline feature, never mutation-tested.
+  2. Mutation-test cache
+     Same campaign on the cache module (TTLCache, @cached, stampede, stale_ttl, tags). Complex, concurrency-heavy, never mutation-tested. Slightly lower stakes than resilience but real gaps likely.
+  3. Finish coordination gaps
+     Close the remaining ~7 mutation clusters from the original report (backend_timeout enforcement, metadata forwarding, last_confirmation_age sign, memory fencing-start). Completes what we started, smaller scope, diminishing returns.
+  4. Launch-readiness sweep
+     Audit LAUNCH_CHECKLIST.md and the comparison/capabilities pages for 1.0-final accuracy, verify every doc example runs against the published artifact, refresh any stale 'why not X' claims. Forward-looking toward 1.0 final and the launch.
+  5. Type something.


### PR DESCRIPTION
## What this fixes

A documentation-accuracy audit cross-checked every doc against the source and found factual drift, all verified against the code. The executed examples (137 snippet/README cases) were already clean; the drift lived in reference tables and prose that no test covers.

### Provider factory matrix (providers.md)
- SQLite `.cache()` and `.circuitbreaker()` cells showed N/A but both are implemented (`sqlite.py:235,243`). Corrected to shipped.
- Prose claiming Postgres "ships `.lock()` and `.leaderelection()`" and SQLite "ships `.lock()` and `.ratelimiter()`" was wrong (both ship more). Corrected to the real factory sets.

### Lock cleanup is vacate-in-place, not DELETE (coordination.md, kubernetes.md)
The docs said expired locks are bulk-DELETEd; the code does `UPDATE ... SET token = NULL, expire_at = NULL` (Postgres/SQLite) and a REPLACE that clears the holder fields (Kubernetes), keeping the row/Lease so the fence counter survives. The old text contradicted the same file's fencing section. Rewritten to match.

### SQLite coverage gaps
- capabilities.md: `LeaderElection × SQLite` was marked shipped, but there is no SQLite election adapter. Now N/A with a legend note.
- comparison.md: SQLite was missing from the Cache and CircuitBreaker backend lists. Added.

### Stale claims
- cache.md: the `@cached` table listed `cache` as required (now optional, mutually exclusive with `ttl=`) and omitted `ttl`/`maxsize` rows. Fixed.
- multiple-apps.md: claimed a second app with `Metrics` raises `MultipleActiveAppsError`; only `Log`/`Trace` are cross-app guarded. Corrected.
- health.md (+ its snippet): non-`HealthError` exceptions render as `"{ExceptionType}: {message}"`, not a generic string. Fixed.
- roadmap.md: removed the "per-provider health check (#363)" bullet, which shipped in 1.0.0a1.
- Smaller fixes: plugins.md (added `coordination.schedule`), metrics.md (up_down_counter not gauge), coordination.md (env prefix `{NAME_UPPER}`, point to `extend()` not `do_acquire`), task.md (`started_at`), and two more `uses=[provider, X(provider)]` redundancies the earlier sweep missed.

mkdocs builds clean, 137 snippet/README tests pass, full gate green.