### PR TITLE
✨ Type FireInfo.outcome as a FireOutcome StrEnum

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@
 ### Features
 
 * ✨ Add a `key=` template to `@cached` for a stable, readable cache key rendered from the arguments, like `@cached(key="user:{user_id}")`. Pass `key_maker=` for the fully dynamic case. Passing both raises `TypeError`.
+* ✨ Type `FireInfo.outcome` as the new `FireOutcome` `StrEnum` (`SUCCESS`, `ERROR`, `SKIPPED`). String comparisons like `outcome == "success"` still work.
 
 ## 1.0.0a2 - 2026-06-21
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -203,9 +203,10 @@ Each task exposes two read-only properties for observability:
   or `None` when the task has not started yet. For interval tasks, this is
   computed from the last loop instant. For cron tasks, it comes from the
   parsed expression.
-- **`last_fire`**: a `FireInfo` with the `started_at` timestamp, outcome
-  (`"success"`, `"error"`, or `"skipped"`), and duration in seconds. `None`
-  before the first fire.
+- **`last_fire`**: a `FireInfo` with the `started_at` timestamp, outcome (a
+  `FireOutcome` enum: `SUCCESS`, `ERROR`, or `SKIPPED`), and duration in
+  seconds. `None` before the first fire. `FireOutcome` is a `StrEnum`, so each
+  member compares equal to its string value (`outcome == "success"`).
 
 Access the task object via `tasks.tasks`:
 

--- a/grelmicro/task/__init__.py
+++ b/grelmicro/task/__init__.py
@@ -1,6 +1,6 @@
 """Task."""
 
-from grelmicro.task._cron import FireInfo
+from grelmicro.task._cron import FireInfo, FireOutcome
 from grelmicro.task._tasks import Tasks
 from grelmicro.task.errors import (
     CronError,
@@ -13,6 +13,7 @@ from grelmicro.task.router import TaskRouter
 __all__ = [
     "CronError",
     "FireInfo",
+    "FireOutcome",
     "FunctionTypeError",
     "TaskAddOperationError",
     "TaskError",

--- a/grelmicro/task/_cron.py
+++ b/grelmicro/task/_cron.py
@@ -6,6 +6,7 @@ import asyncio
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from enum import StrEnum
 from functools import partial
 from logging import getLogger
 from typing import TYPE_CHECKING, Any
@@ -29,12 +30,25 @@ if TYPE_CHECKING:
 logger = getLogger("grelmicro.task")
 
 
+class FireOutcome(StrEnum):
+    """Outcome of a task fire.
+
+    - ``SUCCESS``: the body ran and returned without raising.
+    - ``ERROR``: the body raised an exception.
+    - ``SKIPPED``: the fire was skipped because a sync lock would block.
+    """
+
+    SUCCESS = "success"
+    ERROR = "error"
+    SKIPPED = "skipped"
+
+
 @dataclass(frozen=True)
 class FireInfo:
     """Information about a task fire."""
 
     started_at: datetime
-    outcome: str
+    outcome: FireOutcome
     duration: float
 
 
@@ -431,7 +445,7 @@ class CronTask(Task):
         except WouldBlockError as exc:
             self._last_fire = FireInfo(
                 started_at=_now(self._tz),
-                outcome="skipped",
+                outcome=FireOutcome.SKIPPED,
                 duration=0.0,
             )
             logger.debug("Task skipped: %s (%s)", self.name, exc)
@@ -506,13 +520,13 @@ class CronTask(Task):
         )
         started_at = _now(self._tz)
         start_monotonic = time.perf_counter()
-        outcome = "error"
+        outcome = FireOutcome.ERROR
         try:
             await self._async_function()
-            outcome = "success"
+            outcome = FireOutcome.SUCCESS
             _emit.incr(
                 "grelmicro.task.runs",
-                **{"task.name": self.name, "outcome": "success"},
+                **{"task.name": self.name, "outcome": FireOutcome.SUCCESS},
             )
         except Exception as exc:
             logger.exception("Task execution error: %s", self.name)
@@ -520,7 +534,7 @@ class CronTask(Task):
                 "grelmicro.task.runs",
                 **{
                     "task.name": self.name,
-                    "outcome": "error",
+                    "outcome": FireOutcome.ERROR,
                     "error.type": type(exc).__name__,
                 },
             )

--- a/grelmicro/task/_cron.py
+++ b/grelmicro/task/_cron.py
@@ -35,7 +35,8 @@ class FireOutcome(StrEnum):
 
     - ``SUCCESS``: the body ran and returned without raising.
     - ``ERROR``: the body raised an exception.
