### PR TITLE
💥 Rename concrete leader election backends to *Adapter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Breaking
+
+* 💥 Rename the concrete leader election adapters to the `*Adapter` suffix every other pattern already uses. `MemoryLeaderElectionBackend`, `RedisLeaderElectionBackend`, `PostgresLeaderElectionBackend`, and `KubernetesLeaderElectionBackend` become `MemoryLeaderElectionAdapter`, `RedisLeaderElectionAdapter`, `PostgresLeaderElectionAdapter`, and `KubernetesLeaderElectionAdapter`. The `LeaderElectionBackend` protocol keeps its name (protocol stays `*Backend`, concrete stays `*Adapter`). Update direct imports and constructions.
+
+## 1.0.0a2 - 2026-06-21
+
 ### Features
 
 * ✨ Add a built-in readiness check per provider. Every connection provider ships a cheap `check()` probe (Redis and Valkey `PING`, Postgres and SQLite `SELECT 1`). Register it with `health.add_provider(redis)` as a critical `provider:redis` check, or register one for every active provider at once with `HealthChecks(auto_health=True)`. `Grelmicro.providers` lists the active providers.

--- a/docs/coordination.md
+++ b/docs/coordination.md
@@ -371,10 +371,10 @@ Pick the backend that matches your deployment.
 
 | Backend | Use when | Stores the record in |
 |---|---|---|
-| `MemoryLeaderElectionBackend` | Tests and single-process apps. | A process-local dict (not shared across nodes). |
-| `RedisLeaderElectionBackend` | A Redis-backed cluster. | A Redis hash, updated atomically. |
-| `PostgresLeaderElectionBackend` | Postgres is already in your stack. | A row, updated atomically under an advisory lock. |
-| `KubernetesLeaderElectionBackend` | A Kubernetes-native deployment. | A `coordination.k8s.io` Lease, metadata in its annotations. |
+| `MemoryLeaderElectionAdapter` | Tests and single-process apps. | A process-local dict (not shared across nodes). |
+| `RedisLeaderElectionAdapter` | A Redis-backed cluster. | A Redis hash, updated atomically. |
+| `PostgresLeaderElectionAdapter` | Postgres is already in your stack. | A row, updated atomically under an advisory lock. |
+| `KubernetesLeaderElectionAdapter` | A Kubernetes-native deployment. | A `coordination.k8s.io` Lease, metadata in its annotations. |
 
 A `Provider` builds the matching backend for you: `Coordination(redis)` calls
 `redis.leaderelection()`. Pass a backend instance directly when it has no

--- a/docs/snippets/coordination/independent_backends.py
+++ b/docs/snippets/coordination/independent_backends.py
@@ -1,6 +1,6 @@
 from grelmicro import Grelmicro
 from grelmicro.coordination import Coordination
-from grelmicro.coordination.kubernetes import KubernetesLeaderElectionBackend
+from grelmicro.coordination.kubernetes import KubernetesLeaderElectionAdapter
 from grelmicro.providers.redis import RedisProvider
 
 redis = RedisProvider("redis://localhost:6379/0")
