### PR TITLE
✨ Add Idempotency.run(key, factory) one-call helper

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@
 
 * ✨ Add a `key=` template to `@cached` for a stable, readable cache key rendered from the arguments, like `@cached(key="user:{user_id}")`. Pass `key_maker=` for the fully dynamic case. Passing both raises `TypeError`.
 * ✨ Type `FireInfo.outcome` as the new `FireOutcome` `StrEnum` (`SUCCESS`, `ERROR`, `SKIPPED`). String comparisons like `outcome == "success"` still work.
+* ✨ Add `Idempotency.run(key, factory)`, a one-call helper that runs an operation once and replays its response. It takes a sync or async factory and mirrors `TTLCache.get_or_set`.
 
 ## 1.0.0a2 - 2026-06-21
 

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -71,6 +71,16 @@ On a first execution, `replayed` is `False`. Call `op.store(response)` to persis
 
 Exiting the block without calling `op.store(...)` on a first execution stores nothing. The operation opted out and a later call with the same key executes fresh.
 
+## One-call form
+
+`idem.run(key, factory)` owns the block. It runs the factory once, stores the response, and replays it on a repeated key. The factory can be sync or async. It mirrors `TTLCache.get_or_set`.
+
+```python title="run.py"
+--8<-- "idempotency/run.py"
+```
+
+The first call for a key runs the factory and stores its return value. A later call with the same key replays the stored value without running the factory. A failing factory stores nothing, so a later retry runs fresh. Pass `fingerprint=` to guard against a key reused with a different payload.
+
 ## Decorator
 
 `@idempotent` derives the key from the call arguments and stores the return value. It mirrors `@cached`.

--- a/docs/snippets/idempotency/__init__.py
+++ b/docs/snippets/idempotency/__init__.py
@@ -1,0 +1,1 @@
+"""Idempotency Snippets."""

--- a/docs/snippets/idempotency/run.py
+++ b/docs/snippets/idempotency/run.py
@@ -1,0 +1,19 @@
+from grelmicro import Grelmicro
+from grelmicro.cache import Cache
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.idempotency import Idempotency
+
+micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+
+idem = Idempotency("charge", ttl=3600)
+
+
+async def do_charge(amount: int) -> dict:
+    return {"amount": amount}
+
+
+async def main() -> None:
+    async with micro:
+        # The factory runs only on a first call, then the response replays.
+        response = await idem.run("key-1", lambda: do_charge(100))
+        print(response)

--- a/grelmicro/idempotency/_decorator.py
+++ b/grelmicro/idempotency/_decorator.py
@@ -71,14 +71,11 @@ def idempotent(
                 if fingerprint is not None
                 else None
             )
-            async with idempotency(
-                call_key, fingerprint=call_fingerprint
-            ) as operation:
-                if operation.replayed:
-                    return operation.response
-                result = await func(*args, **kwargs)  # ty: ignore[invalid-await]
-                operation.store(result)
-                return result
+            return await idempotency.run(
+                call_key,
+                lambda: func(*args, **kwargs),
+                fingerprint=call_fingerprint,
+            )
 
         return wrapper  # ty: ignore[invalid-return-type]
 

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -23,6 +23,7 @@ from grelmicro.idempotency.errors import IdempotencyConflictError
 from grelmicro.metrics import _emit
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
     from types import TracebackType
 
     from grelmicro.cache.serializers import CacheSerializer
@@ -462,6 +463,52 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
             key,
             fingerprint if fingerprint is not None else self._fingerprint,
         )
+
+    async def run(
+        self,
+        key: Annotated[
+            str,
+            Doc("The idempotency key derived from the request."),
+        ],
+        factory: Annotated[
+            Callable[[], T] | Callable[[], Awaitable[T]],
+            Doc(
+                "Sync or async callable that produces the response on a"
+                " first execution. Awaited when it returns a coroutine."
+            ),
+        ],
+        *,
+        fingerprint: Annotated[
+            str | None,
+            Doc(
+                """
+                Payload fingerprint for this call.
+
+                Overrides the instance-level `fingerprint`. A replay with
+                a different fingerprint raises `IdempotencyConflictError`.
+                When None, the instance default applies.
+                """,
+            ),
+        ] = None,
+    ) -> T:
+        """Run an operation once for `key`, then replay its response.
+
+        On a first execution the `factory` runs, its result is stored,
+        and the result is returned. A later call with the same key within
+        `ttl` replays the stored response without running the `factory`
+        again. A failing `factory` stores nothing, so a later retry runs
+        fresh.
+        """
+        import asyncio  # noqa: PLC0415
+
+        async with self(key, fingerprint=fingerprint) as operation:
+            if operation.replayed:
+                return cast("T", operation.response)
+            response = factory()
+            if asyncio.iscoroutine(response):
+                response = await response
+            operation.store(cast("T", response))
+            return cast("T", response)
 
     def _scoped(self, key: str) -> str:
         """Return the namespace-scoped storage key."""

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -288,6 +288,91 @@ class TestFingerprint:
 
 
 # ---------------------------------------------------------------------------
