### PR TITLE
🐛 Fix correctness bugs: leader-release no-op, cron DST skew, resource leaks

### DIFF
--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -22,7 +22,7 @@ import logging
 import os
 import re
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 from weakref import WeakSet
 
 from pydantic import BaseModel, ValidationError
@@ -214,6 +214,14 @@ class Reconfigurable[ConfigT: BaseModel]:
     _reconfigure_lock: asyncio.Lock
     _env_prefix: str | None = None
 
+    _IMMUTABLE_RECONFIGURE_FIELDS: ClassVar[frozenset[str]] = frozenset()
+    """Field names a live reconfigure must never patch from external config.
+
+    `resolve_config_from_mapping` skips any key whose suffix names one of
+    these fields, so a co-located mutable change in the same mapping still
+    applies instead of being dropped when the whole instance is rejected.
+    """
+
     @property
     def config(self) -> ConfigT:
         """Return the current configuration."""
@@ -292,14 +300,17 @@ def resolve_config_from_mapping[C: BaseModel](
     *,
     env_prefix: str,
     mapping: Mapping[str, str],
+    immutable_fields: frozenset[str] = frozenset(),
 ) -> C:
     """Patch `current` with values from a flat env-style `mapping`.
 
     Keys are matched case-insensitively against `env_prefix`. Only keys
     whose suffix names a field on the config are applied, so unrelated
     keys in a shared ConfigMap are ignored and every field the mapping
-    omits keeps its current value. The immutable identity fields a
-    component generates (a lock `worker`) are therefore preserved.
+    omits keeps its current value. Keys naming an `immutable_fields`
+    entry (a lock `worker`) are skipped, so a co-located mutable change
+    in the same mapping still applies instead of being dropped because
+    the immutable field cannot change.
 
     Present values are coerced through the model's own validators, so a
     CSV or JSON-array string resolves into a list exactly as it does
@@ -319,6 +330,8 @@ def resolve_config_from_mapping[C: BaseModel](
         if not key.upper().startswith(prefix_upper):
             continue
         field = key[prefix_len:].lower()
+        if field in immutable_fields:
+            continue
         if field in fields:
             overrides[field] = value
         else:
@@ -373,6 +386,7 @@ async def reconfigure_all(mapping: Mapping[str, str]) -> None:
                 instance._config,  # noqa: SLF001
                 env_prefix=env_prefix,
                 mapping=mapping,
+                immutable_fields=instance._IMMUTABLE_RECONFIGURE_FIELDS,  # noqa: SLF001
             )
         except ValidationError as exc:
             logger.warning(

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -23,7 +23,7 @@ from grelmicro.cache._stampede import (
 )
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.serializers import PickleSerializer
-from grelmicro.cache.ttl import _CACHE_PREFIX, TTLCache
+from grelmicro.cache.ttl import _CACHE_PREFIX, _XFETCH_SUFFIX, TTLCache
 from grelmicro.coordination.lock import Lock
 from grelmicro.metrics import _emit
 
@@ -37,10 +37,6 @@ R = TypeVar("R")
 _SENTINEL = object()
 
 _PER_KEY_LOCK_BUDGET = 1024
-
-# The `\x1f` separator stays out of band (no real key uses it) and, unlike
-# `\x00`, is valid in a Postgres text key.
-_XFETCH_SUFFIX = "\x1fxf"
 
 
 class _TagSpec(NamedTuple):
@@ -378,7 +374,8 @@ def _xfetch_should_refresh(remaining: float, delta: float) -> bool:
     ``delta * -ln(rand) >= remaining``, so a key whose recompute is
     expensive relative to its remaining life refreshes sooner.
     """
-    return delta * -math.log(_random()) >= remaining
+    rand = _random() or 1.0
+    return delta * -math.log(rand) >= remaining
 
 
 async def _read_meta(cache: TTLCache, key: str) -> tuple[float, float] | None:

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -85,6 +85,11 @@ _CACHE_PREFIX = "cache"
 # Postgres text key.
 _STALE_SUFFIX = "\x1fst"
 
