### PR TITLE
📝 Date the changelog 1.0.0a2 section

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.0a2 - 2026-06-21
+
 ### Features
 
 * ✨ Add a built-in readiness check per provider. Every connection provider ships a cheap `check()` probe (Redis and Valkey `PING`, Postgres and SQLite `SELECT 1`). Register it with `health.add_provider(redis)` as a critical `provider:redis` check, or register one for every active provider at once with `HealthChecks(auto_health=True)`. `Grelmicro.providers` lists the active providers.


### PR DESCRIPTION
Prepares the changelog for the `1.0.0a2` prerelease. Moves the `auto_health` readiness check entry from `Unreleased` into a dated `1.0.0a2` section.

Internal-only work since `1.0.0a1` (mutation tests, doc-accuracy sweep, CI test-tier split, demo GIF) is not user-facing, so it stays out of the changelog by convention.