### PR TITLE
👷 Run light tests on PRs, full tier on nightly and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
       - name: Install uv
@@ -47,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
       - name: Install uv
@@ -72,7 +72,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
       - name: Run zizmor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,21 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    # Nightly full run: matrix, slow, integration, and demo tiers.
+    - cron: "0 3 * * *"
   workflow_dispatch: {}
 permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
     UV_FROZEN: 1
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -35,6 +42,7 @@ jobs:
   docs:
     name: Docs
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -58,6 +66,7 @@ jobs:
   workflow-lint:
     name: Workflow Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write
@@ -69,95 +78,15 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
 
-  test:
-    name: Test Python ${{ matrix.python }}
-    runs-on: "ubuntu-latest"
+  tests:
+    name: Tests
+    # PRs and pushes to main run the light tier (unit, Python 3.12). The
+    # nightly schedule and manual dispatch run the full tier (matrix, slow,
+    # integration, demo). Release runs the full tier before publishing.
+    uses: ./.github/workflows/reusable-tests.yml
+    with:
+      full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: read
-    strategy:
-      fail-fast: true
-      matrix:
-        python: ${{ fromJSON(github.event_name == 'pull_request' && '["3.12"]' || '["3.12","3.13","3.14"]') }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
-        with:
-          persist-credentials: false
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-          activate-environment: true
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: uv sync
-      - name: Run Unit Tests
-        run: pytest -x -m "not integration and not slow" --cov --junitxml=junit.xml -o junit_family=legacy
-      - name: Upload Unit Test Coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          flags: "unit,python${{ matrix.python }}"
-          token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload Unit Test Results to Codecov
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: "unit,python${{ matrix.python }}"
-          token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Run Slow Tests
-        # Exit code 5 means "no tests collected", which is fine while the
-        # slow tier is empty.
-        run: |
-          set +e
-          pytest -x -m "slow and not integration" --cov --junitxml=junit.xml -o junit_family=legacy
-          status=$?
-          set -e
-          if [ "$status" -ne 0 ] && [ "$status" -ne 5 ]; then
-            exit "$status"
-          fi
-      - name: Upload Slow Test Coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          flags: "slow,python${{ matrix.python }}"
-          token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload Slow Test Results to Codecov
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: "slow,python${{ matrix.python }}"
-          token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Run Integration Tests
-        id: integration_tests
-        run: pytest -x -m integration --cov --junitxml=junit.xml -o junit_family=legacy
-      - name: Upload Integration Test Coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          flags: "integration,python${{ matrix.python }}"
-          token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload Integration Test Results to Codecov
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: "integration,python${{ matrix.python }}"
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  demo:
-    name: Demo Smoke
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
-        with:
-          persist-credentials: false
-      - name: Start the demo stack
-        run: docker compose -f examples/fastapi-demo/compose.yml up --build --wait --wait-timeout 240
-      - name: Probe the health endpoints
-        run: |
-          curl -fsS http://localhost:8000/livez
-          curl -fsS http://localhost:8000/readyz
-          curl -fsS http://localhost:8000/healthz
-      - name: Dump app logs on failure
-        if: failure()
-        run: docker compose -f examples/fastapi-demo/compose.yml logs app
-      - name: Tear down
-        if: always()
-        run: docker compose -f examples/fastapi-demo/compose.yml down -v
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,18 @@ on:
         default: false
 permissions: {}
 jobs:
+  full-checks:
+    # Run the full test tier (matrix, slow, integration, demo) before any
+    # artifact is built or published.
+    uses: ./.github/workflows/reusable-tests.yml
+    with:
+      full: true
+    permissions:
+      contents: read
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   publish-pypi:
+    needs: full-checks
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/reusable-tests.yml
     with:
       full: true
+      ref: ${{ github.event.release.tag_name || github.event.inputs.version }}
     permissions:
       contents: read
     secrets:
@@ -38,7 +39,7 @@ jobs:
       RELEASE_VERSION: ${{ github.event.release.tag_name || github.event.inputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           ref: ${{ env.RELEASE_VERSION }}
           persist-credentials: false
@@ -71,7 +72,7 @@ jobs:
       GH_ACTOR_ID: ${{ github.actor_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           ref: ${{ env.RELEASE_VERSION }}
           fetch-depth: 0

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -1,0 +1,117 @@
+name: Reusable Tests
+on:
+  workflow_call:
+    inputs:
+      full:
+        description: 'Run the full matrix with the slow, integration, and demo tiers.'
+        type: boolean
+        default: false
+    secrets:
+      CODECOV_TOKEN:
+        description: 'Token for uploading coverage and test results to Codecov.'
+        required: false
+permissions: {}
+env:
+    UV_FROZEN: 1
+jobs:
+  test:
+    name: Test Python ${{ matrix.python }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: true
+      matrix:
+        python: ${{ fromJSON(inputs.full && '["3.12","3.13","3.14"]' || '["3.12"]') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          activate-environment: true
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: uv sync
+      - name: Run Unit Tests
+        run: pytest -x -m "not integration and not slow" --cov --junitxml=junit.xml -o junit_family=legacy
+      - name: Upload Unit Test Coverage to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          flags: "unit,python${{ matrix.python }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload Unit Test Results to Codecov
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          flags: "unit,python${{ matrix.python }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Run Slow Tests
+        # Exit code 5 means "no tests collected", which is fine while the
+        # slow tier is empty.
+        if: ${{ inputs.full }}
+        run: |
+          set +e
+          pytest -x -m "slow and not integration" --cov --junitxml=junit.xml -o junit_family=legacy
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ] && [ "$status" -ne 5 ]; then
+            exit "$status"
+          fi
+      - name: Upload Slow Test Coverage to Codecov
+        if: ${{ inputs.full }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          flags: "slow,python${{ matrix.python }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload Slow Test Results to Codecov
+        if: ${{ inputs.full }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          flags: "slow,python${{ matrix.python }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Run Integration Tests
+        if: ${{ inputs.full }}
+        id: integration_tests
+        run: pytest -x -m integration --cov --junitxml=junit.xml -o junit_family=legacy
+      - name: Upload Integration Test Coverage to Codecov
+        if: ${{ inputs.full }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          flags: "integration,python${{ matrix.python }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload Integration Test Results to Codecov
+        if: ${{ inputs.full }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          flags: "integration,python${{ matrix.python }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  demo:
+    name: Demo Smoke
+    if: ${{ inputs.full }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Start the demo stack
+        run: docker compose -f examples/fastapi-demo/compose.yml up --build --wait --wait-timeout 240
+      - name: Probe the health endpoints
+        run: |
+          curl -fsS http://localhost:8000/livez
+          curl -fsS http://localhost:8000/readyz
+          curl -fsS http://localhost:8000/healthz
+      - name: Dump app logs on failure
+        if: failure()
+        run: docker compose -f examples/fastapi-demo/compose.yml logs app
+      - name: Tear down
+        if: always()
+        run: docker compose -f examples/fastapi-demo/compose.yml down -v

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -6,6 +6,10 @@ on:
         description: 'Run the full matrix with the slow, integration, and demo tiers.'
         type: boolean
         default: false
+      ref:
+        description: 'Git ref to check out and test. Defaults to the triggering ref.'
+        type: string
+        default: ''
     secrets:
       CODECOV_TOKEN:
         description: 'Token for uploading coverage and test results to Codecov.'
@@ -26,8 +30,9 @@ jobs:
         python: ${{ fromJSON(inputs.full && '["3.12","3.13","3.14"]' || '["3.12"]') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
+          ref: ${{ inputs.ref }}
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -75,7 +80,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Run Integration Tests
         if: ${{ inputs.full }}
-        id: integration_tests
         run: pytest -x -m integration --cov --junitxml=junit.xml -o junit_family=legacy
       - name: Upload Integration Test Coverage to Codecov
         if: ${{ inputs.full }}
@@ -99,8 +103,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
+          ref: ${{ inputs.ref }}
           persist-credentials: false
       - name: Start the demo stack
         run: docker compose -f examples/fastapi-demo/compose.yml up --build --wait --wait-timeout 240

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Splits CI so pull requests get fast, cheap feedback and the heavy tiers run when they matter. Implements the test-scoping part of #391.

## Behavior
- **PR and push to main**: light tier only. Unit tests on Python 3.12, plus Lint, Docs, and Workflow Lint. No integration, no slow, no Demo Smoke, no 3.13/3.14.
- **Nightly schedule (03:00 UTC) and manual dispatch**: full tier. Matrix 3.12/3.13/3.14, unit + slow + integration, and Demo Smoke.
- **Release**: the full tier runs as a gate before any artifact is built or published (`publish-pypi` now `needs` it).

## How
- New reusable workflow `reusable-tests.yml` holds the test matrix and the demo job, gated by a `full` boolean input. `ci.yml` and `release.yml` both call it, so the test logic lives in one place.
- `ci.yml` passes `full: true` only for `schedule` and `workflow_dispatch`. `release.yml` passes `full: true` always.
- Added `concurrency` with `cancel-in-progress` so superseded PR pushes stop early (the largest routine saving from #391).
- Added `timeout-minutes` to every job so a hung run cannot burn the 360-minute default.
- `CODECOV_TOKEN` is passed explicitly to the reusable workflow rather than `secrets: inherit` (keeps zizmor clean).

## Heads-up: branch protection
Required status checks need updating, because the check names change and some no longer run on PRs:
- Reusable-workflow jobs report as `Tests / Test Python 3.12` (and `Tests / Demo Smoke`), not the old `Test Python 3.12`.
- `Demo Smoke` and `Test Python 3.13/3.14` no longer run on PRs, so they must not be required, or PRs will sit pending.

Recommend requiring only `Tests / Test Python 3.12`, `Lint`, `Docs`, and `Workflow Lint` on PRs.