### PR TITLE
📝 Build docs with --strict in CI and pre-commit to catch snippet and link drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,29 @@ jobs:
       - name: Run Ty
         run: uv run ty check
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          activate-environment: true
+      - name: Install dependencies
+        run: uv sync --group docs
+      - name: Build docs (strict)
+        # --strict fails on broken links and missing nav; check_paths in
+        # mkdocs.yml fails on missing snippet includes. Together they catch
+        # doc and snippet drift that the snippet-execution tests cannot see.
+        run: uv run mkdocs build --strict
+
   workflow-lint:
     name: Workflow Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install Docs Dependencies
         run: uv sync --group docs
       - name: Build Docs
-        run: mkdocs build
+        run: mkdocs build --strict
       - name: Deploy Docs on GitHub Pages
         if: ${{ github.event.inputs.dry_run != 'true' }}
         run: mkdocs gh-deploy --force

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,8 +82,16 @@ repos:
     language: system
     pass_filenames: false
 
+  - id: mkdocs-build
+    name: mkdocs-build
+    description: "Build docs with --strict to catch snippet, link, and nav drift"
+    entry: uv run --group docs mkdocs build --strict
+    language: system
+    pass_filenames: false
+    files: '(^docs/|^mkdocs\.yml$|^README\.md$|^THIRD_PARTY_NOTICES\.md$)'
+
 
 ci:
   autofix_commit_msg: 🎨 [pre-commit.ci] Auto format from pre-commit.com hooks
   autoupdate_commit_msg: ⬆ [pre-commit.ci] pre-commit autoupdate
-  skip: [uv-lock, ty-check, pytest-unit, pytest-integration, coverage-report]
+  skip: [uv-lock, ty-check, pytest-unit, pytest-integration, coverage-report, mkdocs-build]

--- a/docs/task.md
+++ b/docs/task.md
@@ -233,7 +233,7 @@ next_fire = task.next_fire_time  # None until the first loop iteration
 For bigger applications, use the `TaskRouter` class to organize tasks across modules:
 
 ```python
---8<-- "task/router.py:1-10"
+--8<-- "task/router.py:1:10"
 ```
 
 Then include the `TaskRouter` into the `Tasks` or other routers:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,3 +165,4 @@ markdown_extensions:
       alternate_style: true
   - pymdownx.snippets:
       base_path: docs/snippets
+      check_paths: true


### PR DESCRIPTION
Makes documentation-snippet and link drift fail continuously, instead of a one-shot manual audit. This is the standard MkDocs approach.

## The gap
- `test_snippets.py` executes every `docs/snippets/*.py` and `test_readme.py` executes each README block, so **runtime** drift is caught. But a broken `--8<--` include path (the cache.md bug) is invisible to them: the snippet file is fine, the `.md` references it wrongly.
- `pymdownx.snippets` had no `check_paths`, so a missing include was silently swallowed. `mkdocs build` ran only at release, without `--strict`, and never in CI or pre-commit.

I verified this: a deliberately broken include builds with exit 0 under `--strict` alone. Only `check_paths: true` turns it into an error.

## The fix
- `mkdocs.yml`: `check_paths: true` so a missing snippet include fails the build.
- **CI**: new `Docs` job runs `mkdocs build --strict` (fails on broken links, missing nav, and now missing snippets).
- **pre-commit**: a `mkdocs-build` hook (scoped to `docs/`, `mkdocs.yml`, `README.md`, `THIRD_PARTY_NOTICES.md`; skipped on pre-commit.ci like the other heavy hooks, runs locally and in the CI job).
- **release**: `mkdocs build --strict` so the published build is guarded too.

## Latent bug this surfaced
`docs/task.md` used `--8<-- "task/router.py:1-10"` — pymdownx line ranges use colons (`:1:10`), so the dash form was read as a literal path and the **Task Router code blocks were rendering empty in the published docs**. Fixed to `:1:10`. `check_paths` caught it immediately.

## Test plan
- `mkdocs build --strict` passes clean; a broken include now fails (verified both ways).
- Full pre-commit passes locally with no `--no-verify` (the from_thread flake fix from #384 holds), including the new `mkdocs-build` hook.
- zizmor clean on the new CI job; check-yaml passes.