### PR TITLE
✨ Root every component settings error in SettingsValidationError

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@
 * ✨ Add a `key=` template to `@cached` for a stable, readable cache key rendered from the arguments, like `@cached(key="user:{user_id}")`. Pass `key_maker=` for the fully dynamic case. Passing both raises `TypeError`.
 * ✨ Type `FireInfo.outcome` as the new `FireOutcome` `StrEnum` (`SUCCESS`, `ERROR`, `SKIPPED`). String comparisons like `outcome == "success"` still work.
 * ✨ Add `Idempotency.run(key, factory)`, a one-call helper that runs an operation once and replays its response. It takes a sync or async factory and mirrors `TTLCache.get_or_set`.
+* ✨ Every component now raises a typed `*SettingsValidationError` for invalid configuration, rooted in the shared `SettingsValidationError` base. Adds `TracingSettingsValidationError`, `HealthSettingsValidationError`, `LoggingSettingsValidationError`, and `IdempotencySettingsValidationError`. Catch `SettingsValidationError` to handle any of them.
 
 ## 1.0.0a2 - 2026-06-21
 

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
     import asyncio
     from collections.abc import Mapping
 
+    from grelmicro.errors import SettingsValidationError
+
 C = TypeVar("C", bound=BaseModel)
 ConfigT = TypeVar("ConfigT", bound=BaseModel)
 
@@ -119,6 +121,7 @@ def resolve_config[C: BaseModel](
     kwargs: Mapping[str, object | None],
     env_prefix: str,
     env_load: bool | None = None,
+    error_type: type[SettingsValidationError] | None = None,
 ) -> C:
     """Build a validated ``config_cls`` from an explicit instance or kwargs and env.
 
@@ -138,7 +141,10 @@ def resolve_config[C: BaseModel](
     The env path constructs a one-off ``BaseSettings`` subclass that
     inherits ``config_cls`` so its validators, ``frozen``, and
     ``extra`` flags are preserved. Only the ``env_prefix`` is added.
-    Validation failures surface as ``pydantic.ValidationError``.
+
+    Pass ``error_type`` to wrap a ``pydantic.ValidationError`` into a
+    component-specific ``SettingsValidationError``. Without it, the
+    raw ``pydantic.ValidationError`` propagates.
 
     See `docs/architecture/config.md` for the full contract,
     including the name-as-namespace convention used to derive
@@ -155,15 +161,20 @@ def resolve_config[C: BaseModel](
     if env_load is None:
         env_load = env_load_default()
 
-    if not env_load:
-        return config_cls.model_validate(provided)
+    try:
+        if not env_load:
+            return config_cls.model_validate(provided)
 
-    settings_cls = _build_settings_cls(config_cls, env_prefix)
-    # The dynamic subclass is built at runtime via `type(...)` below, so
-    # neither mypy nor ty can prove that `settings_cls` accepts the kwargs
-    # declared on `config_cls` or that it returns `C`. Pydantic's runtime
-    # validation enforces the contract.
-    return settings_cls(**provided)  # type: ignore[return-value, arg-type]  # ty: ignore[invalid-return-type, invalid-argument-type]
+        settings_cls = _build_settings_cls(config_cls, env_prefix)
+        # The dynamic subclass is built at runtime via `type(...)` below, so
+        # neither mypy nor ty can prove that `settings_cls` accepts the kwargs
+        # declared on `config_cls` or that it returns `C`. Pydantic's runtime
+        # validation enforces the contract.
+        return settings_cls(**provided)  # type: ignore[return-value, arg-type]  # ty: ignore[invalid-return-type, invalid-argument-type]
+    except ValidationError as error:
+        if error_type is None:
+            raise
+        raise error_type(error) from None
 
 
 @lru_cache(maxsize=256)
@@ -301,6 +312,7 @@ def resolve_config_from_mapping[C: BaseModel](
     env_prefix: str,
     mapping: Mapping[str, str],
     immutable_fields: frozenset[str] = frozenset(),
+    error_type: type[SettingsValidationError] | None = None,
 ) -> C:
     """Patch `current` with values from a flat env-style `mapping`.
 
