### PR TITLE
🐛 Name the failing source in ExternalConfig reload warnings

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,10 @@
 * ✨ Every component now raises a typed `*SettingsValidationError` for invalid configuration, rooted in the shared `SettingsValidationError` base. Adds `TracingSettingsValidationError`, `HealthSettingsValidationError`, `LoggingSettingsValidationError`, and `IdempotencySettingsValidationError`. Catch `SettingsValidationError` to handle any of them.
 * ✨ Cache adapters (`MemoryCacheAdapter`, `RedisCacheAdapter`, `PostgresCacheAdapter`, `SQLiteCacheAdapter`) now declare the `CacheBackend` protocol explicitly, matching the lock, circuit breaker, and rate limiter adapters.
 
+### Fixed
+
+* 🐛 Name the failing source in the `ExternalConfig` reload warning, so a broken config or secrets mount is no longer a generic warning. Each source loads under its own guard, so a config failure no longer hides a working secrets source. Source values are never logged.
+
 ## 1.0.0a2 - 2026-06-21
 
 ### Features

--- a/grelmicro/config/_external.py
+++ b/grelmicro/config/_external.py
@@ -40,18 +40,6 @@ def _detect_scheme(text: str) -> str:
     return "file"
 
 
-def _source_name(role: str, src: ConfigBackend) -> str:
-    """Return a log-safe name for a source: its role and adapter short name.
-
-    The role is `config` or `secrets`. The adapter short name is the path
-    of a `FileConfigAdapter` or the backend class name otherwise. No secret
-    value is read, only the source identity.
-    """
-    if isinstance(src, FileConfigAdapter):
-        return f"{role} ({src._path})"  # noqa: SLF001
-    return f"{role} ({type(src).__name__})"
-
-
 def _coerce_source(value: ConfigBackend | str | PathLike[str]) -> ConfigBackend:
     """Build a `ConfigBackend` from a string, path, or pass one through.
 
@@ -242,7 +230,7 @@ class ExternalConfig:
 
         Each source loads under its own guard, so a failure is attributed to
         the failing source and the other source still applies. A source that
-        raises is logged by name and its last seen mapping is kept. Each
+        raises is logged by role and its last seen mapping is kept. Each
         source reports `None` when unchanged, so the last seen mapping is kept
         and reused. Secrets override config on a key collision.
         """
@@ -268,14 +256,15 @@ class ExternalConfig:
 
         Returns the new mapping when the source reports a change, the last
         seen mapping when it reports `None` or raises. A raising source is
-        logged by name, never with its values, so the poll loop continues.
+        logged by role, never with its values, so the poll loop continues.
         """
         try:
             data = await src.load()
         except Exception:  # noqa: BLE001
             logger.warning(
-                "External config source %s failed to load, keeping last good config",
-                _source_name(role, src),
+                "External config reload failed for the %s source, "
+                "keeping last good config",
+                role,
                 exc_info=True,
             )
             return last

--- a/grelmicro/config/_external.py
+++ b/grelmicro/config/_external.py
@@ -40,6 +40,18 @@ def _detect_scheme(text: str) -> str:
     return "file"
 
 
+def _source_name(role: str, src: ConfigBackend) -> str:
+    """Return a log-safe name for a source: its role and adapter short name.
+
+    The role is `config` or `secrets`. The adapter short name is the path
+    of a `FileConfigAdapter` or the backend class name otherwise. No secret
+    value is read, only the source identity.
+    """
+    if isinstance(src, FileConfigAdapter):
+        return f"{role} ({src._path})"  # noqa: SLF001
+    return f"{role} ({type(src).__name__})"
+
+
 def _coerce_source(value: ConfigBackend | str | PathLike[str]) -> ConfigBackend:
     """Build a `ConfigBackend` from a string, path, or pass one through.
 
@@ -214,14 +226,7 @@ class ExternalConfig:
         Values rejected by a component are logged and skipped by
         `reconfigure_all`, leaving the running config in place.
         """
-        try:
-            merged = await self._load_merged()
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "External config reload failed, keeping last good config",
-                exc_info=True,
-            )
-            return
+        merged = await self._load_merged()
         if merged is None:
             return
         await reconfigure_all(merged)
@@ -235,17 +240,43 @@ class ExternalConfig:
     async def _load_merged(self) -> Mapping[str, str] | None:
         """Return the merged mapping, or `None` when no source has data yet.
 
