### PR TITLE
♻️ Declare BaseLockConfig frozen via class keywords

### DIFF
--- a/grelmicro/coordination/_base.py
+++ b/grelmicro/coordination/_base.py
@@ -5,7 +5,7 @@ from types import TracebackType
 from typing import Annotated, Protocol
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 from typing_extensions import Doc
 
 from grelmicro.coordination._handle import LockHandle
@@ -23,10 +23,8 @@ def jittered_interval(base: float, jitter: float) -> float:
     return base
 
 
-class BaseLockConfig(BaseModel):
+class BaseLockConfig(BaseModel, frozen=True, extra="forbid"):
     """Base Lock Config."""
-
-    model_config = ConfigDict(frozen=True, extra="forbid")
 
     worker: Annotated[
         str | UUID,

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -31,7 +31,7 @@ from grelmicro.task.abc import Task
 logger = getLogger("grelmicro.leader_election")
 
 
-class LeaderElectionConfig(BaseLockConfig, frozen=True, extra="forbid"):  # ty: ignore[invalid-frozen-dataclass-subclass]
+class LeaderElectionConfig(BaseLockConfig):  # ty: ignore[invalid-frozen-dataclass-subclass]
     """Leader Election Config.
 
     Leader election based on a leased reentrant distributed lock.

--- a/grelmicro/coordination/lock.py
+++ b/grelmicro/coordination/lock.py
@@ -58,7 +58,7 @@ def _validate_lock_name(name: str) -> None:
         raise ValueError(msg)
 
 
-class LockConfig(BaseLockConfig, frozen=True, extra="forbid"):  # ty: ignore[invalid-frozen-dataclass-subclass]
+class LockConfig(BaseLockConfig):  # ty: ignore[invalid-frozen-dataclass-subclass]
     """Lock Config."""
 
     lease_duration: Annotated[

--- a/grelmicro/coordination/tasklock.py
+++ b/grelmicro/coordination/tasklock.py
@@ -39,7 +39,7 @@ from grelmicro.errors import WouldBlockError
 logger = getLogger("grelmicro.coordination")
 
 
-class TaskLockConfig(BaseLockConfig, frozen=True, extra="forbid"):  # ty: ignore[invalid-frozen-dataclass-subclass]
+class TaskLockConfig(BaseLockConfig):  # ty: ignore[invalid-frozen-dataclass-subclass]
     """Task Lock Config."""
 
     min_lock_seconds: Annotated[


### PR DESCRIPTION
Closes #403.

`BaseLockConfig` declared frozen via `model_config = ConfigDict(...)` while its subclasses redeclared `frozen=True, extra="forbid"`. Move the base to the Pydantic v2 class-keyword form so subclasses inherit cleanly:

```python
class BaseLockConfig(BaseModel, frozen=True, extra="forbid"): ...
class LockConfig(BaseLockConfig): ...          # inherits frozen + extra
class TaskLockConfig(BaseLockConfig): ...
class LeaderElectionConfig(BaseLockConfig): ...
```

- Drops the now-unused `ConfigDict` import and the redundant per-subclass `frozen=True, extra="forbid"` redeclarations.
- Runtime behavior is identical: the subclasses remain frozen with `extra="forbid"` (verified by the existing config tests).
- The `# ty: ignore[invalid-frozen-dataclass-subclass]` on the subclasses is kept: `ty` models a Pydantic `frozen=True` model as a frozen dataclass and false-positives on subclassing it (the suppression was present before this change too).

Internal only, no public API or behavior change.