@@ -317,8 +329,13 @@ def resolve_config_from_mapping[C: BaseModel](
     from the environment. Returns `current` unchanged when the mapping
     carries nothing for this prefix.
 
+    Pass `error_type` to wrap a `pydantic.ValidationError` into a
+    component-specific `SettingsValidationError`. Without it, the raw
+    `pydantic.ValidationError` propagates.
+
     Raises:
-        pydantic.ValidationError: If a present value fails validation.
+        pydantic.ValidationError: If a present value fails validation
+            and no `error_type` is given.
     """
     cls = type(current)
     fields = cls.model_fields
@@ -348,7 +365,12 @@ def resolve_config_from_mapping[C: BaseModel](
         )
     if not overrides:
         return current
-    return cls.model_validate({**current.model_dump(), **overrides})
+    try:
+        return cls.model_validate({**current.model_dump(), **overrides})
+    except ValidationError as error:
+        if error_type is None:
+            raise
+        raise error_type(error) from None
 
 
 def _redact_validation_error(exc: ValidationError) -> str:

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -35,6 +35,12 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from grelmicro.errors import SettingsValidationError
+else:
+    # Runtime fallback so `typing.get_type_hints(resolve_config)` resolves the
+    # `error_type` annotation without importing a name used only in
+    # annotations. The real type reaches static checkers via the
+    # `TYPE_CHECKING` branch above.
+    SettingsValidationError = Any
 
 C = TypeVar("C", bound=BaseModel)
 ConfigT = TypeVar("ConfigT", bound=BaseModel)

--- a/grelmicro/health/__init__.py
+++ b/grelmicro/health/__init__.py
@@ -7,7 +7,7 @@ from grelmicro.health._models import (
     HealthStatus,
 )
 from grelmicro.health._types import HealthCheckFunc, HealthDetails
-from grelmicro.health.errors import HealthError
+from grelmicro.health.errors import HealthError, HealthSettingsValidationError
 
 __all__ = [
     "CheckResult",
@@ -17,5 +17,6 @@ __all__ = [
     "HealthDetails",
     "HealthError",
     "HealthReport",
+    "HealthSettingsValidationError",
     "HealthStatus",
 ]

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -24,7 +24,10 @@ from grelmicro.health._types import (
     HealthCheckFunc,
     HealthDetails,
 )
-from grelmicro.health.errors import HealthError
+from grelmicro.health.errors import (
+    HealthError,
+    HealthSettingsValidationError,
+)
 from grelmicro.metrics import _emit
 
 if TYPE_CHECKING:
@@ -197,6 +200,7 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
             kwargs={"timeout": timeout, "cache_ttl": cache_ttl},
             env_prefix=env_prefix or "GREL_HEALTH_",
             env_load=env_load,
+            error_type=HealthSettingsValidationError,
         )
         self._setup(config, name=name, auto_health=auto_health)
 

--- a/grelmicro/health/errors.py
+++ b/grelmicro/health/errors.py
@@ -1,6 +1,8 @@
 """Health Errors."""
 
-from grelmicro.errors import GrelmicroError
+from pydantic import ValidationError
+
+from grelmicro.errors import GrelmicroError, SettingsValidationError
 from grelmicro.health._types import HealthDetails
 
 
@@ -21,3 +23,12 @@ class HealthError(GrelmicroError):
         """Initialize with a message and optional details dict."""
         super().__init__(message)
         self.details = details
+
+
+class HealthSettingsValidationError(HealthError, SettingsValidationError):
+    """Health Settings Validation Error."""
+
+    def __init__(self, error: ValidationError | str) -> None:
+        """Initialize from a Pydantic validation error."""
+        SettingsValidationError.__init__(self, error)
+        self.details = None

--- a/grelmicro/idempotency/__init__.py
+++ b/grelmicro/idempotency/__init__.py
@@ -17,6 +17,7 @@ from grelmicro.idempotency.config import IdempotencyConfig
 from grelmicro.idempotency.errors import (
     IdempotencyConflictError,
     IdempotencyError,
+    IdempotencySettingsValidationError,
 )
 
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     "IdempotencyConfig",
     "IdempotencyConflictError",
     "IdempotencyError",
+    "IdempotencySettingsValidationError",
     "Operation",
     "idempotent",
 ]

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -19,7 +19,10 @@ from grelmicro.cache._stampede import (
 from grelmicro.cache.ttl import _CACHE_PREFIX, TTLCache
 from grelmicro.coordination.lock import Lock
 from grelmicro.idempotency.config import IdempotencyConfig
-from grelmicro.idempotency.errors import IdempotencyConflictError
+from grelmicro.idempotency.errors import (
+    IdempotencyConflictError,
+    IdempotencySettingsValidationError,
+)
 from grelmicro.metrics import _emit
 
 if TYPE_CHECKING:
@@ -357,6 +360,7 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
             kwargs={"ttl": ttl},
             env_prefix=resolved_env_prefix,
             env_load=env_load,
+            error_type=IdempotencySettingsValidationError,
         )
         self._setup(name, config, fingerprint, cache, serializer)
         self._track_reconfigure(resolved_env_prefix)

--- a/grelmicro/idempotency/errors.py
+++ b/grelmicro/idempotency/errors.py
@@ -1,10 +1,16 @@
 """Idempotency Errors."""
 
-from grelmicro.errors import GrelmicroError
+from grelmicro.errors import GrelmicroError, SettingsValidationError
 
 
 class IdempotencyError(GrelmicroError):
     """Base idempotency error."""
+
+
+class IdempotencySettingsValidationError(
+    IdempotencyError, SettingsValidationError
+):
+    """Idempotency Settings Validation Error."""
 
 
 class IdempotencyConflictError(IdempotencyError):

--- a/grelmicro/log/__init__.py
+++ b/grelmicro/log/__init__.py
@@ -20,7 +20,7 @@ from grelmicro.log.config import (
     LoggingSerializerType,
     LoggingTimeZoneType,
 )
-from grelmicro.log.errors import LoggingError
+from grelmicro.log.errors import LoggingError, LoggingSettingsValidationError
 from grelmicro.log.types import ErrorDict, JSONRecordDict
 
 
@@ -107,6 +107,7 @@ def configure(
         },
         env_prefix="GREL_LOG_",
         env_load=env_load,
+        error_type=LoggingSettingsValidationError,
     )
     _apply(config)
     return config
@@ -143,6 +144,7 @@ __all__ = [
     "Log",
     "LoggingConfig",
     "LoggingError",
+    "LoggingSettingsValidationError",
     "RateLimitFilter",
     "RateLimitFilterConfig",
     "configure",

--- a/grelmicro/log/__init__.py
+++ b/grelmicro/log/__init__.py
@@ -91,7 +91,7 @@ def configure(
 
     Raises:
         DependencyNotFoundError: If the selected backend module is not installed.
-        pydantic.ValidationError: If configuration is invalid.
+        LoggingSettingsValidationError: If configuration is invalid.
     """
     config = resolve_config(
         LoggingConfig,

--- a/grelmicro/log/_component.py
+++ b/grelmicro/log/_component.py
@@ -18,6 +18,7 @@ from grelmicro.log.config import (
     LoggingSerializerType,
     LoggingTimeZoneType,
 )
+from grelmicro.log.errors import LoggingSettingsValidationError
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -158,6 +159,7 @@ class Log:
                 kwargs=self._kwargs,
                 env_prefix="GREL_LOG_",
                 env_load=self._env_load,
+                error_type=LoggingSettingsValidationError,
             )
             _apply(self._resolved)
         return self

--- a/grelmicro/log/_dedup.py
+++ b/grelmicro/log/_dedup.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, PositiveFloat, PositiveInt
 from typing_extensions import Doc
 
 from grelmicro._config import resolve_config
+from grelmicro.log.errors import LoggingSettingsValidationError
 
 KeyMode = Literal["rendered", "template"]
 
@@ -197,6 +198,7 @@ class DuplicateFilter(Filter):
             },
             env_prefix=env_prefix or "GREL_DUPLICATE_FILTER_",
             env_load=env_load,
