### PR TITLE
✨ Add from_config to Log, Trace, and Metrics

### DIFF
--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -13,7 +13,7 @@ Components fall in two categories.
 | `__init__(name, **kwargs)` | Positional name + optional fields | Programmatic and environmental construction |
 | `from_config(name, config)` | Positional name + frozen config | Declarative construction from a settings tree |
 
-**Single-instance components** (`HealthChecks`, `RateLimitFilter`, `DuplicateFilter`, `log.configure`) drop the positional name because the application typically holds one:
+**Single-instance components** (`HealthChecks`, `Log`, `Trace`, `Metrics`, `RateLimitFilter`, `DuplicateFilter`, `log.configure`) drop the positional name because the application typically holds one:
 
 | Surface | Form | Intent |
 |---|---|---|

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@
 * ✨ Add `Idempotency.run(key, factory)`, a one-call helper that runs an operation once and replays its response. It takes a sync or async factory and mirrors `TTLCache.get_or_set`.
 * ✨ Every component now raises a typed `*SettingsValidationError` for invalid configuration, rooted in the shared `SettingsValidationError` base. Adds `TracingSettingsValidationError`, `HealthSettingsValidationError`, `LoggingSettingsValidationError`, and `IdempotencySettingsValidationError`. Catch `SettingsValidationError` to handle any of them.
 * ✨ Cache adapters (`MemoryCacheAdapter`, `RedisCacheAdapter`, `PostgresCacheAdapter`, `SQLiteCacheAdapter`) now declare the `CacheBackend` protocol explicitly, matching the lock, circuit breaker, and rate limiter adapters.
+* ✨ Add `Log.from_config`, `Trace.from_config`, and `Metrics.from_config` to build each component from a pre-built config, matching the declarative path on every other pattern. The `config=` kwarg still works.
 
 ### Fixed
 

--- a/grelmicro/log/_component.py
+++ b/grelmicro/log/_component.py
@@ -130,6 +130,31 @@ class Log:
         self._snapshot_handlers: list[logging.Handler] | None = None
         self._snapshot_level: int | None = None
 
+    @classmethod
+    def from_config(
+        cls,
+        config: Annotated[
+            LoggingConfig,
+            Doc(
+                """
+                The pre-built logging configuration.
+
+                Use this path when the configuration is assembled at
+                startup from a settings tree (for example YAML, Vault,
+                or a `pydantic-settings` aggregator). The environment
+                path is bypassed and the config is used as-is.
+                """,
+            ),
+        ],
+        *,
+        name: Annotated[
+            str,
+            Doc("Registration name. Defaults to `'default'`."),
+        ] = "default",
+    ) -> Self:
+        """Construct a `Log` from a pre-built `LoggingConfig`."""
+        return cls(name=name, config=config)
+
     @property
     def name(self) -> str:
         """Return the registration name."""

--- a/grelmicro/metrics/_component.py
+++ b/grelmicro/metrics/_component.py
@@ -153,6 +153,31 @@ class Metrics:
         self._prometheus_registry: Any = None
         self._meters: dict[str, Meter] = {}
 
+    @classmethod
+    def from_config(
+        cls,
+        config: Annotated[
+            MetricsConfig,
+            Doc(
+                """
+                The pre-built metrics configuration.
+
+                Use this path when the configuration is assembled at
+                startup from a settings tree (for example YAML, Vault,
+                or a `pydantic-settings` aggregator). The environment
+                path is bypassed and the config is used as-is.
+                """,
+            ),
+        ],
+        *,
+        name: Annotated[
+            str,
+            Doc("Registration name. Defaults to `'default'`."),
+        ] = "default",
+    ) -> Self:
+        """Construct a `Metrics` from a pre-built `MetricsConfig`."""
+        return cls(name=name, config=config)
+
     @property
     def name(self) -> str:
         """Return the registration name."""

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -142,6 +142,31 @@ class Trace:
         self._provider: Any = None
         self._prior_provider: Any = None
 
