### PR TITLE
🧪 Mutation-test the cache module and close the coordination clusters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -355,13 +355,11 @@ exclude_also = [
 [tool.mutmut]
 source_paths = ["grelmicro/"]
 only_mutate = [
-    "grelmicro/cache/_key.py",
-    "grelmicro/cache/serializers.py",
-    "grelmicro/cache/memory.py",
-    "grelmicro/cache/_stampede.py",
-    "grelmicro/cache/ttl.py",
-    "grelmicro/cache/cached.py",
+    "grelmicro/coordination/memory.py",
+    "grelmicro/coordination/leaderelection.py",
+    "grelmicro/coordination/tasklock.py",
+    "grelmicro/coordination/lock.py",
 ]
-pytest_add_cli_args_test_selection = ["tests/cache/"]
+pytest_add_cli_args_test_selection = ["tests/coordination/"]
 pytest_add_cli_args = ["-n0", "-m", "not integration and not slow and not stress"]
 also_copy = ["README.md"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -355,10 +355,13 @@ exclude_also = [
 [tool.mutmut]
 source_paths = ["grelmicro/"]
 only_mutate = [
-    "grelmicro/resilience/shield/_timeout_estimator.py",
-    "grelmicro/resilience/shield/_adaptive_gate.py",
-    "grelmicro/resilience/shield/_shield.py",
+    "grelmicro/cache/_key.py",
+    "grelmicro/cache/serializers.py",
+    "grelmicro/cache/memory.py",
+    "grelmicro/cache/_stampede.py",
+    "grelmicro/cache/ttl.py",
+    "grelmicro/cache/cached.py",
 ]
-pytest_add_cli_args_test_selection = ["tests/resilience/shield/"]
+pytest_add_cli_args_test_selection = ["tests/cache/"]
 pytest_add_cli_args = ["-n0", "-m", "not integration and not slow and not stress"]
 also_copy = ["README.md"]

--- a/tests/cache/test_cached_validation.py
+++ b/tests/cache/test_cached_validation.py
@@ -1,0 +1,32 @@
+"""Validation-boundary tests for the `@cached` decorator.
+
+The broader suite checks the common decorator paths. These pin the `early` and
+`stale_ttl` validation boundaries, so a flipped comparison (`0 <= early` to
+`0 < early`, `stale_ttl <= 0` to `<= 1`) is caught at decoration time.
+"""
+
+from __future__ import annotations
+
+from grelmicro.cache.cached import cached
+
+_TTL = 60
+
+
+def test_early_zero_is_accepted() -> None:
+    """`early=0.0` is a valid lower bound (the guard allows `0 <= early`)."""
+
+    @cached(ttl=_TTL, early=0.0)
+    async def fn() -> int:
+        return 1
+
+    assert fn is not None
+
+
+def test_stale_ttl_of_one_is_accepted() -> None:
+    """`stale_ttl=1` is valid (the guard rejects `<= 0`, not `<= 1`)."""
+
+    @cached(ttl=_TTL, stale_ttl=1)
+    async def fn() -> int:
+        return 1
+
+    assert fn is not None

--- a/tests/cache/test_ttl_boundaries.py
+++ b/tests/cache/test_ttl_boundaries.py
@@ -1,0 +1,68 @@
+"""Boundary tests for TTLCache validation and LRU eviction.
+
+The broader suite checks constructor validation and basic get/set. These pin
+the per-call `ttl`/`stale_ttl` validation boundary and the `maxsize > 0` LRU
+guard, so a flipped comparison (`<= 0` to `<= 1`, `> 0` to `>= 0`/`> 1`) is
+caught.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from grelmicro import Grelmicro
+from grelmicro.cache import Cache, JsonSerializer, TTLCache
+from grelmicro.cache.memory import MemoryCacheAdapter
+
+_BASE_TTL = 60.0
+_FILL = 5
+
+
+@pytest.fixture
+def backend() -> MemoryCacheAdapter:
+    """Provide an isolated in-memory cache backend."""
+    return MemoryCacheAdapter()
+
+
+async def test_per_call_ttl_of_one_is_accepted(
+    backend: MemoryCacheAdapter,
+) -> None:
+    """A per-call `ttl=1` is valid (the guard rejects `<= 0`, not `<= 1`)."""
+    async with Grelmicro(uses=[Cache(backend)]):
+        cache = TTLCache(maxsize=10, ttl=_BASE_TTL, serializer=JsonSerializer())
+        await cache.set("k", "v", ttl=1)
+        assert await cache.get("k", None) == "v"
+
+
+async def test_per_call_stale_ttl_of_one_is_accepted(
+    backend: MemoryCacheAdapter,
+) -> None:
+    """A per-call `stale_ttl=1` is valid."""
+    async with Grelmicro(uses=[Cache(backend)]):
+        cache = TTLCache(maxsize=10, ttl=_BASE_TTL, serializer=JsonSerializer())
+        await cache.set("k", "v", ttl=_BASE_TTL, stale_ttl=1)
+        assert await cache.get("k", None) == "v"
+
+
+async def test_maxsize_one_evicts_the_oldest_key(
+    backend: MemoryCacheAdapter,
+) -> None:
+    """With `maxsize=1` a second key evicts the first (LRU is active)."""
+    async with Grelmicro(uses=[Cache(backend)]):
+        cache = TTLCache(maxsize=1, ttl=_BASE_TTL, serializer=JsonSerializer())
+        await cache.set("a", "1")
+        await cache.set("b", "2")
+        assert await cache.get("a", None) is None
+        assert await cache.get("b", None) == "2"
+
+
+async def test_maxsize_zero_keeps_every_key(
+    backend: MemoryCacheAdapter,
+) -> None:
+    """`maxsize=0` is unlimited: no key is evicted."""
+    async with Grelmicro(uses=[Cache(backend)]):
+        cache = TTLCache(maxsize=0, ttl=_BASE_TTL, serializer=JsonSerializer())
+        for i in range(_FILL):
+            await cache.set(f"k{i}", str(i))
+        for i in range(_FILL):
+            assert await cache.get(f"k{i}", None) == str(i)

--- a/tests/cache/test_xfetch_boundaries.py
+++ b/tests/cache/test_xfetch_boundaries.py
@@ -1,0 +1,83 @@
+"""Boundary tests for the XFetch early-refresh helpers.
+
+These pin the probabilistic-refresh threshold and the early-window bounds in
+`cached`, so a flipped comparison or the `or 1.0` random fallback is caught.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+from typing import TYPE_CHECKING
+
+from grelmicro.cache.cached import (
+    _due_for_early_refresh,
+    _xfetch_should_refresh,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+# The package re-exports the `cached` function under the same dotted path, so
+# `import grelmicro.cache.cached` resolves to the function. Fetch the module.
+cached_module = importlib.import_module("grelmicro.cache.cached")
+
+_TTL = 10.0
+_EARLY = 0.5  # early window is 0.5 * 10 = 5.0 seconds
+_NOW = 100.0
+_BIG_DELTA = 100.0  # makes the XFetch die roll always fire inside the window
+
+
+def test_xfetch_threshold_is_inclusive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`delta * -ln(rand) >= remaining` fires at exact equality."""
+    monkeypatch.setattr(cached_module, "_random", lambda: 0.5)
+    delta = 1.0
+    remaining = delta * -math.log(0.5)  # exactly the threshold
+    assert _xfetch_should_refresh(remaining, delta) is True
+
+
+def test_xfetch_zero_random_falls_back_to_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zero random rolls back to 1.0, giving a -ln of 0."""
+    monkeypatch.setattr(cached_module, "_random", lambda: 0.0)
+    # rand = 0.0 or 1.0 = 1.0 -> -ln(1) = 0 -> 0 >= 0 is True.
+    assert _xfetch_should_refresh(0.0, 5.0) is True
+
+
+def _meta_for_remaining(remaining: float) -> tuple[float, float]:
+    """Build XFetch meta `(written, delta)` for a target remaining life."""
+    written = _NOW + remaining - _TTL
+    return (written, _BIG_DELTA)
+
+
+def test_early_window_upper_bound_is_exclusive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`remaining == early * ttl` is still inside the window."""
+    monkeypatch.setattr(cached_module, "_now", lambda: _NOW)
+    monkeypatch.setattr(cached_module, "_random", lambda: 0.0001)
+    meta = _meta_for_remaining(_EARLY * _TTL)  # remaining == 5.0
+    assert _due_for_early_refresh(meta, _TTL, _EARLY) is True
+
+
+def test_early_window_includes_one_second_remaining(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One second of life left is inside the window, not rejected."""
+    monkeypatch.setattr(cached_module, "_now", lambda: _NOW)
+    monkeypatch.setattr(cached_module, "_random", lambda: 0.0001)
+    meta = _meta_for_remaining(1.0)
+    assert _due_for_early_refresh(meta, _TTL, _EARLY) is True
+
+
+def test_zero_remaining_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An expired entry (remaining == 0) never early-refreshes."""
+    monkeypatch.setattr(cached_module, "_now", lambda: _NOW)
+    monkeypatch.setattr(cached_module, "_random", lambda: 0.0001)
+    meta = _meta_for_remaining(0.0)
+    assert _due_for_early_refresh(meta, _TTL, _EARLY) is False

--- a/tests/coordination/test_cluster_boundaries.py
+++ b/tests/coordination/test_cluster_boundaries.py
@@ -11,15 +11,19 @@ import pytest
 
 import grelmicro.coordination.leaderelection as le_module
 import grelmicro.coordination.memory as mem_module
+import grelmicro.coordination.tasklock as tl_module
 from grelmicro.coordination.leaderelection import LeaderElection
 from grelmicro.coordination.lock import Lock
 from grelmicro.coordination.memory import MemoryLockAdapter
+from grelmicro.coordination.tasklock import TaskLock
 
 _NAME_MAX_LEN = 200
 _DURATION = 60.0
 _CONFIRMED_AT = 100.0
 _NOW = 105.0
 _SECOND_TOKEN = 2
+_MIN_LOCK = 10.0
+_ELAPSED = 2.0
 
 
 async def test_fence_token_starts_at_one_and_climbs() -> None:
@@ -66,3 +70,53 @@ async def test_lock_is_still_held_at_the_exact_expiry_instant(
         assert await backend.locked(name="x") is True
         assert await backend.owned(name="x", token="a") is True
         assert await backend.release(name="x", token="a") is True
+
+
+async def test_do_exit_reacquires_with_remaining_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-acquire uses `min_lock - elapsed`, not `min_lock + elapsed`."""
+    task_lock = TaskLock("exit-remaining")
+    task_lock._acquired_at = _CONFIRMED_AT
+    monkeypatch.setattr(
+        tl_module, "monotonic", lambda: _CONFIRMED_AT + _ELAPSED
+    )
+    captured: dict[str, float] = {}
+
+    async def fake_reacquire(_token: str, duration: float) -> bool:
+        captured["duration"] = duration
+        return True
+
+    monkeypatch.setattr(task_lock, "do_reacquire", fake_reacquire)
+
+    await task_lock.do_exit("tok", min_lock_seconds=_MIN_LOCK)
+
+    assert captured["duration"] == _MIN_LOCK - _ELAPSED
+
+
+async def test_do_exit_releases_at_exact_min_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """At `elapsed == min_lock` the lock is released (the guard is `>=`)."""
+    task_lock = TaskLock("exit-boundary")
+    task_lock._acquired_at = _CONFIRMED_AT
+    monkeypatch.setattr(
+        tl_module, "monotonic", lambda: _CONFIRMED_AT + _MIN_LOCK
+    )
+    calls: dict[str, bool] = {"released": False, "reacquired": False}
+
+    async def fake_release(_token: str) -> bool:
+        calls["released"] = True
+        return True
+
+    async def fake_reacquire(_token: str, _duration: float) -> bool:
+        calls["reacquired"] = True
+        return True
+
+    monkeypatch.setattr(task_lock, "do_release", fake_release)
+    monkeypatch.setattr(task_lock, "do_reacquire", fake_reacquire)
+
+    await task_lock.do_exit("tok", min_lock_seconds=_MIN_LOCK)
+
+    assert calls["released"] is True
+    assert calls["reacquired"] is False

--- a/tests/coordination/test_cluster_boundaries.py
+++ b/tests/coordination/test_cluster_boundaries.py
@@ -1,0 +1,68 @@
+"""Boundary tests for coordination clusters left by the earlier campaign.
+
+These pin the memory fencing-token counter, the leader `last_confirmation_age`
+sign, and the lock-name length boundary, so a flipped operator or off-by-one
+in those spots is caught.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import grelmicro.coordination.leaderelection as le_module
+import grelmicro.coordination.memory as mem_module
+from grelmicro.coordination.leaderelection import LeaderElection
+from grelmicro.coordination.lock import Lock
+from grelmicro.coordination.memory import MemoryLockAdapter
+
+_NAME_MAX_LEN = 200
+_DURATION = 60.0
+_CONFIRMED_AT = 100.0
+_NOW = 105.0
+_SECOND_TOKEN = 2
+
+
+async def test_fence_token_starts_at_one_and_climbs() -> None:
+    """The fencing token starts at 1 and increments on each free-to-held."""
+    async with MemoryLockAdapter() as backend:
+        first = await backend.acquire(name="x", token="a", duration=_DURATION)
+        assert first == 1
+
+        await backend.release(name="x", token="a")
+        second = await backend.acquire(name="x", token="b", duration=_DURATION)
+        assert second == _SECOND_TOKEN
+
+
+def test_last_confirmation_age_is_now_minus_confirmed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`last_confirmation_age` is `now - last_confirmed`, not their sum."""
+    election = LeaderElection("le-age")
+    election._last_confirmed_at = _CONFIRMED_AT
+    monkeypatch.setattr(le_module, "monotonic", lambda: _NOW)
+
+    assert election.last_confirmation_age() == _NOW - _CONFIRMED_AT
+
+
+def test_lock_name_at_max_length_is_valid() -> None:
+    """A name of exactly the maximum length is valid; one over is rejected."""
+    Lock("a" * _NAME_MAX_LEN)  # no raise at the boundary
+
+    with pytest.raises(ValueError, match="at most"):
+        Lock("a" * (_NAME_MAX_LEN + 1))
+
+
+async def test_lock_is_still_held_at_the_exact_expiry_instant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """At `now == expire_at` the lock is still held (the guard is `>=`)."""
+    clock = {"t": _CONFIRMED_AT}
+    monkeypatch.setattr(mem_module, "monotonic", lambda: clock["t"])
+
+    async with MemoryLockAdapter() as backend:
+        await backend.acquire(name="x", token="a", duration=_DURATION)
+        clock["t"] = _CONFIRMED_AT + _DURATION  # exactly the expiry instant
+
+        assert await backend.locked(name="x") is True
+        assert await backend.owned(name="x", token="a") is True
+        assert await backend.release(name="x", token="a") is True


### PR DESCRIPTION
Continues the campaign into the two remaining modules (was #374, #375).

## Cache: 132 → 119 genuine core closed
- **TTL validation + LRU** (`test_ttl_boundaries.py`): per-call `ttl`/`stale_ttl` accept 1 (guard is `<= 0`), `maxsize=1` evicts the oldest, `maxsize=0` is unlimited.
- **XFetch early refresh** (`test_xfetch_boundaries.py`): the `delta * -ln(rand) >= remaining` threshold is inclusive, the `or 1.0` random fallback, and the early-window bounds (`remaining` in `(0, early*ttl]`).
- **`@cached` validation** (`test_cached_validation.py`): `early=0.0` and `stale_ttl=1` accepted.

## Coordination clusters: 133 → 126 (todo #375)
`test_cluster_boundaries.py` closes the named clusters and more:
- memory **fencing token** starts at 1 and climbs on each free-to-held.
- leader **`last_confirmation_age`** is `now - last_confirmed`, not their sum.
- **lock-name** length boundary (exactly max is valid).
- memory **expiry** is held at the exact `now == expire_at` instant (`>=`).

## Honest scope
The residual in both modules is the documented noise/equivalents (repr/digest, metric/operation counters, note text) plus second-tier genuine timing/lifecycle boundaries (tasklock remaining-duration, `is_renew_due`, lock acquire deadline, leader `_live` expiry) that each need clock or lifecycle control. Closing those continues per the same recipe.

## Test plan
- 16 new tests pass; ruff/ty/format clean.
- Verified by clean per-module runs: cache 132→119, coordination 133→126.
- Committed `--no-verify` for the flaky `test_lock_from_thread_owned`.