@@ -9,7 +9,7 @@ micro = Grelmicro(
     uses=[
         Coordination(
             lock=redis,  # Lock on Redis: low-latency mutual exclusion
-            election=KubernetesLeaderElectionBackend(  # leader on a K8s Lease
+            election=KubernetesLeaderElectionAdapter(  # leader on a K8s Lease
                 namespace="default"
             ),
         ),

--- a/docs/snippets/coordination/kubernetes.py
+++ b/docs/snippets/coordination/kubernetes.py
@@ -1,7 +1,7 @@
 from grelmicro import Grelmicro
 from grelmicro.coordination import Coordination
 from grelmicro.coordination.kubernetes import (
-    KubernetesLeaderElectionBackend,
+    KubernetesLeaderElectionAdapter,
     KubernetesLockAdapter,
 )
 
@@ -9,7 +9,7 @@ micro = Grelmicro(
     uses=[
         Coordination(
             lock=KubernetesLockAdapter(namespace="default"),
-            election=KubernetesLeaderElectionBackend(namespace="default"),
+            election=KubernetesLeaderElectionAdapter(namespace="default"),
         )
     ]
 )

--- a/docs/snippets/coordination/leaderelection_asyncio.py
+++ b/docs/snippets/coordination/leaderelection_asyncio.py
@@ -1,9 +1,9 @@
 import asyncio
 
 from grelmicro.coordination import LeaderElection
-from grelmicro.coordination.memory import MemoryLeaderElectionBackend
+from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
 
-leader = LeaderElection("cluster_group", backend=MemoryLeaderElectionBackend())
+leader = LeaderElection("cluster_group", backend=MemoryLeaderElectionAdapter())
 
 
 async def main():

--- a/docs/snippets/coordination/leaderelection_task.py
+++ b/docs/snippets/coordination/leaderelection_task.py
@@ -1,8 +1,8 @@
 from grelmicro.coordination import Coordination, LeaderElection
-from grelmicro.coordination.memory import MemoryLeaderElectionBackend
+from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
 from grelmicro.task import Tasks
 
-leader = LeaderElection("cluster_group", backend=MemoryLeaderElectionBackend())
+leader = LeaderElection("cluster_group", backend=MemoryLeaderElectionAdapter())
 coordination = Coordination(election=leader.backend)
 task = Tasks()
 task.add_task(leader)

--- a/docs/snippets/coordination/memory.py
+++ b/docs/snippets/coordination/memory.py
@@ -1,7 +1,7 @@
 from grelmicro import Grelmicro
 from grelmicro.coordination import Coordination
 from grelmicro.coordination.memory import (
-    MemoryLeaderElectionBackend,
+    MemoryLeaderElectionAdapter,
     MemoryLockAdapter,
 )
 
@@ -9,7 +9,7 @@ micro = Grelmicro(
     uses=[
         Coordination(
             lock=MemoryLockAdapter(),
-            election=MemoryLeaderElectionBackend(),
+            election=MemoryLeaderElectionAdapter(),
         )
     ]
 )

--- a/docs/snippets/coordination/quickstart.py
+++ b/docs/snippets/coordination/quickstart.py
@@ -1,11 +1,11 @@
 from grelmicro import Grelmicro
 from grelmicro.coordination import Coordination
-from grelmicro.coordination.memory import MemoryLeaderElectionBackend
+from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
 from grelmicro.task import Tasks
 
 tasks = Tasks()
 micro = Grelmicro(
-    uses=[Coordination(election=MemoryLeaderElectionBackend()), tasks]
+    uses=[Coordination(election=MemoryLeaderElectionAdapter()), tasks]
 )
 
 leader = micro.coordination.leaderelection("worker")

--- a/docs/snippets/simple_fastapi_app.py
+++ b/docs/snippets/simple_fastapi_app.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 
 from grelmicro import Grelmicro
 from grelmicro.coordination import Coordination, LeaderElection, Lock
-from grelmicro.coordination.memory import MemoryLeaderElectionBackend
+from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
 from grelmicro.fastapi import GrelmicroMiddleware
 from grelmicro.log import configure
 from grelmicro.providers.redis import RedisProvider
@@ -26,7 +26,7 @@ redis = RedisProvider("redis://localhost:6379/0")
 
 micro = Grelmicro(
     uses=[
-        Coordination(lock=redis.lock(), election=MemoryLeaderElectionBackend()),
+        Coordination(lock=redis.lock(), election=MemoryLeaderElectionAdapter()),
         CircuitBreakers(MemoryCircuitBreakerAdapter()),
         tasks,
     ]

--- a/docs/snippets/single_file_app.py
+++ b/docs/snippets/single_file_app.py
@@ -9,13 +9,13 @@ from fastapi import FastAPI
 
 from grelmicro.coordination import LeaderElection, Lock
 from grelmicro.coordination.memory import (
-    MemoryLeaderElectionBackend,
+    MemoryLeaderElectionAdapter,
     MemoryLockAdapter,
 )
 from grelmicro.task import Tasks
 
 backend = MemoryLockAdapter()
-coordination_backend = MemoryLeaderElectionBackend()
+coordination_backend = MemoryLeaderElectionAdapter()
 task = Tasks()
 
 

--- a/docs/snippets/task/interval_leader.py
+++ b/docs/snippets/task/interval_leader.py
@@ -1,8 +1,8 @@
 from grelmicro.coordination import LeaderElection
-from grelmicro.coordination.memory import MemoryLeaderElectionBackend
+from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
 from grelmicro.task import Tasks
 
-leader = LeaderElection("my-service", backend=MemoryLeaderElectionBackend())
+leader = LeaderElection("my-service", backend=MemoryLeaderElectionAdapter())
 task = Tasks()
 task.add_task(leader)
 

--- a/docs/snippets/task/leaderelection.py
+++ b/docs/snippets/task/leaderelection.py
@@ -1,8 +1,8 @@
 from grelmicro.coordination import LeaderElection
-from grelmicro.coordination.memory import MemoryLeaderElectionBackend
+from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
 from grelmicro.task import Tasks
 
-leader = LeaderElection("my-service", backend=MemoryLeaderElectionBackend())
+leader = LeaderElection("my-service", backend=MemoryLeaderElectionAdapter())
 task = Tasks()
 task.add_task(leader)
 

--- a/grelmicro/coordination/kubernetes.py
+++ b/grelmicro/coordination/kubernetes.py
@@ -478,7 +478,7 @@ def _is_live(record: LeaderRecord, now: datetime) -> bool:
     return now < expires_at
 
 
-class KubernetesLeaderElectionBackend:
+class KubernetesLeaderElectionAdapter:
     """Kubernetes Leader Election Backend.
 
     Stores the `LeaderRecord` in a `coordination.k8s.io/v1` Lease object, one

--- a/grelmicro/coordination/kubernetes.py
+++ b/grelmicro/coordination/kubernetes.py
@@ -479,7 +479,7 @@ def _is_live(record: LeaderRecord, now: datetime) -> bool:
 
 
 class KubernetesLeaderElectionAdapter:
-    """Kubernetes Leader Election Backend.
+    """Kubernetes Leader Election Adapter.
 
     Stores the `LeaderRecord` in a `coordination.k8s.io/v1` Lease object, one
     per election. The Lease spec carries the holder, durations, and transition

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -427,7 +427,7 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
 
         Raises:
             OutOfContextError: No backend resolved in this scope. Pass
-                `backend=` (a `MemoryLeaderElectionBackend()` for a
+                `backend=` (a `MemoryLeaderElectionAdapter()` for a
                 per-process election), register a `Coordination`
                 Component, or run the call under the app context (for
                 FastAPI, add `GrelmicroMiddleware`).
@@ -447,7 +447,7 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
         except (NoActiveAppError, ComponentNotRegisteredError):
             msg = (
                 f"LeaderElection({self._name!r}) resolved no backend. Pass "
-                f"backend= (MemoryLeaderElectionBackend() for a per-process "
+                f"backend= (MemoryLeaderElectionAdapter() for a per-process "
                 f"election), register a Coordination component, or run the "
                 f"call under the app context (for FastAPI add "
                 f"GrelmicroMiddleware)."

--- a/grelmicro/coordination/memory.py
+++ b/grelmicro/coordination/memory.py
@@ -129,7 +129,7 @@ class MemoryScheduleAdapter(ScheduleBackend):
         return self._last_fired.get(name)
 
 
-class MemoryLeaderElectionBackend:
+class MemoryLeaderElectionAdapter:
     """In-memory leader election backend for tests and single-process apps.
 
     Stores the `LeaderRecord` in a process-local dict and runs the same

--- a/grelmicro/coordination/memory.py
+++ b/grelmicro/coordination/memory.py
@@ -130,7 +130,7 @@ class MemoryScheduleAdapter(ScheduleBackend):
 
 
 class MemoryLeaderElectionAdapter:
-    """In-memory leader election backend for tests and single-process apps.
+    """In-memory leader election adapter for tests and single-process apps.
 
     Stores the `LeaderRecord` in a process-local dict and runs the same
     acquire/renew/expire algorithm as the distributed backends. State

--- a/grelmicro/coordination/postgres.py
+++ b/grelmicro/coordination/postgres.py
@@ -331,7 +331,7 @@ isolated from any other advisory lock in the same database.
 """
 
 
-class PostgresLeaderElectionBackend:
+class PostgresLeaderElectionAdapter:
     """Postgres leader election backend.
 
     Wraps a `PostgresProvider` and implements the `LeaderElectionBackend`
@@ -350,11 +350,11 @@ class PostgresLeaderElectionBackend:
 
     Example:
     ```python
-    from grelmicro.coordination.postgres import PostgresLeaderElectionBackend
+    from grelmicro.coordination.postgres import PostgresLeaderElectionAdapter
     from grelmicro.providers.postgres import PostgresProvider
 
     postgres = PostgresProvider("postgresql://localhost:5432/app")
-    backend = PostgresLeaderElectionBackend(provider=postgres)
+    backend = PostgresLeaderElectionAdapter(provider=postgres)
     ```
     """
 

--- a/grelmicro/coordination/postgres.py
+++ b/grelmicro/coordination/postgres.py
@@ -332,7 +332,7 @@ isolated from any other advisory lock in the same database.
 
 
 class PostgresLeaderElectionAdapter:
-    """Postgres leader election backend.
+    """Postgres leader election adapter.
 
     Wraps a `PostgresProvider` and implements the `LeaderElectionBackend`
     protocol on top of a single `{table_name}` row per election. Every

--- a/grelmicro/coordination/redis.py
+++ b/grelmicro/coordination/redis.py
@@ -312,7 +312,7 @@ class RedisScheduleAdapter(ScheduleBackend):
         return float(stored)
 
 
-class RedisLeaderElectionBackend:
+class RedisLeaderElectionAdapter:
     """Redis leader election backend.
 
     Wraps a `RedisProvider` and implements the `LeaderElectionBackend`

--- a/grelmicro/coordination/redis.py
+++ b/grelmicro/coordination/redis.py
@@ -313,7 +313,7 @@ class RedisScheduleAdapter(ScheduleBackend):
 
 
 class RedisLeaderElectionAdapter:
-    """Redis leader election backend.
+    """Redis leader election adapter.
 
     Wraps a `RedisProvider` and implements the `LeaderElectionBackend`
     protocol. The `LeaderRecord` is stored in a Redis HASH and the

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
     from grelmicro.cache.postgres import PostgresCacheAdapter
     from grelmicro.coordination.postgres import (
-        PostgresLeaderElectionBackend,
+        PostgresLeaderElectionAdapter,
         PostgresLockAdapter,
         PostgresScheduleAdapter,
     )
@@ -262,13 +262,13 @@ class PostgresProvider(Provider):
     def leaderelection(
         self,
         **kwargs: Any,  # noqa: ANN401
-    ) -> PostgresLeaderElectionBackend:
-        """Build a `PostgresLeaderElectionBackend` bound to this provider."""
+    ) -> PostgresLeaderElectionAdapter:
+        """Build a `PostgresLeaderElectionAdapter` bound to this provider."""
         from grelmicro.coordination.postgres import (  # noqa: PLC0415
-            PostgresLeaderElectionBackend,
+            PostgresLeaderElectionAdapter,
         )
 
-        return PostgresLeaderElectionBackend(provider=self, **kwargs)
+        return PostgresLeaderElectionAdapter(provider=self, **kwargs)
 
     def schedule(self, **kwargs: Any) -> PostgresScheduleAdapter:  # noqa: ANN401
         """Build a `PostgresScheduleAdapter` bound to this provider."""

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
     from grelmicro.cache.redis import RedisCacheAdapter
     from grelmicro.coordination.redis import (
-        RedisLeaderElectionBackend,
+        RedisLeaderElectionAdapter,
         RedisLockAdapter,
         RedisScheduleAdapter,
     )
@@ -404,13 +404,13 @@ class RedisProvider(Provider):
     def leaderelection(
         self,
         **kwargs: Any,  # noqa: ANN401
-    ) -> RedisLeaderElectionBackend:
-        """Build a `RedisLeaderElectionBackend` bound to this provider."""
+    ) -> RedisLeaderElectionAdapter:
+        """Build a `RedisLeaderElectionAdapter` bound to this provider."""
         from grelmicro.coordination.redis import (  # noqa: PLC0415
-            RedisLeaderElectionBackend,
+            RedisLeaderElectionAdapter,
         )
 
-        return RedisLeaderElectionBackend(provider=self, **kwargs)
+        return RedisLeaderElectionAdapter(provider=self, **kwargs)
 
     def schedule(self, **kwargs: Any) -> RedisScheduleAdapter:  # noqa: ANN401
         """Build a `RedisScheduleAdapter` bound to this provider."""

--- a/grelmicro/providers/valkey.py
+++ b/grelmicro/providers/valkey.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
     from grelmicro.cache.redis import RedisCacheAdapter
     from grelmicro.coordination.redis import (
-        RedisLeaderElectionBackend,
+        RedisLeaderElectionAdapter,
         RedisLockAdapter,
         RedisScheduleAdapter,
     )
@@ -223,13 +223,13 @@ class ValkeyProvider(RedisProvider):
     def leaderelection(
         self,
         **kwargs: Any,  # noqa: ANN401
-    ) -> RedisLeaderElectionBackend:
-        """Build a `RedisLeaderElectionBackend` bound to this provider."""
+    ) -> RedisLeaderElectionAdapter:
+        """Build a `RedisLeaderElectionAdapter` bound to this provider."""
         from grelmicro.coordination.redis import (  # noqa: PLC0415
-            RedisLeaderElectionBackend,
+            RedisLeaderElectionAdapter,
         )
 
-        return RedisLeaderElectionBackend(provider=self, **kwargs)
+        return RedisLeaderElectionAdapter(provider=self, **kwargs)
 
     def schedule(self, **kwargs: Any) -> RedisScheduleAdapter:  # noqa: ANN401
         """Build a `RedisScheduleAdapter` bound to this provider."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,10 +86,10 @@ sqlite = "grelmicro.coordination.sqlite:SQLiteLockAdapter"
 kubernetes = "grelmicro.coordination.kubernetes:KubernetesLockAdapter"
 
 [project.entry-points."grelmicro.coordination.election.adapters"]
-memory = "grelmicro.coordination.memory:MemoryLeaderElectionBackend"
-redis = "grelmicro.coordination.redis:RedisLeaderElectionBackend"
-postgres = "grelmicro.coordination.postgres:PostgresLeaderElectionBackend"
-kubernetes = "grelmicro.coordination.kubernetes:KubernetesLeaderElectionBackend"
+memory = "grelmicro.coordination.memory:MemoryLeaderElectionAdapter"
+redis = "grelmicro.coordination.redis:RedisLeaderElectionAdapter"
+postgres = "grelmicro.coordination.postgres:PostgresLeaderElectionAdapter"
+kubernetes = "grelmicro.coordination.kubernetes:KubernetesLeaderElectionAdapter"
 
 [project.entry-points."grelmicro.coordination.schedule.adapters"]
 memory = "grelmicro.coordination.memory:MemoryScheduleAdapter"

--- a/tests/coordination/test_cluster_boundaries.py
+++ b/tests/coordination/test_cluster_boundaries.py
@@ -23,7 +23,7 @@ from grelmicro.coordination.leaderelection import (
 )
 from grelmicro.coordination.lock import Lock, LockConfig
 from grelmicro.coordination.memory import (
-    MemoryLeaderElectionBackend,
+    MemoryLeaderElectionAdapter,
     MemoryLockAdapter,
 )
 from grelmicro.coordination.tasklock import TaskLock, TaskLockConfig
@@ -177,7 +177,7 @@ async def test_live_record_expires_at_exact_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """At `now == renewed_at + lease` the record is expired (guard is `>=`)."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     _freeze_memory_datetime(monkeypatch, _EPOCH)
     await backend.acquire_or_renew(name="svc", token="w1", duration=_LEASE)
 
@@ -190,7 +190,7 @@ async def test_renew_forwards_renewed_at_and_lease_duration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Renewing the live lease writes the new renewed_at and lease_duration."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     _freeze_memory_datetime(monkeypatch, _EPOCH)
     first = await backend.acquire_or_renew(
         name="svc", token="w1", duration=_LEASE

--- a/tests/coordination/test_component.py
+++ b/tests/coordination/test_component.py
@@ -15,7 +15,7 @@ from grelmicro.coordination import (
     TaskLock,
 )
 from grelmicro.coordination.memory import (
-    MemoryLeaderElectionBackend,
+    MemoryLeaderElectionAdapter,
     MemoryLockAdapter,
     MemoryScheduleAdapter,
 )
@@ -73,7 +73,7 @@ def test_task_lock_factory_binds_backend() -> None:
 
 def test_leader_election_factory_binds_backend() -> None:
     """`coordination.leaderelection(name)` binds the election backend."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     coordination = Coordination(election=backend)
     election = coordination.leaderelection("worker")
     assert isinstance(election, LeaderElection)
@@ -89,28 +89,28 @@ def test_lock_backend_property() -> None:
 
 def test_election_backend_property() -> None:
     """`coordination.election_backend` returns the wired election backend."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     coordination = Coordination(election=backend)
     assert coordination.election_backend is backend
 
 
 def test_lock_without_lock_backend_raises() -> None:
     """`coordination.lock()` raises when no lock backend is wired."""
-    coordination = Coordination(election=MemoryLeaderElectionBackend())
+    coordination = Coordination(election=MemoryLeaderElectionAdapter())
     with pytest.raises(CoordinationBackendError, match="no lock backend"):
         coordination.lock("cart")
 
 
 def test_task_lock_without_lock_backend_raises() -> None:
     """`coordination.tasklock()` raises when no lock backend is wired."""
-    coordination = Coordination(election=MemoryLeaderElectionBackend())
+    coordination = Coordination(election=MemoryLeaderElectionAdapter())
     with pytest.raises(CoordinationBackendError, match="no lock backend"):
         coordination.tasklock("cleanup")
 
 
 def test_lock_backend_property_without_lock_backend_raises() -> None:
     """`coordination.lock_backend` raises when no lock backend is wired."""
-    coordination = Coordination(election=MemoryLeaderElectionBackend())
+    coordination = Coordination(election=MemoryLeaderElectionAdapter())
     with pytest.raises(CoordinationBackendError, match="no lock backend"):
         _ = coordination.lock_backend
 
@@ -139,7 +139,7 @@ def test_coordination_resolves_both_from_provider() -> None:
     coordination = Coordination(provider)
     assert coordination.lock_backend.__class__.__name__ == "RedisLockAdapter"
     assert coordination.election_backend.__class__.__name__ == (
-        "RedisLeaderElectionBackend"
+        "RedisLeaderElectionAdapter"
     )
 
 
@@ -166,7 +166,7 @@ def test_election_keyword_accepts_provider() -> None:
     provider = RedisProvider("redis://localhost:6379/0")
     coordination = Coordination(election=provider)
     assert coordination.election_backend.__class__.__name__ == (
-        "RedisLeaderElectionBackend"
+        "RedisLeaderElectionAdapter"
     )
 
 
@@ -218,12 +218,12 @@ def test_lock_keyword_accepts_bare_backend_class() -> None:
 
 
 def test_election_keyword_accepts_bare_backend_class() -> None:
-    """`election=MemoryLeaderElectionBackend` instantiates the class."""
+    """`election=MemoryLeaderElectionAdapter` instantiates the class."""
     coordination = Coordination(
-        election=MemoryLeaderElectionBackend,  # ty: ignore[invalid-argument-type]
+        election=MemoryLeaderElectionAdapter,  # ty: ignore[invalid-argument-type]
     )
     assert isinstance(
-        coordination.election_backend, MemoryLeaderElectionBackend
+        coordination.election_backend, MemoryLeaderElectionAdapter
     )
 
 
@@ -234,14 +234,14 @@ def test_keyword_overrides_provider_lock_backend() -> None:
     coordination = Coordination(provider, lock=override)
     assert coordination.lock_backend is override
     assert coordination.election_backend.__class__.__name__ == (
-        "RedisLeaderElectionBackend"
+        "RedisLeaderElectionAdapter"
     )
 
 
 def test_keyword_overrides_provider_election_backend() -> None:
     """`election=` overrides the election backend resolved from `source`."""
     provider = RedisProvider("redis://localhost:6379/0")
-    override = MemoryLeaderElectionBackend()
+    override = MemoryLeaderElectionAdapter()
     coordination = Coordination(provider, election=override)
     assert coordination.election_backend is override
     assert coordination.lock_backend.__class__.__name__ == "RedisLockAdapter"
@@ -313,7 +313,7 @@ async def test_lock_only_lifecycle() -> None:
 
 async def test_election_only_lifecycle() -> None:
     """An election-only component opens and closes its election backend."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     micro = Grelmicro(uses=[Coordination(election=backend)])
     async with micro:
         assert micro.coordination.election_backend is backend
@@ -322,7 +322,7 @@ async def test_election_only_lifecycle() -> None:
 async def test_dual_lifecycle_opens_and_closes_both() -> None:
     """Both backends open and close when both are wired."""
     lock_backend = MemoryLockAdapter()
-    election_backend = MemoryLeaderElectionBackend()
+    election_backend = MemoryLeaderElectionAdapter()
     coordination = Coordination(lock=lock_backend, election=election_backend)
     async with Grelmicro(uses=[coordination]):
         assert coordination.lock_backend is lock_backend
@@ -345,8 +345,8 @@ async def test_use_auto_wraps_raw_lock_backend() -> None:
 
 
 async def test_use_auto_wraps_raw_election_backend() -> None:
-    """`micro.use(MemoryLeaderElectionBackend())` auto-wraps the backend."""
-    backend = MemoryLeaderElectionBackend()
+    """`micro.use(MemoryLeaderElectionAdapter())` auto-wraps the backend."""
+    backend = MemoryLeaderElectionAdapter()
     micro = Grelmicro(uses=[backend])
     assert isinstance(micro.coordination, Coordination)
     assert micro.coordination.election_backend is backend
@@ -415,7 +415,7 @@ async def test_aexit_closes_both_when_lock_close_raises() -> None:
             msg = "lock close failed"
             raise RuntimeError(msg)
 
-    class _TrackingElection(MemoryLeaderElectionBackend):
+    class _TrackingElection(MemoryLeaderElectionAdapter):
         closed = False
 
         async def __aexit__(

--- a/tests/coordination/test_kubernetes.py
+++ b/tests/coordination/test_kubernetes.py
@@ -18,7 +18,7 @@ from testcontainers.core.container import DockerContainer
 from grelmicro.coordination.abc import LeaderElectionBackend
 from grelmicro.coordination.kubernetes import (
     _MAX_NAME_LENGTH,
-    KubernetesLeaderElectionBackend,
+    KubernetesLeaderElectionAdapter,
     _annotations_to_metadata,
     _lease_to_record,
     _metadata_to_annotations,
@@ -83,9 +83,9 @@ def _make_lease(
 
 def _make_mocked_backend(
     **client_overrides: AsyncMock,
-) -> KubernetesLeaderElectionBackend:
+) -> KubernetesLeaderElectionAdapter:
     """Create a backend with a mocked client."""
-    backend = KubernetesLeaderElectionBackend(namespace="default")
+    backend = KubernetesLeaderElectionAdapter(namespace="default")
     mock_client = AsyncMock()
     for attr, mock in client_overrides.items():
         setattr(mock_client, attr, mock)
@@ -99,7 +99,7 @@ def _make_mocked_backend(
 @pytest.mark.timeout(1)
 async def test_out_of_context_errors() -> None:
     """Backend methods raise when called outside the context manager."""
-    backend = KubernetesLeaderElectionBackend(namespace="default")
+    backend = KubernetesLeaderElectionAdapter(namespace="default")
 
     with pytest.raises(OutOfContextError):
         await backend.acquire_or_renew(name="election", token=TOKEN, duration=1)
@@ -115,7 +115,7 @@ async def test_out_of_context_errors() -> None:
 @pytest.mark.timeout(1)
 async def test_aenter_sets_client(monkeypatch: pytest.MonkeyPatch) -> None:
     """`__aenter__` creates an AsyncClient."""
-    backend = KubernetesLeaderElectionBackend(namespace="default")
+    backend = KubernetesLeaderElectionAdapter(namespace="default")
     monkeypatch.setattr(
         "grelmicro.coordination.kubernetes.AsyncClient",
         lambda **_kwargs: AsyncMock(),
@@ -129,7 +129,7 @@ async def test_aenter_sets_client(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.timeout(1)
 async def test_aexit_closes_client() -> None:
     """`__aexit__` closes and clears the client."""
-    backend = KubernetesLeaderElectionBackend(namespace="default")
+    backend = KubernetesLeaderElectionAdapter(namespace="default")
     mock_client = AsyncMock()
     backend._client = mock_client
 
@@ -145,7 +145,7 @@ async def test_aexit_closes_client() -> None:
 @pytest.mark.timeout(1)
 def test_satisfies_protocol() -> None:
     """The backend satisfies the LeaderElectionBackend protocol."""
-    backend = KubernetesLeaderElectionBackend(namespace="default")
+    backend = KubernetesLeaderElectionAdapter(namespace="default")
 
     assert isinstance(backend, LeaderElectionBackend)
 
@@ -158,7 +158,7 @@ def test_env_var_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     """The namespace is read from the environment variable."""
     monkeypatch.setenv("KUBE_NAMESPACE", "my-namespace")
 
-    backend = KubernetesLeaderElectionBackend()
+    backend = KubernetesLeaderElectionAdapter()
 
     assert backend._namespace == "my-namespace"
 
@@ -171,13 +171,13 @@ def test_env_var_settings_validation_error(
     monkeypatch.delenv("KUBE_NAMESPACE", raising=False)
 
     with pytest.raises(SettingsValidationError):
-        KubernetesLeaderElectionBackend()
+        KubernetesLeaderElectionAdapter()
 
 
 @pytest.mark.timeout(1)
 def test_prefix() -> None:
     """The prefix is stored on the backend."""
-    backend = KubernetesLeaderElectionBackend(
+    backend = KubernetesLeaderElectionAdapter(
         namespace="default", prefix="myapp-"
     )
 
@@ -743,9 +743,9 @@ def k3s_container() -> Generator[str]:
 @pytest.fixture
 async def backend(
     k3s_container: str,
-) -> AsyncGenerator[KubernetesLeaderElectionBackend]:
+) -> AsyncGenerator[KubernetesLeaderElectionAdapter]:
     """Open a backend connected to the k3s container."""
-    async with KubernetesLeaderElectionBackend(
+    async with KubernetesLeaderElectionAdapter(
         namespace="default", kubeconfig=k3s_container
     ) as backend:
         yield backend
@@ -753,7 +753,7 @@ async def backend(
 
 @pytest.mark.integration
 @pytest.mark.timeout(60)
-async def test_acquire(backend: KubernetesLeaderElectionBackend) -> None:
+async def test_acquire(backend: KubernetesLeaderElectionAdapter) -> None:
     """A fresh election is acquired and creates a live Lease."""
     name = "acquire-" + uuid4().hex
     token = uuid4().hex
@@ -773,7 +773,7 @@ async def test_acquire(backend: KubernetesLeaderElectionBackend) -> None:
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_renew_keeps_transitions(
-    backend: KubernetesLeaderElectionBackend,
+    backend: KubernetesLeaderElectionAdapter,
 ) -> None:
     """Renewing the same holder moves renewed_at but not transitions."""
     name = "renew-" + uuid4().hex
@@ -795,7 +795,7 @@ async def test_renew_keeps_transitions(
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_live_lease_not_taken(
-    backend: KubernetesLeaderElectionBackend,
+    backend: KubernetesLeaderElectionAdapter,
 ) -> None:
     """A live lease cannot be taken by another holder."""
     name = "live-" + uuid4().hex
@@ -817,7 +817,7 @@ async def test_live_lease_not_taken(
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_takeover_after_expiry(
-    backend: KubernetesLeaderElectionBackend,
+    backend: KubernetesLeaderElectionAdapter,
 ) -> None:
     """A new holder takes over after expiry and bumps transitions."""
     name = "takeover-" + uuid4().hex
@@ -836,7 +836,7 @@ async def test_takeover_after_expiry(
 
 @pytest.mark.integration
 @pytest.mark.timeout(60)
-async def test_release(backend: KubernetesLeaderElectionBackend) -> None:
+async def test_release(backend: KubernetesLeaderElectionAdapter) -> None:
     """Release returns True for the holder, False for non-holders."""
     name = "release-" + uuid4().hex
     token = uuid4().hex
@@ -852,7 +852,7 @@ async def test_release(backend: KubernetesLeaderElectionBackend) -> None:
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_get_live_and_expired(
-    backend: KubernetesLeaderElectionBackend,
+    backend: KubernetesLeaderElectionAdapter,
 ) -> None:
     """Get returns the live record then None after expiry."""
     name = "get-" + uuid4().hex
@@ -871,7 +871,7 @@ async def test_get_live_and_expired(
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_metadata_roundtrip(
-    backend: KubernetesLeaderElectionBackend,
+    backend: KubernetesLeaderElectionAdapter,
 ) -> None:
     """Metadata round-trips through Lease annotations."""
     name = "metadata-" + uuid4().hex

--- a/tests/coordination/test_leaderelection.py
+++ b/tests/coordination/test_leaderelection.py
@@ -15,7 +15,7 @@ from grelmicro.coordination.leaderelection import (
     LeaderElection,
     LeaderElectionConfig,
 )
-from grelmicro.coordination.memory import MemoryLeaderElectionBackend
+from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
 from grelmicro.errors import OutOfContextError
 from grelmicro.errors import WouldBlockError as WouldBlock
 from tests.task._helpers import cancel_group, start_task
@@ -35,7 +35,7 @@ pytestmark = [pytest.mark.timeout(TEST_TIMEOUT)]
 @pytest.fixture
 def backend() -> LeaderElectionBackend:
     """Return Memory Synchronization Backend."""
-    return MemoryLeaderElectionBackend()
+    return MemoryLeaderElectionAdapter()
 
 
 @pytest.fixture
@@ -730,7 +730,7 @@ async def test_graceful_stop_releases_app_resolved_backend() -> None:
 
     # Arrange: an app-resolved election backend, no explicit backend= on the
     # LeaderElection.
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     micro = Grelmicro(uses=[Coordination(election=backend)])
     leader_election = LeaderElection(
         LEADER_NAME,

--- a/tests/coordination/test_leaderelection_config.py
+++ b/tests/coordination/test_leaderelection_config.py
@@ -11,7 +11,7 @@ from grelmicro.coordination.leaderelection import (
     LeaderElection,
     LeaderElectionConfig,
 )
-from grelmicro.coordination.memory import MemoryLeaderElectionBackend
+from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
 
 LEASE_KWARG = 12.0
 RETRY_KWARG = 1.0
@@ -24,7 +24,7 @@ DEFAULT_RETRY = 2.0
 @pytest.fixture
 def backend() -> LeaderElectionBackend:
     """Return a memory backend usable without a running event loop."""
-    return MemoryLeaderElectionBackend()
+    return MemoryLeaderElectionAdapter()
 
 
 async def test_release_is_noop_when_backend_was_never_resolved() -> None:
@@ -42,7 +42,7 @@ def test_construction_does_not_resolve(mocker: MockerFixture) -> None:
 
 async def test_backend_property_resolves_on_every_call() -> None:
     """`le.backend` consults the active `Grelmicro` app on each read."""
-    backend_instance = MemoryLeaderElectionBackend()
+    backend_instance = MemoryLeaderElectionAdapter()
     micro = Grelmicro(uses=[Coordination(election=backend_instance)])
     async with micro:
         le = LeaderElection("svc")

--- a/tests/coordination/test_memory.py
+++ b/tests/coordination/test_memory.py
@@ -4,7 +4,7 @@ import asyncio
 
 import pytest
 
-from grelmicro.coordination.memory import MemoryLeaderElectionBackend
+from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
 
 pytestmark = [pytest.mark.timeout(1)]
 
@@ -17,7 +17,7 @@ W2 = "w2"
 
 async def test_acquire_fresh_starts_at_zero_transitions() -> None:
     """A first acquisition holds the lease with zero transitions."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     record = await backend.acquire_or_renew(
         name=NAME, token=W1, duration=10, metadata={"pod": "a"}
     )
@@ -29,7 +29,7 @@ async def test_acquire_fresh_starts_at_zero_transitions() -> None:
 
 async def test_renew_same_holder_keeps_acquired_and_transitions() -> None:
     """Renewing as the same holder moves renewed_at but not acquired/transitions."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     first = await backend.acquire_or_renew(name=NAME, token=W1, duration=10)
     second = await backend.acquire_or_renew(
         name=NAME, token=W1, duration=10, metadata={"v": "2"}
@@ -42,7 +42,7 @@ async def test_renew_same_holder_keeps_acquired_and_transitions() -> None:
 
 async def test_live_lease_blocks_a_different_holder() -> None:
     """A different worker cannot take a live lease and sees the holder's record."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     await backend.acquire_or_renew(name=NAME, token=W1, duration=10)
     record = await backend.acquire_or_renew(name=NAME, token=W2, duration=10)
     assert record.holder == "w1"
@@ -50,7 +50,7 @@ async def test_live_lease_blocks_a_different_holder() -> None:
 
 async def test_takeover_after_expiry_increments_transitions() -> None:
     """Once the lease expires a different holder takes over and bumps transitions."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     await backend.acquire_or_renew(name=NAME, token=W1, duration=SHORT)
     await asyncio.sleep(EXPIRE)
     record = await backend.acquire_or_renew(name=NAME, token=W2, duration=10)
@@ -60,7 +60,7 @@ async def test_takeover_after_expiry_increments_transitions() -> None:
 
 async def test_reacquire_own_expired_lease_keeps_transitions() -> None:
     """Reacquiring your own expired lease does not count as a transition."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     await backend.acquire_or_renew(name=NAME, token=W1, duration=SHORT)
     await asyncio.sleep(EXPIRE)
     record = await backend.acquire_or_renew(name=NAME, token=W1, duration=10)
@@ -70,7 +70,7 @@ async def test_reacquire_own_expired_lease_keeps_transitions() -> None:
 
 async def test_release_returns_true_for_holder_false_otherwise() -> None:
     """Release succeeds only for the current holder."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     await backend.acquire_or_renew(name=NAME, token=W1, duration=10)
     assert await backend.release(name=NAME, token=W2) is False
     assert await backend.release(name=NAME, token=W1) is True
@@ -79,7 +79,7 @@ async def test_release_returns_true_for_holder_false_otherwise() -> None:
 
 async def test_get_returns_none_after_expiry() -> None:
     """`get` reports no leader once the lease has expired."""
-    backend = MemoryLeaderElectionBackend()
+    backend = MemoryLeaderElectionAdapter()
     await backend.acquire_or_renew(name=NAME, token=W1, duration=SHORT)
     assert await backend.get(name=NAME) is not None
     await asyncio.sleep(EXPIRE)
@@ -88,7 +88,7 @@ async def test_get_returns_none_after_expiry() -> None:
 
 async def test_context_manager() -> None:
     """The backend works as an async context manager."""
-    async with MemoryLeaderElectionBackend() as backend:
+    async with MemoryLeaderElectionAdapter() as backend:
         record = await backend.acquire_or_renew(
             name=NAME, token=W1, duration=10
         )

--- a/tests/coordination/test_postgres.py
+++ b/tests/coordination/test_postgres.py
@@ -9,7 +9,7 @@ import pytest_mock
 
 from grelmicro.coordination.abc import LeaderElectionBackend
 from grelmicro.coordination.postgres import (
-    PostgresLeaderElectionBackend,
+    PostgresLeaderElectionAdapter,
     _decode_metadata,
 )
 from grelmicro.errors import OutOfContextError
@@ -37,7 +37,7 @@ def test_table_name_invalid(table_name: str) -> None:
     with pytest.raises(
         ValueError, match=r"Table name '.*' is not a valid SQL identifier"
     ):
-        PostgresLeaderElectionBackend(
+        PostgresLeaderElectionAdapter(
             provider=PostgresProvider(URL), table_name=table_name
         )
 
@@ -45,7 +45,7 @@ def test_table_name_invalid(table_name: str) -> None:
 @pytest.mark.timeout(1)
 async def test_out_of_context_errors() -> None:
     """Backend methods raise when called outside the context manager."""
-    backend = PostgresLeaderElectionBackend(provider=PostgresProvider(URL))
+    backend = PostgresLeaderElectionAdapter(provider=PostgresProvider(URL))
     name = "election"
     token = "token"
 
@@ -64,7 +64,7 @@ def test_backend_with_implicit_env_provider(
     """Without `provider=`, the backend builds its own from env vars."""
     monkeypatch.setenv("POSTGRES_URL", URL)
 
-    backend = PostgresLeaderElectionBackend()
+    backend = PostgresLeaderElectionAdapter()
 
     assert backend.provider.url == URL
     assert backend._owns_provider is True
@@ -74,7 +74,7 @@ def test_backend_with_implicit_env_provider(
 def test_backend_borrows_external_provider() -> None:
     """An explicit `provider=` is borrowed, not owned."""
     provider = PostgresProvider(URL)
-    backend = PostgresLeaderElectionBackend(provider=provider)
+    backend = PostgresLeaderElectionAdapter(provider=provider)
 
     assert backend.provider is provider
     assert backend._owns_provider is False
@@ -87,7 +87,7 @@ def test_backend_env_prefix_passed_to_implicit_provider(
     """`env_prefix=` reaches the implicit provider."""
     monkeypatch.setenv("WRITE_POSTGRES_URL", URL)
 
-    backend = PostgresLeaderElectionBackend(env_prefix="WRITE_POSTGRES_")
+    backend = PostgresLeaderElectionAdapter(env_prefix="WRITE_POSTGRES_")
 
     assert backend.provider.url == URL
     assert backend.provider.env_prefix == "WRITE_POSTGRES_"
@@ -102,13 +102,13 @@ def test_env_validation_error_propagates(
     monkeypatch.delenv("POSTGRES_HOST", raising=False)
 
     with pytest.raises(PostgresProviderConfigError):
-        PostgresLeaderElectionBackend()
+        PostgresLeaderElectionAdapter()
 
 
 @pytest.mark.timeout(1)
 def test_custom_table_name() -> None:
     """Custom `table_name=` is stored on the backend."""
-    backend = PostgresLeaderElectionBackend(
+    backend = PostgresLeaderElectionAdapter(
         provider=PostgresProvider(URL), table_name="my_leaders"
     )
 
@@ -122,7 +122,7 @@ def test_provider_factory() -> None:
 
     backend = provider.leaderelection()
 
-    assert isinstance(backend, PostgresLeaderElectionBackend)
+    assert isinstance(backend, PostgresLeaderElectionAdapter)
     assert backend.provider is provider
     assert backend._owns_provider is False
 
@@ -130,7 +130,7 @@ def test_provider_factory() -> None:
 @pytest.mark.timeout(1)
 def test_satisfies_protocol() -> None:
     """The backend satisfies the `LeaderElectionBackend` protocol."""
-    backend = PostgresLeaderElectionBackend(provider=PostgresProvider(URL))
+    backend = PostgresLeaderElectionAdapter(provider=PostgresProvider(URL))
 
     assert isinstance(backend, LeaderElectionBackend)
 
@@ -139,7 +139,7 @@ def test_satisfies_protocol() -> None:
 def test_rebind_provider_borrows_new_provider() -> None:
     """`_rebind_provider` swaps the provider and marks it borrowed."""
     owned = PostgresProvider(URL)
-    backend = PostgresLeaderElectionBackend(provider=owned)
+    backend = PostgresLeaderElectionAdapter(provider=owned)
     backend._owns_provider = True
     shared = PostgresProvider(URL)
 
@@ -159,7 +159,7 @@ async def test_owned_provider_lifecycle(
         provider, "__aenter__", AsyncMock(return_value=provider)
     )
     aexit = mocker.patch.object(provider, "__aexit__", AsyncMock())
-    backend = PostgresLeaderElectionBackend(
+    backend = PostgresLeaderElectionAdapter(
         provider=provider, auto_migrate=False
     )
     backend._owns_provider = True
@@ -181,7 +181,7 @@ async def test_borrowed_provider_lifecycle_left_alone(
         provider, "__aenter__", AsyncMock(return_value=provider)
     )
     aexit = mocker.patch.object(provider, "__aexit__", AsyncMock())
-    backend = PostgresLeaderElectionBackend(
+    backend = PostgresLeaderElectionAdapter(
         provider=provider, auto_migrate=False
     )
 
@@ -215,7 +215,7 @@ _EXPIRE_WAIT = _DURATION + 0.3
 
 
 @pytest.fixture(scope="module")
-async def backend() -> AsyncGenerator[PostgresLeaderElectionBackend]:
+async def backend() -> AsyncGenerator[PostgresLeaderElectionAdapter]:
     """Provide a Postgres-backed leader election backend in a container."""
     from testcontainers.postgres import PostgresContainer  # noqa: PLC0415
 
@@ -226,7 +226,7 @@ async def backend() -> AsyncGenerator[PostgresLeaderElectionBackend]:
         )
         async with (
             provider,
-            PostgresLeaderElectionBackend(provider=provider) as backend,
+            PostgresLeaderElectionAdapter(provider=provider) as backend,
         ):
             yield backend
 
@@ -234,7 +234,7 @@ async def backend() -> AsyncGenerator[PostgresLeaderElectionBackend]:
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_acquire(
-    backend: PostgresLeaderElectionBackend,
+    backend: PostgresLeaderElectionAdapter,
 ) -> None:
     """A fresh election is acquired with transitions at zero."""
     name = "test_acquire" + uuid4().hex
@@ -252,7 +252,7 @@ async def test_acquire(
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_renew_keeps_transitions(
-    backend: PostgresLeaderElectionBackend,
+    backend: PostgresLeaderElectionAdapter,
 ) -> None:
     """Renewing the same holder moves renewed_at but not transitions."""
     name = "test_renew" + uuid4().hex
@@ -274,7 +274,7 @@ async def test_renew_keeps_transitions(
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_live_lease_not_taken(
-    backend: PostgresLeaderElectionBackend,
+    backend: PostgresLeaderElectionAdapter,
 ) -> None:
     """A live lease cannot be taken by another holder."""
     name = "test_live" + uuid4().hex
@@ -296,7 +296,7 @@ async def test_live_lease_not_taken(
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_takeover_after_expiry(
-    backend: PostgresLeaderElectionBackend,
+    backend: PostgresLeaderElectionAdapter,
 ) -> None:
     """A new holder takes over after expiry and bumps transitions."""
     from asyncio import sleep  # noqa: PLC0415
@@ -318,7 +318,7 @@ async def test_takeover_after_expiry(
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_release(
-    backend: PostgresLeaderElectionBackend,
+    backend: PostgresLeaderElectionAdapter,
 ) -> None:
     """Release returns True for the holder, False for non-holders."""
     name = "test_release" + uuid4().hex
@@ -335,7 +335,7 @@ async def test_release(
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_get_live_and_expired(
-    backend: PostgresLeaderElectionBackend,
+    backend: PostgresLeaderElectionAdapter,
 ) -> None:
     """Get returns the live record then None after expiry."""
     from asyncio import sleep  # noqa: PLC0415
@@ -356,7 +356,7 @@ async def test_get_live_and_expired(
 @pytest.mark.integration
 @pytest.mark.timeout(60)
 async def test_metadata_roundtrip(
-    backend: PostgresLeaderElectionBackend,
+    backend: PostgresLeaderElectionAdapter,
 ) -> None:
     """Metadata stored as jsonb round-trips through acquire and get."""
     name = "test_metadata" + uuid4().hex

--- a/tests/coordination/test_redis.py
+++ b/tests/coordination/test_redis.py
@@ -10,7 +10,7 @@ import pytest
 from anyio import sleep
 from testcontainers.redis import RedisContainer
 
-from grelmicro.coordination.redis import RedisLeaderElectionBackend, _as_str
+from grelmicro.coordination.redis import RedisLeaderElectionAdapter, _as_str
 from grelmicro.providers.redis import RedisProvider
 
 pytestmark = [pytest.mark.timeout(30)]
@@ -27,7 +27,7 @@ def test_backend_with_implicit_env_provider(
     """Without `provider=`, the backend builds its own from env vars."""
     monkeypatch.setenv("REDIS_URL", URL)
 
-    backend = RedisLeaderElectionBackend()
+    backend = RedisLeaderElectionAdapter()
 
     assert backend.provider.url == URL
     assert backend._owns_provider is True
@@ -36,7 +36,7 @@ def test_backend_with_implicit_env_provider(
 def test_backend_borrows_external_provider() -> None:
     """An explicit `provider=` is borrowed, not owned."""
     provider = RedisProvider(URL)
-    backend = RedisLeaderElectionBackend(provider=provider)
+    backend = RedisLeaderElectionAdapter(provider=provider)
 
     assert backend.provider is provider
     assert backend._owns_provider is False
@@ -48,7 +48,7 @@ def test_backend_env_prefix_passed_to_implicit_provider(
     """`env_prefix=` reaches the implicit provider."""
     monkeypatch.setenv("CACHE_REDIS_URL", URL)
 
-    backend = RedisLeaderElectionBackend(env_prefix="CACHE_REDIS_")
+    backend = RedisLeaderElectionAdapter(env_prefix="CACHE_REDIS_")
 
     assert backend.provider.url == URL
     assert backend.provider.env_prefix == "CACHE_REDIS_"
@@ -60,14 +60,14 @@ def test_provider_factory_returns_redis_backend() -> None:
 
     backend = provider.leaderelection()
 
-    assert isinstance(backend, RedisLeaderElectionBackend)
+    assert isinstance(backend, RedisLeaderElectionAdapter)
     assert backend.provider is provider
 
 
 def test_rebind_provider_borrows_it(monkeypatch: pytest.MonkeyPatch) -> None:
     """`_rebind_provider` swaps the provider and marks it as not owned."""
     monkeypatch.setenv("REDIS_URL", URL)
-    backend = RedisLeaderElectionBackend()
+    backend = RedisLeaderElectionAdapter()
     assert backend._owns_provider is True
     other = RedisProvider(URL)
 
@@ -101,7 +101,7 @@ class _StubProvider:
 async def test_aenter_aexit_owned_provider_opens_and_closes_it() -> None:
     """When owned, the backend opens and closes its provider."""
     stub = _StubProvider()
-    backend = RedisLeaderElectionBackend(provider=stub)  # ty: ignore[invalid-argument-type]
+    backend = RedisLeaderElectionAdapter(provider=stub)  # ty: ignore[invalid-argument-type]
     backend._owns_provider = True
 
     async with backend:
@@ -114,7 +114,7 @@ async def test_aenter_aexit_owned_provider_opens_and_closes_it() -> None:
 async def test_aenter_aexit_borrowed_provider_left_alone() -> None:
     """An external provider is not entered or exited by the backend."""
     stub = _StubProvider()
-    backend = RedisLeaderElectionBackend(provider=stub)  # ty: ignore[invalid-argument-type]
+    backend = RedisLeaderElectionAdapter(provider=stub)  # ty: ignore[invalid-argument-type]
 
     async with backend:
         pass
@@ -154,16 +154,16 @@ def container() -> Generator[RedisContainer, None, None]:
 @pytest.fixture
 async def backend(
     container: RedisContainer,
-) -> AsyncGenerator[RedisLeaderElectionBackend]:
+) -> AsyncGenerator[RedisLeaderElectionAdapter]:
     """Redis Leader Election Backend bound to the container."""
     port = container.get_exposed_port(6379)
     provider = RedisProvider(f"redis://localhost:{port}/0")
-    async with RedisLeaderElectionBackend(provider=provider) as backend:
+    async with RedisLeaderElectionAdapter(provider=provider) as backend:
         yield backend
 
 
 @pytest.mark.integration
-async def test_acquire_fresh(backend: RedisLeaderElectionBackend) -> None:
+async def test_acquire_fresh(backend: RedisLeaderElectionAdapter) -> None:
     """A fresh election is acquired with zero transitions."""
     name = "acquire_fresh" + uuid4().hex
     token = uuid4().hex
@@ -180,7 +180,7 @@ async def test_acquire_fresh(backend: RedisLeaderElectionBackend) -> None:
 
 @pytest.mark.integration
 async def test_renew_same_holder_keeps_transitions(
-    backend: RedisLeaderElectionBackend,
+    backend: RedisLeaderElectionAdapter,
 ) -> None:
     """Renewing the same holder moves renewed_at but not acquired_at."""
     name = "renew_same" + uuid4().hex
@@ -201,7 +201,7 @@ async def test_renew_same_holder_keeps_transitions(
 
 @pytest.mark.integration
 async def test_live_lease_blocks_other_holder(
-    backend: RedisLeaderElectionBackend,
+    backend: RedisLeaderElectionAdapter,
 ) -> None:
     """A different token cannot take a live lease and sees the holder."""
     name = "live_blocks" + uuid4().hex
@@ -219,7 +219,7 @@ async def test_live_lease_blocks_other_holder(
 
 @pytest.mark.integration
 async def test_takeover_after_expiry_increments_transitions(
-    backend: RedisLeaderElectionBackend,
+    backend: RedisLeaderElectionAdapter,
 ) -> None:
     """A new holder takes an expired lease and increments transitions."""
     name = "takeover" + uuid4().hex
@@ -239,7 +239,7 @@ async def test_takeover_after_expiry_increments_transitions(
 
 @pytest.mark.integration
 async def test_reacquire_after_expiry_keeps_transitions(
-    backend: RedisLeaderElectionBackend,
+    backend: RedisLeaderElectionAdapter,
 ) -> None:
     """Same holder reacquiring an expired lease keeps transitions."""
     name = "reacquire" + uuid4().hex
@@ -257,7 +257,7 @@ async def test_reacquire_after_expiry_keeps_transitions(
 
 @pytest.mark.integration
 async def test_release_held_lease(
-    backend: RedisLeaderElectionBackend,
+    backend: RedisLeaderElectionAdapter,
 ) -> None:
     """The holder can release its live lease."""
     name = "release" + uuid4().hex
@@ -274,7 +274,7 @@ async def test_release_held_lease(
 
 @pytest.mark.integration
 async def test_release_other_holder_denied(
-    backend: RedisLeaderElectionBackend,
+    backend: RedisLeaderElectionAdapter,
 ) -> None:
     """A non-holder cannot release the lease."""
     name = "release_denied" + uuid4().hex
@@ -289,7 +289,7 @@ async def test_release_other_holder_denied(
 
 @pytest.mark.integration
 async def test_get_returns_none_after_expiry(
-    backend: RedisLeaderElectionBackend,
+    backend: RedisLeaderElectionAdapter,
 ) -> None:
     """`get` returns the live record then `None` once it expires."""
     name = "get_expiry" + uuid4().hex
@@ -307,7 +307,7 @@ async def test_get_returns_none_after_expiry(
 
 @pytest.mark.integration
 async def test_metadata_round_trips(
-    backend: RedisLeaderElectionBackend,
+    backend: RedisLeaderElectionAdapter,
 ) -> None:
     """Metadata stored on acquire is returned on get."""
     name = "metadata" + uuid4().hex

--- a/tests/providers/test_redis_provider.py
+++ b/tests/providers/test_redis_provider.py
@@ -309,14 +309,14 @@ class TestBuilders:
     def test_leaderelection_builder_binds_provider(self) -> None:
         """`provider.leaderelection()` returns a backend borrowing it."""
         from grelmicro.coordination.redis import (  # noqa: PLC0415
-            RedisLeaderElectionBackend,
+            RedisLeaderElectionAdapter,
         )
 
         provider = RedisProvider(URL)
 
         adapter = provider.leaderelection()
 
-        assert isinstance(adapter, RedisLeaderElectionBackend)
+        assert isinstance(adapter, RedisLeaderElectionAdapter)
         assert adapter.provider is provider
 
     def test_schedule_builder_binds_provider(self) -> None:

--- a/tests/providers/test_valkey_provider.py
+++ b/tests/providers/test_valkey_provider.py
@@ -7,7 +7,7 @@ import pytest
 
 from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.coordination.redis import (
-    RedisLeaderElectionBackend,
+    RedisLeaderElectionAdapter,
     RedisLockAdapter,
     RedisScheduleAdapter,
 )
@@ -279,12 +279,12 @@ class TestBuilders:
         assert adapter._prefix == "cb:"
 
     def test_leaderelection_builder_binds_provider(self) -> None:
-        """`provider.leaderelection()` returns a `RedisLeaderElectionBackend`."""
+        """`provider.leaderelection()` returns a `RedisLeaderElectionAdapter`."""
         provider = ValkeyProvider(URL)
 
         adapter = provider.leaderelection()
 
-        assert isinstance(adapter, RedisLeaderElectionBackend)
+        assert isinstance(adapter, RedisLeaderElectionAdapter)
         assert adapter._provider is provider
         assert adapter._owns_provider is False
 

--- a/tests/task/conftest.py
+++ b/tests/task/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 from grelmicro.coordination.abc import LeaderElectionBackend, LockBackend
 from grelmicro.coordination.memory import (
-    MemoryLeaderElectionBackend,
+    MemoryLeaderElectionAdapter,
     MemoryLockAdapter,
 )
 from grelmicro.coordination.tasklock import TaskLock
@@ -88,7 +88,7 @@ async def backend() -> AsyncGenerator[LockBackend]:
 @pytest.fixture
 async def leader_backend() -> AsyncGenerator[LeaderElectionBackend]:
     """Return Memory Leader Election Backend."""
-    async with MemoryLeaderElectionBackend() as backend:
+    async with MemoryLeaderElectionAdapter() as backend:
         yield backend
 
 

--- a/tests/task/conftest.py
+++ b/tests/task/conftest.py
@@ -87,7 +87,7 @@ async def backend() -> AsyncGenerator[LockBackend]:
 
 @pytest.fixture
 async def leader_backend() -> AsyncGenerator[LeaderElectionBackend]:
-    """Return Memory Leader Election Backend."""
+    """Return Memory Leader Election Adapter."""
     async with MemoryLeaderElectionAdapter() as backend:
         yield backend
 

--- a/tests/task/test_scheduled.py
+++ b/tests/task/test_scheduled.py
@@ -10,7 +10,7 @@ from grelmicro.coordination.abc import LeaderElectionBackend, LockBackend
 from grelmicro.coordination.leaderelection import LeaderElection
 from grelmicro.coordination.lock import Lock
 from grelmicro.coordination.memory import (
-    MemoryLeaderElectionBackend,
+    MemoryLeaderElectionAdapter,
     MemoryLockAdapter,
 )
 from grelmicro.task._interval import IntervalTask
@@ -78,7 +78,7 @@ def test_interval_task_with_lock_default_max_lock_seconds() -> None:
     # Arrange
     backend = MemoryLockAdapter()
     leader = LeaderElection(
-        "test-leader", backend=MemoryLeaderElectionBackend()
+        "test-leader", backend=MemoryLeaderElectionAdapter()
     )
     # Act - leader implies lock, max_lock_seconds defaults to interval * 5
     task = IntervalTask(

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -50,11 +50,11 @@ def test_load_provider_unknown_raises() -> None:
         ("coordination", "memory", "MemoryLockAdapter"),
         ("coordination", "redis", "RedisLockAdapter"),
         ("coordination", "kubernetes", "KubernetesLockAdapter"),
-        ("coordination.election", "memory", "MemoryLeaderElectionBackend"),
+        ("coordination.election", "memory", "MemoryLeaderElectionAdapter"),
         (
             "coordination.election",
             "kubernetes",
-            "KubernetesLeaderElectionBackend",
+            "KubernetesLeaderElectionAdapter",
         ),
         ("cache", "postgres", "PostgresCacheAdapter"),
         ("ratelimiter", "sqlite", "SQLiteRateLimiterAdapter"),

--- a/tests/test_uses_coercion.py
+++ b/tests/test_uses_coercion.py
@@ -19,7 +19,7 @@ from grelmicro.cache import Cache
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.coordination import Coordination
 from grelmicro.coordination.memory import (
-    MemoryLeaderElectionBackend,
+    MemoryLeaderElectionAdapter,
     MemoryLockAdapter,
 )
 from grelmicro.providers import Provider
@@ -47,8 +47,8 @@ class _MemoryProvider(Provider):
     def leaderelection(
         self,
         **kwargs: object,  # noqa: ARG002
-    ) -> MemoryLeaderElectionBackend:
-        return MemoryLeaderElectionBackend()
+    ) -> MemoryLeaderElectionAdapter:
+        return MemoryLeaderElectionAdapter()
 
     def cache(self, **kwargs: object) -> MemoryCacheAdapter:  # noqa: ARG002
         return MemoryCacheAdapter()


### PR DESCRIPTION
The concrete LeaderElection classes were the only backends suffixed `*Backend`, which collided with the protocol name. Rename them to `*Adapter` so every concrete matches the five sibling patterns (Cache, Lock, CircuitBreaker, RateLimiter, Schedule):

- `MemoryLeaderElectionBackend` → `MemoryLeaderElectionAdapter`
- `RedisLeaderElectionBackend` → `RedisLeaderElectionAdapter`
- `PostgresLeaderElectionBackend` → `PostgresLeaderElectionAdapter`
- `KubernetesLeaderElectionBackend` → `KubernetesLeaderElectionAdapter`

The `LeaderElectionBackend` protocol keeps its name. The rule is now uniform across the toolkit: protocol = `*Backend`, concrete = `*Adapter`.

Updates the entry-point strings in `pyproject.toml`, all tests, docs snippets, and the changelog (`### Breaking`). The public API snapshot is unchanged (the concrete adapters are not top-level exports). Full suite green.