### PR TITLE
♻️ Declare CacheBackend protocol base on cache adapters

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 * ✨ Type `FireInfo.outcome` as the new `FireOutcome` `StrEnum` (`SUCCESS`, `ERROR`, `SKIPPED`). String comparisons like `outcome == "success"` still work.
 * ✨ Add `Idempotency.run(key, factory)`, a one-call helper that runs an operation once and replays its response. It takes a sync or async factory and mirrors `TTLCache.get_or_set`.
 * ✨ Every component now raises a typed `*SettingsValidationError` for invalid configuration, rooted in the shared `SettingsValidationError` base. Adds `TracingSettingsValidationError`, `HealthSettingsValidationError`, `LoggingSettingsValidationError`, and `IdempotencySettingsValidationError`. Catch `SettingsValidationError` to handle any of them.
+* ✨ Cache adapters (`MemoryCacheAdapter`, `RedisCacheAdapter`, `PostgresCacheAdapter`, `SQLiteCacheAdapter`) now declare the `CacheBackend` protocol explicitly, matching the lock, circuit breaker, and rate limiter adapters.
 
 ## 1.0.0a2 - 2026-06-21
 

--- a/grelmicro/cache/memory.py
+++ b/grelmicro/cache/memory.py
@@ -6,8 +6,10 @@ from time import monotonic
 from types import TracebackType
 from typing import Self
 
+from grelmicro.cache._protocol import CacheBackend
 
-class MemoryCacheAdapter:
+
+class MemoryCacheAdapter(CacheBackend):
     """In-memory cache backend.
 
     Stores entries in a Python dict with lazy TTL expiry.

--- a/grelmicro/cache/postgres.py
+++ b/grelmicro/cache/postgres.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Annotated, Self
 
 from typing_extensions import Doc
 
+from grelmicro.cache._protocol import CacheBackend
 from grelmicro.providers.postgres import PostgresProvider
 
 if TYPE_CHECKING:
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
 
-class PostgresCacheAdapter:
+class PostgresCacheAdapter(CacheBackend):
     """Postgres cache storage backend.
 
     Wraps a `PostgresProvider` and implements the cache protocol:

--- a/grelmicro/cache/redis.py
+++ b/grelmicro/cache/redis.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Self
 
 from typing_extensions import Doc
 
+from grelmicro.cache._protocol import CacheBackend
 from grelmicro.providers.redis import RedisProvider, require_cluster_hash_tag
 
 if TYPE_CHECKING:
@@ -72,7 +73,7 @@ return 1
 """
 
 
-class RedisCacheAdapter:
+class RedisCacheAdapter(CacheBackend):
     """Redis cache storage backend.
 
     Wraps a `RedisProvider` and implements the cache protocol:

--- a/grelmicro/cache/sqlite.py
+++ b/grelmicro/cache/sqlite.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Annotated, Self
 
 from typing_extensions import Doc
 
+from grelmicro.cache._protocol import CacheBackend
 from grelmicro.providers.sqlite import SQLiteProvider
 
 if TYPE_CHECKING:
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
 
-class SQLiteCacheAdapter:
+class SQLiteCacheAdapter(CacheBackend):
     """SQLite cache storage backend.
 
     Borrows the connection and a shared lock from a `SQLiteProvider`

--- a/tests/cache/test_cache_backends.py
+++ b/tests/cache/test_cache_backends.py
@@ -451,3 +451,17 @@ async def test_cached_end_to_end_with_memory() -> None:
         assert first == {"id": 1}
         assert second == {"id": 1}
         assert call_count == 1
+
+
+@pytest.mark.parametrize(
+    "adapter",
+    [
+        MemoryCacheAdapter,
+        RedisCacheAdapter,
+        PostgresCacheAdapter,
+        SQLiteCacheAdapter,
+    ],
+)
+def test_adapter_subclasses_cache_backend(adapter: type) -> None:
+    """Every cache adapter explicitly declares the CacheBackend protocol."""
+    assert issubclass(adapter, CacheBackend)

--- a/tests/cache/test_cache_backends.py
+++ b/tests/cache/test_cache_backends.py
@@ -463,5 +463,9 @@ async def test_cached_end_to_end_with_memory() -> None:
     ],
 )
 def test_adapter_subclasses_cache_backend(adapter: type) -> None:
-    """Every cache adapter explicitly declares the CacheBackend protocol."""
-    assert issubclass(adapter, CacheBackend)
+    """Every cache adapter explicitly declares the CacheBackend protocol.
+
+    Checks the MRO, not `issubclass`: a runtime-checkable Protocol matches
+    structurally, so `issubclass` would pass without explicit inheritance.
+    """
+    assert CacheBackend in adapter.__mro__


### PR DESCRIPTION
Closes #402.

The four cache adapters matched `CacheBackend` structurally only, while the lock, circuit breaker, and rate limiter adapters all declare their protocol base. Declares it explicitly:

```python
class MemoryCacheAdapter(CacheBackend): ...
class RedisCacheAdapter(CacheBackend): ...
class PostgresCacheAdapter(CacheBackend): ...
class SQLiteCacheAdapter(CacheBackend): ...
```

- `CacheBackend` is a `runtime_checkable` Protocol, so this is non-breaking. It tightens the declared contract: `ty` now verifies each adapter implements every protocol member (it does).
- Parametrized conformance test asserts `issubclass(adapter, CacheBackend)` for all four.

Inspiration: PEP 544 explicit conformance, and the project's own lock/circuit-breaker/rate-limiter adapters.