### PR TITLE
🏷️ Type Metrics.gauge return and document RealClock name

### DIFF
--- a/grelmicro/clock/_real.py
+++ b/grelmicro/clock/_real.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING, Any, ClassVar, Self
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
+
+from typing_extensions import Doc
 
 from grelmicro.clock._seam import _active_clock
 
@@ -22,7 +24,14 @@ class RealClock:
 
     kind: ClassVar[str] = "clock"
 
-    def __init__(self, *, name: str = "default") -> None:
+    def __init__(
+        self,
+        *,
+        name: Annotated[
+            str,
+            Doc("Registration name when used as a component."),
+        ] = "default",
+    ) -> None:
         """Initialize the clock."""
         self._name = name
         self._token: Any = None

--- a/grelmicro/metrics/_component.py
+++ b/grelmicro/metrics/_component.py
@@ -30,6 +30,9 @@ if TYPE_CHECKING:
         Meter,
         UpDownCounter,
     )
+    from opentelemetry.metrics import (
+        _Gauge as Gauge,
+    )
 
 
 _logger = logging.getLogger(__name__)
@@ -266,7 +269,7 @@ class Metrics:
         *,
         unit: Annotated[str, Doc("Unit of measure, e.g. `1`.")] = "",
         description: Annotated[str, Doc("Human-readable description.")] = "",
-    ) -> Any:  # noqa: ANN401
+    ) -> Gauge:
         """Create (or reuse) a synchronous `Gauge` recording last-set values.
 
         Raises:


### PR DESCRIPTION
Closes #406. Typing and documentation polish, no behavior change.

- `Metrics.gauge(...)` now returns a concrete `Gauge` (aliased from `opentelemetry.metrics._Gauge`, the sync gauge type `create_gauge` returns) instead of `Any` with a `# noqa: ANN401`. Callers get type info.
- `RealClock`'s `name` parameter gains an `Annotated[str, Doc(...)]` annotation, matching `VirtualClock`.

API snapshot unchanged.