+            error_type=LoggingSettingsValidationError,
         )
         Filter.__init__(self)
         self._setup(config, key)

--- a/grelmicro/log/_ratelimit.py
+++ b/grelmicro/log/_ratelimit.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, PositiveFloat, PositiveInt
 from typing_extensions import Doc
 
 from grelmicro._config import resolve_config
+from grelmicro.log.errors import LoggingSettingsValidationError
 from grelmicro.resilience import MemoryTokenBucket
 
 KeyMode = Literal["logger", "level", "global", "template", "rendered"]
@@ -221,6 +222,7 @@ class RateLimitFilter(Filter):
             },
             env_prefix=env_prefix or "GREL_RATE_LIMIT_FILTER_",
             env_load=env_load,
+            error_type=LoggingSettingsValidationError,
         )
         Filter.__init__(self)
         self._setup(config, key)

--- a/grelmicro/log/_shared.py
+++ b/grelmicro/log/_shared.py
@@ -16,6 +16,7 @@ from grelmicro.log.config import (
     LoggingFormatType,
     LoggingSerializerType,
 )
+from grelmicro.log.errors import LoggingSettingsValidationError
 
 try:
     from opentelemetry import trace
@@ -348,7 +349,7 @@ def load_settings(settings: LoggingConfig | None = None) -> LoadedSettings:
 
     Raises:
         DependencyNotFoundError: If orjson or OpenTelemetry is enabled but not installed.
