### PR TITLE
🧪 Kill resilience retry, shield, and Match boundary mutants

### DIFF
--- a/tests/resilience/shield/test_adaptive_gate_mutants.py
+++ b/tests/resilience/shield/test_adaptive_gate_mutants.py
@@ -1,0 +1,128 @@
+"""Exact-value adaptive-gate tests for boundary and formula survivors.
+
+These pin behavior the existing exact tests miss because they start the
+clock and last-fail at zero: the CUBIC offset subtracts last_fail (a
+sign flip diverges only when last_fail is nonzero), the measured-rate
+clamp multiplies, a sub-second elapsed still refills, the cap may equal
+the floor, and enabling snaps the bucket to zero tokens.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from grelmicro.resilience.shield._adaptive_gate import _AdaptiveGate
+from tests.resilience.shield.conftest import _FakeClock
+
+_C = 0.4
+_BETA = 0.7
+_THIRD = 1.0 / 3.0
+
+_INIT_RATE = 100.0
+_FLOOR = 0.1
+_BIG_CAPACITY = 1000.0
+_START = 50.0
+
+
+def _gate(clock: _FakeClock, *, max_rate_cap: float | None = None) -> _AdaptiveGate:
+    return _AdaptiveGate(
+        initial_max_rate=_INIT_RATE,
+        capacity=_BIG_CAPACITY,
+        min_rate_floor=_FLOOR,
+        max_rate_cap=max_rate_cap,
+        time_source=clock,
+    )
+
+
+def test_cap_equal_to_floor_is_allowed() -> None:
+    """`max_rate_cap == min_rate_floor` is valid (the bound is `<`, not `<=`)."""
+    gate = _AdaptiveGate(
+        initial_max_rate=_INIT_RATE,
+        capacity=_BIG_CAPACITY,
+        min_rate_floor=_FLOOR,
+        max_rate_cap=_FLOOR,
+    )
+    assert gate.max_rate == _INIT_RATE
+
+
+def test_on_success_offset_subtracts_nonzero_last_fail() -> None:
+    """The CUBIC offset is `now - last_fail - k` with a nonzero last_fail."""
+    clock = _FakeClock(start=_START)
+    gate = _gate(clock)
+    gate.on_slow_down()  # last_fail = 50, w_max = initial
+
+    clock.advance(10.0)  # now = 60
+    gate.on_success()
+
+    k = ((_INIT_RATE * (1.0 - _BETA)) / _C) ** _THIRD
+    offset = 60.0 - _START - k  # a `+` flip would use 60 + 50 - k
+    expected = _C * offset**3 + _INIT_RATE
+    assert gate.max_rate == pytest.approx(expected)
+
+
+async def test_measured_rate_finite_for_sub_second_span() -> None:
+    """A span of 0.5 seconds yields a finite rate, not infinity."""
+    clock = _FakeClock(start=_START)
+    gate = _gate(clock)
+
+    await gate.acquire()  # records t=50
+    clock.advance(0.5)
+    await gate.acquire()  # records t=50.5
+
+    # (2 - 1) / 0.5 = 2.0; a `<= 1` guard would wrongly return inf.
+    assert gate.measured_rate() == pytest.approx(2.0)
+
+
+def test_refill_adds_tokens_for_sub_second_elapsed() -> None:
+    """A sub-second elapsed still refills (the guard is `> 0`, not `> 1`)."""
+    clock = _FakeClock(start=_START)
+    gate = _gate(clock)
+    gate._tokens = 0.0
+    gate._updated_at = _START
+    gate._max_rate = 2.0
+
+    clock.advance(0.5)
+    gate._refill(clock())
+
+    assert gate._tokens == pytest.approx(0.5 * 2.0)
+
+
+def test_apply_rate_multiplies_measured_clamp() -> None:
+    """The measured-rate clamp is `1.5 * measured`, not `1.5 / measured`."""
+    clock = _FakeClock(start=_START)
+    gate = _gate(clock)
+    gate.on_slow_down()  # enable
+
+    # Two sends 0.5s apart give measured_rate = 2.0, so the clamp is
+    # 1.5 * 2.0 = 3.0. A `/` flip would clamp at 1.5 / 2.0 = 0.75.
+    gate._send_window.append(_START)
+    gate._send_window.append(_START + 0.5)
+    assert gate.measured_rate() == pytest.approx(2.0)
+
+    clock.advance(100.0)  # huge offset so the CUBIC candidate is large
+    gate.on_success()
+
+    assert gate.max_rate == pytest.approx(3.0)
+
+
+def test_first_slow_down_snaps_tokens_to_zero() -> None:
+    """Enabling the gate snaps the token bucket to zero."""
+    clock = _FakeClock(start=_START)
+    gate = _gate(clock)
+    gate._tokens = 5.0# accumulated while inert
+
+    gate.on_slow_down()
+
+    assert gate._tokens == 0.0
+
+
+async def test_send_window_is_bounded_to_eight_samples() -> None:
+    """The send window keeps at most the last 8 timestamps."""
+    clock = _FakeClock(start=_START)
+    gate = _gate(clock)
+
+    for _ in range(12):
+        await gate.acquire()  # disabled path records the timestamp
+        clock.advance(1.0)
+
+    assert len(gate._send_window) == 8  # noqa: PLR2004

--- a/tests/resilience/shield/test_adaptive_gate_mutants.py
+++ b/tests/resilience/shield/test_adaptive_gate_mutants.py
@@ -24,7 +24,9 @@ _BIG_CAPACITY = 1000.0
 _START = 50.0
 
 
-def _gate(clock: _FakeClock, *, max_rate_cap: float | None = None) -> _AdaptiveGate:
+def _gate(
+    clock: _FakeClock, *, max_rate_cap: float | None = None
+) -> _AdaptiveGate:
     return _AdaptiveGate(
         initial_max_rate=_INIT_RATE,
         capacity=_BIG_CAPACITY,
@@ -109,7 +111,7 @@ def test_first_slow_down_snaps_tokens_to_zero() -> None:
     """Enabling the gate snaps the token bucket to zero."""
     clock = _FakeClock(start=_START)
     gate = _gate(clock)
-    gate._tokens = 5.0# accumulated while inert
+    gate._tokens = 5.0  # accumulated while inert
 
     gate.on_slow_down()
 

--- a/tests/resilience/shield/test_shield_mutants.py
+++ b/tests/resilience/shield/test_shield_mutants.py
@@ -113,9 +113,7 @@ async def test_recorded_latency_is_call_duration() -> None:
     assert await s.run(slow_ok) == "ok"
     # The next estimate is p95 (single sample 0.4) times the 2.5 multiplier.
     # A `+` latency flip would record ~200.4 and blow past the clamp.
-    assert s._state.timeout_estimator.estimate() == pytest.approx(
-        0.4 * 2.5
-    )
+    assert s._state.timeout_estimator.estimate() == pytest.approx(0.4 * 2.5)
 
 
 async def test_cache_key_depends_on_arguments() -> None:

--- a/tests/resilience/shield/test_shield_mutants.py
+++ b/tests/resilience/shield/test_shield_mutants.py
@@ -1,0 +1,265 @@
+"""Exact-value Shield execution tests for boundary and formula survivors.
+
+These pin behavior that loose assertions miss in the run loop: the
+retry-budget refund equals the number of consumed retries, a sub-second
+backoff still sleeps, recorded latency is the call duration, the cache
+key depends on the call arguments, and a partial-wrapped coroutine is
+accepted.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from grelmicro.resilience import ApiShieldConfig, Shield
+from grelmicro.resilience.shield import _shield as shield_module
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+_PRIMED = 7
+_PARTIAL_SUM = 15
+_KWARG_SUM = 7
+_THREE = 3
+_CAP = 42.0
+
+
+class _SignalError(Exception):
+    """Test-only retryable error."""
+
+
+class _Clock:
+    """Manually advanced monotonic clock."""
+
+    def __init__(self, start: float = 100.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+async def test_two_retries_refund_matches_consumed() -> None:
+    """Two consumed retries then success refunds exactly two tokens."""
+    s = Shield(
+        "refund-two",
+        timeout_errors=(_SignalError,),
+        random_source=lambda: 0.0,  # zero backoff, no real sleep
+    )
+    capacity = s._state.retry_budget.capacity
+    attempts = {"count": 0}
+
+    async def flaky() -> str:
+        attempts["count"] += 1
+        if attempts["count"] < _THREE:
+            raise _SignalError
+        return "ok"
+
+    assert await s.run(flaky) == "ok"
+    assert attempts["count"] == _THREE
+    # Two retries consumed two tokens, then a refund of exactly two
+    # restores the budget. A refund of 1 would leave it one short.
+    assert s._state.retry_budget.available == capacity
+
+
+async def test_sub_second_backoff_still_sleeps(
+    mocker: MockerFixture,
+) -> None:
+    """A backoff delay below one second still triggers a sleep."""
+    delays: list[float] = []
+
+    async def _spy(seconds: float) -> None:
+        delays.append(seconds)
+
+    mocker.patch.object(shield_module, "sleep", side_effect=_spy)
+    # random 0.5 and a small scale keep the delay strictly between 0 and 1.
+    s = Shield(
+        "subsec-backoff",
+        timeout_errors=(_SignalError,),
+        random_source=lambda: 0.5,
+    )
+    attempts = {"count": 0}
+
+    async def flaky() -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise _SignalError
+        return "ok"
+
+    assert await s.run(flaky) == "ok"
+    assert len(delays) == 1
+    assert 0.0 < delays[0] < 1.0
+
+
+async def test_recorded_latency_is_call_duration() -> None:
+    """The estimator records the call duration, not the sum of timestamps."""
+    clock = _Clock(start=100.0)
+    s = Shield(
+        "latency",
+        timeout_errors=(_SignalError,),
+        time_source=clock,
+        random_source=lambda: 0.0,
+    )
+
+    async def slow_ok() -> str:
+        clock.advance(0.4)  # the call takes 0.4 virtual seconds
+        return "ok"
+
+    assert await s.run(slow_ok) == "ok"
+    # The next estimate is p95 (single sample 0.4) times the 2.5 multiplier.
+    # A `+` latency flip would record ~200.4 and blow past the clamp.
+    assert s._state.timeout_estimator.estimate() == pytest.approx(
+        0.4 * 2.5
+    )
+
+
+async def test_cache_key_depends_on_arguments() -> None:
+    """The default cache key includes the call arguments."""
+    store: dict[str, Any] = {}
+
+    class _Cache:
+        async def get(self, key: str) -> Any:  # noqa: ANN401
+            return store.get(key)
+
+        async def set(self, key: str, value: Any) -> None:  # noqa: ANN401
+            store[key] = value
+
+    s = Shield(
+        "cache-key",
+        timeout_errors=(_SignalError,),
+        cache=_Cache(),
+        random_source=lambda: 0.0,
+    )
+
+    async def echo(value: int) -> int:
+        if value < 0:
+            raise _SignalError
+        return value
+
+    # Prime the cache for value=7 via a success.
+    assert await s.run(echo, _PRIMED) == _PRIMED
+    # Let the fire-and-forget cache set complete.
+    for task in list(s._pending_tasks):
+        await task
+
+    # A give-up for value=-1 must NOT return the 7 entry: the key differs.
+    with pytest.raises(_SignalError):
+        await s.run(echo, -1)
+
+
+async def test_run_accepts_partial_coroutine() -> None:
+    """`Shield.run` accepts a functools.partial wrapping a coroutine."""
+    s = Shield("partial", timeout_errors=(_SignalError,))
+
+    async def add(a: int, b: int) -> int:
+        return a + b
+
+    bound = functools.partial(add, 10)
+    assert await s.run(bound, 5) == _PARTIAL_SUM
+
+
+async def test_run_forwards_keyword_arguments() -> None:
+    """`Shield.run` forwards keyword arguments to the wrapped call."""
+    s = Shield("kwargs", timeout_errors=(_SignalError,))
+
+    async def echo(a: int, *, b: int) -> int:
+        return a + b
+
+    assert await s.run(echo, 3, b=4) == _KWARG_SUM
+
+
+async def test_custom_cache_key_receives_keyword_arguments() -> None:
+    """A custom cache_key callable receives the call's keyword arguments."""
+    seen: dict[str, Any] = {}
+
+    def key_for(*args: Any, **kwargs: Any) -> str:  # noqa: ANN401
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return "k"
+
+    class _Cache:
+        async def get(self, _key: str) -> Any:  # noqa: ANN401
+            return None
+
+        async def set(self, _key: str, _value: Any) -> None:  # noqa: ANN401
+            return None
+
+    s = Shield(
+        "custom-key",
+        timeout_errors=(_SignalError,),
+        cache=_Cache(),
+        cache_key=key_for,
+        random_source=lambda: 0.0,
+    )
+
+    async def boom(*, flag: bool) -> None:
+        del flag
+        raise _SignalError
+
+    with pytest.raises(_SignalError):
+        await s.run(boom, flag=True)
+
+    assert seen["kwargs"] == {"flag": True}
+
+
+async def test_run_works_after_reconfigure() -> None:
+    """Reconfigure rebuilds a usable state so the next call still runs."""
+    s = Shield("reconf-run", timeout_errors=(_SignalError,))
+    # A different config forces `_apply_reconfigure` to actually rebuild.
+    await s.reconfigure(
+        ApiShieldConfig(timeout_errors=(_SignalError,), max_rate=_CAP)
+    )
+
+    async def ok() -> str:
+        return "ok"
+
+    # A `_state = None` would raise AttributeError on the next call.
+    assert await s.run(ok) == "ok"
+    assert s._state.adaptive_gate._max_rate_cap == _CAP
+
+
+def test_max_rate_caps_the_adaptive_gate() -> None:
+    """A configured `max_rate` becomes the adaptive gate's rate ceiling."""
+    s = Shield("capped", timeout_errors=(_SignalError,), max_rate=_CAP)
+
+    assert s._state.adaptive_gate._max_rate_cap == _CAP
+
+
+def test_no_max_rate_leaves_gate_uncapped() -> None:
+    """Without `max_rate`, the gate cap falls back to the profile default."""
+    s = Shield("uncapped", timeout_errors=(_SignalError,))
+
+    # The api profile default cap is None (uncapped).
+    assert s._state.adaptive_gate._max_rate_cap is None
+
+
+async def test_zero_backoff_delay_does_not_sleep(
+    mocker: MockerFixture,
+) -> None:
+    """A zero backoff delay skips the sleep entirely (`> 0`, not `>= 0`)."""
+    slept: list[float] = []
+
+    async def _spy(seconds: float) -> None:
+        slept.append(seconds)
+
+    mocker.patch.object(shield_module, "sleep", side_effect=_spy)
+    s = Shield(
+        "zero-backoff",
+        timeout_errors=(_SignalError,),
+        random_source=lambda: 0.0,  # delay = 0 * ceiling = 0
+    )
+    attempts = {"count": 0}
+
+    async def flaky() -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise _SignalError
+        return "ok"
+
+    assert await s.run(flaky) == "ok"
+    assert slept == []

--- a/tests/resilience/test_bulkhead_mutants.py
+++ b/tests/resilience/test_bulkhead_mutants.py
@@ -1,0 +1,69 @@
+"""Exact-value bulkhead tests that pin the fail-fast and reconfigure logic.
+
+These tests target mutation survivors that loose assertions miss: the
+default `max_wait` of zero (fail fast, not a one second wait), keyword
+forwarding on the shared-executor path, and the reconfigure guard that
+only rebuilds the private executor when one already exists.
+"""
+
+import asyncio
+
+import pytest
+from pytest_mock import MockerFixture
+
+from grelmicro.resilience import Bulkhead
+
+pytestmark = [pytest.mark.timeout(5)]
+
+_KWARGS_SUM = 5
+
+
+async def test_fail_fast_uses_zero_wait_by_default(
+    mocker: MockerFixture,
+) -> None:
+    """With no `max_wait`, the acquire deadline is exactly zero seconds."""
+    waits: list[float] = []
+    real_timeout = asyncio.timeout
+
+    def _spy(delay: float) -> object:
+        waits.append(delay)
+        return real_timeout(delay)
+
+    mocker.patch("grelmicro.resilience.bulkhead.asyncio.timeout", side_effect=_spy)
+    bulkhead = Bulkhead("api", max_concurrent=1)
+
+    async with bulkhead:
+        pass
+
+    assert waits == [0.0]
+
+
+async def test_to_thread_shared_executor_forwards_kwargs() -> None:
+    """`to_thread` forwards kwargs on the shared-executor path too."""
+    bulkhead = Bulkhead("api")  # no max_workers, shared executor path
+
+    def add(a: int, *, b: int) -> int:
+        return a + b
+
+    assert await bulkhead.to_thread(add, 2, b=3) == _KWARGS_SUM
+
+
+async def test_private_executor_sized_to_max_workers() -> None:
+    """The private pool is built with exactly the configured worker count."""
+    bulkhead = Bulkhead("checkout", max_workers=1)
+
+    await bulkhead.to_thread(lambda: None)
+
+    assert bulkhead._executor is not None
+    assert bulkhead._executor._max_workers == 1
+
+
+async def test_reconfigure_without_executor_does_not_crash() -> None:
+    """Reconfiguring max_workers with no built executor leaves it None."""
+    bulkhead = Bulkhead("api", max_workers=2)
+    # No `to_thread` call yet, so the private executor is never built.
+    await bulkhead.reconfigure(
+        bulkhead.config.model_copy(update={"max_workers": 4})
+    )
+
+    assert bulkhead.config.max_workers == 4  # noqa: PLR2004

--- a/tests/resilience/test_bulkhead_mutants.py
+++ b/tests/resilience/test_bulkhead_mutants.py
@@ -29,7 +29,9 @@ async def test_fail_fast_uses_zero_wait_by_default(
         waits.append(delay)
         return real_timeout(delay)
 
-    mocker.patch("grelmicro.resilience.bulkhead.asyncio.timeout", side_effect=_spy)
+    mocker.patch(
+        "grelmicro.resilience.bulkhead.asyncio.timeout", side_effect=_spy
+    )
     bulkhead = Bulkhead("api", max_concurrent=1)
 
     async with bulkhead:

--- a/tests/resilience/test_fallback_mutants.py
+++ b/tests/resilience/test_fallback_mutants.py
@@ -1,0 +1,55 @@
+"""Exact-value fallback tests for config resolution and FQN handling.
+
+These tests pin behavior that loose assertions miss: the config and
+kwargs are mutually exclusive (even when only `default` is given),
+`from_config` keeps the passed name, and an env FQN keeps its full
+dotted path and must resolve to an Exception subclass.
+"""
+
+import pytest
+
+from grelmicro.resilience import (
+    Fallback,
+    FallbackConfig,
+    Match,
+    Outcome,
+)
+
+
+def test_config_and_default_only_kwarg_conflict() -> None:
+    """Passing `config=` together with only `default=` is rejected."""
+    cfg = FallbackConfig(when=Match.exception(ValueError), default=1)
+    with pytest.raises(TypeError, match="not both"):
+        Fallback("conflict", default=2, config=cfg)
+
+
+def test_from_config_keeps_the_name() -> None:
+    """`Fallback.from_config` keeps the given name, not None."""
+    cfg = FallbackConfig(when=Match.exception(ValueError), default=1)
+    policy = Fallback.from_config("named", cfg)
+    assert policy.name == "named"
+
+
+def test_env_when_resolves_nested_fqn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A multi-segment env FQN resolves through the full module path."""
+    monkeypatch.setenv(
+        "GREL_FALLBACK_NESTEDFQN_WHEN", "asyncio.exceptions.TimeoutError"
+    )
+    monkeypatch.setenv("GREL_FALLBACK_NESTEDFQN_DEFAULT", "null")
+    policy = Fallback("nestedfqn", env_load=True)
+    matcher = policy.config.when
+    assert matcher(Outcome.from_exception(TimeoutError())) is True
+
+
+def test_env_when_rejects_non_exception_fqn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An env FQN that resolves to a non-Exception type is rejected."""
+    monkeypatch.setenv("GREL_FALLBACK_NOTEXC_WHEN", "builtins.int")
+    monkeypatch.setenv("GREL_FALLBACK_NOTEXC_DEFAULT", "null")
+    with pytest.raises(
+        (ValueError, TypeError), match="not an Exception subclass"
+    ):
+        Fallback("notexc", env_load=True)

--- a/tests/resilience/test_match_mutants.py
+++ b/tests/resilience/test_match_mutants.py
@@ -1,0 +1,36 @@
+"""Exact-value Match tests that pin the negated-form delegation.
+
+The negated builders forward their argument to the positive builder.
+A dropped value (``not_result(v)`` building from None) or a dropped
+keyword (``not_exception_message(regex=...)`` losing the regex) would
+change which outcomes engage, so these tests use a non-None value and
+the regex keyword to catch it.
+"""
+
+from grelmicro.resilience import Match, Outcome
+
+_VALUE = 5
+
+
+def test_not_result_forwards_non_none_value() -> None:
+    """`not_result(5)` engages on every returned value except exactly 5."""
+    f = Match.not_result(_VALUE)
+    assert not f(Outcome.from_result(_VALUE))
+    assert f(Outcome.from_result(0))
+    assert f(Outcome.from_result(None))
+
+
+def test_not_exception_message_forwards_regex() -> None:
+    """`not_exception_message(regex=...)` engages on a non-matching message."""
+    f = Match.not_exception_message(regex=r"tim\w+t")
+    assert not f(Outcome.from_exception(RuntimeError("connection timeout")))
+    assert f(Outcome.from_exception(RuntimeError("ok")))
+    assert not f(Outcome.from_result("anything"))
+
+
+def test_not_exception_message_regex_only_does_not_need_contains() -> None:
+    """The regex-only negated form builds without a contains argument."""
+    # A dropped regex keyword would leave both arguments None and raise.
+    f = Match.not_exception_message(regex=r"^boom$")
+    assert f(Outcome.from_exception(RuntimeError("not boom here")))
+    assert not f(Outcome.from_exception(RuntimeError("boom")))

--- a/tests/resilience/test_retry_mutants.py
+++ b/tests/resilience/test_retry_mutants.py
@@ -1,0 +1,1083 @@
+"""Exact-value retry tests that pin formula and boundary behavior.
+
+These tests target mutation survivors in the retry run loops and
+factories. They assert the exact delay sequence, the exact attempt
+count, the exact returned result, and the exact factory defaults, so
+operator flips (``>=`` to ``>``, ``-`` to ``+``, ``or`` to ``and``),
+off-by-one range changes, and dropped arguments all diverge.
+"""
+
+import time as _time
+
+import pytest
+from pytest_mock import MockerFixture
+
+from grelmicro.resilience import (
+    ConstantBackoff,
+    LinearBackoff,
+    Match,
+    Outcome,
+    Retry,
+    retry,
+    retrying,
+)
+from grelmicro.resilience.backoffs import (
+    ConstantBackoff as _Constant,
+)
+from grelmicro.resilience.backoffs import (
+    ExponentialBackoff as _Exponential,
+)
+
+pytestmark = [pytest.mark.timeout(5)]
+
+_DELAY = 7.0
+_ATTEMPTS = 3
+_FIRST = 1
+_SECOND = 2
+_FIVE = 5
+_BUDGET = 50.0
+_SUM = 7
+_BASE_DELAY = 0.1
+_MAX_DELAY = 30.0
+
+
+@pytest.fixture
+def record_async_sleep(mocker: MockerFixture) -> list[float]:
+    """Record the delay passed to each async sleep, never wait."""
+    delays: list[float] = []
+
+    async def _spy(seconds: float) -> None:
+        delays.append(seconds)
+
+    mocker.patch("grelmicro.resilience.retry.clock_sleep", side_effect=_spy)
+    return delays
+
+
+@pytest.fixture
+def record_sync_sleep(mocker: MockerFixture) -> list[float]:
+    """Record the delay passed to each sync sleep, never wait."""
+    delays: list[float] = []
+
+    def _spy(seconds: float) -> None:
+        delays.append(seconds)
+
+    mocker.patch.object(_time, "sleep", side_effect=_spy)
+    return delays
+
+
+# --- Delay sequence: first attempt never sleeps, others use the backoff ---
+
+
+async def test_async_delay_sequence_is_exact(
+    record_async_sleep: list[float],
+) -> None:
+    """Three failing attempts sleep exactly the constant delay twice."""
+    policy = Retry(
+        "delay-async",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+
+    @policy
+    async def boom() -> None:
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        await boom()
+
+    assert record_async_sleep == [_DELAY, _DELAY]
+
+
+def test_sync_delay_sequence_is_exact(
+    record_sync_sleep: list[float],
+) -> None:
+    """Three failing attempts sleep exactly the constant delay twice (sync)."""
+    policy = Retry(
+        "delay-sync",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+
+    @policy
+    def boom() -> None:
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        boom()
+
+    assert record_sync_sleep == [_DELAY, _DELAY]
+
+
+async def test_block_form_delay_sequence_is_exact(
+    record_async_sleep: list[float],
+) -> None:
+    """The async block form sleeps exactly the constant delay between tries."""
+    policy = Retry(
+        "delay-block",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+
+    with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+        async for attempt in policy:
+            async with attempt:
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert record_async_sleep == [_DELAY, _DELAY]
+
+
+def test_sync_block_form_delay_sequence_is_exact(
+    record_sync_sleep: list[float],
+) -> None:
+    """The sync block form sleeps exactly the constant delay between tries."""
+    policy = Retry(
+        "delay-block-sync",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+
+    with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+        for attempt in policy:
+            with attempt:
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert record_sync_sleep == [_DELAY, _DELAY]
+
+
+# --- delay_before exposed on the first attempt is exactly zero ------------
+
+
+async def test_first_attempt_delay_before_is_zero(
+    record_async_sleep: list[float],
+) -> None:
+    """The first yielded attempt reports a zero pre-delay and never sleeps."""
+    policy = Retry(
+        "first-delay",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+    seen: list[float] = []
+
+    async for attempt in policy:
+        seen.append(attempt.delay_before)
+        async with attempt:
+            if attempt.number == _SECOND:
+                break
+            msg = "boom"
+            raise ValueError(msg)
+
+    assert seen == [0.0, _DELAY]
+    assert record_async_sleep == [_DELAY]
+
+
+# --- Result-based retry returns the exact last result --------------------
+
+
+async def test_async_result_retry_returns_exact_last_result(
+    record_async_sleep: list[float],
+) -> None:
+    """When every result still matches, the exact last result is returned."""
+    policy = Retry(
+        "result-async",
+        ConstantBackoff(delay=_DELAY),
+        when=Match.result(lambda value: value is not None and value < 0),
+        attempts=_ATTEMPTS,
+    )
+    seen: list[int] = []
+
+    @policy
+    async def always_negative() -> int:
+        seen.append(len(seen))
+        return -len(seen)
+
+    # Every result keeps matching, so the loop exhausts and returns the
+    # last produced value rather than None or the first one.
+    assert await always_negative() == -_ATTEMPTS
+    assert len(seen) == _ATTEMPTS
+    assert record_async_sleep == [_DELAY, _DELAY]
+
+
+def test_sync_result_retry_returns_exact_last_result(
+    record_sync_sleep: list[float],
+) -> None:
+    """The sync path returns the exact last matching result on exhaustion."""
+    policy = Retry(
+        "result-sync",
+        ConstantBackoff(delay=_DELAY),
+        when=Match.result(lambda value: value is not None and value < 0),
+        attempts=_ATTEMPTS,
+    )
+    seen: list[int] = []
+
+    @policy
+    def always_negative() -> int:
+        seen.append(len(seen))
+        return -len(seen)
+
+    assert always_negative() == -_ATTEMPTS
+    assert len(seen) == _ATTEMPTS
+    assert record_sync_sleep == [_DELAY, _DELAY]
+
+
+@pytest.mark.usefixtures("record_async_sleep")
+async def test_async_result_retry_stops_on_budget_before_attempts(
+    mocker: MockerFixture,
+) -> None:
+    """A matching result stops on the budget even with attempts left."""
+    # started_at=100, first result check at 110 (elapsed 10, under budget),
+    # second at 200 (elapsed 100, over the 50 budget) so it stops at call 2.
+    reads = iter([100.0, 110.0, 200.0])
+    mocker.patch(
+        "grelmicro.resilience.retry.clock_monotonic",
+        side_effect=lambda: next(reads, 200.0),
+    )
+    policy = Retry(
+        "result-budget-async",
+        ConstantBackoff(delay=_DELAY),
+        when=Match.result(lambda value: value is not None and value < 0),
+        attempts=_FIVE,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    @policy
+    async def always_negative() -> int:
+        nonlocal calls
+        calls += 1
+        return -calls
+
+    assert await always_negative() == -_SECOND
+    assert calls == _SECOND
+
+
+@pytest.mark.usefixtures("record_sync_sleep")
+def test_sync_result_retry_stops_on_budget_before_attempts(
+    mocker: MockerFixture,
+) -> None:
+    """A matching result stops on the budget even with attempts left (sync)."""
+    reads = iter([100.0, 110.0, 200.0])
+    mocker.patch(
+        "grelmicro.resilience.retry.clock_monotonic",
+        side_effect=lambda: next(reads, 200.0),
+    )
+    policy = Retry(
+        "result-budget-sync",
+        ConstantBackoff(delay=_DELAY),
+        when=Match.result(lambda value: value is not None and value < 0),
+        attempts=_FIVE,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    @policy
+    def always_negative() -> int:
+        nonlocal calls
+        calls += 1
+        return -calls
+
+    assert always_negative() == -_SECOND
+    assert calls == _SECOND
+
+
+# --- args and kwargs are both forwarded to the wrapped function ----------
+
+
+async def test_async_forwards_args_and_kwargs() -> None:
+    """Both positional and keyword arguments reach the wrapped coroutine."""
+    policy = Retry(
+        "args-async", ConstantBackoff(delay=_DELAY), when=ValueError
+    )
+    received: dict[str, object] = {}
+
+    @policy
+    async def echo(a: int, *, b: int) -> int:
+        received["a"] = a
+        received["b"] = b
+        return a + b
+
+    assert await echo(3, b=4) == _SUM
+    assert received == {"a": 3, "b": 4}
+
+
+def test_sync_forwards_args_and_kwargs() -> None:
+    """Both positional and keyword arguments reach the wrapped function."""
+    policy = Retry(
+        "args-sync", ConstantBackoff(delay=_DELAY), when=ValueError
+    )
+    received: dict[str, object] = {}
+
+    @policy
+    def echo(a: int, *, b: int) -> int:
+        received["a"] = a
+        received["b"] = b
+        return a + b
+
+    assert echo(3, b=4) == _SUM
+    assert received == {"a": 3, "b": 4}
+
+
+# --- max_seconds budget: elapsed formula and boundary --------------------
+
+# The clock starts at a nonzero value so an `elapsed = now - started_at`
+# mutated to `now + started_at` diverges (one stays under budget, the
+# other shoots far past it). The budget is checked with `>=`, so an
+# elapsed exactly equal to the budget must stop.
+_START = 100.0
+_UNDER = 110.0
+_AT_BUDGET = _START + _BUDGET
+
+
+def _fixed_clock(mocker: MockerFixture, first: float, rest: float) -> None:
+    """Patch the retry clock: return `first` once, then `rest` forever."""
+    reads = iter([first])
+
+    def _read() -> float:
+        return next(reads, rest)
+
+    mocker.patch(
+        "grelmicro.resilience.retry.clock_monotonic", side_effect=_read
+    )
+
+
+@pytest.mark.usefixtures("record_async_sleep")
+async def test_async_budget_under_continues_to_exhaustion(
+    mocker: MockerFixture,
+) -> None:
+    """Elapsed under the budget keeps retrying until attempts run out."""
+    _fixed_clock(mocker, _START, _UNDER)
+    policy = Retry(
+        "budget-under-async",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    @policy
+    async def boom() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom") as info:
+        await boom()
+
+    assert calls == _ATTEMPTS
+    note = "\n".join(info.value.__notes__)
+    assert "attempts exhausted" in note
+    assert "budget elapsed" not in note
+
+
+@pytest.mark.usefixtures("record_sync_sleep")
+def test_sync_budget_under_continues_to_exhaustion(
+    mocker: MockerFixture,
+) -> None:
+    """Elapsed under the budget keeps retrying until attempts run out (sync)."""
+    _fixed_clock(mocker, _START, _UNDER)
+    policy = Retry(
+        "budget-under-sync",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    @policy
+    def boom() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom") as info:
+        boom()
+
+    assert calls == _ATTEMPTS
+    note = "\n".join(info.value.__notes__)
+    assert "attempts exhausted" in note
+    assert "budget elapsed" not in note
+
+
+@pytest.mark.usefixtures("record_async_sleep")
+async def test_block_form_budget_under_continues_to_exhaustion(
+    mocker: MockerFixture,
+) -> None:
+    """The block form keeps retrying while elapsed stays under the budget."""
+    _fixed_clock(mocker, _START, _UNDER)
+    policy = Retry(
+        "budget-under-block",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    with pytest.raises(ValueError, match="boom") as info:  # noqa: PT012
+        async for attempt in policy:
+            async with attempt:
+                calls += 1
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert calls == _ATTEMPTS
+    note = "\n".join(info.value.__notes__)
+    assert "attempts exhausted" in note
+    assert "budget elapsed" not in note
+
+
+async def test_async_budget_at_boundary_stops(
+    mocker: MockerFixture,
+    record_async_sleep: list[float],
+) -> None:
+    """Elapsed exactly equal to the budget stops retrying (>= boundary)."""
+    _fixed_clock(mocker, _START, _AT_BUDGET)
+    policy = Retry(
+        "budget-at-async",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    @policy
+    async def boom() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom") as info:
+        await boom()
+
+    assert calls == _FIRST
+    assert record_async_sleep == []
+    assert any("budget elapsed" in note for note in info.value.__notes__)
+
+
+def test_sync_budget_at_boundary_stops(
+    mocker: MockerFixture,
+    record_sync_sleep: list[float],
+) -> None:
+    """Elapsed exactly equal to the budget stops retrying (sync >= boundary)."""
+    _fixed_clock(mocker, _START, _AT_BUDGET)
+    policy = Retry(
+        "budget-at-sync",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    @policy
+    def boom() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom") as info:
+        boom()
+
+    assert calls == _FIRST
+    assert record_sync_sleep == []
+    assert any("budget elapsed" in note for note in info.value.__notes__)
+
+
+async def test_block_form_budget_at_boundary_stops(
+    mocker: MockerFixture,
+    record_async_sleep: list[float],
+) -> None:
+    """The block form stops when elapsed exactly equals the budget."""
+    _fixed_clock(mocker, _START, _AT_BUDGET)
+    policy = Retry(
+        "budget-at-block",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    with pytest.raises(ValueError, match="boom") as info:  # noqa: PT012
+        async for attempt in policy:
+            async with attempt:
+                calls += 1
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert calls == _FIRST
+    assert record_async_sleep == []
+    assert any("budget elapsed" in note for note in info.value.__notes__)
+
+
+# --- Exhaustion note names the backoff and the attempt count -------------
+
+
+async def test_async_exhaustion_note_names_backoff_and_attempts() -> None:
+    """The exhaustion note carries the backoff name and the attempt total."""
+    policy = Retry(
+        "note-async",
+        ConstantBackoff(delay=0.0001),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+
+    @policy
+    async def boom() -> None:
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom") as info:
+        await boom()
+
+    note = "\n".join(info.value.__notes__)
+    assert "constant backoff" in note
+    assert f"{_ATTEMPTS}/{_ATTEMPTS} attempts" in note
+
+
+async def test_block_form_exhaustion_note_names_backoff() -> None:
+    """The block-form exhaustion note carries the backoff name."""
+    policy = Retry(
+        "note-block",
+        ConstantBackoff(delay=0.0001),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+
+    with pytest.raises(ValueError, match="boom") as info:  # noqa: PT012
+        async for attempt in policy:
+            async with attempt:
+                msg = "boom"
+                raise ValueError(msg)
+
+    note = "\n".join(info.value.__notes__)
+    assert "constant backoff" in note
+    assert f"{_ATTEMPTS}/{_ATTEMPTS} attempts" in note
+
+
+# --- A clean exit suppresses nothing and stops the loop ------------------
+
+
+async def test_successful_attempt_stops_and_does_not_suppress() -> None:
+    """A body that does not raise yields exactly one attempt."""
+    policy = Retry(
+        "success-stop",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+    numbers: list[int] = []
+
+    async for attempt in policy:
+        numbers.append(attempt.number)
+        async with attempt:
+            pass
+
+    assert numbers == [_FIRST]
+
+
+# --- Factory default values are exact ------------------------------------
+
+
+def test_exponential_factory_defaults_are_exact() -> None:
+    """`Retry.exponential` defaults to 3 attempts and a 0.1/30.0 backoff."""
+    policy = Retry.exponential("exp-defaults", when=ValueError)
+    config = policy.config
+    backoff = config.backoff
+    assert config.attempts == _ATTEMPTS
+    assert isinstance(backoff, _Exponential)
+    assert backoff.base_delay == _BASE_DELAY
+    assert backoff.max_delay == _MAX_DELAY
+
+
+def test_constant_factory_defaults_are_exact() -> None:
+    """`Retry.constant` defaults to 3 attempts and a 1.0 second delay."""
+    policy = Retry.constant("const-defaults", when=ValueError)
+    config = policy.config
+    backoff = config.backoff
+    assert config.attempts == _ATTEMPTS
+    assert isinstance(backoff, _Constant)
+    assert backoff.delay == 1.0
+
+
+@pytest.mark.usefixtures("record_async_sleep")
+async def test_retry_decorator_default_attempts_is_three(
+) -> None:
+    """`@retry(when=...)` runs exactly three attempts by default."""
+    calls = 0
+
+    @retry(when=ValueError)
+    async def boom() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        await boom()
+
+    assert calls == _ATTEMPTS
+
+
+async def test_retry_exponential_default_base_delay_is_point_one(
+    mocker: MockerFixture,
+    record_async_sleep: list[float],
+) -> None:
+    """`@retry.exponential` defaults the first backoff to base_delay 0.1."""
+    # Force full jitter to take its upper bound so the raw delay is observable.
+    mocker.patch(
+        "grelmicro.resilience.backoffs.exponential.random.uniform",
+        side_effect=lambda _low, high: high,
+    )
+    calls = 0
+
+    @retry.exponential(when=ValueError, attempts=_SECOND)
+    async def boom() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        await boom()
+
+    assert calls == _SECOND
+    assert record_async_sleep == pytest.approx([0.1])
+
+
+async def test_retrying_constant_default_delay_is_one(
+    record_async_sleep: list[float],
+) -> None:
+    """`retrying.constant` defaults the delay to 1.0 second."""
+    calls = 0
+
+    with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+        async for attempt in retrying.constant(when=ValueError):
+            async with attempt:
+                calls += 1
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert calls == _ATTEMPTS
+    assert record_async_sleep == [1.0, 1.0]
+
+
+async def test_retrying_exponential_default_base_delay_is_point_one(
+    mocker: MockerFixture,
+    record_async_sleep: list[float],
+) -> None:
+    """`retrying.exponential` defaults the first backoff to base_delay 0.1."""
+    mocker.patch(
+        "grelmicro.resilience.backoffs.exponential.random.uniform",
+        side_effect=lambda _low, high: high,
+    )
+    calls = 0
+
+    with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+        async for attempt in retrying.exponential(
+            when=ValueError, attempts=_SECOND
+        ):
+            async with attempt:
+                calls += 1
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert calls == _SECOND
+    assert record_async_sleep == pytest.approx([0.1])
+
+
+async def test_retry_constant_default_attempts_and_delay(
+    record_async_sleep: list[float],
+) -> None:
+    """`@retry.constant(when=...)` defaults to 3 attempts and a 1.0 delay."""
+    calls = 0
+
+    @retry.constant(when=ValueError)
+    async def boom() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        await boom()
+
+    assert calls == _ATTEMPTS
+    assert record_async_sleep == [1.0, 1.0]
+
+
+@pytest.mark.usefixtures("record_async_sleep")
+async def test_retrying_default_attempts_is_three(
+) -> None:
+    """Bare `retrying(when=...)` runs exactly three attempts by default."""
+    calls = 0
+
+    with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+        async for attempt in retrying(when=ValueError):
+            async with attempt:
+                calls += 1
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert calls == _ATTEMPTS
+
+
+async def test_retry_exponential_default_max_delay_caps_at_thirty(
+    mocker: MockerFixture,
+    record_async_sleep: list[float],
+) -> None:
+    """`@retry.exponential` caps the default backoff at 30.0 seconds."""
+    mocker.patch(
+        "grelmicro.resilience.backoffs.exponential.random.uniform",
+        side_effect=lambda _low, high: high,
+    )
+
+    @retry.exponential(when=ValueError, attempts=11)
+    async def boom() -> None:
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        await boom()
+
+    # 0.1 * 2**9 = 51.2 is capped to the 30.0 default max_delay.
+    assert max(record_async_sleep) == pytest.approx(30.0)
+
+
+@pytest.mark.usefixtures("record_async_sleep")
+async def test_retry_exponential_default_attempts_is_three(
+) -> None:
+    """`@retry.exponential(when=...)` runs exactly three attempts by default."""
+    calls = 0
+
+    @retry.exponential(when=ValueError)
+    async def boom() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        await boom()
+
+    assert calls == _ATTEMPTS
+
+
+@pytest.mark.usefixtures("record_async_sleep")
+async def test_retrying_exponential_default_attempts_is_three(
+) -> None:
+    """`retrying.exponential(when=...)` runs exactly three attempts by default."""
+    calls = 0
+
+    with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+        async for attempt in retrying.exponential(when=ValueError):
+            async with attempt:
+                calls += 1
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert calls == _ATTEMPTS
+
+
+async def test_retrying_exponential_default_max_delay_caps_at_thirty(
+    mocker: MockerFixture,
+    record_async_sleep: list[float],
+) -> None:
+    """`retrying.exponential` caps the default backoff at 30.0 seconds."""
+    mocker.patch(
+        "grelmicro.resilience.backoffs.exponential.random.uniform",
+        side_effect=lambda _low, high: high,
+    )
+
+    with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+        async for attempt in retrying.exponential(when=ValueError, attempts=11):
+            async with attempt:
+                msg = "boom"
+                raise ValueError(msg)
+
+    # 0.1 * 2**9 = 51.2 is capped to the 30.0 default max_delay.
+    assert max(record_async_sleep) == pytest.approx(30.0)
+
+
+# --- Sync paths: sub-second delay, attempt-indexed delay, block budget ---
+
+_SUB_SECOND = 0.5
+_LINEAR_BASE = 2.0
+
+
+def test_sync_decorator_sleeps_sub_second_delay(
+    record_sync_sleep: list[float],
+) -> None:
+    """A sub-second delay still triggers a sleep (`> 0`, not `> 1`)."""
+    policy = Retry(
+        "subsec-sync",
+        ConstantBackoff(delay=_SUB_SECOND),
+        when=ValueError,
+        attempts=_SECOND,
+    )
+
+    @policy
+    def boom() -> None:
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        boom()
+
+    assert record_sync_sleep == [_SUB_SECOND]
+
+
+def test_sync_block_form_sleeps_sub_second_delay(
+    record_sync_sleep: list[float],
+) -> None:
+    """The sync block form sleeps a sub-second delay (`> 0`, not `> 1`)."""
+    policy = Retry(
+        "subsec-block-sync",
+        ConstantBackoff(delay=_SUB_SECOND),
+        when=ValueError,
+        attempts=_SECOND,
+    )
+
+    with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+        for attempt in policy:
+            with attempt:
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert record_sync_sleep == [_SUB_SECOND]
+
+
+def test_sync_decorator_uses_attempt_indexed_delay(
+    record_sync_sleep: list[float],
+) -> None:
+    """The sync exception path feeds the real attempt number to the backoff."""
+    policy = Retry(
+        "linear-sync",
+        LinearBackoff(base_delay=_LINEAR_BASE, max_delay=100.0),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+
+    @policy
+    def boom() -> None:
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        boom()
+
+    # Linear: base*1 then base*2. A dropped attempt number would feed
+    # None to the backoff and raise a TypeError.
+    assert record_sync_sleep == [_LINEAR_BASE, _LINEAR_BASE * _SECOND]
+
+
+def test_sync_block_form_uses_attempt_indexed_delay(
+    record_sync_sleep: list[float],
+) -> None:
+    """The sync block form feeds the real attempt number to the backoff."""
+    policy = Retry(
+        "linear-block-sync",
+        LinearBackoff(base_delay=_LINEAR_BASE, max_delay=100.0),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+
+    with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+        for attempt in policy:
+            with attempt:
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert record_sync_sleep == [_LINEAR_BASE, _LINEAR_BASE * _SECOND]
+
+
+async def test_async_result_retry_uses_attempt_indexed_delay(
+    record_async_sleep: list[float],
+) -> None:
+    """The async result path feeds the real attempt number to the backoff."""
+    policy = Retry(
+        "linear-result-async",
+        LinearBackoff(base_delay=_LINEAR_BASE, max_delay=100.0),
+        when=Match.result(lambda value: value is not None and value < 0),
+        attempts=_ATTEMPTS,
+    )
+
+    @policy
+    async def always_negative() -> int:
+        return -1
+
+    assert await always_negative() == -_FIRST
+    assert record_async_sleep == [_LINEAR_BASE, _LINEAR_BASE * _SECOND]
+
+
+def test_sync_result_retry_uses_attempt_indexed_delay(
+    record_sync_sleep: list[float],
+) -> None:
+    """The sync result path feeds the real attempt number to the backoff."""
+    policy = Retry(
+        "linear-result-sync",
+        LinearBackoff(base_delay=_LINEAR_BASE, max_delay=100.0),
+        when=Match.result(lambda value: value is not None and value < 0),
+        attempts=_ATTEMPTS,
+    )
+
+    @policy
+    def always_negative() -> int:
+        return -1
+
+    assert always_negative() == -_FIRST
+    assert record_sync_sleep == [_LINEAR_BASE, _LINEAR_BASE * _SECOND]
+
+
+def test_sync_block_form_first_attempt_delay_before_is_zero(
+    record_sync_sleep: list[float],
+) -> None:
+    """The first sync attempt reports a zero pre-delay and never sleeps."""
+    policy = Retry(
+        "first-delay-sync",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+    )
+    seen: list[float] = []
+
+    for attempt in policy:
+        seen.append(attempt.delay_before)
+        with attempt:
+            if attempt.number == _SECOND:
+                break
+            msg = "boom"
+            raise ValueError(msg)
+
+    assert seen == [0.0, _DELAY]
+    assert record_sync_sleep == [_DELAY]
+
+
+def test_sync_block_form_budget_at_boundary_stops(
+    mocker: MockerFixture,
+    record_sync_sleep: list[float],
+) -> None:
+    """The sync block form stops when elapsed exactly equals the budget."""
+    _fixed_clock(mocker, _START, _AT_BUDGET)
+    policy = Retry(
+        "budget-at-block-sync",
+        ConstantBackoff(delay=_DELAY),
+        when=ValueError,
+        attempts=_ATTEMPTS,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    with pytest.raises(ValueError, match="boom") as info:  # noqa: PT012
+        for attempt in policy:
+            with attempt:
+                calls += 1
+                msg = "boom"
+                raise ValueError(msg)
+
+    assert calls == _FIRST
+    assert record_sync_sleep == []
+    assert any("budget elapsed" in note for note in info.value.__notes__)
+
+
+# --- Result-path budget boundary is inclusive (>=) -----------------------
+
+
+@pytest.mark.usefixtures("record_async_sleep")
+async def test_async_result_budget_at_boundary_stops(
+    mocker: MockerFixture,
+) -> None:
+    """A matching result stops when elapsed exactly equals the budget."""
+    # started_at=100, result check at 150 (elapsed exactly 50 == budget).
+    reads = iter([_START, _AT_BUDGET])
+    mocker.patch(
+        "grelmicro.resilience.retry.clock_monotonic",
+        side_effect=lambda: next(reads, _AT_BUDGET),
+    )
+    policy = Retry(
+        "result-budget-eq-async",
+        ConstantBackoff(delay=_DELAY),
+        when=Match.result(lambda value: value is not None and value < 0),
+        attempts=_FIVE,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    @policy
+    async def always_negative() -> int:
+        nonlocal calls
+        calls += 1
+        return -calls
+
+    assert await always_negative() == -_FIRST
+    assert calls == _FIRST
+
+
+@pytest.mark.usefixtures("record_sync_sleep")
+def test_sync_result_budget_at_boundary_stops(
+    mocker: MockerFixture,
+) -> None:
+    """A matching result stops when elapsed exactly equals the budget (sync)."""
+    reads = iter([_START, _AT_BUDGET])
+    mocker.patch(
+        "grelmicro.resilience.retry.clock_monotonic",
+        side_effect=lambda: next(reads, _AT_BUDGET),
+    )
+    policy = Retry(
+        "result-budget-eq-sync",
+        ConstantBackoff(delay=_DELAY),
+        when=Match.result(lambda value: value is not None and value < 0),
+        attempts=_FIVE,
+        max_seconds=_BUDGET,
+    )
+    calls = 0
+
+    @policy
+    def always_negative() -> int:
+        nonlocal calls
+        calls += 1
+        return -calls
+
+    assert always_negative() == -_FIRST
+    assert calls == _FIRST
+
+
+# --- FQN resolution keeps the full dotted module path --------------------
+
+
+def test_env_when_resolves_nested_fqn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A multi-segment FQN resolves through the full module path."""
+    monkeypatch.setenv(
+        "GREL_RETRY_NESTEDFQN_WHEN", "asyncio.exceptions.TimeoutError"
+    )
+    policy = Retry("nestedfqn", env_load=True)  # type: ignore[call-arg]
+    matcher = policy.config.when
+    assert matcher(Outcome.from_exception(TimeoutError())) is True
+
+
+def test_env_when_rejects_non_exception_fqn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An FQN that resolves to a non-Exception type is rejected."""
+    monkeypatch.setenv("GREL_RETRY_NOTEXC_WHEN", "builtins.int")
+    with pytest.raises(
+        (ValueError, TypeError), match="not an Exception subclass"
+    ):
+        Retry("notexc", env_load=True)  # type: ignore[call-arg]

--- a/tests/resilience/test_retry_mutants.py
+++ b/tests/resilience/test_retry_mutants.py
@@ -293,9 +293,7 @@ def test_sync_result_retry_stops_on_budget_before_attempts(
 
 async def test_async_forwards_args_and_kwargs() -> None:
     """Both positional and keyword arguments reach the wrapped coroutine."""
-    policy = Retry(
-        "args-async", ConstantBackoff(delay=_DELAY), when=ValueError
-    )
+    policy = Retry("args-async", ConstantBackoff(delay=_DELAY), when=ValueError)
     received: dict[str, object] = {}
 
     @policy
@@ -310,9 +308,7 @@ async def test_async_forwards_args_and_kwargs() -> None:
 
 def test_sync_forwards_args_and_kwargs() -> None:
     """Both positional and keyword arguments reach the wrapped function."""
-    policy = Retry(
-        "args-sync", ConstantBackoff(delay=_DELAY), when=ValueError
-    )
+    policy = Retry("args-sync", ConstantBackoff(delay=_DELAY), when=ValueError)
     received: dict[str, object] = {}
 
     @policy
@@ -616,8 +612,7 @@ def test_constant_factory_defaults_are_exact() -> None:
 
 
 @pytest.mark.usefixtures("record_async_sleep")
-async def test_retry_decorator_default_attempts_is_three(
-) -> None:
+async def test_retry_decorator_default_attempts_is_three() -> None:
     """`@retry(when=...)` runs exactly three attempts by default."""
     calls = 0
 
@@ -722,8 +717,7 @@ async def test_retry_constant_default_attempts_and_delay(
 
 
 @pytest.mark.usefixtures("record_async_sleep")
-async def test_retrying_default_attempts_is_three(
-) -> None:
+async def test_retrying_default_attempts_is_three() -> None:
     """Bare `retrying(when=...)` runs exactly three attempts by default."""
     calls = 0
 
@@ -760,8 +754,7 @@ async def test_retry_exponential_default_max_delay_caps_at_thirty(
 
 
 @pytest.mark.usefixtures("record_async_sleep")
-async def test_retry_exponential_default_attempts_is_three(
-) -> None:
+async def test_retry_exponential_default_attempts_is_three() -> None:
     """`@retry.exponential(when=...)` runs exactly three attempts by default."""
     calls = 0
 
@@ -779,8 +772,7 @@ async def test_retry_exponential_default_attempts_is_three(
 
 
 @pytest.mark.usefixtures("record_async_sleep")
-async def test_retrying_exponential_default_attempts_is_three(
-) -> None:
+async def test_retrying_exponential_default_attempts_is_three() -> None:
     """`retrying.exponential(when=...)` runs exactly three attempts by default."""
     calls = 0
 

--- a/tests/resilience/test_retry_mutants.py
+++ b/tests/resilience/test_retry_mutants.py
@@ -1059,7 +1059,7 @@ def test_env_when_resolves_nested_fqn(
     monkeypatch.setenv(
         "GREL_RETRY_NESTEDFQN_WHEN", "asyncio.exceptions.TimeoutError"
     )
-    policy = Retry("nestedfqn", env_load=True)  # type: ignore[call-arg]
+    policy = Retry("nestedfqn", env_load=True)
     matcher = policy.config.when
     assert matcher(Outcome.from_exception(TimeoutError())) is True
 


### PR DESCRIPTION
Finishes the resilience mutation-testing sweep for the in-scope logic files (#373). Each file was mutation-tested with `tools/run_mutmut.py` against `tests/resilience/`. Genuine survivors now die to exact-value tests with a nonzero clock and non-unit rates. Residual survivors are documented equivalents.

## Survivors per file (before -> after)

| File | Before | After (equivalents) | Killing tests added |
| --- | --- | --- | --- |
| backoffs/exponential.py | 0 | 0 | none (already covered) |
| backoffs/fibonacci.py | 0 | 0 | none (2 loop mutants caught as timeouts) |
| backoffs/random.py | 0 | 0 | none |
| backoffs/constant.py | 0 | 0 | none |
| backoffs/linear.py | 0 | 0 | none |
| retry.py | 127 | 53 | `test_retry_mutants.py` (delay sequence, result return, budget boundary, factory defaults, FQN) |
| timeout.py | 10 | 10 | none (all equivalent) |
| bulkhead.py | 25 | 20 | `test_bulkhead_mutants.py` (zero default wait, kwargs, reconfigure guard, pool size) |
| fallback.py | 15 | 9 | `test_fallback_mutants.py` (config/kwarg conflict, from_config name, FQN) |
| _match.py | 54 | 50 | `test_match_mutants.py` (not_result value, not_exception_message regex) |
| shield/_retry_budget.py | 1 | 1 | none (equivalent) |
| shield/_timeout_estimator.py | 8 | 8 | none (all equivalent) |
| shield/_adaptive_gate.py | 16 | 9 | `test_adaptive_gate_mutants.py` (CUBIC offset, measured-rate clamp, sub-second refill, cap-equals-floor, snap, window bound) |
| shield/_profile.py | 0 | 0 | none |
| shield/_shield.py | 90 | 63 | `test_shield_mutants.py` (refund count, sub-second/zero backoff, latency sign, cache key, kwargs, max_rate cap, reconfigure-then-run) |
| shield/_decorator.py | 36 | 36 | none (see flag below) |

## Documented residual equivalents

- retry.py: exception/metric message text, metric name and outcome args (metrics not asserted in `tests/resilience`), `env_load=None` and dropped-kwarg defaults that Pydantic or the factory refills, `range(..., +1)` to `+2` (guarded by the exhaustion check), result-path `>=` to `>` on the attempts clause (unreachable boundary), `last_result` init value (always overwritten before return), `_AttemptLoop._done = None` (falsy like False), `_handle_exit` return on a clean exit (the value is ignored when there is no exception), `_coerce_to_match` `and` to `or` (the discriminating input is intercepted by the validator).
- timeout.py: all 10 are message text, `env_load`, metric args, the unreachable `# pragma: no cover` task guard, and passing None for `exc`/`tb` to `asyncio.Timeout.__aexit__` (it reads only `exc_type`).
- bulkhead.py: message text in unreachable guards, `env_load`, metric name/value/delta args (metrics not asserted here), `_opened = None` (falsy), `shutdown(wait=False)` to None/True (no observable difference).
- fallback.py: `_coerce_to_match` `and` to `or` (validator-intercepted), the dotless-FQN message text, `FallbackResult` init values (overwritten by `set`), `_handle_exit` clean-exit return, `env_load`.
- _match.py: 50 remaining are all `_repr`/`explain` text, `cast(None, ...)` (cast is a runtime no-op), logging-only `_coerce_bool` args, and `or`/`and` flips on `not raised or exc is None` guards that no `Outcome` can distinguish (raised always carries an exception, returned never does).
- shield/_retry_budget.py: `refund` `<= 0` to `< 0` (refund of 0 is a no-op either way).
- shield/_timeout_estimator.py: clamp-bound `<` to `<=` and `>` to `>=` (equal value returns the same number), buffer init value (unread slots), `_count` off-by-one (absorbed by the slice and the rank `min`), `estimate` rank `max(0,...)` to `max(1,...)` (clamped back by the `min`).
- shield/_adaptive_gate.py: 9 remaining are the init CUBIC fields set to None/other (all re-initialized by `on_slow_down` before the gate acts, since the gate is inert until the first slow-down), `_initial_max_rate` (a dead store, never read), and `_refill` `> 0` to `>= 0` (elapsed 0 is a no-op).
- shield/_shield.py: 63 remaining are config-forwarding to coinciding defaults, `env_load`, log/note/exception message text, trailing-comma no-ops, clamped refunds (budget already at capacity), loop-guard-absorbed bounds, init values overwritten before use, the `register` default (every caller passes it explicitly), the fire-and-forget done-callback set to None (fails silently in the loop), and `_is_async_callable` (redundant on this Python, where `inspect.iscoroutinefunction` already unwraps `functools.partial`).

## Flag: shield/_decorator.py could not be driven to zero

The 36 survivors in `shield/_decorator.py` are not killable through mutmut's per-mutant test selection. `_build_profile_decorator(...)` runs once at import to build the `internal`/`api`/`slow` staticmethods, so mutmut's coverage maps those mutants only to whichever test triggers the import, not to the decorator tests. The decorated behavior is exercised by `tests/resilience/shield/test_decorator.py`, but the mutants live in the import-time closure that the coverage-based selection never re-runs. The `__call__` survivors are equivalent: the inner `Shield.__call__` already applies `functools.wraps`, and the Shield name is not surfaced on any tested path.

Closes #373