-        Each source reports `None` when unchanged, so the last seen mapping
-        is kept and reused. Secrets override config on a key collision.
+        Each source loads under its own guard, so a failure is attributed to
+        the failing source and the other source still applies. A source that
+        raises is logged by name and its last seen mapping is kept. Each
+        source reports `None` when unchanged, so the last seen mapping is kept
+        and reused. Secrets override config on a key collision.
         """
         if self._config_src is not None:
-            data = await self._config_src.load()
-            if data is not None:
-                self._config_data = data
+            self._config_data = await self._load_source(
+                "config", self._config_src, self._config_data
+            )
         if self._secrets_src is not None:
-            data = await self._secrets_src.load()
-            if data is not None:
-                self._secrets_data = data
+            self._secrets_data = await self._load_source(
+                "secrets", self._secrets_src, self._secrets_data
+            )
         if self._config_data is None and self._secrets_data is None:
             return None
         return {**(self._config_data or {}), **(self._secrets_data or {})}
+
+    async def _load_source(
+        self,
+        role: str,
+        src: ConfigBackend,
+        last: Mapping[str, str] | None,
+    ) -> Mapping[str, str] | None:
+        """Load one source, keeping its last good mapping on failure.
+
+        Returns the new mapping when the source reports a change, the last
+        seen mapping when it reports `None` or raises. A raising source is
+        logged by name, never with its values, so the poll loop continues.
+        """
+        try:
+            data = await src.load()
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "External config source %s failed to load, keeping last good config",
+                _source_name(role, src),
+                exc_info=True,
+            )
+            return last
+        return data if data is not None else last

--- a/tests/test_external_config.py
+++ b/tests/test_external_config.py
@@ -17,7 +17,6 @@ from grelmicro.config import ConfigBackend, ExternalConfig, FileConfigAdapter
 from grelmicro.config._external import (
     _coerce_source,
     _detect_scheme,
-    _source_name,
 )
 from grelmicro.coordination.lock import Lock
 from grelmicro.coordination.memory import MemoryLockAdapter
@@ -301,7 +300,7 @@ async def test_reload_failure_names_failing_config_source(
         assert rl.config.limit == 20  # noqa: PLR2004
         with caplog.at_level(logging.WARNING, logger="grelmicro"):
             await external.reload()  # must not raise
-        assert "source config" in caplog.text
+        assert "config source" in caplog.text
         assert "secrets" not in caplog.text
         assert "keeping last good config" in caplog.text
         # The bad config load did not change the running config.
@@ -327,7 +326,7 @@ async def test_reload_failure_names_failing_secrets_source(
         assert rl.config.limit == 20  # noqa: PLR2004
         with caplog.at_level(logging.WARNING, logger="grelmicro"):
             await external.reload()  # must not raise
-        assert "source secrets" in caplog.text
+        assert "secrets source" in caplog.text
         assert "keeping last good config" in caplog.text
         # The config source still applied despite the secrets failure.
         assert isinstance(rl.config, SlidingWindowConfig)
@@ -349,7 +348,7 @@ async def test_reload_failure_never_logs_source_values(
     async with external:
         with caplog.at_level(logging.WARNING, logger="grelmicro"):
             await external.reload()  # must not raise
-        assert "source config" in caplog.text
+        assert "config source" in caplog.text
         assert secret_value not in caplog.text
 
 
@@ -466,20 +465,6 @@ def test_config_backend_protocol_accepts_adapters(tmp_path: Path) -> None:
 def test_detect_scheme(text: str, expected: str) -> None:
     """Scheme detection routes URLs and falls back to the filesystem."""
     assert _detect_scheme(text) == expected
-
-
-def test_source_name_includes_role_and_file_path(tmp_path: Path) -> None:
-    """A file source is named by its role and mount path."""
-    name = _source_name("secrets", FileConfigAdapter(tmp_path / "mount"))
-    assert name.startswith("secrets (")
-    assert str(tmp_path / "mount") in name
-
-
-def test_source_name_falls_back_to_backend_class() -> None:
-    """A non-file backend is named by its role and class name."""
-    assert (
-        _source_name("config", _RaisingBackend()) == "config (_RaisingBackend)"
-    )
 
 
 def test_coerce_source_path_builds_file_adapter(tmp_path: Path) -> None:

--- a/tests/test_external_config.py
+++ b/tests/test_external_config.py
@@ -14,7 +14,11 @@ from grelmicro._config import (
     resolve_config_from_mapping,
 )
 from grelmicro.config import ConfigBackend, ExternalConfig, FileConfigAdapter
-from grelmicro.config._external import _coerce_source, _detect_scheme
+from grelmicro.config._external import (
+    _coerce_source,
+    _detect_scheme,
+    _source_name,
+)
 from grelmicro.coordination.lock import Lock
 from grelmicro.coordination.memory import MemoryLockAdapter
 from grelmicro.errors import AdapterNotRegisteredError
@@ -279,6 +283,76 @@ async def test_reload_raising_backend_does_not_raise() -> None:
         await external.reload()  # must not raise
 
 
+async def test_reload_failure_names_failing_config_source(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A config-source failure names the config source and keeps last good."""
+    rl = RateLimiter.sliding_window("namedcfg", limit=10, window=1.0)
+    config = _ScriptedBackend(
+        [
+            {"GREL_RATELIMITER_NAMEDCFG_LIMIT": "20"},
+            OSError("config mount unreadable"),
+        ]
+    )
+    secrets = _ScriptedBackend([{}, {}])
+    external = ExternalConfig(config=config, secrets=secrets, interval=999.0)
+    async with external:
+        assert isinstance(rl.config, SlidingWindowConfig)
+        assert rl.config.limit == 20  # noqa: PLR2004
+        with caplog.at_level(logging.WARNING, logger="grelmicro"):
+            await external.reload()  # must not raise
+        assert "source config" in caplog.text
+        assert "secrets" not in caplog.text
+        assert "keeping last good config" in caplog.text
+        # The bad config load did not change the running config.
+        assert isinstance(rl.config, SlidingWindowConfig)
+        assert rl.config.limit == 20  # noqa: PLR2004
+
+
+async def test_reload_failure_names_failing_secrets_source(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A secrets-source failure names the secrets source, config still applies."""
+    rl = RateLimiter.sliding_window("namedsec", limit=10, window=1.0)
+    config = _ScriptedBackend(
+        [
+            {"GREL_RATELIMITER_NAMEDSEC_LIMIT": "20"},
+            {"GREL_RATELIMITER_NAMEDSEC_LIMIT": "30"},
+        ]
+    )
+    secrets = _ScriptedBackend([{}, OSError("secret mount unreadable")])
+    external = ExternalConfig(config=config, secrets=secrets, interval=999.0)
+    async with external:
+        assert isinstance(rl.config, SlidingWindowConfig)
+        assert rl.config.limit == 20  # noqa: PLR2004
+        with caplog.at_level(logging.WARNING, logger="grelmicro"):
+            await external.reload()  # must not raise
+        assert "source secrets" in caplog.text
+        assert "keeping last good config" in caplog.text
+        # The config source still applied despite the secrets failure.
+        assert isinstance(rl.config, SlidingWindowConfig)
+        assert rl.config.limit == 30  # noqa: PLR2004
+
+
+async def test_reload_failure_never_logs_source_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failing source is named, never echoing the values it last carried."""
+    secret_value = "s3cr3t-should-not-appear"
+    config = _ScriptedBackend(
+        [
+            {"GREL_RATELIMITER_REDACTED_LIMIT": secret_value},
+            OSError("config mount unreadable"),
+        ]
+    )
+    external = ExternalConfig(config=config, interval=999.0)
+    async with external:
+        with caplog.at_level(logging.WARNING, logger="grelmicro"):
+            await external.reload()  # must not raise
+        assert "source config" in caplog.text
+        assert secret_value not in caplog.text
+
+
 class _TrackingBackend:
     """A ConfigBackend that records how often it is entered and exited."""
 
@@ -392,6 +466,20 @@ def test_config_backend_protocol_accepts_adapters(tmp_path: Path) -> None:
 def test_detect_scheme(text: str, expected: str) -> None:
     """Scheme detection routes URLs and falls back to the filesystem."""
     assert _detect_scheme(text) == expected
+
+
+def test_source_name_includes_role_and_file_path(tmp_path: Path) -> None:
+    """A file source is named by its role and mount path."""
+    name = _source_name("secrets", FileConfigAdapter(tmp_path / "mount"))
+    assert name.startswith("secrets (")
+    assert str(tmp_path / "mount") in name
+
+
+def test_source_name_falls_back_to_backend_class() -> None:
+    """A non-file backend is named by its role and class name."""
+    assert (
+        _source_name("config", _RaisingBackend()) == "config (_RaisingBackend)"
+    )
 
 
 def test_coerce_source_path_builds_file_adapter(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #405.

A failed `ExternalConfig` reload logged a generic warning and kept the last good config, so an operator could not tell which source broke. Now config and secrets load under separate guards and the warning names the failing source:

```
External config source config (/etc/grelmicro/config) failed to load, keeping last good config
```

- Per-source isolation: a broken config mount no longer hides a working secrets mount (and vice versa). Each keeps its own last-good mapping.
- `reload()` still never raises and never crashes the poll loop. Success path and public API unchanged.
- Redaction preserved: only the role and adapter identity (mount path or class name) are logged, never keys or values, including under `exc_info`. A dedicated test asserts no source value reaches the log.

Observability only.