-        pydantic.ValidationError: If environment variables are invalid.
+        LoggingSettingsValidationError: If environment variables are invalid.
     """
     if settings is None:
         settings = resolve_config(
@@ -356,6 +357,7 @@ def load_settings(settings: LoggingConfig | None = None) -> LoadedSettings:
             explicit=None,
             kwargs={},
             env_prefix="GREL_LOG_",
+            error_type=LoggingSettingsValidationError,
         )
 
     json_dumps: Callable[[Mapping[str, Any]], str]

--- a/grelmicro/log/errors.py
+++ b/grelmicro/log/errors.py
@@ -1,7 +1,11 @@
 """Logging Errors."""
 
-from grelmicro.errors import GrelmicroError
+from grelmicro.errors import GrelmicroError, SettingsValidationError
 
 
 class LoggingError(GrelmicroError):
     """Base logging error."""
+
+
+class LoggingSettingsValidationError(LoggingError, SettingsValidationError):
+    """Logging Settings Validation Error."""

--- a/grelmicro/metrics/_component.py
+++ b/grelmicro/metrics/_component.py
@@ -16,7 +16,10 @@ from grelmicro.metrics.config import (
     MetricsConfig,
     MetricsExporterType,
 )
-from grelmicro.metrics.errors import MetricsError
+from grelmicro.metrics.errors import (
+    MetricsError,
+    MetricsSettingsValidationError,
+)
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -286,6 +289,7 @@ class Metrics:
             kwargs=self._kwargs,
             env_prefix="GREL_METRICS_",
             env_load=self._env_load,
+            error_type=MetricsSettingsValidationError,
         )
         # `opentelemetry.metrics.set_meter_provider()` refuses to replace an
         # already-installed provider, so `Metrics` patches the private

--- a/grelmicro/metrics/errors.py
+++ b/grelmicro/metrics/errors.py
@@ -1,11 +1,11 @@
 """Metrics Errors."""
 
-from grelmicro.errors import GrelmicroError
+from grelmicro.errors import GrelmicroError, SettingsValidationError
 
 
 class MetricsError(GrelmicroError):
     """Base metrics error."""
 
 
-class MetricsSettingsValidationError(MetricsError, ValueError):
+class MetricsSettingsValidationError(MetricsError, SettingsValidationError):
     """Raised when the metrics configuration fails validation."""

--- a/grelmicro/trace/__init__.py
+++ b/grelmicro/trace/__init__.py
@@ -14,7 +14,7 @@ from grelmicro.trace.config import (
     TracingProcessorType,
     TracingSamplerType,
 )
-from grelmicro.trace.errors import TracingError
+from grelmicro.trace.errors import TracingError, TracingSettingsValidationError
 
 __all__ = [
     "Trace",
@@ -23,6 +23,7 @@ __all__ = [
     "TracingExporterType",
     "TracingProcessorType",
     "TracingSamplerType",
+    "TracingSettingsValidationError",
     "add_context",
     "get_context",
     "instrument",

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -17,7 +17,10 @@ from grelmicro.trace.config import (
     TracingProcessorType,
     TracingSamplerType,
 )
-from grelmicro.trace.errors import TracingError
+from grelmicro.trace.errors import (
+    TracingError,
+    TracingSettingsValidationError,
+)
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -181,6 +184,7 @@ class Trace:
             kwargs=self._kwargs,
             env_prefix="GREL_TRACE_",
             env_load=self._env_load,
+            error_type=TracingSettingsValidationError,
         )
         # `opentelemetry.trace.set_tracer_provider()` refuses to replace an
         # already-installed provider, so `Trace` patches the private

--- a/grelmicro/trace/errors.py
+++ b/grelmicro/trace/errors.py
@@ -1,7 +1,11 @@
 """Tracing Errors."""
 
-from grelmicro.errors import GrelmicroError
+from grelmicro.errors import GrelmicroError, SettingsValidationError
 
 
 class TracingError(GrelmicroError):
     """Base tracing error."""
+
+
+class TracingSettingsValidationError(TracingError, SettingsValidationError):
+    """Tracing Settings Validation Error."""

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -184,6 +184,9 @@
       "()": "(message, *, details=...)"
     },
     "HealthReport": null,
+    "HealthSettingsValidationError": {
+      "()": "(error)"
+    },
     "HealthStatus": {
       "()": "(*values)"
     }
@@ -200,6 +203,9 @@
       "()": "(*, name, key)"
     },
     "IdempotencyError": null,
+    "IdempotencySettingsValidationError": {
+      "()": "(error)"
+    },
     "Operation": {
       "()": "(*, replayed, response)"
     },
@@ -224,6 +230,9 @@
       "()": "(*, backend=..., level=..., format=..., timezone=..., json_serializer=..., caller_enabled=..., otel_enabled=...)"
     },
     "LoggingError": null,
+    "LoggingSettingsValidationError": {
+      "()": "(error)"
+    },
     "RateLimitFilter": {
       "()": "(*, capacity=..., refill_rate=..., key_mode=..., cost=..., key=..., env_prefix=..., env_load=...)",
       ".from_config": "(config, *, key=...)"
@@ -249,7 +258,9 @@
     "MetricsExporterType": {
       "()": "(*values)"
     },
-    "MetricsSettingsValidationError": null,
+    "MetricsSettingsValidationError": {
+      "()": "(error)"
+    },
     "measure": {
       "()": "(func=..., *, name=..., record_in_flight=...)"
     },
@@ -610,6 +621,9 @@
     },
     "TracingSamplerType": {
       "()": "(*values)"
+    },
+    "TracingSettingsValidationError": {
+      "()": "(error)"
     },
     "add_context": {
       "()": "(**fields)"

--- a/tests/health/test_checks.py
+++ b/tests/health/test_checks.py
@@ -5,13 +5,14 @@ import logging
 import time
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from grelmicro import (
     ComponentAlreadyRegisteredError,
     ComponentNotRegisteredError,
     Grelmicro,
 )
+from grelmicro.health import HealthSettingsValidationError
 from grelmicro.health._checks import HealthChecks
 from grelmicro.health._models import HealthStatus
 from grelmicro.health._types import HealthDetails
@@ -497,19 +498,19 @@ async def test_timeout_logs_warning(
 
 def test_timeout_zero_raises() -> None:
     """timeout=0 is rejected."""
-    with pytest.raises(ValidationError, match="greater than 0"):
+    with pytest.raises(HealthSettingsValidationError, match="greater than 0"):
         HealthChecks(timeout=0)
 
 
 def test_timeout_negative_raises() -> None:
     """Negative timeout is rejected."""
-    with pytest.raises(ValidationError, match="greater than 0"):
+    with pytest.raises(HealthSettingsValidationError, match="greater than 0"):
         HealthChecks(timeout=-1.0)
 
 
 def test_cache_ttl_negative_raises() -> None:
     """Negative cache_ttl is rejected."""
-    with pytest.raises(ValidationError):
+    with pytest.raises(HealthSettingsValidationError):
         HealthChecks(cache_ttl=-1.0)
 
 

--- a/tests/health/test_checks_config.py
+++ b/tests/health/test_checks_config.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from grelmicro.errors import SettingsValidationError
+from grelmicro.health import HealthSettingsValidationError
 from grelmicro.health._checks import HealthChecks, HealthChecksConfig
 
 TIMEOUT_KWARG = 2.5
@@ -84,3 +86,17 @@ def test_from_config_keeps_default_name() -> None:
     cfg = HealthChecksConfig()
     registry = HealthChecks.from_config(cfg)
     assert registry.name == "default"
+
+
+def test_invalid_config_raises_settings_error() -> None:
+    """Invalid kwargs raise a catchable `HealthSettingsValidationError`."""
+    with pytest.raises(HealthSettingsValidationError) as exc_info:
+        HealthChecks(timeout=-5)
+    assert isinstance(exc_info.value, SettingsValidationError)
+    assert "timeout" in str(exc_info.value)
+    assert "-5" not in str(exc_info.value)
+
+
+def test_settings_error_is_settings_validation_error() -> None:
+    """`HealthSettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(HealthSettingsValidationError, SettingsValidationError)

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -16,11 +16,12 @@ from grelmicro.cache.serializers import JsonSerializer
 from grelmicro.cache.ttl import TTLCache
 from grelmicro.coordination import Coordination
 from grelmicro.coordination.memory import MemoryLockAdapter
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import OutOfContextError, SettingsValidationError
 from grelmicro.idempotency import (
     Idempotency,
     IdempotencyConfig,
     IdempotencyConflictError,
+    IdempotencySettingsValidationError,
     idempotent,
 )
 
@@ -599,3 +600,17 @@ class TestCoverageGaps:
             await reconfigure_all({"GREL_IDEMPOTENCY_CHARGE_BAD_TTL": "42"})
 
         assert any("rejected" in record.message for record in caplog.records)
+
+
+def test_invalid_config_raises_settings_error() -> None:
+    """Invalid kwargs raise a catchable `IdempotencySettingsValidationError`."""
+    with pytest.raises(IdempotencySettingsValidationError) as exc_info:
+        Idempotency("charge", ttl=-1)
+    assert isinstance(exc_info.value, SettingsValidationError)
+
+
+def test_settings_error_is_settings_validation_error() -> None:
+    """`IdempotencySettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(
+        IdempotencySettingsValidationError, SettingsValidationError
+    )

