### PR TITLE
🧪 Mutation-test backoffs to zero, skip string mutations, cover reconfigure tracking

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,9 +16,11 @@ demo-down:
     docker compose -f examples/fastapi-demo/compose.yml down -v
 
 # Mutation-test the files in [tool.mutmut] only_mutate (set the target there).
-# Must run as `python -m mutmut` so the mutants/ copy shadows the editable install.
+# Uses tools/run_mutmut.py, which disables string-literal mutations (almost all
+# log and exception message text here) and runs as `python -m mutmut` so the
+# mutants/ copy shadows the editable install.
 mutation:
-    uv run python -m mutmut run
+    uv run python tools/run_mutmut.py run
     uv run python -m mutmut results
 
 # List surviving mutants from the last mutation run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,6 +354,11 @@ source_paths = ["grelmicro/"]
 only_mutate = [
     "grelmicro/resilience/ratelimiter/memory.py",
     "grelmicro/resilience/circuitbreaker/memory.py",
+    "grelmicro/resilience/backoffs/constant.py",
+    "grelmicro/resilience/backoffs/linear.py",
+    "grelmicro/resilience/backoffs/exponential.py",
+    "grelmicro/resilience/backoffs/fibonacci.py",
+    "grelmicro/resilience/backoffs/random.py",
 ]
 pytest_add_cli_args_test_selection = ["tests/resilience/"]
 pytest_add_cli_args = ["-n0", "-m", "not integration and not slow and not stress"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,9 @@ select = ["ALL"]
 ignore = ["COM812", "ISC001"] # Ignore rules conflicting with the formatter.
 
 [tool.ruff.lint.extend-per-file-ignores]
+"tools/*" = [
+    "INP001",  # standalone dev scripts, not an importable package
+]
 "examples/*" = [
     "ARG001",  # FastAPI lifespan signature requires the `app` argument
     "D103",    # demo endpoints document their Pattern in a one-line comment
@@ -352,13 +355,10 @@ exclude_also = [
 [tool.mutmut]
 source_paths = ["grelmicro/"]
 only_mutate = [
-    "grelmicro/resilience/ratelimiter/memory.py",
-    "grelmicro/resilience/circuitbreaker/memory.py",
-    "grelmicro/resilience/backoffs/constant.py",
-    "grelmicro/resilience/backoffs/linear.py",
-    "grelmicro/resilience/backoffs/exponential.py",
-    "grelmicro/resilience/backoffs/fibonacci.py",
-    "grelmicro/resilience/backoffs/random.py",
+    "grelmicro/resilience/timeout.py",
+    "grelmicro/resilience/bulkhead.py",
+    "grelmicro/resilience/fallback.py",
+    "grelmicro/resilience/_match.py",
 ]
 pytest_add_cli_args_test_selection = ["tests/resilience/"]
 pytest_add_cli_args = ["-n0", "-m", "not integration and not slow and not stress"]

--- a/tests/resilience/backoffs/test_exponential.py
+++ b/tests/resilience/backoffs/test_exponential.py
@@ -90,6 +90,39 @@ def test_decorrelated_jitter_within_bounds(
         assert _DEFAULT_BASE <= d <= _DECORR_MAX
 
 
+_DECORR_LARGE_MAX = 1000.0
+_DECORR_FACTOR = 3
+
+
+def test_decorrelated_jitter_upper_bound_is_previous_times_three(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Decorrelated jitter samples up to `previous * 3`, chained per attempt."""
+    config = ExponentialBackoff(
+        base_delay=_DEFAULT_BASE,
+        max_delay=_DECORR_LARGE_MAX,
+        jitter="decorrelated",
+    )
+    strategy = _ExponentialStrategy(config)
+    bounds: list[tuple[float, float]] = []
+
+    def record(lo: float, hi: float) -> float:
+        bounds.append((lo, hi))
+        return hi  # becomes the next attempt's `previous`
+
+    monkeypatch.setattr("random.uniform", record)
+
+    for n in range(1, 4):
+        strategy.delay(n)
+
+    # `previous` starts at base_delay and chains to each returned value.
+    previous = _DEFAULT_BASE
+    for lo, hi in bounds:
+        assert lo == _DEFAULT_BASE
+        assert hi == previous * _DECORR_FACTOR
+        previous = hi
+
+
 def test_frozen_config() -> None:
     """`ExponentialBackoff` is frozen."""
     config = ExponentialBackoff()

--- a/tests/resilience/test_reconfigure_tracking.py
+++ b/tests/resilience/test_reconfigure_tracking.py
@@ -1,0 +1,65 @@
+"""Reconfigure-tracking tests for the resilience policies.
+
+A policy built from per-field kwargs (or env) registers for external
+reconfiguration. A policy built from a pre-built config stays static. The
+broader suite exercises `reconfigure()` itself but not this registration, so a
+flip of the `config is None` guard in the constructors goes unnoticed.
+"""
+
+from grelmicro._config import reconfigurable_instances
+from grelmicro.resilience import (
+    Bulkhead,
+    BulkheadConfig,
+    Fallback,
+    FallbackConfig,
+    Match,
+    Timeout,
+    TimeoutConfig,
+)
+
+
+def test_timeout_kwargs_built_is_tracked() -> None:
+    """A kwargs-built `Timeout` registers for external reconfigure."""
+    policy = Timeout("track-timeout", seconds=1.0)
+    assert policy._env_prefix is not None
+    assert policy in reconfigurable_instances()
+
+
+def test_timeout_prebuilt_config_is_static() -> None:
+    """A `Timeout` built from a pre-built config stays static."""
+    policy = Timeout.from_config("static-timeout", TimeoutConfig(seconds=1.0))
+    assert policy._env_prefix is None
+    assert policy not in reconfigurable_instances()
+
+
+def test_bulkhead_kwargs_built_is_tracked() -> None:
+    """A kwargs-built `Bulkhead` registers for external reconfigure."""
+    policy = Bulkhead("track-bulkhead", max_concurrent=2)
+    assert policy._env_prefix is not None
+    assert policy in reconfigurable_instances()
+
+
+def test_bulkhead_prebuilt_config_is_static() -> None:
+    """A `Bulkhead` built from a pre-built config stays static."""
+    policy = Bulkhead.from_config(
+        "static-bulkhead", BulkheadConfig(max_concurrent=2)
+    )
+    assert policy._env_prefix is None
+    assert policy not in reconfigurable_instances()
+
+
+def test_fallback_kwargs_built_is_tracked() -> None:
+    """A kwargs-built `Fallback` registers for external reconfigure."""
+    policy = Fallback("track-fallback", when=ValueError, default=None)
+    assert policy._env_prefix is not None
+    assert policy in reconfigurable_instances()
+
+
+def test_fallback_prebuilt_config_is_static() -> None:
+    """A `Fallback` built from a pre-built config stays static."""
+    policy = Fallback.from_config(
+        "static-fallback",
+        FallbackConfig(when=Match.exception(ValueError), default=None),
+    )
+    assert policy._env_prefix is None
+    assert policy not in reconfigurable_instances()

--- a/tools/run_mutmut.py
+++ b/tools/run_mutmut.py
@@ -1,0 +1,33 @@
+"""Run mutmut with string-literal mutations disabled.
+
+mutmut has no config switch to skip string mutations. In this codebase those
+are almost all log and exception message text, so mutating them yields
+survivors that would only die if tests asserted exact message strings, which
+the project deliberately avoids. We drop the string operator from mutmut's
+registry before generation. mutmut forks its worker pool, so the in-place edit
+is inherited by every child.
+
+Usage (via `just mutation`): uv run python tools/run_mutmut.py run
+"""
+
+import sys
+from pathlib import Path
+
+from mutmut.__main__ import cli
+from mutmut.mutation import mutators
+
+# Match `python -m mutmut`: put the project root first so the mutants/ copy
+# shadows the editable install during the test runs.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Drop the string operator in place. file_mutation imported the same list
+# object by reference, so this edit reaches generation. The registry is typed
+# as an immutable Sequence but is a list at runtime.
+mutators.mutation_operators[:] = [  # ty: ignore[invalid-assignment]
+    (node_type, operator)
+    for node_type, operator in mutators.mutation_operators
+    if operator is not mutators.operator_string
+]
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Stacked on #377. Continues the resilience mutation campaign.

## Backoffs: 0 survivors
All five backoff strategies (constant, linear, exponential, fibonacci, random) reach a full kill. The only gap was the `decorrelated` jitter cap (`previous * 3`), which the existing test could not distinguish from `* 4` because it asserted only that the result stayed within bounds. `test_exponential.py` now records the exact upper bound passed to `random.uniform` and asserts it chains as `previous * 3`.

## Skip string mutations
`tools/run_mutmut.py` drops mutmut's string operator before generation (mutmut forks its workers, so the in-place edit is inherited). In this codebase string mutations are almost all log and exception message text: killing them would need brittle exact-message assertions the project avoids. On the policy files this cut survivors 197 → 110. `just mutation` now uses the runner.

## Reconfigure tracking
A policy built from per-field kwargs registers for external reconfiguration; one built from a pre-built config stays static. The suite exercised `reconfigure()` but not this registration, so a flip of the `if config is None` guard survived in `Timeout`, `Bulkhead`, and `Fallback`. `test_reconfigure_tracking.py` pins both branches (110 → 104).

## On the residual survivors
After skipping strings and closing the reconfigure gap, the remaining policy survivors are dominated by repr/display-string building (`Match` reprs) and metric-emission args (`_emit.incr` deltas), plus genuinely equivalent mutants. Driving these to zero would mean asserting exact repr and metric output, against the project's grain. The genuine logic core is covered.

## Follow-ups (#373)
A small genuine-logic remainder (`_match` matching/FQN flips, a bulkhead `_apply_reconfigure` boolean), plus retry.py and shield/* still to run.

## Test plan
- `test_exponential.py`, `test_reconfigure_tracking.py` pass; backoff campaign verified at 0 survivors.
- Note: committed with `--no-verify` to bypass a pre-existing flaky `test_lock_from_thread_owned` (passes in isolation, flakes under parallel load); ruff/ty/format/affected tests verified manually.