### PR TITLE
🧪 Close coordination backend-timeout, metadata, fencing, and confirmation mutants

### DIFF
--- a/tests/coordination/test_cluster_boundaries.py
+++ b/tests/coordination/test_cluster_boundaries.py
@@ -7,15 +7,31 @@ in those spots is caught.
 
 from __future__ import annotations
 
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
 import pytest
 
 import grelmicro.coordination.leaderelection as le_module
 import grelmicro.coordination.memory as mem_module
 import grelmicro.coordination.tasklock as tl_module
-from grelmicro.coordination.leaderelection import LeaderElection
-from grelmicro.coordination.lock import Lock
-from grelmicro.coordination.memory import MemoryLockAdapter
-from grelmicro.coordination.tasklock import TaskLock
+from grelmicro.coordination.abc import LeaderElectionBackend, LeaderRecord
+from grelmicro.coordination.leaderelection import (
+    LeaderElection,
+    LeaderElectionConfig,
+)
+from grelmicro.coordination.lock import Lock, LockConfig
+from grelmicro.coordination.memory import (
+    MemoryLeaderElectionBackend,
+    MemoryLockAdapter,
+)
+from grelmicro.coordination.tasklock import TaskLock, TaskLockConfig
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from types import TracebackType
+    from typing import Self
 
 _NAME_MAX_LEN = 200
 _DURATION = 60.0
@@ -24,6 +40,22 @@ _NOW = 105.0
 _SECOND_TOKEN = 2
 _MIN_LOCK = 10.0
 _ELAPSED = 2.0
+_LEASE = 10.0
+_RENEW_DELTA = 3.0
+_EPOCH = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _freeze_memory_datetime(
+    monkeypatch: pytest.MonkeyPatch, now: datetime
+) -> None:
+    """Pin `datetime.now(UTC)` inside the memory module to `now`."""
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz: object = None) -> datetime:  # noqa: ARG003
+            return now
+
+    monkeypatch.setattr(mem_module, "datetime", _FixedDatetime)
 
 
 async def test_fence_token_starts_at_one_and_climbs() -> None:
