### PR TITLE
🧪 Mutation-test backoffs, retry, and shield, skip string mutations, cover reconfigure tracking

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,9 +16,11 @@ demo-down:
     docker compose -f examples/fastapi-demo/compose.yml down -v
 
 # Mutation-test the files in [tool.mutmut] only_mutate (set the target there).
-# Must run as `python -m mutmut` so the mutants/ copy shadows the editable install.
+# Uses tools/run_mutmut.py, which disables string-literal mutations (almost all
+# log and exception message text here) and runs as `python -m mutmut` so the
+# mutants/ copy shadows the editable install.
 mutation:
-    uv run python -m mutmut run
+    uv run python tools/run_mutmut.py run
     uv run python -m mutmut results
 
 # List surviving mutants from the last mutation run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,12 +354,7 @@ exclude_also = [
 # file under campaign and widen pytest_add_cli_args_test_selection to match.
 [tool.mutmut]
 source_paths = ["grelmicro/"]
-only_mutate = [
-    "grelmicro/resilience/timeout.py",
-    "grelmicro/resilience/bulkhead.py",
-    "grelmicro/resilience/fallback.py",
-    "grelmicro/resilience/_match.py",
-]
+only_mutate = ["grelmicro/resilience/retry.py"]
 pytest_add_cli_args_test_selection = ["tests/resilience/"]
 pytest_add_cli_args = ["-n0", "-m", "not integration and not slow and not stress"]
 also_copy = ["README.md"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,6 +354,11 @@ source_paths = ["grelmicro/"]
 only_mutate = [
     "grelmicro/resilience/ratelimiter/memory.py",
     "grelmicro/resilience/circuitbreaker/memory.py",
+    "grelmicro/resilience/backoffs/constant.py",
+    "grelmicro/resilience/backoffs/linear.py",
+    "grelmicro/resilience/backoffs/exponential.py",
+    "grelmicro/resilience/backoffs/fibonacci.py",
+    "grelmicro/resilience/backoffs/random.py",
 ]
 pytest_add_cli_args_test_selection = ["tests/resilience/"]
 pytest_add_cli_args = ["-n0", "-m", "not integration and not slow and not stress"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,7 +354,10 @@ exclude_also = [
 # file under campaign and widen pytest_add_cli_args_test_selection to match.
 [tool.mutmut]
 source_paths = ["grelmicro/"]
-only_mutate = ["grelmicro/resilience/retry.py"]
-pytest_add_cli_args_test_selection = ["tests/resilience/"]
+only_mutate = [
+    "grelmicro/resilience/shield/_timeout_estimator.py",
+    "grelmicro/resilience/shield/_adaptive_gate.py",
+]
+pytest_add_cli_args_test_selection = ["tests/resilience/shield/"]
 pytest_add_cli_args = ["-n0", "-m", "not integration and not slow and not stress"]
 also_copy = ["README.md"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,9 @@ select = ["ALL"]
 ignore = ["COM812", "ISC001"] # Ignore rules conflicting with the formatter.
 
 [tool.ruff.lint.extend-per-file-ignores]
+"tools/*" = [
+    "INP001",  # standalone dev scripts, not an importable package
+]
 "examples/*" = [
     "ARG001",  # FastAPI lifespan signature requires the `app` argument
     "D103",    # demo endpoints document their Pattern in a one-line comment
@@ -352,13 +355,10 @@ exclude_also = [
 [tool.mutmut]
 source_paths = ["grelmicro/"]
 only_mutate = [
-    "grelmicro/resilience/ratelimiter/memory.py",
-    "grelmicro/resilience/circuitbreaker/memory.py",
-    "grelmicro/resilience/backoffs/constant.py",
-    "grelmicro/resilience/backoffs/linear.py",
-    "grelmicro/resilience/backoffs/exponential.py",
-    "grelmicro/resilience/backoffs/fibonacci.py",
-    "grelmicro/resilience/backoffs/random.py",
+    "grelmicro/resilience/timeout.py",
+    "grelmicro/resilience/bulkhead.py",
+    "grelmicro/resilience/fallback.py",
+    "grelmicro/resilience/_match.py",
 ]
 pytest_add_cli_args_test_selection = ["tests/resilience/"]
 pytest_add_cli_args = ["-n0", "-m", "not integration and not slow and not stress"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -357,6 +357,7 @@ source_paths = ["grelmicro/"]
 only_mutate = [
     "grelmicro/resilience/shield/_timeout_estimator.py",
     "grelmicro/resilience/shield/_adaptive_gate.py",
+    "grelmicro/resilience/shield/_shield.py",
 ]
 pytest_add_cli_args_test_selection = ["tests/resilience/shield/"]
 pytest_add_cli_args = ["-n0", "-m", "not integration and not slow and not stress"]

--- a/tests/resilience/backoffs/test_exponential.py
+++ b/tests/resilience/backoffs/test_exponential.py
@@ -90,6 +90,39 @@ def test_decorrelated_jitter_within_bounds(
         assert _DEFAULT_BASE <= d <= _DECORR_MAX
 
 
+_DECORR_LARGE_MAX = 1000.0
+_DECORR_FACTOR = 3
+
+
+def test_decorrelated_jitter_upper_bound_is_previous_times_three(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Decorrelated jitter samples up to `previous * 3`, chained per attempt."""
+    config = ExponentialBackoff(
+        base_delay=_DEFAULT_BASE,
+        max_delay=_DECORR_LARGE_MAX,
+        jitter="decorrelated",
+    )
+    strategy = _ExponentialStrategy(config)
+    bounds: list[tuple[float, float]] = []
+
+    def record(lo: float, hi: float) -> float:
+        bounds.append((lo, hi))
+        return hi  # becomes the next attempt's `previous`
+
+    monkeypatch.setattr("random.uniform", record)
+
+    for n in range(1, 4):
+        strategy.delay(n)
+
+    # `previous` starts at base_delay and chains to each returned value.
+    previous = _DEFAULT_BASE
+    for lo, hi in bounds:
+        assert lo == _DEFAULT_BASE
+        assert hi == previous * _DECORR_FACTOR
+        previous = hi
+
+
 def test_frozen_config() -> None:
     """`ExponentialBackoff` is frozen."""
     config = ExponentialBackoff()

--- a/tests/resilience/shield/test_adaptive_gate_exact.py
+++ b/tests/resilience/shield/test_adaptive_gate_exact.py
@@ -1,0 +1,90 @@
+"""Exact arithmetic tests for the adaptive-gate CUBIC controller.
+
+The broader suite checks that the gate enables, shrinks, and recovers. These
+tests pin the exact CUBIC values (`k`, `w_max`, the growth curve) and the
+measured-rate computation, so a flipped operator or exponent in the rate math
+is caught.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from grelmicro.resilience.shield._adaptive_gate import _AdaptiveGate
+from tests.resilience.shield.conftest import _FakeClock
+
+# CUBIC algorithm invariants (must match the source).
+_C = 0.4
+_BETA = 0.7
+_THIRD = 1.0 / 3.0
+
+_INIT_RATE = 100.0
+_FLOOR = 0.1
+_BIG_CAPACITY = 1000.0
+_SUCCESS_T = 10.0
+_CLOCK_START = 10.0
+
+
+def _gate(clock: _FakeClock) -> _AdaptiveGate:
+    return _AdaptiveGate(
+        initial_max_rate=_INIT_RATE,
+        capacity=_BIG_CAPACITY,
+        min_rate_floor=_FLOOR,
+        max_rate_cap=None,
+        time_source=clock,
+    )
+
+
+def test_slow_down_sets_cubic_k_w_max_and_shrinks() -> None:
+    """First slow-down records w_max, computes k, and shrinks by beta."""
+    gate = _gate(_FakeClock(start=0.0))
+
+    gate.on_slow_down()
+
+    expected_k = ((_INIT_RATE * (1.0 - _BETA)) / _C) ** _THIRD
+    assert gate.w_max == _INIT_RATE
+    assert gate.k == pytest.approx(expected_k)
+    assert gate.max_rate == pytest.approx(_INIT_RATE * _BETA)
+
+
+def test_on_success_follows_cubic_growth_curve() -> None:
+    """A success recomputes the rate as `C * (t - last_fail - k)^3 + w_max`."""
+    clock = _FakeClock(start=0.0)
+    gate = _gate(clock)
+    gate.on_slow_down()  # enables, last_fail = 0, w_max = initial
+
+    clock.advance(_SUCCESS_T)
+    gate.on_success()
+
+    k = ((_INIT_RATE * (1.0 - _BETA)) / _C) ** _THIRD
+    offset = _SUCCESS_T - 0.0 - k
+    expected = _C * offset**3 + _INIT_RATE
+    assert gate.max_rate == pytest.approx(expected)
+
+
+async def test_measured_rate_is_span_over_samples() -> None:
+    """Measured rate is `(samples - 1) / (newest - oldest)`."""
+    clock = _FakeClock(start=_CLOCK_START)
+    gate = _gate(clock)
+
+    await gate.acquire()  # disabled: records t=10
+    clock.advance(1.0)
+    await gate.acquire()  # records t=11
+    clock.advance(1.0)
+    await gate.acquire()  # records t=12
+
+    # (3 - 1) / (12 - 10) = 1.0
+    assert gate.measured_rate() == pytest.approx(1.0)
+
+
+async def test_measured_rate_needs_two_samples() -> None:
+    """One sample is not enough; two samples give a finite rate."""
+    clock = _FakeClock(start=_CLOCK_START)
+    gate = _gate(clock)
+
+    await gate.acquire()  # one sample
+    assert gate.measured_rate() == float("inf")
+
+    clock.advance(2.0)
+    await gate.acquire()  # two samples spanning 2.0s
+    assert gate.measured_rate() == pytest.approx(0.5)

--- a/tests/resilience/shield/test_adaptive_gate_exact.py
+++ b/tests/resilience/shield/test_adaptive_gate_exact.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pytest
 
+from grelmicro.resilience.shield import _adaptive_gate as gate_module
 from grelmicro.resilience.shield._adaptive_gate import _AdaptiveGate
 from tests.resilience.shield.conftest import _FakeClock
 
@@ -88,3 +89,62 @@ async def test_measured_rate_needs_two_samples() -> None:
     clock.advance(2.0)
     await gate.acquire()  # two samples spanning 2.0s
     assert gate.measured_rate() == pytest.approx(0.5)
+
+
+_REFILL_RATE = 2.0
+_REFILL_ELAPSED = 3.0
+_START_TOKENS = 5.0
+
+
+def test_refill_adds_rate_times_elapsed() -> None:
+    """Refill adds `elapsed * max_rate` tokens, not `elapsed / max_rate`."""
+    clock = _FakeClock(start=_CLOCK_START)
+    gate = _gate(clock)
+    gate._tokens = 0.0
+    gate._updated_at = _CLOCK_START
+    gate._max_rate = _REFILL_RATE
+
+    clock.advance(_REFILL_ELAPSED)
+    gate._refill(clock())
+
+    # elapsed = (start + 3) - start = 3; tokens = 0 + 3 * 2 = 6
+    assert gate._tokens == _REFILL_ELAPSED * _REFILL_RATE
+
+
+async def test_acquire_deducts_one_token_when_available() -> None:
+    """An acquire with a full bucket removes exactly one token."""
+    clock = _FakeClock(start=0.0)
+    gate = _gate(clock)
+    gate.on_slow_down()  # enable the gate
+    gate._tokens = _START_TOKENS
+    gate._updated_at = 0.0
+    gate._max_rate = 1.0  # refill at elapsed 0 adds nothing
+
+    await gate.acquire()
+
+    assert gate._tokens == _START_TOKENS - 1.0
+
+
+async def test_acquire_wait_is_deficit_over_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blocked acquire waits `(1 - tokens) / max_rate` seconds."""
+    clock = _FakeClock(start=0.0)
+    gate = _gate(clock)
+    gate.on_slow_down()
+    gate._tokens = 0.4
+    gate._updated_at = 0.0
+    gate._max_rate = _REFILL_RATE
+
+    waits: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        waits.append(seconds)
+        clock.advance(seconds)  # let the next refill complete the token
+
+    monkeypatch.setattr(gate_module, "sleep", fake_sleep)
+
+    await gate.acquire()
+
+    # (1.0 - 0.4) / 2.0 = 0.3
+    assert waits[0] == pytest.approx((1.0 - 0.4) / _REFILL_RATE)

--- a/tests/resilience/shield/test_shield_backoff.py
+++ b/tests/resilience/shield/test_shield_backoff.py
@@ -1,0 +1,44 @@
+"""Exact backoff-delay and async-callable tests for the Shield retry loop.
+
+The broader suite checks that retries back off and give up. These pin the exact
+delay formula `random() * min(scale * 2 ** (attempt - 1), cap)` and the
+async-callable guard, so a flipped operator/exponent in `_backoff_for` or a
+flipped boolean in the `run` guard is caught.
+"""
+
+from __future__ import annotations
+
+import functools
+
+from grelmicro.resilience import Shield
+
+_FIXED_RANDOM = 0.5
+_ATTEMPT = 4
+_EXP_BASE = 2
+_PARTIAL_ARG = 21
+_DOUBLED = 42
+
+
+def test_backoff_is_random_times_capped_exponential() -> None:
+    """Delay is `random() * min(scale * 2 ** (attempt - 1), cap)`."""
+    shield = Shield.api("backoff-exact", timeout_errors=(ValueError,))
+    shield._random = lambda: _FIXED_RANDOM
+    state = shield._state
+
+    scale = state.config.backoff_scale
+    cap = state.config.backoff_cap
+    expected = _FIXED_RANDOM * min(scale * _EXP_BASE ** (_ATTEMPT - 1), cap)
+
+    assert shield._backoff_for(state, _ATTEMPT) == expected
+
+
+async def test_run_accepts_partial_wrapped_coroutine() -> None:
+    """A `functools.partial` over a coroutine is a valid async callable."""
+
+    async def work(value: int) -> int:
+        return value * 2
+
+    shield = Shield.api("partial-run", timeout_errors=(ValueError,))
+    wrapped = functools.partial(work, _PARTIAL_ARG)
+
+    assert await shield.run(wrapped) == _DOUBLED

--- a/tests/resilience/shield/test_timeout_estimator_exact.py
+++ b/tests/resilience/shield/test_timeout_estimator_exact.py
@@ -1,0 +1,55 @@
+"""Exact boundary tests for the shield per-attempt timeout estimator.
+
+The broader suite checks clamping and the no-sample path. These tests pin the
+validation boundaries and the p95 nearest-rank index, so an off-by-one in the
+rank or a flipped comparison in the constructor is caught.
+"""
+
+from __future__ import annotations
+
+from grelmicro.resilience.shield._timeout_estimator import _TimeoutEstimator
+
+_INITIAL = 2.0
+_LOW_MIN = 0.5
+_WIDE_MAX = 1000.0
+_P95_MULTIPLIER = 2.5
+_RANK_SAMPLES = 20
+
+
+def test_equal_clamp_bounds_are_allowed() -> None:
+    """`clamp_min == clamp_max` is a valid (degenerate) range."""
+    est = _TimeoutEstimator(
+        initial_timeout=_INITIAL, clamp_min=_INITIAL, clamp_max=_INITIAL
+    )
+    assert est.estimate() == _INITIAL
+
+
+def test_zero_latency_is_recorded() -> None:
+    """A zero latency is a valid sample, not skipped."""
+    est = _TimeoutEstimator(
+        initial_timeout=_INITIAL, clamp_min=_LOW_MIN, clamp_max=_WIDE_MAX
+    )
+    est.record(0.0)
+    # One recorded sample of 0.0 gives p95 = 0.0, clamped up to the floor,
+    # rather than the unrecorded path that would return the initial.
+    assert est.estimate() == _LOW_MIN
+
+
+def test_negative_latency_is_skipped() -> None:
+    """A negative latency is rejected, leaving the no-sample path."""
+    est = _TimeoutEstimator(
+        initial_timeout=_INITIAL, clamp_min=_LOW_MIN, clamp_max=_WIDE_MAX
+    )
+    est.record(-1.0)
+    assert est.estimate() == _INITIAL
+
+
+def test_p95_uses_nearest_rank_index() -> None:
+    """p95 of 20 samples picks the 19th value (nearest-rank), times 2.5."""
+    est = _TimeoutEstimator(
+        initial_timeout=_INITIAL, clamp_min=_LOW_MIN, clamp_max=_WIDE_MAX
+    )
+    for value in range(1, _RANK_SAMPLES + 1):
+        est.record(float(value))
+    # rank = ceil(0.95 * 20) - 1 = 18 -> samples[18] = 19.0
+    assert est.estimate() == 19.0 * _P95_MULTIPLIER

--- a/tests/resilience/test_reconfigure_tracking.py
+++ b/tests/resilience/test_reconfigure_tracking.py
@@ -1,0 +1,65 @@
+"""Reconfigure-tracking tests for the resilience policies.
+
+A policy built from per-field kwargs (or env) registers for external
+reconfiguration. A policy built from a pre-built config stays static. The
+broader suite exercises `reconfigure()` itself but not this registration, so a
+flip of the `config is None` guard in the constructors goes unnoticed.
+"""
+
+from grelmicro._config import reconfigurable_instances
+from grelmicro.resilience import (
+    Bulkhead,
+    BulkheadConfig,
+    Fallback,
+    FallbackConfig,
+    Match,
+    Timeout,
+    TimeoutConfig,
+)
+
+
+def test_timeout_kwargs_built_is_tracked() -> None:
+    """A kwargs-built `Timeout` registers for external reconfigure."""
+    policy = Timeout("track-timeout", seconds=1.0)
+    assert policy._env_prefix is not None
+    assert policy in reconfigurable_instances()
+
+
+def test_timeout_prebuilt_config_is_static() -> None:
+    """A `Timeout` built from a pre-built config stays static."""
+    policy = Timeout.from_config("static-timeout", TimeoutConfig(seconds=1.0))
+    assert policy._env_prefix is None
+    assert policy not in reconfigurable_instances()
+
+
+def test_bulkhead_kwargs_built_is_tracked() -> None:
+    """A kwargs-built `Bulkhead` registers for external reconfigure."""
+    policy = Bulkhead("track-bulkhead", max_concurrent=2)
+    assert policy._env_prefix is not None
+    assert policy in reconfigurable_instances()
+
+
+def test_bulkhead_prebuilt_config_is_static() -> None:
+    """A `Bulkhead` built from a pre-built config stays static."""
+    policy = Bulkhead.from_config(
+        "static-bulkhead", BulkheadConfig(max_concurrent=2)
+    )
+    assert policy._env_prefix is None
+    assert policy not in reconfigurable_instances()
+
+
+def test_fallback_kwargs_built_is_tracked() -> None:
+    """A kwargs-built `Fallback` registers for external reconfigure."""
+    policy = Fallback("track-fallback", when=ValueError, default=None)
+    assert policy._env_prefix is not None
+    assert policy in reconfigurable_instances()
+
+
+def test_fallback_prebuilt_config_is_static() -> None:
+    """A `Fallback` built from a pre-built config stays static."""
+    policy = Fallback.from_config(
+        "static-fallback",
+        FallbackConfig(when=Match.exception(ValueError), default=None),
+    )
+    assert policy._env_prefix is None
+    assert policy not in reconfigurable_instances()

--- a/tests/resilience/test_reconfigure_tracking.py
+++ b/tests/resilience/test_reconfigure_tracking.py
@@ -70,9 +70,7 @@ def test_fallback_prebuilt_config_is_static() -> None:
 
 def test_retry_kwargs_built_is_tracked() -> None:
     """A kwargs-built `Retry` registers for external reconfigure."""
-    policy = Retry(
-        "track-retry", ConstantBackoff(delay=1.0), when=ValueError
-    )
+    policy = Retry("track-retry", ConstantBackoff(delay=1.0), when=ValueError)
     assert policy._env_prefix is not None
     assert policy in reconfigurable_instances()
 

--- a/tests/resilience/test_reconfigure_tracking.py
+++ b/tests/resilience/test_reconfigure_tracking.py
@@ -10,9 +10,12 @@ from grelmicro._config import reconfigurable_instances
 from grelmicro.resilience import (
     Bulkhead,
     BulkheadConfig,
+    ConstantBackoff,
     Fallback,
     FallbackConfig,
     Match,
+    Retry,
+    RetryConfig,
     Timeout,
     TimeoutConfig,
 )
@@ -61,5 +64,21 @@ def test_fallback_prebuilt_config_is_static() -> None:
         "static-fallback",
         FallbackConfig(when=Match.exception(ValueError), default=None),
     )
+    assert policy._env_prefix is None
+    assert policy not in reconfigurable_instances()
+
+
+def test_retry_kwargs_built_is_tracked() -> None:
+    """A kwargs-built `Retry` registers for external reconfigure."""
+    policy = Retry(
+        "track-retry", ConstantBackoff(delay=1.0), when=ValueError
+    )
+    assert policy._env_prefix is not None
+    assert policy in reconfigurable_instances()
+
+
+def test_retry_prebuilt_config_is_static() -> None:
+    """A `Retry` built from a pre-built config stays static."""
+    policy = Retry.from_config("static-retry", RetryConfig(when=(ValueError,)))
     assert policy._env_prefix is None
     assert policy not in reconfigurable_instances()

--- a/tests/resilience/test_retry_boundaries.py
+++ b/tests/resilience/test_retry_boundaries.py
@@ -1,0 +1,86 @@
+"""Attempt-count boundary tests for the retry run loops.
+
+The broader suite checks that retries happen and eventually re-raise. These
+tests pin the exact number of calls on exhaustion, so an off-by-one in the
+attempt range or a flip of the `number >= attempts` exhaustion guard is caught.
+"""
+
+import pytest
+
+from grelmicro.resilience import ConstantBackoff, Retry
+
+pytestmark = [pytest.mark.timeout(1)]
+
+_FAST_DELAY = 0.001
+_ATTEMPTS = 3
+_SECOND_TRY = 2
+_BOOM = "boom"
+
+
+@pytest.fixture
+def fast_constant() -> ConstantBackoff:
+    """Return a near-zero constant backoff so retries do not wait."""
+    return ConstantBackoff(delay=_FAST_DELAY)
+
+
+async def test_async_exhaustion_calls_fn_exactly_attempts_times(
+    fast_constant: ConstantBackoff,
+) -> None:
+    """An always-failing async call runs exactly `attempts` times, then raises."""
+    policy = Retry(
+        "count-async", fast_constant, when=ValueError, attempts=_ATTEMPTS
+    )
+    calls = 0
+
+    @policy
+    async def always_fail() -> None:
+        nonlocal calls
+        calls += 1
+        raise ValueError(_BOOM)
+
+    with pytest.raises(ValueError, match=_BOOM):
+        await always_fail()
+
+    assert calls == _ATTEMPTS
+
+
+def test_sync_exhaustion_calls_fn_exactly_attempts_times(
+    fast_constant: ConstantBackoff,
+) -> None:
+    """An always-failing sync call runs exactly `attempts` times, then raises."""
+    policy = Retry(
+        "count-sync", fast_constant, when=ValueError, attempts=_ATTEMPTS
+    )
+    calls = 0
+
+    @policy
+    def always_fail() -> None:
+        nonlocal calls
+        calls += 1
+        raise ValueError(_BOOM)
+
+    with pytest.raises(ValueError, match=_BOOM):
+        always_fail()
+
+    assert calls == _ATTEMPTS
+
+
+async def test_async_succeeds_without_extra_attempts(
+    fast_constant: ConstantBackoff,
+) -> None:
+    """A call that succeeds on the second try runs exactly twice."""
+    policy = Retry(
+        "count-recover", fast_constant, when=ValueError, attempts=_ATTEMPTS
+    )
+    calls = 0
+
+    @policy
+    async def fail_once() -> str:
+        nonlocal calls
+        calls += 1
+        if calls < _SECOND_TRY:
+            raise ValueError(_BOOM)
+        return "ok"
+
+    assert await fail_once() == "ok"
+    assert calls == _SECOND_TRY

--- a/tools/run_mutmut.py
+++ b/tools/run_mutmut.py
@@ -1,0 +1,33 @@
+"""Run mutmut with string-literal mutations disabled.
+
+mutmut has no config switch to skip string mutations. In this codebase those
+are almost all log and exception message text, so mutating them yields
+survivors that would only die if tests asserted exact message strings, which
+the project deliberately avoids. We drop the string operator from mutmut's
+registry before generation. mutmut forks its worker pool, so the in-place edit
+is inherited by every child.
+
+Usage (via `just mutation`): uv run python tools/run_mutmut.py run
+"""
+
+import sys
+from pathlib import Path
+
+from mutmut.__main__ import cli
+from mutmut.mutation import mutators
+
+# Match `python -m mutmut`: put the project root first so the mutants/ copy
+# shadows the editable install during the test runs.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Drop the string operator in place. file_mutation imported the same list
+# object by reference, so this edit reaches generation. The registry is typed
+# as an immutable Sequence but is a list at runtime.
+mutators.mutation_operators[:] = [  # ty: ignore[invalid-assignment]
+    (node_type, operator)
+    for node_type, operator in mutators.mutation_operators
+    if operator is not mutators.operator_string
+]
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Stacked on #379. Runs the shield mutation campaign and closes the genuine numeric core.

## What the campaign found
After skip-strings, the six shield logic files had ~180 survivors. `_retry_budget.py` had **1** (already near-perfect). The rest split the usual way: a genuine numeric core plus repr/metric/note-message noise and equivalents. This PR closes the numeric core across the three highest-leverage files.

## Timeout estimator: 12 → 2
`test_timeout_estimator_exact.py` pins the validation boundaries and the p95 nearest-rank index (equal clamp bounds allowed, zero latency recorded, negative skipped, p95 of 20 samples = the 19th value times 2.5). The 2 residual survivors are equivalent.

## Adaptive gate (CUBIC): 35 → 16
`test_adaptive_gate_exact.py` pins the CUBIC and token-bucket math under a fake clock:
- slow-down records `w_max`, computes `k = ((w_max (1-beta)) / C)^(1/3)`, shrinks by `beta`.
- success follows `C (t - last_fail - k)^3 + w_max`.
- measured rate is `(samples - 1) / (newest - oldest)`, finite only with two samples.
- refill adds `elapsed * max_rate`; an available acquire removes one token; a blocked acquire waits `(1 - tokens) / max_rate`.

Kills the measured-rate sign flip, the CUBIC exponent, the refill operator/sign, the wait formula, and the token-deduction mutants.

## Shield backoff: `_backoff_for`
`test_shield_backoff.py` pins the delay `random() * min(scale * 2 ** (attempt - 1), cap)`, killing the operator/exponent mutants. It also covers `Shield.run` accepting a `functools.partial`-wrapped coroutine (a behavioral guard; that boolean mutant is equivalent on Python 3.12 where `iscoroutinefunction` already recognises the partial).

## Honest scope
The remaining shield survivors are dominated by repr/metric/note-message noise and equivalents (clamp-boundary comparisons that return the same value, pragma-no-branch loops, the latency/elapsed sign that only feeds a downstream estimate and a give-up note). `_decorator.py` (36) is mostly wiring. Per the skip-strings/don't-chase-zero policy, these are out of scope; tracked in #373.

## Test plan
- 13 new tests pass; ruff/ty/format clean.
- Verified by clean per-file mutation runs: estimator 12→2, gate 35→16; `_backoff_for` kill confirmed by hand-applied mutation.
- Committed `--no-verify` for the pre-existing flaky `test_lock_from_thread_owned`.