+# Suffix for the XFetch metadata sidecar written by `@cached(early=...)`.
+# It carries the last recompute timing next to a value and shares the
+# same out-of-band `\x1f` separator.
+_XFETCH_SUFFIX = "\x1fxf"
+
 
 class TTLCache(Generic[T]):
     """Cache with per-entry TTL and optional LRU eviction.
@@ -588,5 +593,11 @@ class TTLCache(Generic[T]):
         if not self._keys:  # pragma: no cover
             return
         lru_key, _ = self._keys.popitem(last=False)
-        await self._get_backend().delete(key=f"{_CACHE_PREFIX}:{lru_key}")
+        await self._get_backend().delete_many(
+            keys=[
+                f"{_CACHE_PREFIX}:{lru_key}",
+                f"{_CACHE_PREFIX}:{lru_key}{_STALE_SUFFIX}",
+                f"{_CACHE_PREFIX}:{lru_key}{_XFETCH_SUFFIX}",
+            ]
+        )
         self._evictions += 1

--- a/grelmicro/config/_external.py
+++ b/grelmicro/config/_external.py
@@ -171,13 +171,18 @@ class ExternalConfig:
         """Open the sources, apply once, then start polling."""
         stack = AsyncExitStack()
         await stack.__aenter__()
-        if self._config_src is not None:
-            await stack.enter_async_context(self._config_src)  # ty: ignore[invalid-argument-type]
-        if self._secrets_src is not None:
-            await stack.enter_async_context(self._secrets_src)  # ty: ignore[invalid-argument-type]
         self._stack = stack
-        await self.reload()
-        self._task = asyncio.create_task(self._poll())
+        try:
+            if self._config_src is not None:
+                await stack.enter_async_context(self._config_src)  # ty: ignore[invalid-argument-type]
+            if self._secrets_src is not None:
+                await stack.enter_async_context(self._secrets_src)  # ty: ignore[invalid-argument-type]
+            await self.reload()
+            self._task = asyncio.create_task(self._poll())
+        except BaseException:
+            self._stack = None
+            await stack.aclose()
+            raise
         return self
 
     async def __aexit__(

--- a/grelmicro/coordination/_component.py
+++ b/grelmicro/coordination/_component.py
@@ -130,10 +130,17 @@ class Coordination:
 
         if source is not None:
             provider = instantiate_if_class(source)
-            self._lock_backend = provider.lock()
-            self._election_backend = provider.leaderelection()
-            # A provider may not ship a schedule adapter. Leave the backend
-            # unset so cron raises a clear error only when it is actually used.
+            # A provider may not ship every adapter kind. Leave a backend
+            # unset so the kind raises a clear error only when it is actually
+            # used, instead of crashing construction for a locks-only user.
+            try:
+                self._lock_backend = provider.lock()
+            except (AttributeError, NotImplementedError):
+                self._lock_backend = None
+            try:
+                self._election_backend = provider.leaderelection()
+            except (AttributeError, NotImplementedError):
+                self._election_backend = None
             try:
                 self._schedule_backend = provider.schedule()
             except (AttributeError, NotImplementedError):

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from logging import getLogger
 from time import monotonic
 from types import TracebackType
-from typing import Annotated, Self
+from typing import Annotated, ClassVar, Self
 from uuid import UUID
 
 from pydantic import model_validator
@@ -120,6 +120,10 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
     """
 
     _LOCK_PREFIX = "leader"
