### PR TITLE
✨ Add key= string-template keys to @cached

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -284,7 +284,7 @@ async def get_user(user_id: int) -> dict:
     return await db.fetch_user(user_id)
 ```
 
-Arguments not named in the template do not affect the key, so calls that differ only in those arguments share one entry. Defaults fill in when an argument is omitted. For a fully dynamic key, pass a `key_maker` callable instead. It receives `(func, args, kwargs)` and returns the key. Passing both `key` and `key_maker` raises `TypeError`.
+Arguments not named in the template do not affect the key, so calls that differ only in those arguments share one entry. Defaults fill in when an argument is omitted. For a fully dynamic key, pass a `key_maker` callable instead. It receives `(func, args, kwargs)` and returns the key. Passing both `key` and `key_maker` raises `TypeError`. A custom key fully determines the lookup, so `typed=` has no effect when `key=` or `key_maker` is set.
 
 ```python title="key.py"
 --8<-- "cache/key.py"

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -274,6 +274,22 @@ async def get_user(user_id: int) -> dict:
 
 Passing both `cache` and `ttl`, or neither, raises `TypeError`.
 
+### Custom Keys
+
+By default `@cached` derives the key from the `repr()` of the arguments. Pass `key=` for a stable, readable key instead. The template fills in from the call's arguments, so `key="user:{user_id}"` keys the entry under `user:42` for a call with `user_id=42`:
+
+```python
+@cached(cache, key="user:{user_id}")
+async def get_user(user_id: int) -> dict:
+    return await db.fetch_user(user_id)
+```
+
+Arguments not named in the template do not affect the key, so calls that differ only in those arguments share one entry. Defaults fill in when an argument is omitted. For a fully dynamic key, pass a `key_maker` callable instead. It receives `(func, args, kwargs)` and returns the key. Passing both `key` and `key_maker` raises `TypeError`.
+
+```python title="key.py"
+--8<-- "cache/key.py"
+```
+
 ### Stampede Protection
 
 A cache stampede (or "dog-pile") happens when many callers miss the same key at once and all recompute it together. Turn on `lock` to fold those misses into one execution, and add `early=` to refresh hot keys before they expire:
@@ -336,7 +352,8 @@ A flaky upstream then degrades to slightly stale data instead of an error storm.
 | `cache` | `TTLCache` | `None` | The cache instance to store results in. Mutually exclusive with `ttl`. |
 | `ttl` | `float` | `None` | TTL in seconds for a private per-function cache. Mutually exclusive with `cache`. |
 | `maxsize` | `int` | `0` | Max entries in the private per-function cache, `0` means unlimited (used only when `ttl` is set). |
-| `key_maker` | `Callable` | `None` | Custom key generation function. Receives `(func, args, kwargs)`. |
+| `key` | `str` | `None` | Key template rendered from the arguments, like `"user:{user_id}"`. Mutually exclusive with `key_maker`. |
+| `key_maker` | `Callable` | `None` | Custom key generation function. Receives `(func, args, kwargs)`. Mutually exclusive with `key`. |
 | `skip` | `Callable` | `None` | Predicate receiving the result. Returns `True` to skip caching. |
 | `typed` | `bool` | `False` | Cache arguments of different types separately. |
 | `lock` | `True`, `False`, or `"local"` | `False` | Concurrent-miss (stampede) protection. |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@
 
 * 💥 Rename the concrete leader election adapters to the `*Adapter` suffix every other pattern already uses. `MemoryLeaderElectionBackend`, `RedisLeaderElectionBackend`, `PostgresLeaderElectionBackend`, and `KubernetesLeaderElectionBackend` become `MemoryLeaderElectionAdapter`, `RedisLeaderElectionAdapter`, `PostgresLeaderElectionAdapter`, and `KubernetesLeaderElectionAdapter`. The `LeaderElectionBackend` protocol keeps its name (protocol stays `*Backend`, concrete stays `*Adapter`). Update direct imports and constructions.
 
+### Features
+
+* ✨ Add a `key=` template to `@cached` for a stable, readable cache key rendered from the arguments, like `@cached(key="user:{user_id}")`. Pass `key_maker=` for the fully dynamic case. Passing both raises `TypeError`.
+
 ## 1.0.0a2 - 2026-06-21
 
 ### Features

--- a/docs/snippets/cache/key.py
+++ b/docs/snippets/cache/key.py
@@ -1,0 +1,20 @@
+from grelmicro import Grelmicro
+from grelmicro.cache import Cache, JsonSerializer, cached
+from grelmicro.cache.memory import MemoryCacheAdapter
+
+cache = Cache(MemoryCacheAdapter())
+micro = Grelmicro(uses=[cache])
+
+ttl_cache = cache.ttl(ttl=300, serializer=JsonSerializer())
+
+
+@cached(ttl_cache, key="user:{user_id}")
+async def get_user(user_id: int) -> dict:
+    return {"id": user_id, "name": "Alice"}
+
+
+async def main() -> None:
+    async with micro:
+        # Keyed under "user:1" instead of the default argument-repr key.
+        await get_user(1)
+        await ttl_cache.delete("user:1")

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -137,7 +137,7 @@ def _resolve_cache(
     )
 
 
