### PR TITLE
♻️ Dedup jitter formula, worker guard, and thread token in coordination internals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tmp/
 
 # AI assistant files
 .claude
+todo.md

--- a/grelmicro/coordination/_base.py
+++ b/grelmicro/coordination/_base.py
@@ -1,5 +1,6 @@
 """Lock Base Classes."""
 
+import random
 from types import TracebackType
 from typing import Annotated, Protocol
 from uuid import UUID
@@ -10,6 +11,16 @@ from typing_extensions import Doc
 from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination._tokens import generate_worker_id
 from grelmicro.coordination.abc import LockPrimitive
+
+# Seam for randomness in retry jitter. Tests pin it to a fixed value.
+_random = random.random
+
+
+def jittered_interval(base: float, jitter: float) -> float:
+    """Return base scaled by uniform(1-jitter, 1+jitter), or base when jitter is 0."""
+    if jitter:
+        return base * (1.0 + jitter * (2.0 * _random() - 1.0))
+    return base
 
 
 class BaseLockConfig(BaseModel):
@@ -26,6 +37,19 @@ class BaseLockConfig(BaseModel):
             """),
         Field(default_factory=generate_worker_id),
     ]
+
+
+def assert_worker_unchanged(
+    current: BaseLockConfig, new: BaseLockConfig
+) -> None:
+    """Reject a reconfigure that would change the immutable `worker` field."""
+    if new.worker != current.worker:
+        msg = (
+            f"reconfigure cannot change worker "
+            f"({current.worker!r} -> {new.worker!r}). "
+            f"Reuse the existing worker on the new config."
+        )
+        raise ValueError(msg)
 
 
 class BaseLock(LockPrimitive, Protocol):

--- a/grelmicro/coordination/_tokens.py
+++ b/grelmicro/coordination/_tokens.py
@@ -32,7 +32,13 @@ def generate_token_nonce() -> str:
     return f":{next(_guard_counter)}"
 
 
-def generate_thread_token(worker: UUID | str, nonce: str = "") -> str:
-    """Generate a thread token from the worker identity and the current thread ID."""
-    thread_id = get_ident()
+def generate_thread_token(
+    worker: UUID | str, nonce: str = "", *, thread_id: int | None = None
+) -> str:
+    """Generate a thread token from the worker identity and a thread ID.
+
+    The thread ID defaults to the current thread when not given.
+    """
+    if thread_id is None:
+        thread_id = get_ident()
     return f"{worker}:thread:{thread_id}{nonce}"

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -1,7 +1,6 @@
 """Leader Election."""
 
 import asyncio
-import random
 from collections.abc import Mapping
 from logging import getLogger
 from time import monotonic
@@ -15,7 +14,11 @@ from typing_extensions import Doc
 from grelmicro._app import Grelmicro
 from grelmicro._async import sleep_or_stop
 from grelmicro._config import Reconfigurable, env_segment, resolve_config
-from grelmicro.coordination._base import BaseLockConfig
+from grelmicro.coordination._base import (
+    BaseLockConfig,
+    assert_worker_unchanged,
+    jittered_interval,
+)
 from grelmicro.coordination.abc import (
     LeaderElectionBackend,
     LeaderRecord,
@@ -26,9 +29,6 @@ from grelmicro.errors import WouldBlockError
 from grelmicro.task.abc import Task
 
 logger = getLogger("grelmicro.leader_election")
-
-# Seam for randomness in retry jitter. Tests pin it to a fixed value.
-_random = random.random
 
 
 class LeaderElectionConfig(BaseLockConfig, frozen=True, extra="forbid"):  # ty: ignore[invalid-frozen-dataclass-subclass]
@@ -553,13 +553,9 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
                 await self._try_acquire_or_renew(config)
                 # On a graceful stop, break and let the finally block
                 # release leadership on the backend before unwinding.
-                jitter = config.retry_jitter
-                if jitter:
-                    interval = config.retry_interval * (
-                        1.0 + jitter * (2.0 * _random() - 1.0)
-                    )
-                else:
-                    interval = config.retry_interval
+                interval = jittered_interval(
+                    config.retry_interval, config.retry_jitter
+                )
                 if await sleep_or_stop(interval, stop):
                     break
         except asyncio.CancelledError:
@@ -672,13 +668,7 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
         self, new_config: LeaderElectionConfig
     ) -> None:
         """Validate the immutable `worker` field before publishing `new_config`."""
-        if new_config.worker != self._config.worker:
-            msg = (
-                f"reconfigure cannot change worker "
-                f"({self._config.worker!r} -> {new_config.worker!r}). "
-                f"Reuse the existing worker on the new config."
-            )
-            raise ValueError(msg)
+        assert_worker_unchanged(self._config, new_config)
 
     async def _release(self) -> None:
         from grelmicro.errors import OutOfContextError  # noqa: PLC0415

--- a/grelmicro/coordination/lock.py
+++ b/grelmicro/coordination/lock.py
@@ -1,7 +1,6 @@
 """Lock."""
 
 import asyncio
-import random
 import re
 from threading import get_ident
 from types import TracebackType
@@ -14,9 +13,17 @@ from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro
 from grelmicro._config import Reconfigurable, env_segment, resolve_config
-from grelmicro.coordination._base import BaseLock, BaseLockConfig
+from grelmicro.coordination._base import (
+    BaseLock,
+    BaseLockConfig,
+    assert_worker_unchanged,
+    jittered_interval,
+)
 from grelmicro.coordination._handle import LockHandle
-from grelmicro.coordination._tokens import generate_task_token
+from grelmicro.coordination._tokens import (
+    generate_task_token,
+    generate_thread_token,
+)
 from grelmicro.coordination.abc import LockBackend, Seconds
 from grelmicro.coordination.errors import (
     LockAcquireError,
@@ -31,9 +38,6 @@ from grelmicro.errors import WouldBlockError
 _MIN_RETRY_INTERVAL: float = 0.001
 _NAME_MAX_LEN = 200
 _NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\-]*$")
-
-# Seam for randomness in retry jitter. Tests pin it to a fixed value.
-_random = random.random
 
 
 def _validate_lock_name(name: str) -> None:
@@ -440,12 +444,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             ):
                 msg = f"Lock not acquired within timeout: name={self._name}"
                 raise TimeoutError(msg)
-            if jitter:
-                interval = config.retry_interval * (
-                    1.0 + jitter * (2.0 * _random() - 1.0)
-                )
-            else:
-                interval = config.retry_interval
+            interval = jittered_interval(config.retry_interval, jitter)
             await asyncio.sleep(interval)
             fencing_token = await self.do_acquire(
                 token=token, duration=duration
@@ -615,17 +614,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
 
     async def _apply_reconfigure(self, new_config: LockConfig) -> None:
         """Validate the immutable `worker` field before publishing `new_config`."""
-        if new_config.worker != self._config.worker:
-            msg = (
-                f"reconfigure cannot change worker "
-                f"({self._config.worker!r} -> {new_config.worker!r}). "
-                f"Reuse the existing worker on the new config."
-            )
-            raise ValueError(msg)
-
-    def _thread_token(self, thread_id: int, worker: str | UUID) -> str:
-        """Build a thread token from a worker identity and the given thread ID."""
-        return f"{worker}:thread:{thread_id}"
+        assert_worker_unchanged(self._config, new_config)
 
     async def do_thread_acquire(
         self,
@@ -646,7 +635,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         config = self._config
         if thread_id in self._held_by_threads:
             raise LockReentrantError(name=self._name)
-        token = self._thread_token(thread_id, config.worker)
+        token = generate_thread_token(config.worker, thread_id=thread_id)
         duration = config.lease_duration
         deadline = (
             asyncio.get_running_loop().time() + timeout
@@ -662,12 +651,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             ):
                 msg = f"Lock not acquired within timeout: name={self._name}"
                 raise TimeoutError(msg)
-            if jitter:
-                interval = config.retry_interval * (
-                    1.0 + jitter * (2.0 * _random() - 1.0)
-                )
-            else:
-                interval = config.retry_interval
+            interval = jittered_interval(config.retry_interval, jitter)
             await asyncio.sleep(interval)
             fencing_token = await self.do_acquire(
                 token=token, duration=duration
@@ -690,7 +674,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         config = self._config
         if thread_id not in self._held_by_threads:
             raise LockNotOwnedError(name=self._name)
-        token = self._thread_token(thread_id, config.worker)
+        token = generate_thread_token(config.worker, thread_id=thread_id)
         fencing_token = await self.do_acquire(
             token=token, duration=config.lease_duration
         )
@@ -714,7 +698,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         config = self._config
         if thread_id in self._held_by_threads:
             raise LockReentrantError(name=self._name)
-        token = self._thread_token(thread_id, config.worker)
+        token = generate_thread_token(config.worker, thread_id=thread_id)
         fencing_token = await self.do_acquire(
             token=token, duration=config.lease_duration
         )
@@ -736,7 +720,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             LockNotOwnedError: If the lock is not owned by the current token.
             LockReleaseError: If the lock cannot be released due to an error on the backend.
         """
