### PR TITLE
✅ Pin the retry exponential full-jitter default with a test

### DIFF
--- a/tests/resilience/test_retry.py
+++ b/tests/resilience/test_retry.py
@@ -61,9 +61,10 @@ def test_config_requires_when() -> None:
 def test_config_default_attempts_and_backoff() -> None:
     """Defaults: 3 attempts, exponential backoff with full jitter.
 
-    Pins the safe default: a bare `retry`/`retrying` (which delegate to
-    `RetryConfig`) backs off exponentially with full jitter, never fixed
-    or no backoff.
+    Pins `RetryConfig`'s default backoff. The bare `retry`/`retrying`
+    forms inject the same `ExponentialBackoff()` default (via `_decorator`),
+    so this guards the safe default for both: exponential with full jitter,
+    never fixed or no backoff.
     """
     config = RetryConfig(when=(ValueError,))  # ty: ignore[missing-argument,invalid-argument-type]
     assert config.attempts == _DEFAULT_ATTEMPTS

--- a/tests/resilience/test_retry.py
+++ b/tests/resilience/test_retry.py
@@ -59,10 +59,16 @@ def test_config_requires_when() -> None:
 
 
 def test_config_default_attempts_and_backoff() -> None:
-    """Defaults: 3 attempts, exponential backoff."""
+    """Defaults: 3 attempts, exponential backoff with full jitter.
+
+    Pins the safe default: a bare `retry`/`retrying` (which delegate to
+    `RetryConfig`) backs off exponentially with full jitter, never fixed
+    or no backoff.
+    """
     config = RetryConfig(when=(ValueError,))  # ty: ignore[missing-argument,invalid-argument-type]
     assert config.attempts == _DEFAULT_ATTEMPTS
     assert isinstance(config.backoff, ExponentialBackoff)
+    assert config.backoff.jitter == "full"
 
 
 def test_config_frozen() -> None:


### PR DESCRIPTION
Closes #424.

Locks the safe retry default with a regression test rather than reshaping the API. `RetryConfig` defaults (which bare `retry`/`retrying` delegate to) back off exponentially with `jitter="full"`, never fixed or no backoff. The test now asserts `config.backoff.jitter == "full"` in addition to the type and attempt count.

No API change. The default is already documented in `docs/resilience/retry.md` ("The default is exponential with full jitter... The safe default").

Inspiration: tenacity's bare `@retry` does no backoff (an unsafe default everyone overrides); grelmicro's safe default is now guarded against regression.