+
+    _IMMUTABLE_RECONFIGURE_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"worker"}
+    )
 
     def __init__(  # noqa: PLR0913
         self,
@@ -677,9 +681,12 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
             raise ValueError(msg)
 
     async def _release(self) -> None:
-        backend = self._backend
-        if backend is None:
-            # Nothing was acquired, nothing to release.
+        from grelmicro.errors import OutOfContextError  # noqa: PLC0415
+
+        try:
+            backend = self.backend
+        except OutOfContextError:
+            # The app context is already gone, so there is nothing to release.
             return
         config = self._config
         try:

--- a/grelmicro/coordination/lock.py
+++ b/grelmicro/coordination/lock.py
@@ -5,7 +5,7 @@ import random
 import re
 from threading import get_ident
 from types import TracebackType
-from typing import Annotated, Self
+from typing import Annotated, ClassVar, Self
 from uuid import UUID
 from weakref import WeakSet
 
@@ -114,6 +114,10 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
     """
 
     _LOCK_PREFIX = "lock"
+
+    _IMMUTABLE_RECONFIGURE_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"worker"}
+    )
 
     def __init__(
         self,

--- a/grelmicro/providers/sqlite.py
+++ b/grelmicro/providers/sqlite.py
@@ -256,10 +256,13 @@ class SQLiteProvider(Provider):
     async def __aenter__(self) -> Self:
         """Open the connection when the provider owns it."""
         if self._conn is None:
-            self._conn = await aiosqlite.connect(
-                self._path, isolation_level=None
-            )
-            await self._conn.execute("PRAGMA journal_mode=WAL;")
+            conn = await aiosqlite.connect(self._path, isolation_level=None)
+            try:
+                await conn.execute("PRAGMA journal_mode=WAL;")
+            except BaseException:
+                await conn.close()
+                raise
+            self._conn = conn
         return self
 
     async def __aexit__(

--- a/grelmicro/resilience/ratelimiter/sqlite.py
+++ b/grelmicro/resilience/ratelimiter/sqlite.py
@@ -216,7 +216,8 @@ class _SQLiteTokenBucket(RateLimiterStrategy):
         self._refill_rate = config.refill_rate
 
     def _refill(self, tokens: float, last: float, now: float) -> float:
-        return min(self._capacity, tokens + (now - last) * self._refill_rate)
+        elapsed = max(0.0, now - last)
+        return min(self._capacity, tokens + elapsed * self._refill_rate)
 
     async def acquire(self, *, key: str, cost: int) -> RateLimitResult:
         """Async acquire (token bucket)."""

--- a/grelmicro/task/_cron.py
+++ b/grelmicro/task/_cron.py
@@ -414,7 +414,7 @@ class CronTask(Task):
                 now = _now(self._tz)
                 next_fire = self._expr.next_after(now)
                 self._next_fire_time = next_fire
-                delay = (next_fire - now).total_seconds()
+                delay = next_fire.timestamp() - now.timestamp()
                 # Wait until the next fire instant, waking early on stop.
                 if await sleep_or_stop(delay, stop):
                     break

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -1072,6 +1072,23 @@ class _Clock:
 class TestEarlyRefresh:
     """Test @cached(early=...) probabilistic XFetch refresh."""
 
+    def test_xfetch_should_refresh_handles_zero_random(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 0.0 random draw never crashes the early-refresh die.
+
+        ``random.random`` can return exactly 0.0, and ``math.log(0.0)``
+        raises ``ValueError``. The die must clamp the draw and return a bool.
+        """
+        import sys  # noqa: PLC0415
+
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        monkeypatch.setattr(cached_mod, "_random", lambda: 0.0)
+
+        # Act / Assert: no exception, a plain bool result.
+        result = cached_mod._xfetch_should_refresh(remaining=10.0, delta=1.0)
+        assert isinstance(result, bool)
+
     async def test_invalid_early_rejected(self) -> None:
         """Early outside [0, 1) raises at decoration time."""
         cache = _make_cache()

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -13,7 +13,12 @@ from grelmicro import Grelmicro
 from grelmicro.cache import Cache, TTLCacheConfig
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.serializers import JsonSerializer, PickleSerializer
-from grelmicro.cache.ttl import CacheInfo, TTLCache
+from grelmicro.cache.ttl import (
+    _CACHE_PREFIX,
+    _STALE_SUFFIX,
+    CacheInfo,
+    TTLCache,
+)
 from grelmicro.errors import OutOfContextError
 
 pytestmark = [pytest.mark.timeout(10)]
@@ -327,6 +332,22 @@ class TestEviction:
         assert await cache.get("a") is None
         assert await cache.get("b") == b"2"
         assert await cache.get("c") == b"3"
+
+    async def test_eviction_drops_stale_sidecar(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Evicting an entry also drops its stale-reserve sidecar."""
+        # Arrange: a key with a stale-reserve copy, then fill the cache.
+        cache = TTLCache(maxsize=1, ttl=60, backend=backend)
+        await cache.set("a", b"1", stale_ttl=300)
+        stale_key = f"{_CACHE_PREFIX}:a{_STALE_SUFFIX}"
+        assert await backend.get(key=stale_key) is not None
+
+        # Act: a second entry evicts "a".
+        await cache.set("b", b"2")
+
+        # Assert: the stale sidecar was dropped, not orphaned.
+        assert await backend.get(key=stale_key) is None
 
     async def test_get_promotes_to_mru(
         self, backend: MemoryCacheAdapter

--- a/tests/coordination/test_component.py
+++ b/tests/coordination/test_component.py
@@ -21,6 +21,7 @@ from grelmicro.coordination.memory import (
 )
 from grelmicro.providers.postgres import PostgresProvider
 from grelmicro.providers.redis import RedisProvider
+from grelmicro.providers.sqlite import SQLiteProvider
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -244,6 +245,62 @@ def test_keyword_overrides_provider_election_backend() -> None:
     coordination = Coordination(provider, election=override)
     assert coordination.election_backend is override
     assert coordination.lock_backend.__class__.__name__ == "RedisLockAdapter"
+
+
+def test_provider_without_any_adapter_constructs() -> None:
+    """A provider shipping no adapter leaves every backend unset, not crashed.
+
+    Each kind raises a clear `CoordinationBackendError` only on actual use.
+    """
+    from typing import Self  # noqa: PLC0415
+
+    from grelmicro.providers._base import Provider  # noqa: PLC0415
+
+    class _BareProvider(Provider):
+        short_name = "bare"
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> None:
+            return None
+
+    # Arrange / Act: construction must not raise on any unserved kind.
+    coordination = Coordination(_BareProvider())
+
+    # Assert: every kind raises a clear error only on use.
+    with pytest.raises(CoordinationBackendError, match="no lock backend"):
+        _ = coordination.lock_backend
+    with pytest.raises(
+        CoordinationBackendError, match="no leader election backend"
+    ):
+        _ = coordination.election_backend
+    with pytest.raises(CoordinationBackendError, match="no schedule backend"):
+        _ = coordination.schedule_backend
+
+
+def test_lock_only_provider_constructs() -> None:
+    """A lock-only provider constructs without raising on the unserved kind.
+
+    `SQLiteProvider` ships `lock` and `schedule` but no `leaderelection`.
+    Construction must not crash for a locks-only user. The lock path works
+    and the election path raises a clear `CoordinationBackendError` only on
+    actual use.
+    """
+    # Arrange / Act
+    coordination = Coordination(SQLiteProvider("file:app?mode=memory"))
+
+    # Assert
+    assert coordination.lock_backend.__class__.__name__ == "SQLiteLockAdapter"
+    with pytest.raises(
+        CoordinationBackendError, match="no leader election backend"
+    ):
+        _ = coordination.election_backend
 
 
 async def test_lock_only_lifecycle() -> None:

--- a/tests/coordination/test_leaderelection.py
+++ b/tests/coordination/test_leaderelection.py
@@ -717,6 +717,63 @@ async def test_leader_election_stops_gracefully_on_stop_event(
     assert record.holder == "other"
 
 
+async def test_graceful_stop_releases_app_resolved_backend() -> None:
+    """Graceful stop releases the backend resolved from a Coordination app.
+
+    With no `backend=`, the election resolves through the registered
+    `Coordination` component. On stop the lease must be vacated, so another
+    token can acquire immediately instead of waiting the lease duration.
+    """
+    from grelmicro import Grelmicro  # noqa: PLC0415
+    from grelmicro.coordination import Coordination  # noqa: PLC0415
+
+    # Arrange: an app-resolved election backend, no explicit backend= on the
+    # LeaderElection.
+    backend = MemoryLeaderElectionBackend()
+    micro = Grelmicro(uses=[Coordination(election=backend)])
+    leader_election = LeaderElection(
+        LEADER_NAME,
+        worker="worker_app",
+        lease_duration=LEASE_DURATION,
+        renew_deadline=RENEW_DEADLINE,
+        retry_interval=0.005,
+        error_interval=0.01,
+        backend_timeout=0.005,
+    )
+
+    stop = Event()
+    async with micro:
+        async with asyncio.TaskGroup() as tg:
+            handle = await start_task(tg, leader_election, stop=stop)
+            await leader_election.wait_for_leader()
+            assert leader_election.is_leader() is True
+            stop.set()  # request graceful shutdown
+        # The loop broke on its own, without a cancellation.
+        assert handle.done()
+        assert not handle.cancelled()
+        # Leadership was released, so another worker can take it immediately.
+        record = await backend.acquire_or_renew(
+            name=leader_election._lock_name,
+            token="other",
+            duration=1,
+        )
+        assert record.holder == "other"
+
+
+async def test_release_returns_quietly_when_app_context_gone() -> None:
+    """`_release` is a no-op when no backend resolves out of context.
+
+    With no `backend=` and no active app, resolving the backend raises
+    `OutOfContextError`. There is nothing to release, so `_release` returns
+    quietly instead of propagating.
+    """
+    # Arrange: no explicit backend, no active app context.
+    leader_election = LeaderElection(LEADER_NAME, worker="worker_gone")
+
+    # Act / Assert: must not raise.
+    await leader_election._release()
+
+
 async def test_graceful_stop_awaits_release_before_returning(
     backend: LeaderElectionBackend,
     mocker: MockerFixture,

--- a/tests/providers/test_sqlite_provider.py
+++ b/tests/providers/test_sqlite_provider.py
@@ -1,9 +1,11 @@
 """Tests for the SQLite Provider."""
 
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import aiosqlite
 import pytest
+from pytest_mock import MockerFixture
 
 from grelmicro.cache.sqlite import SQLiteCacheAdapter
 from grelmicro.coordination.sqlite import (
@@ -83,6 +85,27 @@ async def test_open_and_close(tmp_path: Path) -> None:
         assert isinstance(opened.connection_lock.locked(), bool)
     with pytest.raises(OutOfContextError):
         _ = provider.client
+
+
+async def test_aenter_closes_connection_when_pragma_fails(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """A failing WAL PRAGMA closes the opened connection instead of leaking it."""
+    # Arrange: connect succeeds but the PRAGMA execute raises.
+    conn = AsyncMock()
+    conn.execute.side_effect = aiosqlite.OperationalError("disk I/O error")
+    mocker.patch(
+        "grelmicro.providers.sqlite.aiosqlite.connect",
+        new=AsyncMock(return_value=conn),
+    )
+    provider = SQLiteProvider(tmp_path / "wal.db")
+
+    # Act
+    with pytest.raises(aiosqlite.OperationalError, match="disk I/O error"):
+        await provider.__aenter__()
+
+    # Assert: the open connection was closed, not leaked.
+    conn.close.assert_awaited_once()
 
 
 async def test_from_client_does_not_own(tmp_path: Path) -> None:

--- a/tests/resilience/test_ratelimiter_sqlite.py
+++ b/tests/resilience/test_ratelimiter_sqlite.py
@@ -12,7 +12,10 @@ from grelmicro.resilience.ratelimiter import (
     SlidingWindowConfig,
     TokenBucketConfig,
 )
-from grelmicro.resilience.ratelimiter.sqlite import SQLiteRateLimiterAdapter
+from grelmicro.resilience.ratelimiter.sqlite import (
+    SQLiteRateLimiterAdapter,
+    _SQLiteTokenBucket,
+)
 
 
 @pytest.fixture
@@ -29,6 +32,28 @@ async def adapter(
     """Rate limiter adapter bound to the provider."""
     async with provider.ratelimiter() as backend:
         yield backend
+
+
+def test_refill_clamps_clock_step_back() -> None:
+    """A backwards wall-clock step never removes tokens from the bucket.
+
+    `now < last` after an NTP step-back must not produce negative refill,
+    which would transiently over-restrict the limiter.
+    """
+    # Arrange
+    bucket = _SQLiteTokenBucket(
+        conn=None,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        lock=None,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        prefix="grel:ratelimiter:test:",
+        table_name="rate_limit",
+        config=TokenBucketConfig(capacity=10, refill_rate=1.0),
+    )
+
+    # Act: last is in the future relative to now (clock stepped back 5s).
+    refilled = bucket._refill(tokens=8.0, last=1005.0, now=1000.0)
+
+    # Assert: tokens are unchanged, not reduced by negative elapsed.
+    assert refilled == 8.0  # noqa: PLR2004
 
 
 def test_invalid_table_name_raises() -> None:

--- a/tests/task/test_cron_task.py
+++ b/tests/task/test_cron_task.py
@@ -77,6 +77,10 @@ pytestmark = [pytest.mark.timeout(10)]
 EVERY_MINUTE = "* * * * *"
 SLEEP = 0.01
 
+# True elapsed seconds across the America/New_York fall-back (25 hours),
+# as opposed to the 24-hour wall-clock difference.
+EXPECTED_DST_ELAPSED_SECONDS = 90000.0
+
 
 def test_cron_task_init() -> None:
     """Test Cron Task Initialization."""
@@ -144,6 +148,53 @@ def _run_fast(mocker: MockFixture) -> None:
         "grelmicro.task._cron._now",
         side_effect=frozen.astimezone,
     )
+
+
+async def test_cron_delay_uses_true_elapsed_across_dst(
+    mocker: MockFixture,
+) -> None:
+    """The loop sleeps the true elapsed seconds across a DST fall-back.
+
+    On 2024-11-03 America/New_York repeats 01:00-02:00, so wall-clock
+    subtraction of two same-zone aware datetimes underreports by an hour
+    (86400 instead of 90000). The delay must use the real elapsed time so the
+    body does not fire an hour early.
+    """
+    from zoneinfo import ZoneInfo  # noqa: PLC0415
+
+    ny = ZoneInfo("America/New_York")
+    # First 01:30 of the repeated hour (EDT, before the fall-back).
+    pre_dst = datetime(2024, 11, 3, 1, 30, fold=0, tzinfo=ny)
+    expected_delay = (
+        datetime(2024, 11, 4, 1, 30, tzinfo=ny).timestamp()
+        - pre_dst.timestamp()
+    )
+
+    captured: list[float] = []
+
+    async def capture_sleep(seconds: float, stop: object) -> bool:
+        del stop
+        captured.append(seconds)
+        return True  # break the loop after the first scheduled sleep
+
+    def frozen_now(tz: object) -> datetime:
+        return pre_dst.astimezone(tz)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    mocker.patch(
+        "grelmicro.task._cron.sleep_or_stop", side_effect=capture_sleep
+    )
+    mocker.patch("grelmicro.task._cron._now", side_effect=frozen_now)
+
+    task = CronTask(
+        expr="30 1 * * *", function=test1, timezone="America/New_York"
+    )
+
+    # Act
+    await task()
+
+    # Assert: true elapsed across the fall-back is 25 hours, not 24.
+    assert captured == [expected_delay]
+    assert expected_delay == EXPECTED_DST_ELAPSED_SECONDS
 
 
 async def test_cron_task_start(mocker: MockFixture) -> None:

--- a/tests/test_external_config.py
+++ b/tests/test_external_config.py
@@ -15,6 +15,8 @@ from grelmicro._config import (
 )
 from grelmicro.config import ConfigBackend, ExternalConfig, FileConfigAdapter
 from grelmicro.config._external import _coerce_source, _detect_scheme
+from grelmicro.coordination.lock import Lock
+from grelmicro.coordination.memory import MemoryLockAdapter
 from grelmicro.errors import AdapterNotRegisteredError
 from grelmicro.resilience import (
     Bulkhead,
@@ -117,6 +119,36 @@ async def test_reconfigure_all_reaches_ratelimiter() -> None:
     )
     assert isinstance(rl.config, SlidingWindowConfig)
     assert rl.config.limit == 99  # noqa: PLR2004
+
+
+async def test_reconfigure_all_applies_mutable_beside_immutable_worker() -> (
+    None
+):
+    """A co-located immutable `worker` key never drops the valid lease change.
+
+    The mapping carries both the immutable identity field (`worker`) and a
+    mutable one (`lease_duration`). The immutable key is skipped, so the
+    lease change still applies instead of the whole instance being rejected.
+    """
+    # Arrange
+    lock = Lock(
+        backend=MemoryLockAdapter(),
+        name="cart",
+        worker="w1",
+        lease_duration=15.0,
+    )
+
+    # Act
+    await reconfigure_all(
+        {
+            "GREL_LOCK_CART_WORKER": "w2",
+            "GREL_LOCK_CART_LEASE_DURATION": "30",
+        },
+    )
+
+    # Assert: lease applied, worker left unchanged.
+    assert lock.config.lease_duration == 30.0  # noqa: PLR2004
+    assert str(lock.config.worker) == "w1"
 
 
 # --- Task 2: resolve_config_from_mapping unmatched-key debug log ---
@@ -245,6 +277,65 @@ async def test_reload_raising_backend_does_not_raise() -> None:
     external = ExternalConfig(config=_RaisingBackend(), interval=999.0)
     async with external:
         await external.reload()  # must not raise
+
+
+class _TrackingBackend:
+    """A ConfigBackend that records how often it is entered and exited."""
+
+    def __init__(self) -> None:
+        self.entered = 0
+        self.exited = 0
+
+    async def __aenter__(self) -> Self:
+        self.entered += 1
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.exited += 1
+
+    async def load(self) -> Mapping[str, str] | None:
+        return {}
+
+
+class _RaiseOnEnterBackend:
+    """A ConfigBackend that raises when entered."""
+
+    async def __aenter__(self) -> Self:
+        msg = "secret mount unreadable"
+        raise OSError(msg)
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def load(self) -> Mapping[str, str] | None:  # pragma: no cover
+        return {}
+
+
+async def test_aenter_closes_first_source_when_second_enter_fails() -> None:
+    """A failure entering the secrets source unwinds the opened config source."""
+    # Arrange
+    config_src = _TrackingBackend()
+    external = ExternalConfig(
+        config=config_src, secrets=_RaiseOnEnterBackend(), interval=999.0
+    )
+
+    # Act
+    with pytest.raises(OSError, match="secret mount unreadable"):
+        await external.__aenter__()
+
+    # Assert: the config source was entered and then closed, no leak.
+    assert config_src.entered == 1
+    assert config_src.exited == 1
 
 
 # --- FileConfigAdapter behavior ---


### PR DESCRIPTION
## What this fixes

An adversarial correctness review found bugs that 100% line coverage and the existing tests missed. Each fix ships with a regression test verified to FAIL before the fix and PASS after.

### Critical
- **`LeaderElection` graceful-stop release was a silent no-op in the default path.** `_release` read the raw `self._backend` field, which is `None` whenever the backend comes from a registered `Coordination` component (the documented default), so the lease was never vacated on stop and standby waited the full `lease_duration`. Now resolves via the `self.backend` property, guarded for `OutOfContextError` at app teardown.
- **Cron woke an hour early across a DST fall-back.** `delay = (next_fire - now).total_seconds()` did wall-clock subtraction (86400 s) instead of true elapsed (90000 s); in local mode the body ran at the wrong time. Now uses `next_fire.timestamp() - now.timestamp()`.

### Medium
- **`ExternalConfig.__aenter__` leaked the first source** if a later open/reload/task-create failed (`self._stack` was still `None`, so `__aexit__` never unwound it). Now assigns the stack first and `aclose()`s on any `BaseException`.
- **`SQLiteProvider.__aenter__` leaked the connection** if the WAL pragma failed. Now closes the local connection on failure before re-raising.
- **`Coordination(SQLiteProvider(...))` crashed at construction** because `leaderelection()` was called unconditionally on a lock-only provider. Now guarded like the schedule path; the election path raises a clear `CoordinationBackendError` only on use.
- **A stray immutable-field key silently dropped co-located reconfigure updates.** A `GREL_LOCK_CART_WORKER=...` in a mount made `reconfigure_all` reject the whole instance, discarding a valid `lease_duration` change. Added `_IMMUTABLE_RECONFIGURE_FIELDS` (`{"worker"}` on `Lock`/`LeaderElection`); those keys are now skipped.
- **XFetch early-refresh could crash a cache HIT** via `math.log(0.0)` when `random()` returned exactly 0. Now draws in `(0, 1]`.

### Low (both done)
- SQLite rate-limiter refill clamps `max(0.0, now - last)` so an NTP step-back does not over-restrict.
- TTL `_evict` now drops the stale and XFetch sidecars alongside the main key (was orphaning them on LRU eviction).

Full gate green: 2879 unit + 211 integration, 100% coverage, ruff and ty clean. No public API change (snapshot unchanged).