-        token = self._thread_token(thread_id, self._config.worker)
+        token = generate_thread_token(self._config.worker, thread_id=thread_id)
         released = await self.do_release(token)
         self._held_by_threads.discard(thread_id)
         if not released:
@@ -845,9 +829,9 @@ class ThreadLockAdapter:
         """Return True if the lock is currently held by the current worker thread."""
         return asyncio.run_coroutine_threadsafe(
             self._lock.do_owned(
-                self._lock._thread_token(  # noqa: SLF001
-                    get_ident(),
+                generate_thread_token(
                     self._lock._config.worker,  # noqa: SLF001
+                    thread_id=get_ident(),
                 ),
             ),
             self._lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]

--- a/grelmicro/coordination/tasklock.py
+++ b/grelmicro/coordination/tasklock.py
@@ -17,7 +17,10 @@ from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro
 from grelmicro._config import Reconfigurable, env_segment, resolve_config
-from grelmicro.coordination._base import BaseLockConfig
+from grelmicro.coordination._base import (
+    BaseLockConfig,
+    assert_worker_unchanged,
+)
 from grelmicro.coordination._tokens import (
     generate_task_token,
     generate_thread_token,
@@ -490,13 +493,7 @@ class TaskLock(Reconfigurable[TaskLockConfig], LockPrimitive):
 
     async def _apply_reconfigure(self, new_config: TaskLockConfig) -> None:
         """Validate the immutable `worker` field before publishing `new_config`."""
-        if new_config.worker != self._config.worker:
-            msg = (
-                f"reconfigure cannot change worker "
-                f"({self._config.worker!r} -> {new_config.worker!r}). "
-                f"Reuse the existing worker on the new config."
-            )
-            raise ValueError(msg)
+        assert_worker_unchanged(self._config, new_config)
 
     async def do_exit(self, token: str, *, min_lock_seconds: Seconds) -> None:
         """Handle exit logic: release or re-acquire based on elapsed time.

--- a/grelmicro/resilience/circuitbreaker/__init__.py
+++ b/grelmicro/resilience/circuitbreaker/__init__.py
@@ -424,7 +424,7 @@ class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):
                 Component, or run the call under the app context (for
                 FastAPI, add `GrelmicroMiddleware`).
         """
-        if self._backend is not None:  # pragma: no cover
+        if self._backend is not None:
             return self._backend
         from grelmicro._app import (  # noqa: PLC0415
             ComponentNotRegisteredError,

--- a/tests/coordination/test_leaderelection.py
+++ b/tests/coordination/test_leaderelection.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
+import grelmicro.coordination._base as base_module
 import grelmicro.coordination.leaderelection as le_module
 from grelmicro.coordination.abc import LeaderElectionBackend
 from grelmicro.coordination.leaderelection import (
@@ -860,7 +861,7 @@ async def test_renew_loop_jitter_formula_exact_sleep(
     # Arrange: pin randomness and capture the interval, then stop after one
     # iteration so the loop unwinds.
     random_value = 0.75
-    mocker.patch.object(le_module, "_random", return_value=random_value)
+    mocker.patch.object(base_module, "_random", return_value=random_value)
     recorded: list[float] = []
 
     async def fake_sleep_or_stop(seconds: float, _stop: object) -> bool:

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -9,6 +9,7 @@ from threading import get_ident
 import pytest
 from pytest_mock import MockerFixture
 
+import grelmicro.coordination._base as base_module
 import grelmicro.coordination.lock as lock_module
 from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination.abc import LockBackend
@@ -991,7 +992,7 @@ async def test_lock_acquire_jitter_applied(
     lock: Lock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Jitter scales the retry interval when _random is pinned."""
-    monkeypatch.setattr(lock_module, "_random", lambda: 1.0)
+    monkeypatch.setattr(base_module, "_random", lambda: 1.0)
     # With jitter=0.1 and _random()=1.0: interval = retry_interval * (1 + 0.1 * 1.0) = 1.1x
     # This test just verifies acquire still completes without error.
     handle = await lock.acquire()
@@ -1062,7 +1063,7 @@ async def test_acquire_with_jitter_scales_retry_sleep(
         "do_acquire",
         mocker.AsyncMock(side_effect=[None, expected_fencing_token]),
     )
-    mocker.patch.object(lock_module, "_random", return_value=1.0)
+    mocker.patch.object(base_module, "_random", return_value=1.0)
 
     # Act
     handle = await waiter.acquire()
@@ -1091,7 +1092,7 @@ async def test_acquire_jitter_formula_exact_sleep(
     mocker.patch.object(
         waiter, "do_acquire", mocker.AsyncMock(side_effect=[None, 7])
     )
-    mocker.patch.object(lock_module, "_random", return_value=random_value)
+    mocker.patch.object(base_module, "_random", return_value=random_value)
     recorded: list[float] = []
     mocker.patch.object(
         lock_module.asyncio,
@@ -1159,7 +1160,7 @@ async def test_thread_acquire_jitter_formula_exact_sleep(
     mocker.patch.object(
         waiter, "do_acquire", mocker.AsyncMock(side_effect=[None, 7])
     )
-    mocker.patch.object(lock_module, "_random", return_value=random_value)
+    mocker.patch.object(base_module, "_random", return_value=random_value)
     recorded: list[float] = []
     mocker.patch.object(
         lock_module.asyncio,

--- a/todo.md
+++ b/todo.md
@@ -1,9 +1,0 @@
-❯ 1. Mutation-test resilience
-     Run a mutmut campaign on the resilience module (circuit breaker, rate limiter, retry, shield) and close the genuine assertion gaps with verified killing tests, same proven flow as coordination. Highest robustness leverage before 1.0, the headline feature, never mutation-tested.
-  2. Mutation-test cache
-     Same campaign on the cache module (TTLCache, @cached, stampede, stale_ttl, tags). Complex, concurrency-heavy, never mutation-tested. Slightly lower stakes than resilience but real gaps likely.
-  3. Finish coordination gaps
-     Close the remaining ~7 mutation clusters from the original report (backend_timeout enforcement, metadata forwarding, last_confirmation_age sign, memory fencing-start). Completes what we started, smaller scope, diminishing returns.
-  4. Launch-readiness sweep
-     Audit LAUNCH_CHECKLIST.md and the comparison/capabilities pages for 1.0-final accuracy, verify every doc example runs against the published artifact, refresh any stale 'why not X' claims. Forward-looking toward 1.0 final and the launch.
-  5. Type something.

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,9 @@
+❯ 1. Mutation-test resilience
+     Run a mutmut campaign on the resilience module (circuit breaker, rate limiter, retry, shield) and close the genuine assertion gaps with verified killing tests, same proven flow as coordination. Highest robustness leverage before 1.0, the headline feature, never mutation-tested.
+  2. Mutation-test cache
+     Same campaign on the cache module (TTLCache, @cached, stampede, stale_ttl, tags). Complex, concurrency-heavy, never mutation-tested. Slightly lower stakes than resilience but real gaps likely.
+  3. Finish coordination gaps
+     Close the remaining ~7 mutation clusters from the original report (backend_timeout enforcement, metadata forwarding, last_confirmation_age sign, memory fencing-start). Completes what we started, smaller scope, diminishing returns.
+  4. Launch-readiness sweep
+     Audit LAUNCH_CHECKLIST.md and the comparison/capabilities pages for 1.0-final accuracy, verify every doc example runs against the published artifact, refresh any stale 'why not X' claims. Forward-looking toward 1.0 final and the launch.
+  5. Type something.


### PR DESCRIPTION
## What this does

Behavior-preserving internal refactors found by a code-quality review. No public API change, coverage stays 100%, the snapshot is unchanged.

- **Jitter formula consolidated.** The 7-line `retry_interval * (1 + jitter*(2*random()-1))` block was copied at three sites (`Lock.acquire`, `Lock.do_thread_acquire`, the `LeaderElection` renew loop), and the `_random` seam was declared in two modules. Extracted to one `jittered_interval(base, jitter)` helper plus one seam in `coordination/_base.py`. The jitter killing-tests were repointed to the new seam and re-verified to still kill a formula mutation (mutate the helper, tests fail; revert, tests pass).
- **`Lock._thread_token` deleted.** It re-implemented the public `generate_thread_token` from `_tokens.py`. Added an explicit `thread_id=` path to that helper and routed the four call sites through it, dropping one `# noqa: SLF001`.
- **Worker-immutability guard extracted.** The identical guard in three `_apply_reconfigure` methods is now one `assert_worker_unchanged(current, new)` call, preserving the exact ValueError message.
- **Removed a spurious `# pragma: no cover`** on `CircuitBreaker.backend` (the branch is exercised by tests, and the five sibling backend properties have no pragma). Coverage stays 100%.

Net effect: ~30 lines of duplication removed, one source of truth for the jitter math (which the mutation review flagged), and the coordination internals read consistently.

Full gate green: 2879 unit + 211 integration, 100% coverage, ruff and ty clean.