### PR TITLE
📝 Clarify SQLite ships durable cron but not leader election in capability legend

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -32,7 +32,7 @@ See [Backends and Adapters](architecture/backends.md) for the full model.
 Legend:
 
 - ✅ ships today.
-- `N/A` does not apply. `Retry`, `Bulkhead`, `Fallback`, and `Timeout` are in-process Patterns with no remote state to share. For `Schedule` (cron), Kubernetes has no Adapter on purpose: run a native [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) instead. For `LeaderElection`, SQLite has no adapter: leader election is meaningful only across multiple nodes, and SQLite does not coordinate across nodes.
+- `N/A` does not apply. `Retry`, `Bulkhead`, `Fallback`, and `Timeout` are in-process Patterns with no remote state to share. For `Schedule` (cron), Kubernetes has no Adapter on purpose: run a native [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) instead. For `LeaderElection`, SQLite has no adapter: leader election is meaningful only across multiple nodes, and SQLite does not coordinate across nodes. `Schedule` (cron) on SQLite does ship, because durable cron across processes on a single host is still useful.
 
 ## Picking an Adapter
 


### PR DESCRIPTION
Launch sweep #376 doc-accuracy pass for 1.0.

## What
- Capability legend now states SQLite ships durable single-host cron (`Schedule`) even though it has no `LeaderElection` adapter, removing the apparent contradiction with "SQLite does not coordinate across nodes".

## Audit results (no changes needed)
- Full 12-category accuracy audit of `docs/comparison.md` and `docs/capabilities.md` against the source: backend/adapter matrix, RateLimiter algorithms, Retry waits/stops, `Match` DSL, cache serializers and stampede `lock=`/`early=`, health-check options, lock token/reentrancy/`from_thread`, `RateLimitResult` fields, `reconfigure()`, and Redis Sentinel-Cluster + Valkey providers. All accurate.
- Matrix re-checked against the actual adapter classes: exact match.
- The `TTLCache[T]` + `PydanticSerializer(T)` cross-reference is already present in `comparison.md`.

## Not done (release-time gate)
- Item 1 (verify snippets against the **published** artifact) cannot be done until 1.0 is on PyPI (latest is 0.27.0). Repo-state coverage already lives in `tests/test_snippets.py` and `tests/test_readme.py`.

Closes part of #376.