+    @classmethod
+    def from_config(
+        cls,
+        config: Annotated[
+            TracingConfig,
+            Doc(
+                """
+                The pre-built tracing configuration.
+
+                Use this path when the configuration is assembled at
+                startup from a settings tree (for example YAML, Vault,
+                or a `pydantic-settings` aggregator). The environment
+                path is bypassed and the config is used as-is.
+                """,
+            ),
+        ],
+        *,
+        name: Annotated[
+            str,
+            Doc("Registration name. Defaults to `'default'`."),
+        ] = "default",
+    ) -> Self:
+        """Construct a `Trace` from a pre-built `TracingConfig`."""
+        return cls(name=name, config=config)
+
     @property
     def name(self) -> str:
         """Return the registration name."""

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -224,7 +224,8 @@
     "ErrorDict": null,
     "JSONRecordDict": null,
     "Log": {
-      "()": "(*, name=..., config=..., backend=..., level=..., format=..., timezone=..., json_serializer=..., caller_enabled=..., otel_enabled=..., env_load=...)"
+      "()": "(*, name=..., config=..., backend=..., level=..., format=..., timezone=..., json_serializer=..., caller_enabled=..., otel_enabled=..., env_load=...)",
+      ".from_config": "(config, *, name=...)"
     },
     "LoggingConfig": {
       "()": "(*, backend=..., level=..., format=..., timezone=..., json_serializer=..., caller_enabled=..., otel_enabled=...)"
@@ -249,7 +250,8 @@
   },
   "grelmicro.metrics": {
     "Metrics": {
-      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., export_interval=..., export_timeout=..., resource_attributes=..., shutdown_timeout=..., env_load=...)"
+      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., export_interval=..., export_timeout=..., resource_attributes=..., shutdown_timeout=..., env_load=...)",
+      ".from_config": "(config, *, name=...)"
     },
     "MetricsConfig": {
       "()": "(*, service_name=..., exporter=..., endpoint=..., headers=..., export_interval=..., export_timeout=..., resource_attributes=..., shutdown_timeout=...)"
@@ -607,7 +609,8 @@
   },
   "grelmicro.trace": {
     "Trace": {
-      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., shutdown_timeout=..., env_load=...)"
+      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., shutdown_timeout=..., env_load=...)",
+      ".from_config": "(config, *, name=...)"
     },
     "TracingConfig": {
       "()": "(*, service_name=..., exporter=..., endpoint=..., headers=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., shutdown_timeout=...)"

--- a/tests/logging/test_component.py
+++ b/tests/logging/test_component.py
@@ -61,6 +61,21 @@ async def test_log_accepts_prebuilt_config(reset_stdlib: None) -> None:  # noqa:
         assert micro.log.config is config
 
 
+def test_log_from_config_matches_config_kwarg() -> None:
+    """`Log.from_config(cfg)` matches `Log(config=cfg)`."""
+    config = LoggingConfig(level=LoggingLevelType.WARNING)
+    log = Log.from_config(config)
+    assert log._explicit_config is config
+    assert log.name == "default"
+
+
+def test_log_from_config_keeps_name() -> None:
+    """`Log.from_config(..., name=...)` keeps the registration name."""
+    config = LoggingConfig()
+    log = Log.from_config(config, name="audit")
+    assert log.name == "audit"
+
+
 async def test_log_restores_root_handlers_on_exit(
     reset_stdlib: None,  # noqa: ARG001
 ) -> None:

--- a/tests/metrics/test_component.py
+++ b/tests/metrics/test_component.py
@@ -126,6 +126,23 @@ async def test_metrics_accepts_prebuilt_config() -> None:
         assert micro.metrics.config is config
 
 
+def test_metrics_from_config_matches_config_kwarg() -> None:
+    """`Metrics.from_config(cfg)` matches `Metrics(config=cfg)`."""
+    config = MetricsConfig(
+        exporter=MetricsExporterType.NONE, service_name="payments"
+    )
+    metrics = Metrics.from_config(config)
+    assert metrics._explicit_config is config
+    assert metrics.name == "default"
+
+
+def test_metrics_from_config_keeps_name() -> None:
+    """`Metrics.from_config(..., name=...)` keeps the registration name."""
+    config = MetricsConfig(exporter=MetricsExporterType.NONE)
+    metrics = Metrics.from_config(config, name="audit")
+    assert metrics.name == "audit"
+
+
 async def test_metrics_console_exporter() -> None:
     """`exporter=console` builds a periodic console reader pipeline."""
     micro = Grelmicro(uses=[Metrics(exporter=MetricsExporterType.CONSOLE)])

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -106,6 +106,23 @@ async def test_trace_accepts_prebuilt_config() -> None:
         assert micro.trace.config is config
 
 
+def test_trace_from_config_matches_config_kwarg() -> None:
+    """`Trace.from_config(cfg)` matches `Trace(config=cfg)`."""
+    config = TracingConfig(
+        exporter=TracingExporterType.NONE, service_name="payments"
+    )
+    trace = Trace.from_config(config)
+    assert trace._explicit_config is config
+    assert trace.name == "default"
+
+
+def test_trace_from_config_keeps_name() -> None:
+    """`Trace.from_config(..., name=...)` keeps the registration name."""
+    config = TracingConfig(exporter=TracingExporterType.NONE)
+    trace = Trace.from_config(config, name="audit")
+    assert trace.name == "audit"
+
+
 def test_trace_provider_unavailable_before_enter() -> None:
     """`Trace.provider` raises before the component has been entered."""
     trace = Trace(exporter=TracingExporterType.NONE)


### PR DESCRIPTION
Closes #415.

`Log`, `Trace`, and `Metrics` took only a `config=` kwarg, a fourth construction shape vs the `from_config()` classmethod used across the rest of the toolkit. Adds it, matching the single-instance `HealthChecks.from_config(config, *, name="default") -> Self` convention:

```python
Log.from_config(cfg)
Trace.from_config(cfg)
Metrics.from_config(cfg)
```

- Thin delegators to the constructor (`cls(name=name, config=config)`), inheriting its validation. The `config=` kwarg is kept.
- Tests assert `from_config(cfg)` matches `X(config=cfg)` for default and explicit names. API snapshot gains the three `.from_config` lines (matching `HealthChecks`). Architecture doc single-instance list updated.

Inspiration: alternate-constructor idiom (datetime.fromtimestamp, Pydantic model_validate) and the toolkit's own `from_config`.