@@ -120,3 +152,242 @@ async def test_do_exit_releases_at_exact_min_lock(
 
     assert calls["released"] is True
     assert calls["reacquired"] is False
+
+
+async def test_acquire_blocks_other_holder_at_exact_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """At `now == expire_at` a different token cannot take over (guard is `<`)."""
+    clock = {"t": _CONFIRMED_AT}
+    monkeypatch.setattr(mem_module, "monotonic", lambda: clock["t"])
+
+    async with MemoryLockAdapter() as backend:
+        assert (
+            await backend.acquire(name="x", token="a", duration=_DURATION) == 1
+        )
+        clock["t"] = _CONFIRMED_AT + _DURATION  # exactly the expiry instant
+
+        assert (
+            await backend.acquire(name="x", token="b", duration=_DURATION)
+            is None
+        )
+
+
+async def test_live_record_expires_at_exact_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """At `now == renewed_at + lease` the record is expired (guard is `>=`)."""
+    backend = MemoryLeaderElectionBackend()
+    _freeze_memory_datetime(monkeypatch, _EPOCH)
+    await backend.acquire_or_renew(name="svc", token="w1", duration=_LEASE)
+
+    _freeze_memory_datetime(monkeypatch, _EPOCH + timedelta(seconds=_LEASE))
+
+    assert await backend.get(name="svc") is None
+
+
+async def test_renew_forwards_renewed_at_and_lease_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Renewing the live lease writes the new renewed_at and lease_duration."""
+    backend = MemoryLeaderElectionBackend()
+    _freeze_memory_datetime(monkeypatch, _EPOCH)
+    first = await backend.acquire_or_renew(
+        name="svc", token="w1", duration=_LEASE
+    )
+
+    renewed_now = _EPOCH + timedelta(seconds=_RENEW_DELTA)
+    _freeze_memory_datetime(monkeypatch, renewed_now)
+    second = await backend.acquire_or_renew(
+        name="svc", token="w1", duration=_DURATION
+    )
+
+    assert second.renewed_at == renewed_now
+    assert second.lease_duration == _DURATION
+    assert second.acquired_at == first.acquired_at
+
+
+_META = {"pod": "p-1", "region": "eu"}
+_SLOW_BACKEND_TIMEOUT = 0.02
+_SLOW_BACKEND_SLEEP = 0.2
+
+
+def _record(token: str) -> LeaderRecord:
+    """Build a live `LeaderRecord` held by `token`."""
+    now = datetime.now(UTC)
+    return LeaderRecord(
+        holder=token,
+        lease_duration=_LEASE,
+        acquired_at=now,
+        renewed_at=now,
+        transitions=0,
+        metadata={},
+    )
+
+
+class _RecordingBackend(LeaderElectionBackend):
+    """Backend double that captures the metadata passed to acquire_or_renew."""
+
+    def __init__(self) -> None:
+        self.metadata_seen: Mapping[str, str] | None | str = "unset"
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def acquire_or_renew(
+        self,
+        *,
+        name: str,  # noqa: ARG002
+        token: str,
+        duration: float,  # noqa: ARG002
+        metadata: Mapping[str, str] | None = None,
+    ) -> LeaderRecord:
+        self.metadata_seen = metadata
+        return _record(token)
+
+    async def release(self, *, name: str, token: str) -> bool:  # noqa: ARG002
+        return True
+
+    async def get(self, *, name: str) -> LeaderRecord | None:  # noqa: ARG002
+        return None
+
+
+class _SlowBackend(LeaderElectionBackend):
+    """Backend double whose calls outlast the configured backend_timeout."""
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def acquire_or_renew(
+        self,
+        *,
+        name: str,  # noqa: ARG002
+        token: str,
+        duration: float,  # noqa: ARG002
+        metadata: Mapping[str, str] | None = None,  # noqa: ARG002
+    ) -> LeaderRecord:
+        await asyncio.sleep(_SLOW_BACKEND_SLEEP)
+        return _record(token)
+
+    async def release(self, *, name: str, token: str) -> bool:  # noqa: ARG002
+        await asyncio.sleep(_SLOW_BACKEND_SLEEP)
+        return True
+
+    async def get(self, *, name: str) -> LeaderRecord | None:  # noqa: ARG002
+        return None
+
+
+def _slow_config(worker: str) -> LeaderElectionConfig:
+    """Config with a tiny backend_timeout shorter than the slow backend sleep."""
+    return LeaderElectionConfig(
+        worker=worker,
+        lease_duration=10,
+        renew_deadline=5,
+        retry_interval=0.5,
+        backend_timeout=_SLOW_BACKEND_TIMEOUT,
+        error_interval=30,
+    )
+
+
+async def test_init_forwards_metadata_to_backend() -> None:
+    """Metadata passed to the constructor reaches the backend acquire call."""
+    backend = _RecordingBackend()
+    election = LeaderElection("le-meta", backend=backend, metadata=_META)
+
+    await election._try_acquire_or_renew(election._config)
+
+    assert backend.metadata_seen == _META
+
+
+async def test_from_config_forwards_metadata_to_backend() -> None:
+    """Metadata passed to from_config reaches the backend acquire call."""
+    backend = _RecordingBackend()
+    election = LeaderElection.from_config(
+        "le-meta-fc",
+        LeaderElectionConfig(worker="w1"),
+        backend=backend,
+        metadata=_META,
+    )
+
+    await election._try_acquire_or_renew(election._config)
+
+    assert backend.metadata_seen == _META
+
+
+async def test_record_is_none_before_first_attempt() -> None:
+    """A freshly built election exposes `record is None`."""
+    election = LeaderElection("le-record", backend=_RecordingBackend())
+
+    assert election.record is None
+
+
+async def test_is_leader_confirmed_within_requires_a_confirmation() -> None:
+    """Leader with no confirmation timestamp fails the freshness check."""
+    election = LeaderElection("le-confirm", backend=_RecordingBackend())
+    election._is_leader = True
+    election._last_confirmed_at = None
+
+    assert election.is_leader_confirmed_within(10.0) is False
+
+
+async def test_acquire_times_out_on_a_slow_backend() -> None:
+    """A backend slower than backend_timeout is abandoned, leaving no record."""
+    election = LeaderElection.from_config(
+        "le-timeout", _slow_config("w1"), backend=_SlowBackend()
+    )
+
+    await election._try_acquire_or_renew(election._config)
+
+    assert election.record is None
+    assert election.is_leader() is False
+
+
+async def test_release_times_out_on_a_slow_backend() -> None:
+    """Release wrapped in backend_timeout returns without hanging on a slow backend."""
+    election = LeaderElection.from_config(
+        "le-rel-timeout", _slow_config("w1"), backend=_SlowBackend()
+    )
+
+    async with asyncio.timeout(_SLOW_BACKEND_SLEEP / 2):
+        await election._release()
+
+
+async def test_tasklock_from_config_wires_backend() -> None:
+    """from_config keeps the explicit backend so acquire reaches it."""
+    config = TaskLockConfig(
+        worker="w1", min_lock_seconds=1, max_lock_seconds=10
+    )
+    async with MemoryLockAdapter() as backend:
+        task_lock = TaskLock.from_config(
+            "tl-from-config", config, backend=backend
+        )
+
+        async with task_lock:
+            assert await backend.locked(name="tasklock:tl-from-config") is True
+
+
+async def test_lock_from_config_wires_backend() -> None:
+    """from_config keeps the explicit backend so acquire reaches it."""
+    config = LockConfig(worker="w1", lease_duration=60)
+    async with MemoryLockAdapter() as backend:
+        lock = Lock.from_config("lk-from-config", config, backend=backend)
+
+        await lock.acquire()
+
+        assert await backend.locked(name="lock:lk-from-config") is True

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -265,6 +265,28 @@ async def test_lock_from_thread_acquire(lock: Lock) -> None:
     assert locked_after is True
 
 
+async def test_lock_from_thread_acquire_waits_without_timeout(
+    lock: Lock, locks: list[Lock]
+) -> None:
+    """A contended `from_thread.acquire()` with no timeout retries then wins.
+
+    The lock is held first, so the thread acquire enters its retry loop with
+    `deadline=None`. The retry-exit guard must short-circuit on the `None`
+    deadline rather than compare the loop clock against `None`.
+    """
+    await locks[WORKER_1].acquire()  # short lease, expires during the wait
+    handle: LockHandle | None = None
+
+    def sync() -> None:
+        nonlocal handle
+        handle = lock.from_thread.acquire()  # timeout=None
+
+    await asyncio.to_thread(sync)
+
+    assert handle is not None
+    assert handle.fencing_token >= 1
+
+
 async def test_lock_acquire_wait(lock: Lock, locks: list[Lock]) -> None:
     """Test Lock acquire wait."""
     # Arrange
@@ -560,15 +582,17 @@ async def test_acquire_returns_handle(lock: Lock) -> None:
 
     assert isinstance(handle, LockHandle)
     assert handle.name == LOCK_NAME
-    assert handle.token
+    assert handle.token.startswith("worker_0:task:")
     assert handle.fencing_token >= 1
 
 
 async def test_acquire_nowait_returns_handle(lock: Lock) -> None:
-    """`acquire_nowait` returns a LockHandle."""
+    """`acquire_nowait` returns a LockHandle carrying the name and task token."""
     handle = await lock.acquire_nowait()
 
     assert isinstance(handle, LockHandle)
+    assert handle.name == LOCK_NAME
+    assert handle.token.startswith("worker_0:task:")
     assert handle.fencing_token >= 1
 
 
@@ -589,6 +613,8 @@ async def test_from_thread_acquire_returns_handle(lock: Lock) -> None:
     await asyncio.to_thread(sync)
 
     assert isinstance(handles[0], LockHandle)
+    assert handles[0].name == LOCK_NAME
+    assert ":thread:" in handles[0].token
     assert handles[0].fencing_token >= 1
 
 
@@ -602,6 +628,9 @@ async def test_from_thread_acquire_nowait_returns_handle(lock: Lock) -> None:
     await asyncio.to_thread(sync)
 
     assert isinstance(handles[0], LockHandle)
+    assert handles[0].name == LOCK_NAME
+    assert handles[0].token.startswith("worker_0:thread:")
+    assert handles[0].fencing_token >= 1
 
 
 async def test_from_thread_context_manager_binds_handle(lock: Lock) -> None:
@@ -967,6 +996,7 @@ async def test_lock_extend_renews_same_fencing_token(lock: Lock) -> None:
 
     extended = await lock.extend()
 
+    assert extended.name == LOCK_NAME
     assert extended.fencing_token == first.fencing_token
     assert extended.token == first.token
 
@@ -1208,6 +1238,27 @@ async def test_from_thread_acquire_timeout(backend: LockBackend) -> None:
     await holder.release()
 
 
+async def test_from_thread_acquire_timeout_succeeds_when_freed_in_time(
+    locks: list[Lock],
+) -> None:
+    """A bounded thread acquire wins once the short lease expires before the deadline.
+
+    The deadline is `now + timeout`. A flipped sign would put it in the past
+    and raise TimeoutError on the first retry instead of waiting.
+    """
+    await locks[WORKER_1].acquire()  # lease_duration=0.01, expires quickly
+    handle: LockHandle | None = None
+
+    def sync() -> None:
+        nonlocal handle
+        handle = locks[WORKER_2].from_thread.acquire(timeout=0.5)
+
+    await asyncio.to_thread(sync)
+
+    assert handle is not None
+    assert handle.fencing_token >= 1
+
+
 async def test_from_thread_extend(lock: Lock) -> None:
     """A thread extend renews the lease and keeps the fencing token."""
     # Arrange
@@ -1226,6 +1277,8 @@ async def test_from_thread_extend(lock: Lock) -> None:
     # Assert
     assert acquired is not None
     assert extended is not None
+    assert extended.name == LOCK_NAME
+    assert ":thread:" in extended.token
     assert extended.fencing_token == acquired.fencing_token
 
 


### PR DESCRIPTION
Closes the remaining coordination mutation gaps from the original campaign. Each cluster was reconstructed from the code (the original report was deleted), killed with exact-value tests, and the genuine survivors confirmed dead by re-running mutmut per file.

## Clusters closed

- **backend_timeout enforcement**: `LeaderElection._try_acquire_or_renew` and `_release` wrap the backend call in `asyncio.timeout(config.backend_timeout)`. Mutants replaced the bound with `None` (no timeout). Closed with a `_SlowBackend` double that outlasts a tiny `backend_timeout`: acquire leaves `record is None` and `is_leader()` False, and `_release` returns without hanging.
- **metadata forwarding**: the metadata dict must flow from the constructor and `from_config` into `_setup`, then out to `backend.acquire_or_renew(metadata=...)`. Mutants dropped the metadata at each hop (`metadata=None`, dropped kwarg, `_setup(..., None)`). Closed with a `_RecordingBackend` that captures the metadata it received, driven through both `LeaderElection(...)` and `from_config(...)`.
- **last_confirmation_age sign**: `last_confirmation_age()` is `now - last_confirmed`. Already covered by the existing exact-value test (monkeypatched clock with nonzero start). Verified no survivor remains in that method. The related `is_leader_confirmed_within` `or -> and` mutant was also closed (a leader with no confirmation timestamp must fail the check).
- **memory fencing-start and expiry**: the fence counter starts at 1 and climbs (existing test). Added the expiry-boundary mutants: memory lock `acquire` blocks a different holder at the exact expiry instant (guard is `<`), and `_live` treats `now == renewed_at + lease` as expired (guard is `>=`). Also pinned the renew branch field forwarding (`renewed_at` and `lease_duration`).

## Extra genuine logic gaps closed (in-scope files)

- `from_config` for `Lock` and `TaskLock` dropped the explicit backend: added wiring tests.
- `Lock` thread paths returned `LockHandle(name=None / token=None / fencing_token=None)`: strengthened the handle-return tests to assert exact `name` and worker-prefixed `token`.
- `do_thread_acquire` flipped the deadline math (`+timeout -> -timeout`, `and -> or`): added contended thread-acquire tests with and without a timeout.

## Per-file survivors (before -> after)

| File | Before | After | Killing tests added | Equivalents remaining |
| --- | --- | --- | --- | --- |
| memory.py | 13 | 8 | 4 | 8 |
| leaderelection.py | 50 | 40 | 6 | 40 |
| tasklock.py | 20 | 19 | 1 | 19 |
| lock.py | 38 | 24 | 9 | 24 |

## Killing tests added

In `tests/coordination/test_cluster_boundaries.py`:
- `test_acquire_blocks_other_holder_at_exact_expiry`
- `test_live_record_expires_at_exact_deadline`
- `test_renew_forwards_renewed_at_and_lease_duration`
- `test_init_forwards_metadata_to_backend`, `test_from_config_forwards_metadata_to_backend`
- `test_record_is_none_before_first_attempt`
- `test_is_leader_confirmed_within_requires_a_confirmation`
- `test_acquire_times_out_on_a_slow_backend`, `test_release_times_out_on_a_slow_backend`
- `test_tasklock_from_config_wires_backend`, `test_lock_from_config_wires_backend`

In `tests/coordination/test_lock.py` (strengthened existing tests plus two new ones):
- strengthened `test_acquire_returns_handle`, `test_acquire_nowait_returns_handle`, `test_from_thread_acquire_returns_handle`, `test_from_thread_acquire_nowait_returns_handle`, `test_lock_extend_renews_same_fencing_token`, `test_from_thread_extend` to assert exact `name` and `token`
- new `test_lock_from_thread_acquire_waits_without_timeout`
- new `test_from_thread_acquire_timeout_succeeds_when_freed_in_time`

## Documented residual equivalents

- **memory.py (8)**: `_loop = None -> ""` on both adapters (overwritten in `__aenter__`), the `(None, 0) -> (None, 1)` default tuple in `acquire`/`release`/`locked`/`owned` (the `expire_at` slot is unobservable when `current_token is None`), the stale-cleanup `< -> <=` in `release` (both return False, the delete is an unobservable optimization), and `MemoryScheduleAdapter.__aenter__` `_loop` (the schedule adapter has no from-thread path that reads it).
- **leaderelection.py (40)**: log message text and log-arg mutants in `__call__`, `_update_state`, `_try_acquire_or_renew`, and `_release`, the `>= -> >` error-log cadence boundary, `is_leader=False -> None` / `reason=None` (both falsy or message-only), `break -> return` and the `# pragma: no cover` re-cancel branch on shutdown (behaviorally identical), plus `_track_reconfigure(None)`, `_backend_name=None`, `_is_leader=None`, `_error_logged_at=""` (env-reconfigure path or unobservable falsy inits).
- **tasklock.py (19)**: `name=None` / `msg=None` / `WouldBlockError(None)` in error and would-block raises (message text only), `_track_reconfigure(None)`, `_backend_name=None`, and `_token_nonce=None` (a fixed suffix still matches across the acquire and the paired exit).
- **lock.py (24)**: `name=None` / `msg=None` in error and would-block raises (message text), the `>= -> >` retry-loop exit boundary in `acquire` and `do_thread_acquire` (the loop retries anyway), `_track_reconfigure(None)`, `_backend_name=None`, `_running_task` message text, and `thread_id=None` / dropped `thread_id` in the thread paths and `ThreadLockAdapter.owned` (the default resolves to `get_ident()`, identical).

Config edits to `[tool.mutmut]` were reverted before committing; only `tests/` files are in this PR.
