### PR TITLE
✅ Fix from_thread test flakiness and the latent CI ty errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,9 +306,12 @@ max-args = 10
 [tool.ty.src]
 # The logo build script is an adhoc PEP 723 utility (``uv run`` pulls its
 # deps into an ephemeral env). Project-level type checking can't see
-# ``resvg_py`` or ``fontTools`` and has no reason to.
+# ``resvg_py`` or ``fontTools`` and has no reason to. The mutmut runner
+# imports ``mutmut``, which lives in the optional ``mutation`` dependency
+# group that CI does not install.
 exclude = [
     "docs/img/logo/build_logo.py",
+    "tools/run_mutmut.py",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -27,7 +27,10 @@ from grelmicro.errors import OutOfContextError
 from grelmicro.errors import WouldBlockError as WouldBlock
 from tests._faults import cancel_midflight
 
-pytestmark = [pytest.mark.timeout(1)]
+# 5s, not 1s: the from_thread tests do several thread-to-loop round-trips that
+# slow down under heavy parallel CI load. The timeout guards against hangs, so
+# the extra headroom avoids flakes without weakening that guarantee.
+pytestmark = [pytest.mark.timeout(5)]
 
 WORKER_1 = 0
 WORKER_2 = 1

--- a/tests/resilience/test_match_validation.py
+++ b/tests/resilience/test_match_validation.py
@@ -14,10 +14,10 @@ from grelmicro.resilience import Match
 def test_exception_rejects_a_non_exception_type() -> None:
     """A plain class that is not an exception is rejected."""
     with pytest.raises(TypeError):
-        Match.exception(int)
+        Match.exception(int)  # ty: ignore[invalid-argument-type]
 
 
 def test_exception_cause_rejects_a_non_exception_type() -> None:
     """A plain class that is not an exception is rejected for the cause form."""
     with pytest.raises(TypeError):
-        Match.exception_cause(int)
+        Match.exception_cause(int)  # ty: ignore[invalid-argument-type]

--- a/tests/resilience/test_reconfigure_tracking.py
+++ b/tests/resilience/test_reconfigure_tracking.py
@@ -77,6 +77,9 @@ def test_retry_kwargs_built_is_tracked() -> None:
 
 def test_retry_prebuilt_config_is_static() -> None:
     """A `Retry` built from a pre-built config stays static."""
-    policy = Retry.from_config("static-retry", RetryConfig(when=(ValueError,)))
+    policy = Retry.from_config(
+        "static-retry",
+        RetryConfig(when=(ValueError,)),  # ty: ignore[missing-argument,invalid-argument-type]
+    )
     assert policy._env_prefix is None
     assert policy not in reconfigurable_instances()


### PR DESCRIPTION
Fixes the recurring flake in `tests/coordination/test_lock.py::test_lock_from_thread_owned` (and the other from_thread tests) that has been forcing `--no-verify` on commits.

## Root cause
The module sets a blanket `pytest.mark.timeout(1)`. Ten of the from_thread tests do 3-5 sequential thread-to-loop round-trips via `asyncio.run_coroutine_threadsafe(...).result()`. Under heavy parallel CI load the loop thread is descheduled often enough that the accumulated round-trip latency exceeds 1s, and pytest-timeout fails the test. The bridge itself is correct; the timeout was simply too tight for cross-thread work under contention.

## Fix
Raise the module timeout `1s -> 5s`. The timeout guards against genuine hangs (which fail regardless of the value), so the extra headroom removes the flake without weakening that guarantee. `test_lock_from_thread_owned` (the reported offender, 5 round-trips) now passes even under load.

## Note
A separate, pre-existing flake in `tests/providers/test_valkey_provider.py::test_circuitbreaker_factory` surfaced under the same extreme local load (passes in isolation). It is unrelated to this change and worth its own look if CI shows it.

## Test plan
- `test_lock.py` passes in full under `-n auto` locally; the from_thread subset is green.
- Strictly loosens a timeout, so it cannot regress behavior.