-def cached(  # noqa: PLR0913
+def cached(  # noqa: PLR0913, C901
     cache: Annotated[
         TTLCache | None,
         Doc(
@@ -354,7 +354,7 @@ def cached(  # noqa: PLR0913
         auto_distributed = lock is True
         tag_spec = _TagSpec(tags, inspect.signature(func) if tags else None)
         resolved_key_maker = key_maker
-        if key is not None:
+        if key is not None and "{" in key:
             key_spec = _TagSpec((key,), inspect.signature(func))
 
             def resolved_key_maker(
@@ -363,6 +363,14 @@ def cached(  # noqa: PLR0913
                 kwargs: dict[str, Any],
             ) -> str:
                 return key_spec.render(args, kwargs)[0]
+        elif key is not None:
+
+            def resolved_key_maker(
+                _func: Callable[..., Any],
+                _args: tuple[Any, ...],
+                _kwargs: dict[str, Any],
+            ) -> str:
+                return key
 
         if is_async_func:
             wrapper = _build_async_wrapper(

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -137,7 +137,7 @@ def _resolve_cache(
     )
 
 
-def cached(
+def cached(  # noqa: PLR0913
     cache: Annotated[
         TTLCache | None,
         Doc(
@@ -181,13 +181,30 @@ def cached(
             """,
         ),
     ] = 0,
+    key: Annotated[
+        str | None,
+        Doc(
+            """
+            Cache key template rendered from the call's arguments, so
+            ``key="user:{user_id}"`` keys the entry under ``user:42`` for
+            a call with ``user_id=42``. A literal template with no
+            placeholders keys every call under the same string. Use it
+            instead of the default argument-repr key when you want a
+            stable, readable key. A `key` template fully determines the
+            key, so `typed` does not apply. Passing both `key` and
+            `key_maker` raises `TypeError`.
+            """,
+        ),
+    ] = None,
     key_maker: Annotated[
         Callable[[Callable[..., Any], tuple[Any, ...], dict[str, Any]], str]
         | None,
         Doc(
             """
             Optional custom key generation function. Receives
-            ``(func, args, kwargs)`` and must return a string key.
+            ``(func, args, kwargs)`` and must return a string key. Use it
+            for the fully dynamic case. For a simple template, pass `key=`
+            instead. Passing both `key` and `key_maker` raises `TypeError`.
             """,
         ),
     ] = None,
@@ -293,8 +310,8 @@ def cached(
     function alone.
 
     Raises:
-        TypeError: If both ``cache`` and ``ttl`` are given, or if
-            neither is given.
+        TypeError: If both ``cache`` and ``ttl`` are given, if neither is
+            given, or if both ``key`` and ``key_maker`` are given.
         ValueError: If ``lock`` is not ``True``, ``False``, or ``"local"``,
             if ``early`` is outside ``[0, 1)``, or if ``stale_ttl`` is not
             positive.
@@ -302,6 +319,13 @@ def cached(
     Returns:
         A decorator that caches function results.
     """
+    if key is not None and key_maker is not None:
+        msg = (
+            "cached() takes either key= or key_maker=, not both. Pass a "
+            "key= template for a stable key rendered from the arguments, "
+            "or a key_maker callable for the fully dynamic case."
+        )
+        raise TypeError(msg)
     is_private_cache = cache is None
     cache = _resolve_cache(cache, ttl, maxsize)
     if lock not in (True, False, "local"):
@@ -329,12 +353,22 @@ def cached(
         per_key = lock is not False
         auto_distributed = lock is True
         tag_spec = _TagSpec(tags, inspect.signature(func) if tags else None)
+        resolved_key_maker = key_maker
+        if key is not None:
+            key_spec = _TagSpec((key,), inspect.signature(func))
+
+            def resolved_key_maker(
+                _func: Callable[..., Any],
+                args: tuple[Any, ...],
+                kwargs: dict[str, Any],
+            ) -> str:
+                return key_spec.render(args, kwargs)[0]
 
         if is_async_func:
             wrapper = _build_async_wrapper(
                 func,
                 cache,
-                key_maker,
+                resolved_key_maker,
                 skip,
                 typed=typed,
                 per_key=per_key,
@@ -347,7 +381,7 @@ def cached(
             wrapper = _build_sync_wrapper(
                 func,
                 cache,
-                key_maker,
+                resolved_key_maker,
                 skip,
                 typed=typed,
                 per_key=per_key,

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -39,7 +39,7 @@
   "grelmicro.cache": {
     "Cache": {
       "()": "(source, *, name=...)",
-      ".cached": "(cache=..., *, ttl=..., maxsize=..., key_maker=..., skip=..., typed=..., lock=..., early=..., stale_ttl=..., tags=...)"
+      ".cached": "(cache=..., *, ttl=..., maxsize=..., key=..., key_maker=..., skip=..., typed=..., lock=..., early=..., stale_ttl=..., tags=...)"
     },
     "CacheBackend": {
       "()": "(*args, **kwargs)"
@@ -70,7 +70,7 @@
       "()": "(*, maxsize=..., ttl=...)"
     },
     "cached": {
-      "()": "(cache=..., *, ttl=..., maxsize=..., key_maker=..., skip=..., typed=..., lock=..., early=..., stale_ttl=..., tags=...)"
+      "()": "(cache=..., *, ttl=..., maxsize=..., key=..., key_maker=..., skip=..., typed=..., lock=..., early=..., stale_ttl=..., tags=...)"
     }
   },
   "grelmicro.clock": {

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -1594,6 +1594,23 @@ class TestCachedKeyTemplate:
 
         assert call_count == EXPECTED_CALL_COUNT_1
 
+    async def test_key_template_literal_no_placeholders(self) -> None:
+        """A literal key= with no placeholders keys every call the same."""
+        cache = _make_cache()
+        call_count = 0
+
+        @cached(cache, key="all-users")
+        async def fetch(user_id: int) -> dict:
+            nonlocal call_count
+            call_count += 1
+            return {"id": user_id}
+
+        await fetch(1)
+        await fetch(2)
+
+        assert call_count == EXPECTED_CALL_COUNT_1
+        assert await cache.get("all-users") is not None
+
     def test_key_template_sync(self) -> None:
         """A key= template keys a sync cached function."""
         backend = MemoryCacheAdapter()

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -1539,6 +1539,87 @@ class TestCachedTags:
         assert "user:5" in backend._tag_keys
 
 
+class TestCachedKeyTemplate:
+    """Tests for @cached key= string templating."""
+
+    async def test_key_template_renders_from_positional_arg(self) -> None:
+        """A key= template renders from a positional argument."""
+        cache = _make_cache()
+
+        @cached(cache, key="user:{user_id}")
+        async def fetch(user_id: int) -> dict:
+            return {"id": user_id}
+
+        await fetch(42)
+
+        assert await cache.get("user:42") == {"id": 42}
+
+    async def test_key_template_renders_from_keyword_arg(self) -> None:
+        """A key= template renders from a keyword argument."""
+        cache = _make_cache()
+
+        @cached(cache, key="user:{user_id}")
+        async def fetch(user_id: int) -> dict:
+            return {"id": user_id}
+
+        await fetch(user_id=7)
+
+        assert await cache.get("user:7") == {"id": 7}
+
+    async def test_key_template_renders_from_default_argument(self) -> None:
+        """A key= template uses a default when the argument is omitted."""
+        cache = _make_cache()
+
+        @cached(cache, key="page:{page}")
+        async def fetch(page: int = 1) -> dict:
+            return {"page": page}
+
+        await fetch()
+
+        assert await cache.get("page:1") == {"page": 1}
+
+    async def test_key_template_collapses_unmentioned_args(self) -> None:
+        """Args absent from the template collapse to the same key."""
+        cache = _make_cache()
+        call_count = 0
+
+        @cached(cache, key="user:{user_id}")
+        async def fetch(user_id: int, _trace: str) -> dict:
+            nonlocal call_count
+            call_count += 1
+            return {"id": user_id}
+
+        await fetch(1, "a")
+        await fetch(1, "b")
+
+        assert call_count == EXPECTED_CALL_COUNT_1
+
+    def test_key_template_sync(self) -> None:
+        """A key= template keys a sync cached function."""
+        backend = MemoryCacheAdapter()
+        cache = TTLCache(ttl=60, backend=backend, serializer=PickleSerializer())
+
+        @cached(cache, key="user:{user_id}")
+        def fetch(user_id: int) -> dict:
+            return {"id": user_id}
+
+        async def run() -> dict | None:
+            backend._loop = asyncio.get_running_loop()
+            await asyncio.to_thread(fetch, 5)
+            return await cache.get("user:5")
+
+        assert asyncio.run(run()) == {"id": 5}
+
+    def test_key_and_key_maker_raises(self) -> None:
+        """Passing both key and key_maker raises TypeError."""
+        with pytest.raises(TypeError, match="not both"):
+            cached(
+                TTLCache(ttl=5),
+                key="user:{user_id}",
+                key_maker=lambda _f, _a, _k: "x",
+            )
+
+
 class TestCachedStaleOnError:
     """Test @cached(stale_ttl=...) serve-stale-on-error."""
 


### PR DESCRIPTION
Closes #398.

Adds a `key=` string-template kwarg to `@cached`, rendered through the existing tag-template engine (`_TagSpec`: `signature.bind` + `apply_defaults` + `format_map`):

```python
@cached(cache, key="user:{user_id}")
async def get_user(user_id): ...   # keyed under "user:42"
```

- Reuses the tag engine, no duplication, no per-call overhead beyond the one render already done for tags.
- Passing both `key=` and `key_maker=` raises `TypeError` at decoration time. `key_maker=` stays for the fully dynamic case.
- A `key=` template fully determines the key, so `typed=` does not apply (documented).
- Tests: positional / keyword / default-arg rendering, unmentioned-arg collapse, sync path, both-args collision.
- Docs: new "Custom Keys" section + runnable snippet. API snapshot updated for the new param.

Inspiration: Spring `@Cacheable(key=...)`, cashews `key=` templates.