### PR TITLE
📝 Docs: interval timing, directory-per-key, provider sharing, AdmissionError family

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -196,6 +196,8 @@ Components share a connection pool through a `Provider`: pass the same `RedisPro
 
 The default behavior is **share when possible, isolate when asked**. Distinct Providers opt into per-domain isolation.
 
+A Provider is shared by identity: every Component that uses the same Provider attaches to the same connection pool. To break that sharing, build a distinct Provider with its own `env_prefix=`, pass a separate Provider instance, or wrap an externally owned client with `from_client`. There is no `shared=False` flag.
+
 ## Error handling
 
 Accessing a Component that has not been registered raises `ComponentNotRegisteredError` with a descriptive message. Resolving a Pattern outside any `async with micro:` block raises `NoActiveAppError`.

--- a/docs/configuration/reconfigure-from-configmap.md
+++ b/docs/configuration/reconfigure-from-configmap.md
@@ -77,7 +77,9 @@ async def test_lease_reload(tmp_path):
 
 ## File formats
 
-A single file source is read by its extension. A directory mount stays one file per key.
+A mounted `ConfigMap` or `Secret` is a directory, one file per key. The file name is the `GREL_...` key and the file content is its value. This is the default mounted shape, so point `ExternalConfig` at the mount directory.
+
+A single file source is read by its extension instead:
 
 - `.json`, `.yaml`, `.yml`, and `.toml` files hold a mapping document.
 - Any other file is read as `.env` lines (`KEY=VALUE`, blanks and `#` comments ignored).

--- a/docs/resilience/index.md
+++ b/docs/resilience/index.md
@@ -26,6 +26,27 @@ See [Composing patterns](composition.md) for the recommended outside-in order wh
 
 For synchronous, in-process token-bucket rate limiting on a performance-critical sync path (the main example is the logging pipeline), see [`MemoryTokenBucket`](rate-limiter.md#standalone-memorytokenbucket). It powers `grelmicro.log.RateLimitFilter`.
 
+## The AdmissionError family
+
+The gatekeeping primitives refuse a call when they turn it away. Each refusal subclasses `AdmissionError`, so one `except` catches them all:
+
+| Error | Raised by |
+|---|---|
+| `WouldBlockError` | a non-blocking `Lock` acquire that would have blocked |
+| `BulkheadFullError` | a `Bulkhead` with no free permit |
+| `RateLimitExceededError` | a `RateLimiter` over budget |
+| `CircuitBreakerError` | an open `CircuitBreaker` |
+
+```python
+from grelmicro.errors import AdmissionError
+
+try:
+    ...
+except AdmissionError:
+    # turned away by a lock, bulkhead, rate limiter, or circuit breaker
+    ...
+```
+
 ## With FastStream
 
 The same primitives drop into a FastStream consumer without changes.

--- a/docs/task.md
+++ b/docs/task.md
@@ -61,6 +61,8 @@ Use the `interval` decorator to run a task at a fixed interval:
 !!! note
     The interval specifies the waiting time between task executions. Ensure that the task execution duration is considered to meet deadlines effectively.
 
+    The interval is measured from the end of one run to the start of the next (end-to-start). A run that takes longer than the interval pushes the next attempt back.
+
 !!! tip "Sensitive workflows: pass an explicit `name=`"
     When `name=` is omitted, the task reference is derived from the function's
     `module:qualname`. That reference appears in logs, distributed


### PR DESCRIPTION
Closes #425. Documentation only, no code change.

Four approved doc improvements from the 1.0 API review:
- `docs/task.md`: state the interval timing model (measured end-of-run to start-of-next, a long run pushes the next attempt back).
- `docs/configuration/reconfigure-from-configmap.md`: lead with the directory-per-key shape as the default mounted ConfigMap/Secret form, single-file second.
- `docs/architecture/backends.md`: document the provider auto-share-by-identity default and the escape hatches (distinct `env_prefix`, separate Provider instance, `from_client`). No `shared=False` flag.
- `docs/resilience/index.md`: add an `AdmissionError` family section so `except AdmissionError` is discoverable (`WouldBlockError`, `BulkheadFullError`, `RateLimitExceededError`, `CircuitBreakerError`).

Class names verified against source. `mkdocs build --strict` passes.