### PR TITLE
🧪 Kill cache stampede, stale-TTL, and tag mutants

### DIFF
--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -453,6 +453,52 @@ class TestAsyncCachedStampede:
             stampede_mod._evict_idle_locks(locks)
         assert len(locks) == 4  # noqa: PLR2004
 
+    async def test_per_key_lock_eviction_trims_oversize_dict_in_one_call(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """One call trims a dict already far over budget down to the budget.
+
+        Adds many idle locks at once before a single `_evict_idle_locks`
+        call, so a body that stops after one eviction (`break` to `return`)
+        is caught.
+        """
+        import sys  # noqa: PLC0415
+        from collections import OrderedDict  # noqa: PLC0415
+
+        import grelmicro.cache._stampede  # noqa: F401, PLC0415
+
+        stampede_mod = sys.modules["grelmicro.cache._stampede"]
+
+        monkeypatch.setattr(stampede_mod, "_PER_KEY_LOCK_BUDGET", 3)
+        locks: OrderedDict[str, asyncio.Lock] = OrderedDict(
+            (f"k{i}", asyncio.Lock()) for i in range(10)
+        )
+
+        stampede_mod._evict_idle_locks(locks)
+
+        assert len(locks) == 3  # noqa: PLR2004
+        # Eviction drops the oldest first, so the newest keys remain.
+        assert list(locks) == ["k7", "k8", "k9"]
+
+    def test_stampede_lock_name_is_prefixed_32_char_digest(self) -> None:
+        """The lock name is `cache.stampede.<first 32 hex of sha256(key)>`."""
+        import hashlib  # noqa: PLC0415
+        import sys  # noqa: PLC0415
+
+        import grelmicro.cache._stampede  # noqa: F401, PLC0415
+
+        stampede_mod = sys.modules["grelmicro.cache._stampede"]
+
+        key = "my.module.fn:abc123"
+        digest = hashlib.sha256(key.encode()).hexdigest()[:32]
+        expected = f"cache.stampede.{digest}"
+
+        name = stampede_mod._stampede_lock_name(key)
+
+        assert name == expected
+        assert len(digest) == 32  # noqa: PLR2004
+
     async def test_per_key_lock_eviction_keeps_held_entries(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/cache/test_cached_mutations.py
+++ b/tests/cache/test_cached_mutations.py
@@ -1,0 +1,693 @@
+"""Mutation-killing tests for the `@cached` decorator.
+
+These pin behavior the broader suite left under-asserted: private-cache
+config from `ttl=`/`maxsize=`, the `typed` and `key_maker` plumbing through
+the wrapper builders, the early-refresh path actually storing a new value (not
+just rerunning the function), the recompute-duration sign, the sync per-key
+lock budget, and the distributed compute path's kwargs, skip, and tag
+rendering. Values use a nonzero clock and non-unit TTLs so operator and sign
+mutants diverge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+from collections import OrderedDict
+from contextlib import suppress
+
+import pytest
+
+from grelmicro import Grelmicro
+from grelmicro.cache.cached import _make_key, _read_meta, cached
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache.serializers import PickleSerializer
+from grelmicro.cache.ttl import TTLCache
+from grelmicro.coordination import Coordination
+from grelmicro.coordination.memory import MemoryLockAdapter
+
+pytestmark = [pytest.mark.timeout(10)]
+
+_PRIVATE_TTL = 45.0
+_PRIVATE_MAXSIZE = 7
+
+
+def _make_cache(maxsize: int = 10, ttl: float = 60) -> TTLCache:
+    """Create a TTLCache on a primed in-memory backend."""
+    backend = MemoryCacheAdapter()
+    with suppress(RuntimeError):
+        backend._loop = asyncio.get_running_loop()
+    return TTLCache(
+        maxsize=maxsize, ttl=ttl, backend=backend, serializer=PickleSerializer()
+    )
+
+
+def _shared_cache(loop: asyncio.AbstractEventLoop) -> TTLCache:
+    """Build a TTLCache on a backend whose loop is already primed."""
+    backend = MemoryCacheAdapter()
+    backend._loop = loop
+    return TTLCache(backend=backend, serializer=PickleSerializer())
+
+
+class _Clock:
+    """Mutable wall clock standing in for ``cached._now``."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _private_cache(wrapper: object) -> TTLCache:
+    """Return the private TTLCache the decorator bound to a wrapper.
+
+    The wrapper's `cache_info` is the cache's bound method, so its
+    `__self__` is the cache instance.
+    """
+    cache = wrapper.cache_info.__self__  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    assert isinstance(cache, TTLCache)
+    return cache
+
+
+class TestPrivateCacheConfig:
+    """Pin the private cache built from `ttl=`/`maxsize=`."""
+
+    async def test_private_cache_uses_the_given_ttl(self) -> None:
+        """`@cached(ttl=45)` builds a private cache with config.ttl == 45."""
+
+        @cached(ttl=_PRIVATE_TTL)
+        async def fetch(x: int) -> int:
+            return x
+
+        assert _private_cache(fetch).config.ttl == _PRIVATE_TTL
+
+    async def test_private_cache_uses_the_given_maxsize(self) -> None:
+        """`@cached(ttl=..., maxsize=7)` carries maxsize into the cache."""
+
+        @cached(ttl=_PRIVATE_TTL, maxsize=_PRIVATE_MAXSIZE)
+        async def fetch(x: int) -> int:
+            return x
+
+        assert _private_cache(fetch).config.maxsize == _PRIVATE_MAXSIZE
+
+    async def test_private_cache_default_maxsize_is_zero(self) -> None:
+        """The default `maxsize` is 0 (unlimited), not 1."""
+
+        @cached(ttl=_PRIVATE_TTL)
+        async def fetch(x: int) -> int:
+            return x
+
+        assert _private_cache(fetch).config.maxsize == 0
+
+
+class _SameReprA:
+    """Distinct type that shares a repr with `_SameReprB`."""
+
+    def __repr__(self) -> str:
+        return "X"
+
+
+class _SameReprB:
+    """Distinct type that shares a repr with `_SameReprA`."""
+
+    def __repr__(self) -> str:
+        return "X"
+
+
+class TestTypedPlumbing:
+    """Pin that `typed` reaches the key builder for async and sync wrappers.
+
+    Same-repr-different-type values are used so an untyped key (the result
+    of dropping `typed` or flipping it to a falsy value) collides while a
+    typed key separates them.
+    """
+
+    async def test_typed_true_separates_same_repr_async(self) -> None:
+        """`@cached(typed=True)` on an async func separates same-repr types."""
+        cache = _make_cache()
+        calls = 0
+
+        @cached(cache, typed=True)
+        async def fetch(x: object) -> str:
+            nonlocal calls
+            calls += 1
+            return type(x).__name__
+
+        await fetch(_SameReprA())
+        await fetch(_SameReprB())
+        assert calls == 2  # noqa: PLR2004
+
+    async def test_typed_true_separates_same_repr_sync(self) -> None:
+        """`@cached(typed=True)` on a sync func separates same-repr types."""
+        cache = _make_cache()
+        calls = 0
+
+        @cached(cache, typed=True)
+        def fetch(x: object) -> str:
+            nonlocal calls
+            calls += 1
+            return type(x).__name__
+
+        await asyncio.to_thread(lambda: fetch(_SameReprA()))
+        await asyncio.to_thread(lambda: fetch(_SameReprB()))
+        assert calls == 2  # noqa: PLR2004
+
+    async def test_typed_default_false_merges_same_repr_async(self) -> None:
+        """The default `typed=False` merges same-repr types (async)."""
+        cache = _make_cache()
+        calls = 0
+
+        @cached(cache)
+        async def fetch(x: object) -> str:
+            nonlocal calls
+            calls += 1
+            return type(x).__name__
+
+        await fetch(_SameReprA())
+        await fetch(_SameReprB())
+        assert calls == 1
+
+
+class TestKeyMakerPlumbing:
+    """Pin that a custom key_maker reaches the async and sync wrappers."""
+
+    async def test_custom_key_maker_collapses_entries_async(self) -> None:
+        """A fixed-key key_maker folds all async calls to one entry."""
+        cache = _make_cache()
+        calls = 0
+
+        @cached(cache, key_maker=lambda _func, _args, _kwargs: "fixed")
+        async def fetch(x: int) -> int:
+            nonlocal calls
+            calls += 1
+            return x
+
+        first = await fetch(1)
+        second = await fetch(2)  # different arg, same fixed key
+        assert first == second == 1
+        assert calls == 1
+
+    async def test_custom_key_maker_collapses_entries_sync(self) -> None:
+        """A fixed-key key_maker folds all sync calls to one entry."""
+        cache = _make_cache()
+        calls = 0
+
+        @cached(cache, key_maker=lambda _func, _args, _kwargs: "fixed")
+        def fetch(x: int) -> int:
+            nonlocal calls
+            calls += 1
+            return x
+
+        first = await asyncio.to_thread(lambda: fetch(1))
+        second = await asyncio.to_thread(lambda: fetch(2))
+        assert first == second == 1
+        assert calls == 1
+
+    async def test_key_maker_receives_function_args_and_kwargs(self) -> None:
+        """The key_maker is called with `(func, args, kwargs)` intact.
+
+        Asserting the kwargs reach the key_maker catches a mutation that
+        passes `None` in place of the kwargs dict.
+        """
+        cache = _make_cache()
+        seen: list[tuple[object, tuple, dict]] = []
+
+        def key_maker(func, args, kwargs) -> str:  # noqa: ANN001
+            seen.append((func, args, kwargs))
+            return f"k:{args[0]}:{kwargs}"
+
+        @cached(cache, key_maker=key_maker)
+        async def fetch(x: int, *, label: str) -> int:  # noqa: ARG001
+            return x
+
+        await fetch(1, label="hot")
+        assert seen
+        func, args, kwargs = seen[0]
+        assert getattr(func, "__name__", None) == "fetch"
+        assert args == (1,)
+        assert kwargs == {"label": "hot"}
+
+    async def test_default_key_includes_function_identity(self) -> None:
+        """Two functions with the same args do not share a default key."""
+        cache = _make_cache()
+
+        @cached(cache)
+        async def fetch_a(x: int) -> str:  # noqa: ARG001
+            return "a"
+
+        @cached(cache)
+        async def fetch_b(x: int) -> str:  # noqa: ARG001
+            return "b"
+
+        assert await fetch_a(1) == "a"
+        assert await fetch_b(1) == "b"
+
+
+class TestSyncLockBudget:
+    """Pin the sync per-key lock eviction budget and trim-in-one-call."""
+
+    def test_sync_eviction_keeps_exactly_the_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A dict at exactly the budget is not trimmed (`>` not `>=`)."""
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        monkeypatch.setattr(cached_mod, "_PER_KEY_LOCK_BUDGET", 3)
+        locks: OrderedDict[str, threading.Lock] = OrderedDict(
+            (f"k{i}", threading.Lock()) for i in range(3)
+        )
+
+        cached_mod._evict_idle_locks_sync(locks)
+
+        assert len(locks) == 3  # noqa: PLR2004
+
+    def test_sync_eviction_trims_oversize_in_one_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One call trims a far-oversize dict down to the budget."""
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        monkeypatch.setattr(cached_mod, "_PER_KEY_LOCK_BUDGET", 3)
+        locks: OrderedDict[str, threading.Lock] = OrderedDict(
+            (f"k{i}", threading.Lock()) for i in range(10)
+        )
+
+        cached_mod._evict_idle_locks_sync(locks)
+
+        assert len(locks) == 3  # noqa: PLR2004
+        assert list(locks) == ["k7", "k8", "k9"]
+
+
+class TestEarlyRefreshStoresValue:
+    """Pin that the early refresh actually updates the cached value."""
+
+    async def test_async_refresh_stores_the_new_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A background refresh writes the recomputed value into the cache.
+
+        The function returns an incrementing counter, so after the refresh
+        a fresh read (outside the early window) must see the second value.
+        A refresh that runs the function but fails to store would leave the
+        first value in place.
+        """
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+        counter = 0
+
+        async def impl(x: int) -> int:  # noqa: ARG001
+            nonlocal counter
+            counter += 1
+            return counter
+
+        fetch = cached(cache, early=0.5)(impl)
+
+        assert await fetch(5) == 1  # miss at t=1000, stores 1
+        clock.t = 1040  # inside the early window (remaining 20 <= 30)
+        await fetch(5)  # hit, schedules a background refresh storing 2
+
+        for _ in range(100):
+            await asyncio.sleep(0.005)
+            key = _make_key(impl, (5,), {}, None, typed=False)
+            stored = await cache._peek(key)
+            if stored == 2:  # noqa: PLR2004
+                break
+        assert stored == 2  # noqa: PLR2004
+
+    async def test_refresh_records_a_small_recompute_delta(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The stored XFetch delta is the elapsed time, not a sum.
+
+        `perf_counter() - started` is a tiny positive duration. A `+ started`
+        mutation yields a value in the thousands, so a sub-second bound
+        catches it.
+        """
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        cache = _make_cache(ttl=60)
+
+        async def impl(x: int) -> int:
+            return x * 2
+
+        fetch = cached(cache, early=0.5)(impl)
+        await fetch(5)  # cold miss writes meta with the recompute delta
+
+        key = _make_key(impl, (5,), {}, None, typed=False)
+        meta = await _read_meta(cache, key)
+        assert meta is not None
+        _written, delta = meta
+        assert 0 <= delta < 1.0
+
+
+class TestDistributedComputePath:
+    """Pin the sync distributed orchestrate path's kwargs, skip, and tags.
+
+    The cross-replica `_distributed_orchestrate` runs only for the sync
+    wrapper, so these decorate sync functions and drive them from a worker
+    thread under an app with a lock backend.
+    """
+
+    async def test_distributed_compute_passes_kwargs(self) -> None:
+        """The cross-replica compute forwards keyword arguments."""
+        loop = asyncio.get_running_loop()
+        cache = _shared_cache(loop)
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+
+        def impl(x: int, *, factor: int) -> int:
+            return x * factor
+
+        fetch = cached(cache, lock=True)(impl)
+        async with micro:
+            result = await asyncio.to_thread(lambda: fetch(5, factor=3))
+        assert result == 15  # noqa: PLR2004
+
+    async def test_distributed_compute_renders_tags_from_args(self) -> None:
+        """The distributed path tags the entry from the call arguments."""
+        loop = asyncio.get_running_loop()
+        cache = _shared_cache(loop)
+        backend = cache._backend
+        assert isinstance(backend, MemoryCacheAdapter)
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+
+        def impl(user_id: int) -> int:
+            return user_id
+
+        fetch = cached(cache, lock=True, tags=["user:{user_id}"])(impl)
+        async with micro:
+            await asyncio.to_thread(lambda: fetch(42))
+            members = backend._tag_keys.get("user:42")
+        assert members is not None
+        assert len(members) == 1
+
+    async def test_distributed_compute_skip_passes_the_result(self) -> None:
+        """The skip predicate sees the real result in the distributed path."""
+        loop = asyncio.get_running_loop()
+        cache = _shared_cache(loop)
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+        calls = 0
+
+        def impl(x: int) -> int:
+            nonlocal calls
+            calls += 1
+            return x * 2
+
+        # skip when the result equals 10, so the value-5 call is never cached.
+        fetch = cached(cache, lock=True, skip=lambda result: result == 10)(impl)  # noqa: PLR2004
+        async with micro:
+            assert await asyncio.to_thread(lambda: fetch(5)) == 10  # noqa: PLR2004
+            assert await asyncio.to_thread(lambda: fetch(5)) == 10  # noqa: PLR2004
+        assert calls == 2  # noqa: PLR2004
+
+
+class TestLockDefault:
+    """Pin that `lock` defaults to False (no folding) for `@cached`."""
+
+    async def test_default_lock_does_not_fold_concurrent_misses(self) -> None:
+        """With no `lock` argument, concurrent misses each run the function.
+
+        A `lock=True` default would fold them to one call, so the count of
+        two pins the `False` default.
+        """
+        cache = _make_cache()
+        calls = 0
+        barrier = asyncio.Event()
+
+        @cached(cache)
+        async def fetch(x: int) -> int:
+            nonlocal calls
+            calls += 1
+            await barrier.wait()
+            return x * 2
+
+        task_a = asyncio.create_task(fetch(5))
+        task_b = asyncio.create_task(fetch(5))
+        await asyncio.sleep(0.05)
+        barrier.set()
+        await task_a
+        await task_b
+
+        assert calls == 2  # noqa: PLR2004
+
+
+class TestSyncEarlyRefresh:
+    """Pin the sync early-refresh value store and recompute-delta sign."""
+
+    async def test_sync_refresh_stores_the_new_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sync background refresh writes the recomputed value."""
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+        counter = 0
+
+        def impl(x: int) -> int:  # noqa: ARG001
+            nonlocal counter
+            counter += 1
+            return counter
+
+        fetch = cached(cache, early=0.5)(impl)
+
+        assert await asyncio.to_thread(lambda: fetch(5)) == 1  # miss, stores 1
+        clock.t = 1040  # inside the early window
+        await asyncio.to_thread(lambda: fetch(5))  # hit, refresh stores 2
+
+        key = _make_key(impl, (5,), {}, None, typed=False)
+        stored = None
+        for _ in range(100):
+            await asyncio.sleep(0.005)
+            stored = await cache._peek(key)
+            if stored == 2:  # noqa: PLR2004
+                break
+        assert stored == 2  # noqa: PLR2004
+
+    async def test_sync_cold_miss_records_small_delta(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sync cold miss with early= stores a sub-second recompute delta.
+
+        Pins the `perf_counter() - started` sign in the sync compute path.
+        """
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        cache = _make_cache(ttl=60)
+
+        def impl(x: int) -> int:
+            return x * 2
+
+        fetch = cached(cache, early=0.5)(impl)
+        await asyncio.to_thread(lambda: fetch(5))
+
+        key = _make_key(impl, (5,), {}, None, typed=False)
+        meta = await _read_meta(cache, key)
+        assert meta is not None
+        _written, delta = meta
+        assert 0 <= delta < 1.0
+
+
+class TestEarlyRefreshRewritesMeta:
+    """Pin that the async refresh re-arms XFetch metadata (early= reaches it)."""
+
+    async def test_refresh_rewrites_meta_at_the_new_time(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After a refresh, the stored meta carries the refresh timestamp.
+
+        The refresh calls the compute helper with `early=` so it rewrites
+        the XFetch sidecar. A mutation dropping `early` would leave the
+        meta at the original cold-miss timestamp.
+        """
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+
+        async def impl(x: int) -> int:
+            return x * 2
+
+        fetch = cached(cache, early=0.5)(impl)
+        await fetch(5)  # cold miss at t=1000, meta written at 1000
+        clock.t = 1040  # inside the early window
+        await fetch(5)  # hit, schedules refresh writing meta at 1040
+
+        key = _make_key(impl, (5,), {}, None, typed=False)
+        written = 1000.0
+        for _ in range(100):
+            await asyncio.sleep(0.005)
+            meta = await _read_meta(cache, key)
+            if meta is not None and meta[0] == 1040.0:  # noqa: PLR2004
+                written = meta[0]
+                break
+        assert written == 1040.0  # noqa: PLR2004
+
+
+class TestEarlyRefreshRespectsStaleTtl:
+    """Pin that the refresh forwards `stale_ttl` so the reserve re-arms."""
+
+    async def test_refresh_writes_a_stale_reserve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refresh under stale_ttl rewrites the stale reserve copy.
+
+        After the refresh stores value 2, the stale reserve must also hold
+        2, so a dropped `stale_ttl` (no reserve written) is caught.
+        """
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+        counter = 0
+
+        async def impl(x: int) -> int:  # noqa: ARG001
+            nonlocal counter
+            counter += 1
+            return counter
+
+        fetch = cached(cache, early=0.5, stale_ttl=30)(impl)
+        await fetch(5)  # cold miss stores value 1 and reserve 1
+        clock.t = 1040  # inside the early window
+        await fetch(5)  # hit, refresh stores value 2 and reserve 2
+
+        key = _make_key(impl, (5,), {}, None, typed=False)
+        reserve = None
+        for _ in range(100):
+            await asyncio.sleep(0.005)
+            reserve = await cache._read_stale(key)
+            if reserve == 2:  # noqa: PLR2004
+                break
+        assert reserve == 2  # noqa: PLR2004
+
+
+class TestDistributedComputeDeltaAndStale:
+    """Pin the distributed sync compute path's delta sign and stale reserve."""
+
+    async def test_distributed_sync_records_small_delta(self) -> None:
+        """A distributed sync cold miss with early= records a sub-second delta.
+
+        Pins the `perf_counter() - started` sign inside
+        `_distributed_orchestrate`.
+        """
+        loop = asyncio.get_running_loop()
+        cache = _shared_cache(loop)
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+
+        def impl(x: int) -> int:
+            return x * 2
+
+        fetch = cached(cache, lock=True, early=0.5)(impl)
+        async with micro:
+            await asyncio.to_thread(lambda: fetch(5))
+            key = _make_key(impl, (5,), {}, None, typed=False)
+            meta = await _read_meta(cache, key)
+        assert meta is not None
+        _written, delta = meta
+        assert 0 <= delta < 1.0
+
+    async def test_distributed_sync_writes_stale_reserve(self) -> None:
+        """A distributed sync miss with stale_ttl writes the stale reserve.
+
+        Pins that `_distributed_orchestrate` forwards `stale_ttl` to `set`.
+        """
+        loop = asyncio.get_running_loop()
+        cache = _shared_cache(loop)
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+
+        def impl(x: int) -> int:
+            return x * 2
+
+        fetch = cached(cache, lock=True, stale_ttl=30)(impl)
+        async with micro:
+            await asyncio.to_thread(lambda: fetch(5))
+            key = _make_key(impl, (5,), {}, None, typed=False)
+            reserve = await cache._read_stale(key)
+        assert reserve == 10  # noqa: PLR2004
+
+
+class TestSyncRefreshMetaAndStale:
+    """Pin that the sync refresh re-arms XFetch meta and the stale reserve."""
+
+    async def test_sync_refresh_rewrites_meta_at_the_new_time(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sync refresh rewrites the XFetch sidecar at the refresh time.
+
+        Pins that `early` reaches the sync refresh compute call.
+        """
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+
+        def impl(x: int) -> int:
+            return x * 2
+
+        fetch = cached(cache, early=0.5)(impl)
+        await asyncio.to_thread(lambda: fetch(5))  # cold miss, meta at 1000
+        clock.t = 1040  # inside the early window
+        await asyncio.to_thread(lambda: fetch(5))  # hit, refresh meta at 1040
+
+        key = _make_key(impl, (5,), {}, None, typed=False)
+        written = 1000.0
+        for _ in range(100):
+            await asyncio.sleep(0.005)
+            meta = await _read_meta(cache, key)
+            if meta is not None and meta[0] == 1040.0:  # noqa: PLR2004
+                written = meta[0]
+                break
+        assert written == 1040.0  # noqa: PLR2004
+
+    async def test_sync_refresh_writes_stale_reserve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sync refresh under stale_ttl rewrites the stale reserve copy.
+
+        Pins that `stale_ttl` reaches the sync refresh compute call.
+        """
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+        counter = 0
+
+        def impl(x: int) -> int:  # noqa: ARG001
+            nonlocal counter
+            counter += 1
+            return counter
+
+        fetch = cached(cache, early=0.5, stale_ttl=30)(impl)
+        await asyncio.to_thread(lambda: fetch(5))  # cold miss, reserve 1
+        clock.t = 1040  # inside the early window
+        await asyncio.to_thread(lambda: fetch(5))  # hit, refresh reserve 2
+
+        key = _make_key(impl, (5,), {}, None, typed=False)
+        reserve = None
+        for _ in range(100):
+            await asyncio.sleep(0.005)
+            reserve = await cache._read_stale(key)
+            if reserve == 2:  # noqa: PLR2004
+                break
+        assert reserve == 2  # noqa: PLR2004

--- a/tests/cache/test_key.py
+++ b/tests/cache/test_key.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+
 from grelmicro.cache._key import make_cache_key
 
 
@@ -21,3 +23,54 @@ def test_typed_changes_the_key() -> None:
     untyped = make_cache_key(_func, (3,), {}, typed=False)
     typed = make_cache_key(_func, (3,), {}, typed=True)
     assert typed != untyped
+
+
+def test_untyped_key_has_exact_module_qualname_digest_format() -> None:
+    """The key is `{module}.{qualname}:{sha256(repr((args, kwargs)))}`."""
+    args = (7, "x")
+    kwargs = {"b": 2, "a": 1}
+    raw = repr((args, sorted(kwargs.items())))
+    digest = hashlib.sha256(raw.encode()).hexdigest()
+    expected = f"{_func.__module__}.{_func.__qualname__}:{digest}"
+    assert make_cache_key(_func, args, kwargs) == expected
+
+
+def test_typed_key_has_exact_format_with_types_appended() -> None:
+    """`typed=True` appends `repr((arg_types, kwarg_types))` to the digest."""
+    args = (7, "x")
+    kwargs = {"b": 2, "a": 1}
+    raw = repr((args, sorted(kwargs.items())))
+    arg_types = tuple(type(value) for value in args)
+    kwarg_types = tuple(type(value) for _, value in sorted(kwargs.items()))
+    raw += repr((arg_types, kwarg_types))
+    digest = hashlib.sha256(raw.encode()).hexdigest()
+    expected = f"{_func.__module__}.{_func.__qualname__}:{digest}"
+    assert make_cache_key(_func, args, kwargs, typed=True) == expected
+
+
+def test_typed_default_is_false() -> None:
+    """No `typed` argument means untyped, so the key matches `typed=False`."""
+    assert make_cache_key(_func, (3,), {}) == make_cache_key(
+        _func, (3,), {}, typed=False
+    )
+
+
+def test_typed_keeps_argument_values_in_the_digest() -> None:
+    """Same types, different values still give different typed keys.
+
+    Guards against the digest dropping `repr((args, kwargs))` and hashing
+    only the type tuples (`raw =` instead of `raw +=`).
+    """
+    first = make_cache_key(_func, (7,), {}, typed=True)
+    second = make_cache_key(_func, (8,), {}, typed=True)
+    assert first != second
+
+
+def test_typed_distinguishes_kwarg_value_types() -> None:
+    """A kwarg of `3` and `3.0` produce different typed keys.
+
+    Guards against the kwarg type tuple being dropped or fixed to one type.
+    """
+    as_int = make_cache_key(_func, (), {"n": 3}, typed=True)
+    as_float = make_cache_key(_func, (), {"n": 3.0}, typed=True)
+    assert as_int != as_float

--- a/tests/cache/test_memory.py
+++ b/tests/cache/test_memory.py
@@ -1,9 +1,11 @@
 """Tests for MemoryCacheAdapter."""
 
+import asyncio
 from asyncio import sleep
 
 import pytest
 
+import grelmicro.cache.memory as memory_module
 from grelmicro.cache.memory import MemoryCacheAdapter
 
 pytestmark = [pytest.mark.timeout(5)]
@@ -388,3 +390,64 @@ class TestMemoryCacheAdapterBatch:
         assert await backend.get(key="a") is None
         assert await backend.get(key="b") is None
         assert "t" not in backend._tag_keys
+
+
+class TestMemoryCacheAdapterMutationGaps:
+    """Exact-value tests that pin loop capture, scan continuation, and tags.
+
+    These close mutation survivors where a loose assertion missed a real
+    behavior change (loop capture, `continue` flipped to `break`, expiry
+    boundary).
+    """
+
+    async def test_aenter_captures_the_running_loop(self) -> None:
+        """`__aenter__` stores the running loop, not None."""
+        backend = MemoryCacheAdapter()
+        async with backend:
+            assert backend._loop is asyncio.get_running_loop()
+
+    async def test_get_many_keeps_scanning_past_a_missing_key(self) -> None:
+        """A missing key in the middle does not stop the scan."""
+        backend = MemoryCacheAdapter()
+        await backend.set(key="b", value=b"bb", ttl=60)
+
+        result = await backend.get_many(keys=["missing", "b"])
+
+        assert result == {"b": b"bb"}
+
+    async def test_get_many_keeps_scanning_past_an_expired_key(self) -> None:
+        """An expired key in the middle does not stop the scan."""
+        backend = MemoryCacheAdapter()
+        await backend.set(key="gone", value=b"x", ttl=0.05)
+        await backend.set(key="live", value=b"yy", ttl=60)
+        await sleep(0.1)
+
+        result = await backend.get_many(keys=["gone", "live"])
+
+        assert result == {"live": b"yy"}
+
+    async def test_get_many_at_exact_expiry_drops_the_entry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`now >= expiry` drops an entry whose expiry equals now exactly."""
+        clock = [1000.0]
+        monkeypatch.setattr(memory_module, "monotonic", lambda: clock[0])
+        backend = MemoryCacheAdapter()
+        await backend.set(key="k", value=b"v", ttl=30.0)
+
+        clock[0] = 1030.0  # exactly at expiry (1000 + 30)
+        result = await backend.get_many(keys=["k"])
+
+        assert result == {}
+
+    async def test_delete_tags_keeps_processing_past_an_unknown_tag(
+        self,
+    ) -> None:
+        """An unknown tag does not stop deletion of the next known tag."""
+        backend = MemoryCacheAdapter()
+        await backend.set(key="a", value=b"a", ttl=60, tags=["known"])
+
+        await backend.delete_tags(tags=["unknown", "known"])
+
+        assert await backend.get(key="a") is None
+        assert "known" not in backend._tag_keys

--- a/tests/cache/test_serializers.py
+++ b/tests/cache/test_serializers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pickle
+
 import pytest
 from pydantic import BaseModel
 from typing_extensions import TypedDict
@@ -70,6 +72,23 @@ class TestPickleSerializer:
         result = serializer.loads(data)
 
         assert result == {"key": "value"}
+
+    def test_protocol_is_stored_and_used_for_dumps(self) -> None:
+        """`dumps` uses the configured protocol, not the pickle default.
+
+        The bytes from a non-default protocol must match
+        the standard library output for that protocol exactly, so dropping
+        the protocol kwarg (which falls back to the default) is caught.
+        """
+        non_default_protocol = 2
+        obj = {"key": "value"}
+        serializer = PickleSerializer(protocol=non_default_protocol)
+
+        assert serializer._protocol == non_default_protocol
+        assert serializer.dumps(obj) == pickle.dumps(
+            obj, protocol=non_default_protocol
+        )
+        assert serializer.dumps(obj) != pickle.dumps(obj, protocol=None)
 
 
 class TestJsonSerializer:

--- a/tests/cache/test_ttl_mutations.py
+++ b/tests/cache/test_ttl_mutations.py
@@ -1,0 +1,344 @@
+"""Mutation-killing tests for `TTLCache` logic.
+
+These pin behavior that the broader suite asserted too loosely: the default
+TTL value, the `maxsize > 0` LRU guard, per-call TTL forwarding, stale-reserve
+tagging, stat accumulation, and folding in the stale branch. Each test asserts
+exact values with a nonzero base TTL and non-unit overrides so sign and
+operator mutants diverge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from grelmicro import Grelmicro
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache.serializers import JsonSerializer, PickleSerializer
+from grelmicro.cache.ttl import _CACHE_PREFIX, _STALE_SUFFIX, TTLCache
+from grelmicro.coordination import Coordination
+from grelmicro.coordination.memory import MemoryLockAdapter
+
+pytestmark = [pytest.mark.timeout(10)]
+
+_BASE_TTL = 60.0
+_OVERRIDE_TTL = 25.0
+_STALE_TTL = 40.0
+
+
+@pytest.fixture
+def backend() -> MemoryCacheAdapter:
+    """Provide an isolated in-memory cache backend."""
+    return MemoryCacheAdapter()
+
+
+def test_default_ttl_is_sixty() -> None:
+    """The unset TTL default is exactly 60 seconds."""
+    cache = TTLCache()
+    assert cache.config.ttl == 60.0  # noqa: PLR2004
+
+
+class TestMaxsizeGuard:
+    """Pin the `maxsize > 0` guard against `>= 0` and `> 1` mutants."""
+
+    async def test_maxsize_zero_never_tracks_keys_on_hit(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """`maxsize=0` skips LRU tracking, so a hit leaves currsize at 0."""
+        cache = TTLCache(maxsize=0, ttl=_BASE_TTL, backend=backend)
+        await cache.set("k", b"v")
+        assert await cache.get("k") == b"v"
+        assert cache.cache_info().currsize == 0
+
+    async def test_maxsize_one_tracks_key_on_hit(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """`maxsize=1` tracks the key, so currsize becomes 1 after a hit."""
+        cache = TTLCache(maxsize=1, ttl=_BASE_TTL, backend=backend)
+        await cache.set("k", b"v")
+        assert await cache.get("k") == b"v"
+        assert cache.cache_info().currsize == 1
+
+    async def test_get_many_maxsize_zero_keeps_currsize_zero(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """`get_many` under `maxsize=0` does not start LRU tracking."""
+        cache = TTLCache(
+            maxsize=0,
+            ttl=_BASE_TTL,
+            backend=backend,
+            serializer=JsonSerializer(),
+        )
+        await cache.set("a", {"v": 1})
+        await cache.get_many(["a"])
+        assert cache.cache_info().currsize == 0
+
+    async def test_get_many_promotes_the_found_key_not_none(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """`get_many` promotes the actual found key, keeping LRU correct.
+
+        With `maxsize=2`, reading "a" then inserting a third key must evict
+        "b" (the untouched key), not "a".
+        """
+        cache = TTLCache(
+            maxsize=2,
+            ttl=_BASE_TTL,
+            backend=backend,
+            serializer=JsonSerializer(),
+        )
+        await cache.set("a", {"v": 1})
+        await cache.set("b", {"v": 2})
+
+        await cache.get_many(["a"])  # promote "a" to most-recent
+        await cache.set("c", {"v": 3})  # evicts the LRU key
+
+        assert await cache.get("a") == {"v": 1}
+        assert await cache.get("b") is None
+        assert await cache.get("c") == {"v": 3}
+
+
+class TestPerCallTTLForwarding:
+    """Pin that `get_or_set` forwards its `ttl` override to `set`."""
+
+    async def test_get_or_set_stores_with_override_ttl(
+        self,
+        backend: MemoryCacheAdapter,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A `ttl=` override reaches the backend, expiring the entry early.
+
+        With base TTL 60 and override 25, the entry is gone at 30 seconds
+        but would still be present if the override were dropped or nulled.
+        """
+        import grelmicro.cache.memory as memory_module  # noqa: PLC0415
+
+        cache = TTLCache(
+            ttl=_BASE_TTL, backend=backend, serializer=JsonSerializer()
+        )
+        now = 1000.0
+        clock = [now]
+        monkeypatch.setattr(memory_module, "monotonic", lambda: clock[0])
+
+        await cache.get_or_set("k", lambda: {"v": 1}, ttl=_OVERRIDE_TTL)
+        clock[0] = now + 30.0  # past the 25s override, before 60s base
+        assert await cache.get("k") is None
+
+
+class TestStaleReserveTags:
+    """Pin that the stale reserve carries the value's tags."""
+
+    async def test_set_tags_the_stale_reserve(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """The stale sidecar key is tagged alongside the value."""
+        cache = TTLCache(
+            ttl=_BASE_TTL, backend=backend, serializer=JsonSerializer()
+        )
+
+        await cache.set("k", {"v": 1}, tags=["g"], stale_ttl=_STALE_TTL)
+
+        stale_key = f"{_CACHE_PREFIX}:k{_STALE_SUFFIX}"
+        assert backend._tag_keys["g"] == {f"{_CACHE_PREFIX}:k", stale_key}
+
+
+class TestStatAccumulation:
+    """Pin that hit and eviction counters accumulate, not reset to 1."""
+
+    async def test_get_many_accumulates_hits(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Two found keys record two hits, not one."""
+        cache = TTLCache(
+            ttl=_BASE_TTL, backend=backend, serializer=JsonSerializer()
+        )
+        await cache.set("a", {"v": 1})
+        await cache.set("b", {"v": 2})
+
+        await cache.get_many(["a", "b"])
+
+        assert cache.cache_info().hits == 2  # noqa: PLR2004
+
+    async def test_evictions_accumulate(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Two evictions count as two, not reset to one each time."""
+        cache = TTLCache(maxsize=1, ttl=_BASE_TTL, backend=backend)
+        await cache.set("a", b"a")
+        await cache.set("b", b"b")  # evicts "a"
+        await cache.set("c", b"c")  # evicts "b"
+
+        assert cache.cache_info().evictions == 2  # noqa: PLR2004
+
+
+class TestSetManyBoundaries:
+    """Pin `set_many` TTL validation and the maxsize guard."""
+
+    async def test_set_many_ttl_one_is_accepted(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """`ttl=1` is valid (the guard rejects `<= 0`, not `<= 1`)."""
+        cache = TTLCache(
+            ttl=_BASE_TTL, backend=backend, serializer=JsonSerializer()
+        )
+
+        await cache.set_many({"a": {"v": 1}}, ttl=1)
+
+        assert await cache.get("a") == {"v": 1}
+
+    async def test_set_many_maxsize_one_evicts(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """`maxsize=1` (the `> 0` guard) evicts when set_many overflows."""
+        cache = TTLCache(maxsize=1, ttl=_BASE_TTL, backend=backend)
+        await cache.set("old", b"old")
+
+        await cache.set_many({"new": b"new"})
+
+        assert await cache.get("old") is None
+        assert await cache.get("new") == b"new"
+        assert cache.cache_info().currsize == 1
+
+
+class TestDeleteManyUntracked:
+    """Pin that delete_many tolerates keys absent from the LRU tracker."""
+
+    async def test_delete_many_with_untracked_key_does_not_raise(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """A key never tracked locally is popped with a default, not raised."""
+        cache = TTLCache(maxsize=10, ttl=_BASE_TTL, backend=backend)
+        await cache.set("a", b"a")
+
+        # "ghost" was never set, so it is absent from the LRU tracker.
+        await cache.delete_many(["a", "ghost"])
+
+        assert await cache.get("a") is None
+
+
+class TestStaleBranchFolding:
+    """Pin folding in the `stale_ttl is not None` branch of get_or_set."""
+
+    async def test_stale_branch_folds_concurrent_misses(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """With `stale_ttl` set, concurrent misses still fold to one call.
+
+        Exercises the second `compute_with_stampede` call (the try branch),
+        so a `per_key=False` mutation there is caught.
+        """
+        cache = TTLCache(
+            ttl=_BASE_TTL, backend=backend, serializer=JsonSerializer()
+        )
+        calls = 0
+        barrier = asyncio.Event()
+
+        async def factory() -> dict:
+            nonlocal calls
+            calls += 1
+            await barrier.wait()
+            return {"v": calls}
+
+        task_a = asyncio.create_task(
+            cache.get_or_set("k", factory, stale_ttl=_STALE_TTL)
+        )
+        task_b = asyncio.create_task(
+            cache.get_or_set("k", factory, stale_ttl=_STALE_TTL)
+        )
+        await asyncio.sleep(0.05)
+        barrier.set()
+
+        assert await task_a == {"v": 1}
+        assert await task_b == {"v": 1}
+        assert calls == 1
+
+
+def _shared_cache(loop: asyncio.AbstractEventLoop) -> TTLCache:
+    """Build a TTLCache on a backend whose loop is already primed."""
+    shared_backend = MemoryCacheAdapter()
+    shared_backend._loop = loop
+    return TTLCache(backend=shared_backend, serializer=PickleSerializer())
+
+
+class TestDistributedGetOrSet:
+    """Pin `auto_distributed=True` folding across simulated replicas."""
+
+    async def test_two_caches_fold_across_the_distributed_lock(self) -> None:
+        """Two caches sharing a backend fold concurrent misses to one call.
+
+        Each cache has its own in-process guard, so only the cross-replica
+        `Lock` (driven by `auto_distributed=True`) can fold them. A mutation
+        to `auto_distributed=False` lets both compute.
+        """
+        loop = asyncio.get_running_loop()
+        shared_backend = MemoryCacheAdapter()
+        shared_backend._loop = loop
+        cache_a = TTLCache(
+            backend=shared_backend, serializer=PickleSerializer()
+        )
+        cache_b = TTLCache(
+            backend=shared_backend, serializer=PickleSerializer()
+        )
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+        calls = 0
+        barrier = asyncio.Event()
+
+        async def factory() -> int:
+            nonlocal calls
+            calls += 1
+            await barrier.wait()
+            return calls * 10
+
+        async with micro:
+            task_a = asyncio.create_task(cache_a.get_or_set("k", factory))
+            task_b = asyncio.create_task(cache_b.get_or_set("k", factory))
+            await asyncio.sleep(0.05)
+            barrier.set()
+            result_a = await task_a
+            result_b = await task_b
+
+        assert calls == 1
+        assert result_a == 10  # noqa: PLR2004
+        assert result_b == 10  # noqa: PLR2004
+
+    async def test_distributed_stale_branch_folds(self) -> None:
+        """The stale branch also folds across replicas via the shared lock.
+
+        Pins `auto_distributed=True` inside the `stale_ttl is not None`
+        try branch.
+        """
+        loop = asyncio.get_running_loop()
+        shared_backend = MemoryCacheAdapter()
+        shared_backend._loop = loop
+        cache_a = TTLCache(
+            backend=shared_backend, serializer=PickleSerializer()
+        )
+        cache_b = TTLCache(
+            backend=shared_backend, serializer=PickleSerializer()
+        )
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+        calls = 0
+        barrier = asyncio.Event()
+
+        async def factory() -> int:
+            nonlocal calls
+            calls += 1
+            await barrier.wait()
+            return calls * 10
+
+        async with micro:
+            task_a = asyncio.create_task(
+                cache_a.get_or_set("k", factory, stale_ttl=_STALE_TTL)
+            )
+            task_b = asyncio.create_task(
+                cache_b.get_or_set("k", factory, stale_ttl=_STALE_TTL)
+            )
+            await asyncio.sleep(0.05)
+            barrier.set()
+            result_a = await task_a
+            result_b = await task_b
+
+        assert calls == 1
+        assert result_a == 10  # noqa: PLR2004
+        assert result_b == 10  # noqa: PLR2004

--- a/tests/cache/test_ttl_mutations.py
+++ b/tests/cache/test_ttl_mutations.py
@@ -254,13 +254,6 @@ class TestStaleBranchFolding:
         assert calls == 1
 
 
-def _shared_cache(loop: asyncio.AbstractEventLoop) -> TTLCache:
-    """Build a TTLCache on a backend whose loop is already primed."""
-    shared_backend = MemoryCacheAdapter()
-    shared_backend._loop = loop
-    return TTLCache(backend=shared_backend, serializer=PickleSerializer())
-
-
 class TestDistributedGetOrSet:
     """Pin `auto_distributed=True` folding across simulated replicas."""
 


### PR DESCRIPTION
Mutation-tested every in-scope cache logic file, added exact-value tests to kill genuine survivors, and documented the residual equivalents. Backend I/O files (redis/postgres/sqlite) stay out of scope.

## Per-file survivor counts (before -> after)

| File | Before | After | Killed | Equivalents remaining |
| --- | --- | --- | --- | --- |
| `grelmicro/cache/_stampede.py` | 3 | 0 | 3 | 0 |
| `grelmicro/cache/serializers.py` | 3 | 0 | 3 | 0 |
| `grelmicro/cache/_key.py` | 14 | 5 | 9 | 5 |
| `grelmicro/cache/memory.py` | 6 | 2 | 4 | 2 |
| `grelmicro/cache/ttl.py` | 45 | 25 | 20 | 25 |
| `grelmicro/cache/cached.py` | 48 | 16 | 32 | 16 |
| Total | 119 | 48 | 71 | 48 |

All 48 residual survivors are equivalent or unobservable. No genuine logic survivor remains.

## Killing tests added

`tests/cache/test_key.py`
- Exact `{module}.{qualname}:{sha256}` format for untyped and typed keys.
- `typed` default is False, typed keeps argument values, typed distinguishes kwarg value types.

`tests/cache/test_serializers.py`
- `PickleSerializer` stores and uses its protocol (bytes match `pickle.dumps(..., protocol=2)`, differ from the default).

`tests/cache/test_memory.py`
- `__aenter__` captures the running loop.
- `get_many` keeps scanning past a missing or expired key, and drops an entry at exact expiry.
- `delete_tags` keeps processing past an unknown tag.

`tests/cache/test_cached.py`
- `_evict_idle_locks` trims an oversize dict to budget in one call (async).
- `_stampede_lock_name` is `cache.stampede.<first 32 hex of sha256>`.

`tests/cache/test_ttl_mutations.py` (new)
- Default TTL is 60.
- `maxsize > 0` LRU guard (zero never tracks, get_many promotes the found key not None).
- `get_or_set` forwards its per-call `ttl` to `set`.
- Stale reserve carries the value's tags.
- Hits and evictions accumulate (not reset to 1).
- `set_many` ttl=1 accepted, maxsize=1 evicts.
- `delete_many` tolerates untracked keys.
- Stale branch folds concurrent misses, distributed get_or_set folds across replicas (plain and stale branch).

`tests/cache/test_cached_mutations.py` (new)
- Private cache uses the given ttl and maxsize (default maxsize 0).
- `typed` and `key_maker` reach both async and sync wrappers (same-repr types, kwargs forwarded, function identity in the default key).
- Sync per-key lock budget (keeps exactly the budget, trims oversize in one call).
- Early refresh actually stores the new value (async and sync) and records a sub-second recompute delta.
- Early refresh re-arms XFetch meta and the stale reserve (async and sync).
- `lock` defaults to False (concurrent misses do not fold).
- Distributed sync compute forwards kwargs, renders tags from args, passes the real result to skip, records a sub-second delta, and writes the stale reserve.

## Residual equivalent mutants

`_key.py` (5)
- `getattr` fallback defaults on `__module__` / `__qualname__` (None, dropped arg, `repr(None)`). Real functions always carry these dunders, so the fallback is unreachable.

`memory.py` (2)
- `delete_tags` `pop(tag, None)` -> `pop(None, None)`: the tag's forward set is already removed by the per-key drop, so the pop is a no-op either way.
- `_remove_from_tags` `continue` -> `break` in the forward/reverse out-of-sync branch (already `# pragma: no cover`, unreachable).

`ttl.py` (25)
- All `_emit.incr(...)` argument mutants (metric name/label to None, dropped kwarg): observability only, tests deliberately do not assert metric wire details.
- All `cast("T", ...)` -> `cast(None, ...)` / dropped: `cast` is a runtime no-op.
- `_get_backend` `.get("cache", "default")` -> `.get("cache",)`: the name parameter defaults to `"default"`, so the explicit value is redundant.
- `_promote` `self._keys[key] = None` -> `= ""`: the dict value is never read (OrderedDict used as an ordered set).
- `_evict` `popitem(last=False)` -> `popitem(last=None)`: None is falsy, identical to False.
- `get` / `get_many` `maxsize > 0` -> `maxsize > 1`: differs only at maxsize 1, where the single LRU slot makes the promote unobservable.

`cached.py` (16)
- `_emit.incr("grelmicro.cache.stale_serves")` -> `_emit.incr(None)` in both stale helpers: metric observability only.
- `_PrivateMemoryCacheAdapter.get` loop-capture mutants: the private cache is async only, so `_loop` is never read.
- `_TagSpec.render` `list(self.templates)` -> `list(None)` in the `signature is None` branch (already `# pragma: no cover`, unreachable since empty templates return first).
- `task.add_done_callback(lambda _: None)` -> `None` / `lambda _: 0`: the callback only drops a lookup reference, its result is unused and a failure is invisible.
- `threading.Thread(..., daemon=True)` -> `daemon=None` / dropped / `daemon=False`: the daemon flag does not change observable refresh behavior under test.
- `acquire(blocking=False)` -> `blocking=None` in both sync eviction probes: identical for idle locks, and the held-lock difference is only reachable with a held lock at the head of the eviction scan.
- `_maybe_refresh_async` / `_maybe_refresh_sync` lock keyed by `None` and `skip` -> `None`: best-effort background refresh dedup and skip-on-refresh, both deep concurrency paths with no deterministic exact-value observation.

Closes #374