--- a/tests/logging/test_backends.py
+++ b/tests/logging/test_backends.py
@@ -12,11 +12,10 @@ import pytest
 import pytest_mock
 import structlog
 from loguru import logger as loguru_logger
-from pydantic import ValidationError
 
 from grelmicro._json import json_default
 from grelmicro.errors import DependencyNotFoundError
-from grelmicro.log import configure
+from grelmicro.log import LoggingSettingsValidationError, configure
 from grelmicro.log._shared import (
     _logfmt_format_value,
     get_otel_trace_context,
@@ -219,7 +218,7 @@ class TestConfigureLoggingLevel:
 
         # Act / Assert
         with pytest.raises(
-            ValidationError,
+            LoggingSettingsValidationError,
             match=(
                 r"Input should be 'DEBUG', 'INFO', 'WARNING', "
                 r"'ERROR' or 'CRITICAL'"
@@ -485,7 +484,7 @@ class TestLoadSettings:
         monkeypatch.setenv("GREL_LOG_LEVEL", "INVALID")
 
         # Act / Assert
-        with pytest.raises(ValidationError):
+        with pytest.raises(LoggingSettingsValidationError):
             load_settings()
 
 

--- a/tests/logging/test_dedup.py
+++ b/tests/logging/test_dedup.py
@@ -6,9 +6,12 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from freezegun import freeze_time
-from pydantic import ValidationError
 
-from grelmicro.log import DuplicateFilter, configure
+from grelmicro.log import (
+    DuplicateFilter,
+    LoggingSettingsValidationError,
+    configure,
+)
 from grelmicro.log._dedup import _key_by_rendered
 from tests.logging.conftest import BACKENDS
 
@@ -330,8 +333,8 @@ def test_explicit_key_callable_overrides_mode() -> None:
 
 
 def test_invalid_key_mode_rejected() -> None:
-    """Unknown ``key_mode`` values raise a pydantic ValidationError."""
-    with pytest.raises(ValidationError, match="key_mode"):
+    """Unknown ``key_mode`` values raise a LoggingSettingsValidationError."""
+    with pytest.raises(LoggingSettingsValidationError, match="key_mode"):
         DuplicateFilter(key_mode="bogus")  # ty: ignore[invalid-argument-type]
 
 
@@ -411,8 +414,8 @@ def test_ttl_none_disables_time_expiry() -> None:
 
 @pytest.mark.parametrize("bad_ttl", [0, -0.5, -1])
 def test_non_positive_ttl_rejected(bad_ttl: float) -> None:
-    """Non-positive ``ttl_seconds`` values raise a pydantic ValidationError."""
-    with pytest.raises(ValidationError, match="greater than 0"):
+    """Non-positive ``ttl_seconds`` values raise a LoggingSettingsValidationError."""
+    with pytest.raises(LoggingSettingsValidationError, match="greater than 0"):
         DuplicateFilter(ttl_seconds=bad_ttl)
 
 
@@ -421,8 +424,8 @@ def test_non_positive_ttl_rejected(bad_ttl: float) -> None:
     [(0, 10), (-1, 10), (10, 0), (10, -5)],
 )
 def test_invalid_config_rejected(allowed: int, cache: int) -> None:
-    """Non-positive config values raise a pydantic ValidationError."""
-    with pytest.raises(ValidationError, match="greater than 0"):
+    """Non-positive config values raise a LoggingSettingsValidationError."""
+    with pytest.raises(LoggingSettingsValidationError, match="greater than 0"):
         DuplicateFilter(allowed_repetitions=allowed, cache_size=cache)
 
 

--- a/tests/logging/test_log_config.py
+++ b/tests/logging/test_log_config.py
@@ -1,10 +1,11 @@
 """Tests for the three-paths `log.configure` construction contract."""
 
 import pytest
-from pydantic import ValidationError
 
+from grelmicro.errors import SettingsValidationError
 from grelmicro.log import (
     LoggingConfig,
+    LoggingSettingsValidationError,
     configure,
     configure_with,
 )
@@ -54,14 +55,20 @@ def test_configure_env_load_false_ignores_env(
     assert cfg.level == LoggingLevelType.INFO  # default
 
 
-def test_configure_invalid_level_raises_validation_error(
+def test_configure_invalid_level_raises_settings_error(
     monkeypatch: pytest.MonkeyPatch,
     reset_backend: None,  # noqa: ARG001
 ) -> None:
-    """Invalid env values raise `pydantic.ValidationError`, not a custom wrapper."""
+    """Invalid env values raise a catchable `LoggingSettingsValidationError`."""
     monkeypatch.setenv("GREL_LOG_LEVEL", "BOGUS")
-    with pytest.raises(ValidationError):
+    with pytest.raises(LoggingSettingsValidationError) as exc_info:
         configure()
+    assert isinstance(exc_info.value, SettingsValidationError)
+
+
+def test_logging_settings_error_is_settings_validation_error() -> None:
+    """`LoggingSettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(LoggingSettingsValidationError, SettingsValidationError)
 
 
 def test_configure_with_returns_passed_config(

--- a/tests/logging/test_ratelimit.py
+++ b/tests/logging/test_ratelimit.py
@@ -6,7 +6,11 @@ from collections.abc import Generator
 import pytest
 from pydantic import ValidationError
 
-from grelmicro.log import RateLimitFilter, RateLimitFilterConfig
+from grelmicro.log import (
+    LoggingSettingsValidationError,
+    RateLimitFilter,
+    RateLimitFilterConfig,
+)
 
 pytestmark = [pytest.mark.timeout(2)]
 
@@ -75,9 +79,9 @@ def test_config_property_is_frozen() -> None:
     ],
 )
 def test_invalid_config(capacity: int, refill_rate: float, cost: float) -> None:
-    """Test non-positive values raise ValidationError."""
+    """Test non-positive values raise LoggingSettingsValidationError."""
     # Act & Assert
-    with pytest.raises(ValidationError, match="greater than"):
+    with pytest.raises(LoggingSettingsValidationError, match="greater than"):
         RateLimitFilter(capacity=capacity, refill_rate=refill_rate, cost=cost)
 
 

--- a/tests/metrics/test_component.py
+++ b/tests/metrics/test_component.py
@@ -7,6 +7,7 @@ from opentelemetry import metrics as otel_metrics
 from opentelemetry.sdk.metrics import MeterProvider
 
 from grelmicro import Component, ComponentAlreadyRegisteredError, Grelmicro
+from grelmicro.errors import SettingsValidationError
 from grelmicro.health import HealthChecks
 from grelmicro.metrics import (
     Metrics,
@@ -14,7 +15,10 @@ from grelmicro.metrics import (
     MetricsExporterType,
 )
 from grelmicro.metrics import _hub as hub
-from grelmicro.metrics.errors import MetricsError
+from grelmicro.metrics.errors import (
+    MetricsError,
+    MetricsSettingsValidationError,
+)
 
 
 def test_metrics_config_accepts_case_insensitive_enums() -> None:
@@ -250,3 +254,20 @@ def test_metrics_singleton_skips_other_kinds() -> None:
         ]
     )
     assert micro is not None
+
+
+async def test_metrics_invalid_env_config_raises_settings_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid env config raises a catchable `MetricsSettingsValidationError`."""
+    monkeypatch.setenv("GREL_METRICS_EXPORTER", "bogus")
+    micro = Grelmicro(uses=[Metrics(env_load=True)])
+    with pytest.raises(MetricsSettingsValidationError) as exc_info:
+        async with micro:
+            pass
+    assert isinstance(exc_info.value, SettingsValidationError)
+
+
+def test_metrics_settings_error_is_settings_validation_error() -> None:
+    """`MetricsSettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(MetricsSettingsValidationError, SettingsValidationError)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,14 @@ from grelmicro._config import (
     env_segment,
     parse_csv_or_json,
     resolve_config,
+    resolve_config_from_mapping,
 )
+from grelmicro.errors import SettingsValidationError
+
+
+class _SampleSettingsError(SettingsValidationError):
+    """Settings error used to test `error_type` wrapping."""
+
 
 DEFAULT_TIMEOUT = 5.0
 DEFAULT_RETRIES = 3
@@ -183,6 +190,44 @@ def test_invalid_env_value_raises_validation_error(
             kwargs={"name": "a"},
             env_prefix="X_",
             env_load=True,
+        )
+
+
+def test_error_type_wraps_validation_error() -> None:
+    """`error_type` wraps a `ValidationError` into the typed settings error."""
+    with pytest.raises(_SampleSettingsError) as exc_info:
+        resolve_config(
+            _Sample,
+            explicit=None,
+            kwargs={"name": "a", "timeout": -1.0},
+            env_prefix="X_",
+            env_load=False,
+            error_type=_SampleSettingsError,
+        )
+    assert isinstance(exc_info.value, SettingsValidationError)
+
+
+def test_from_mapping_error_type_wraps_validation_error() -> None:
+    """`resolve_config_from_mapping` wraps with `error_type` too."""
+    current = _Sample(name="a")
+    with pytest.raises(_SampleSettingsError) as exc_info:
+        resolve_config_from_mapping(
+            current,
+            env_prefix="X_",
+            mapping={"X_TIMEOUT": "-1.0"},
+            error_type=_SampleSettingsError,
+        )
+    assert isinstance(exc_info.value, SettingsValidationError)
+
+
+def test_from_mapping_without_error_type_raises_validation_error() -> None:
+    """Without `error_type`, the raw `ValidationError` propagates."""
+    current = _Sample(name="a")
+    with pytest.raises(ValidationError):
+        resolve_config_from_mapping(
+            current,
+            env_prefix="X_",
+            mapping={"X_TIMEOUT": "-1.0"},
         )
 
 

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -7,13 +7,17 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
 
 from grelmicro import Component, ComponentAlreadyRegisteredError, Grelmicro
+from grelmicro.errors import SettingsValidationError
 from grelmicro.trace import (
     Trace,
     TracingConfig,
     TracingExporterType,
     TracingSamplerType,
 )
-from grelmicro.trace.errors import TracingError
+from grelmicro.trace.errors import (
+    TracingError,
+    TracingSettingsValidationError,
+)
 
 
 def test_tracing_config_accepts_case_insensitive_enums() -> None:
@@ -224,3 +228,20 @@ async def test_trace_raises_when_private_otel_global_missing(
     with pytest.raises(TracingError, match="_TRACER_PROVIDER"):
         async with micro:
             pass
+
+
+async def test_trace_invalid_env_config_raises_settings_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid env config raises a catchable `TracingSettingsValidationError`."""
+    monkeypatch.setenv("GREL_TRACE_EXPORTER", "bogus")
+    micro = Grelmicro(uses=[Trace(env_load=True)])
+    with pytest.raises(TracingSettingsValidationError) as exc_info:
+        async with micro:
+            pass
+    assert isinstance(exc_info.value, SettingsValidationError)
+
+
+def test_trace_settings_error_is_settings_validation_error() -> None:
+    """`TracingSettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(TracingSettingsValidationError, SettingsValidationError)


### PR DESCRIPTION
Closes #401.

Makes `except SettingsValidationError` correct library-wide.

- Reroots `MetricsSettingsValidationError(MetricsError, ValueError)` to `(MetricsError, SettingsValidationError)` (non-breaking: the base already subclasses `ValueError`).
- Adds typed `*SettingsValidationError` to `trace`, `health`, `log`, `idempotency` (task has no config, skipped), each `(XxxError, SettingsValidationError)`, exported alphabetically.
- Wraps `pydantic.ValidationError` at the chokepoint: `resolve_config` / `resolve_config_from_mapping` gain an optional `error_type=`, passed by every in-scope component (5 log call sites included). Default `None` preserves the raw-`ValidationError` behavior, so existing cache/coordination/resilience tests are unchanged.
- `HealthSettingsValidationError` overrides `__init__(self, error)` so its public signature matches the siblings (`HealthError` otherwise shadowed it).
- The redaction property is preserved and now asserted: config values never appear in the error message (only field names).

Tests per component + a redaction assertion. API snapshot regenerated.