-    - ``SKIPPED``: the fire was skipped because a sync lock would block.
+    - ``SKIPPED``: the fire was skipped because acquiring a lock would
+      block (a ``WouldBlockError``).
     """
 
     SUCCESS = "success"

--- a/grelmicro/task/_interval.py
+++ b/grelmicro/task/_interval.py
@@ -18,7 +18,7 @@ from grelmicro.coordination.leaderelection import LeaderElection
 from grelmicro.coordination.tasklock import TaskLock
 from grelmicro.errors import WouldBlockError
 from grelmicro.metrics import _emit
-from grelmicro.task._cron import FireInfo
+from grelmicro.task._cron import FireInfo, FireOutcome
 from grelmicro.task._utils import validate_and_generate_reference
 from grelmicro.task.abc import Task
 
@@ -159,7 +159,7 @@ class IntervalTask(Task):
                 except WouldBlockError as exc:
                     self._last_fire = FireInfo(
                         started_at=datetime.now(UTC),
-                        outcome="skipped",
+                        outcome=FireOutcome.SKIPPED,
                         duration=0.0,
                     )
                     logger.debug("Task skipped: %s (%s)", self.name, exc)
@@ -202,13 +202,13 @@ class IntervalTask(Task):
             )
             started_at = datetime.now(UTC)
             start_monotonic = time.perf_counter()
-            outcome = "error"
+            outcome = FireOutcome.ERROR
             try:
                 await self._async_function()
-                outcome = "success"
+                outcome = FireOutcome.SUCCESS
                 _emit.incr(
                     "grelmicro.task.runs",
-                    **{"task.name": self.name, "outcome": "success"},
+                    **{"task.name": self.name, "outcome": FireOutcome.SUCCESS},
                 )
             except Exception as exc:
                 logger.exception("Task execution error: %s", self.name)
@@ -216,7 +216,7 @@ class IntervalTask(Task):
                     "grelmicro.task.runs",
                     **{
                         "task.name": self.name,
-                        "outcome": "error",
+                        "outcome": FireOutcome.ERROR,
                         "error.type": type(exc).__name__,
                     },
                 )

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -566,6 +566,9 @@
     "FireInfo": {
       "()": "(started_at, outcome, duration)"
     },
+    "FireOutcome": {
+      "()": "(*values)"
+    },
     "FunctionTypeError": {
       "()": "(reference)"
     },

--- a/tests/task/test_cron_task.py
+++ b/tests/task/test_cron_task.py
@@ -15,7 +15,7 @@ from grelmicro.coordination.abc import LockPrimitive
 from grelmicro.coordination.errors import LockNotOwnedError
 from grelmicro.coordination.memory import MemoryScheduleAdapter
 from grelmicro.errors import OutOfContextError
-from grelmicro.task._cron import CronTask, FireInfo
+from grelmicro.task._cron import CronTask, FireInfo, FireOutcome
 from grelmicro.task.errors import CronError
 from tests.task import samples
 from tests.task._helpers import cancel_group, start_task
@@ -439,8 +439,10 @@ async def test_cron_task_last_fire_success(mocker: MockFixture) -> None:
         async with samples.condition:
             await samples.condition.wait()
         assert task.last_fire is not None
-        assert task.last_fire.outcome == "success"
         assert isinstance(task.last_fire, FireInfo)
+        assert task.last_fire.outcome is FireOutcome.SUCCESS
+        assert isinstance(task.last_fire.outcome, FireOutcome)
+        assert task.last_fire.outcome == "success"
         assert task.last_fire.duration >= 0
         cancel_group(tg)
 
@@ -453,6 +455,7 @@ async def test_cron_task_last_fire_error(mocker: MockFixture) -> None:
         await start_task(tg, task)
         await sleep(SLEEP * 3)
         assert task.last_fire is not None
+        assert task.last_fire.outcome is FireOutcome.ERROR
         assert task.last_fire.outcome == "error"
         cancel_group(tg)
 
@@ -465,9 +468,18 @@ async def test_cron_task_last_fire_skipped(mocker: MockFixture) -> None:
         await start_task(tg, task)
         await sleep(SLEEP * 3)
         assert task.last_fire is not None
+        assert task.last_fire.outcome is FireOutcome.SKIPPED
         assert task.last_fire.outcome == "skipped"
         assert task.last_fire.duration == 0.0
         cancel_group(tg)
+
+
+def test_fire_outcome_is_str_enum() -> None:
+    """FireOutcome members are str-compatible with their literal values."""
+    assert isinstance(FireOutcome.SUCCESS, str)
+    assert FireOutcome.SUCCESS == "success"
+    assert FireOutcome.ERROR == "error"
+    assert FireOutcome.SKIPPED == "skipped"
 
 
 # --- Synchronization and tick error handling ---

--- a/tests/task/test_interval.py
+++ b/tests/task/test_interval.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import pytest
 from pytest_mock import MockFixture
 
-from grelmicro.task._cron import FireInfo
+from grelmicro.task._cron import FireInfo, FireOutcome
 from grelmicro.task._interval import IntervalTask
 from tests.task import samples
 from tests.task._helpers import cancel_group, start_task
@@ -62,6 +62,21 @@ async def test_interval_task_start() -> None:
         await start_task(tg, task)
         async with samples.condition:
             await samples.condition.wait()
+        cancel_group(tg)
+
+
+async def test_interval_task_last_fire_outcome() -> None:
+    """last_fire.outcome is the FireOutcome.SUCCESS member after a run."""
+    task = IntervalTask(seconds=1, function=notify)
+    async with asyncio.TaskGroup() as tg:
+        await start_task(tg, task)
+        async with samples.condition:
+            await samples.condition.wait()
+        assert task.last_fire is not None
+        assert isinstance(task.last_fire, FireInfo)
+        assert task.last_fire.outcome is FireOutcome.SUCCESS
+        assert isinstance(task.last_fire.outcome, FireOutcome)
+        assert task.last_fire.outcome == "success"
         cancel_group(tg)
 
 


### PR DESCRIPTION
Closes #399.

Types `FireInfo.outcome` as a new closed `FireOutcome(StrEnum)` (`SUCCESS`/`ERROR`/`SKIPPED`), exported from `grelmicro.task`, replacing the bare string literals at every construction site (in both `_cron.py` and `_interval.py`).

- `StrEnum`, so `outcome == "success"` keeps working (non-breaking).
- The enum is the single source of truth: a repo-wide grep finds the three literals only in the member definitions.
- Matches the existing `HealthStatus` / `CircuitBreakerState` StrEnum style.
- Tests: success/error/skipped paths assert the member and string equality, plus an isinstance(str) check. Docs + changelog + API snapshot updated.

Inspiration: Python 3.11+ `enum.StrEnum`, already used for `HealthStatus` and `CircuitBreakerState`.