+# run helper
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    """Test the one-call `run(key, factory)` helper."""
+
+    async def test_first_call_executes_and_returns(
+        self, cache: TTLCache
+    ) -> None:
+        """The first call runs the factory and returns its result."""
+        idem = Idempotency("charge", ttl=3600, cache=cache)
+        calls = 0
+
+        async def factory() -> dict:
+            nonlocal calls
+            calls += 1
+            return {"status": "ok"}
+
+        result = await idem.run("key-1", factory)
+
+        assert result == {"status": "ok"}
+        assert calls == 1
+
+    async def test_second_call_replays_without_executing(
+        self, cache: TTLCache
+    ) -> None:
+        """A repeated key replays the stored response without re-running."""
+        idem = Idempotency("charge", ttl=3600, cache=cache)
+        calls = 0
+
+        async def factory() -> dict:
+            nonlocal calls
+            calls += 1
+            return {"n": calls}
+
+        first = await idem.run("key-1", factory)
+        second = await idem.run("key-1", factory)
+
+        assert first == {"n": 1}
+        assert second == {"n": 1}
+        assert calls == 1
+
+    async def test_sync_factory(self, cache: TTLCache) -> None:
+        """A plain sync factory runs and its result is stored."""
+        idem = Idempotency("charge", ttl=3600, cache=cache)
+
+        result = await idem.run("key-1", lambda: {"status": "ok"})
+
+        assert result == {"status": "ok"}
+        replay = await idem.run("key-1", lambda: {"status": "other"})
+        assert replay == {"status": "ok"}
+
+    async def test_failing_factory_stores_nothing(
+        self, cache: TTLCache
+    ) -> None:
+        """A failing factory stores nothing and a retry runs fresh."""
+        idem = Idempotency("charge", ttl=3600, cache=cache)
+        calls = 0
+
+        async def factory() -> dict:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                msg = "boom"
+                raise RuntimeError(msg)
+            return {"ok": True}
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await idem.run("key-1", factory)
+
+        assert await idem.run("key-1", factory) == {"ok": True}
+        assert calls == EXPECTED_CALLS_2
+
+    async def test_fingerprint_conflict_raises(self, cache: TTLCache) -> None:
+        """A replay with a different fingerprint raises a conflict."""
+        idem = Idempotency("charge", ttl=3600, cache=cache)
+
+        await idem.run("key-1", lambda: {"status": "ok"}, fingerprint="abc")
+
+        with pytest.raises(IdempotencyConflictError):
+            await idem.run("key-1", lambda: {"status": "ok"}, fingerprint="xyz")
+
+
+# ---------------------------------------------------------------------------
 # Decorator
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #400.

Adds `Idempotency.run(key, factory, *, fingerprint=None)`, a one-call helper that owns the check / run / store dance, mirroring `TTLCache.get_or_set`:

```python
result = await idem.run(key, do_work)
```

- Reuses the existing async-CM internals (`async with self(key, ...) as operation`), no reimplemented replay/store logic.
- Matches `get_or_set`'s exact sync/async factory handling (`factory()` then await if coroutine).
- A failing factory stores nothing (the CM exit handles it), so a retry executes fresh. `fingerprint=` forwarded unchanged.
- `@idempotent` now delegates to `run()`, removing the duplicated dance (two stale `# ty: ignore` comments dropped).
- Tests: first-exec, replay-without-reexec, sync+async factory, failing-factory-retries-fresh, fingerprint conflict. Docs + snippet + changelog.

Inspiration: AWS Lambda Powertools idempotency, the cache layer's `get_or_set`.