### PR TITLE
✨ Accept timedelta on the interval task decorator

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 
 ### Features
 
+* ✨ Accept a `timedelta` for the interval `seconds=`, like `@task.interval(seconds=timedelta(minutes=2))`. A plain number of seconds still works.
 * ✨ Add a `key=` template to `@cached` for a stable, readable cache key rendered from the arguments, like `@cached(key="user:{user_id}")`. Pass `key_maker=` for the fully dynamic case. Passing both raises `TypeError`.
 * ✨ Type `FireInfo.outcome` as the new `FireOutcome` `StrEnum` (`SUCCESS`, `ERROR`, `SKIPPED`). String comparisons like `outcome == "success"` still work.
 * ✨ Add `Idempotency.run(key, factory)`, a one-call helper that runs an operation once and replays its response. It takes a sync or async factory and mirrors `TTLCache.get_or_set`.

--- a/docs/task.md
+++ b/docs/task.md
@@ -91,7 +91,7 @@ Set `max_lock_seconds` to enable distributed locking: the task runs at most once
 
 | Parameter | Description |
 |-----------|-------------|
-| `seconds` | Duration in seconds between each scheduling attempt. Each worker retries every N seconds, but only one executes per interval. |
+| `seconds` | Duration between each scheduling attempt, as a number of seconds or a `timedelta`. Each worker retries every interval, but only one executes per interval. |
 | `max_lock_seconds` | Crash protection TTL. Must be >= `seconds`. If a worker crashes, the lock expires after this duration. |
 | `min_lock_seconds` | Minimum duration to hold the lock after task completion. Prevents re-execution on other nodes too soon. Defaults to `seconds`. |
 

--- a/grelmicro/task/_interval.py
+++ b/grelmicro/task/_interval.py
@@ -42,7 +42,7 @@ class IntervalTask(Task):
         *,
         function: Callable[..., Any],
         name: str | None = None,
-        seconds: float,
+        seconds: float | timedelta,
         max_lock_seconds: float | None = None,
         min_lock_seconds: float | None = None,
         leader: LeaderElection | None = None,
@@ -59,6 +59,11 @@ class IntervalTask(Task):
             ValueError: If min_lock_seconds is set without max_lock_seconds or leader.
             ValueError: If min_lock_seconds is greater than max_lock_seconds.
         """
+        seconds = (
+            seconds.total_seconds()
+            if isinstance(seconds, timedelta)
+            else seconds
+        )
         if seconds <= 0:
             msg = "seconds must be greater than 0"
             raise ValueError(msg)

--- a/grelmicro/task/router.py
+++ b/grelmicro/task/router.py
@@ -1,6 +1,7 @@
 """Task Router."""
 
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from typing import TYPE_CHECKING, Annotated, Any
 from uuid import UUID
 
@@ -61,10 +62,12 @@ class TaskRouter:
         self,
         *,
         seconds: Annotated[
-            float,
+            float | timedelta,
             Doc(
                 """
-                The duration in seconds between each task run.
+                The duration between each task run.
+
+                Accepts a number of seconds or a `timedelta`.
 
                 Accuracy is not guaranteed and may vary with system load. Consider the
                 execution time of the task when setting the interval.

--- a/tests/task/test_interval.py
+++ b/tests/task/test_interval.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from asyncio import sleep
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 from pytest_mock import MockFixture
@@ -44,6 +44,26 @@ def test_interval_task_init_with_name() -> None:
     task = IntervalTask(seconds=1, function=test1, name="test1")
     # Assert
     assert task.name == "test1"
+
+
+def test_interval_task_init_with_seconds_float() -> None:
+    """Test Interval Task accepts a number of seconds."""
+    # Arrange
+    seconds = 5
+    # Act
+    task = IntervalTask(seconds=seconds, function=test1)
+    # Assert
+    assert task._seconds == seconds
+
+
+def test_interval_task_init_with_seconds_timedelta() -> None:
+    """Test Interval Task accepts a timedelta and resolves it to seconds."""
+    # Arrange
+    interval = timedelta(minutes=2)
+    # Act
+    task = IntervalTask(seconds=interval, function=test1)
+    # Assert
+    assert task._seconds == interval.total_seconds()
 
 
 def test_interval_task_init_with_invalid_interval() -> None:

--- a/tests/task/test_router.py
+++ b/tests/task/test_router.py
@@ -1,6 +1,7 @@
 """Test Task Router."""
 
 import re
+from datetime import timedelta
 from functools import partial
 
 import pytest
@@ -82,6 +83,24 @@ def test_router_interval() -> None:
     assert router.tasks[1].name == "test1"
     assert router.tasks[2].name == "test2"
     assert router.tasks[3].name == "tests.task.samples:test3"
+
+
+def test_router_interval_with_timedelta() -> None:
+    """Test Task Router add interval task with a timedelta interval."""
+    # Arrange
+    router = TaskRouter()
+    interval = timedelta(minutes=2)
+    seconds = 5
+
+    # Act
+    router.interval(seconds=interval)(test1)
+    router.interval(seconds=seconds)(test2)
+
+    # Assert
+    assert isinstance(router.tasks[0], IntervalTask)
+    assert router.tasks[0]._seconds == interval.total_seconds()
+    assert isinstance(router.tasks[1], IntervalTask)
+    assert router.tasks[1]._seconds == seconds
 
 
 def test_router_interval_name_generation() -> None:


### PR DESCRIPTION
Closes #404.

Widens the interval decorator and `IntervalTask` to accept `seconds: float | timedelta`:

```python
@task.interval(seconds=timedelta(minutes=2))
@task.interval(seconds=5)   # still works
```

- Single conversion at the `IntervalTask.__init__` boundary (`seconds.total_seconds()`), before all validation, so the internal scheduling/lock logic stays float-based and unchanged. `TaskRouter.interval` (and the inherited `Tasks.interval`) just forward.
- Pure widening, fully backward compatible. Negative/zero timedelta is caught by the existing `seconds <= 0` guard.
- `Doc(...)` annotation and `docs/task.md` updated. Tests at both the `IntervalTask` and decorator levels.

API snapshot unchanged (it records param names, not types).

Inspiration: APScheduler / Celery beat duration objects.