### PR TITLE
💥 Rename Tracing* symbols to Trace*

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 Rename the `Trace` component symbols to the `Trace` stem so they match the component name. `TracingConfig`, `TracingError`, `TracingExporterType`, `TracingProcessorType`, `TracingSamplerType`, and `TracingSettingsValidationError` become `TraceConfig`, `TraceError`, `TraceExporterType`, `TraceProcessorType`, `TraceSamplerType`, and `TraceSettingsValidationError`. Update imports.
 * 💥 Rename the concrete leader election adapters to the `*Adapter` suffix every other pattern already uses. `MemoryLeaderElectionBackend`, `RedisLeaderElectionBackend`, `PostgresLeaderElectionBackend`, and `KubernetesLeaderElectionBackend` become `MemoryLeaderElectionAdapter`, `RedisLeaderElectionAdapter`, `PostgresLeaderElectionAdapter`, and `KubernetesLeaderElectionAdapter`. The `LeaderElectionBackend` protocol keeps its name (protocol stays `*Backend`, concrete stays `*Adapter`). Update direct imports and constructions.
 
 ### Features
@@ -12,7 +13,7 @@
 * ✨ Add a `key=` template to `@cached` for a stable, readable cache key rendered from the arguments, like `@cached(key="user:{user_id}")`. Pass `key_maker=` for the fully dynamic case. Passing both raises `TypeError`.
 * ✨ Type `FireInfo.outcome` as the new `FireOutcome` `StrEnum` (`SUCCESS`, `ERROR`, `SKIPPED`). String comparisons like `outcome == "success"` still work.
 * ✨ Add `Idempotency.run(key, factory)`, a one-call helper that runs an operation once and replays its response. It takes a sync or async factory and mirrors `TTLCache.get_or_set`.
-* ✨ Every component now raises a typed `*SettingsValidationError` for invalid configuration, rooted in the shared `SettingsValidationError` base. Adds `TracingSettingsValidationError`, `HealthSettingsValidationError`, `LoggingSettingsValidationError`, and `IdempotencySettingsValidationError`. Catch `SettingsValidationError` to handle any of them.
+* ✨ Every component now raises a typed `*SettingsValidationError` for invalid configuration, rooted in the shared `SettingsValidationError` base. Adds `TraceSettingsValidationError`, `HealthSettingsValidationError`, `LoggingSettingsValidationError`, and `IdempotencySettingsValidationError`. Catch `SettingsValidationError` to handle any of them.
 * ✨ Cache adapters (`MemoryCacheAdapter`, `RedisCacheAdapter`, `PostgresCacheAdapter`, `SQLiteCacheAdapter`) now declare the `CacheBackend` protocol explicitly, matching the lock, circuit breaker, and rate limiter adapters.
 * ✨ Add `Log.from_config`, `Trace.from_config`, and `Metrics.from_config` to build each component from a pre-built config, matching the declarative path on every other pattern. The `config=` kwarg still works.
 

--- a/docs/reference/trace.md
+++ b/docs/reference/trace.md
@@ -13,6 +13,7 @@
         - TraceExporterType
         - TraceProcessorType
         - TraceSamplerType
+        - TraceSettingsValidationError
         - add_context
         - get_context
         - instrument

--- a/docs/reference/trace.md
+++ b/docs/reference/trace.md
@@ -8,11 +8,11 @@
       show_submodules: true
       members:
         - Trace
-        - TracingConfig
-        - TracingError
-        - TracingExporterType
-        - TracingProcessorType
-        - TracingSamplerType
+        - TraceConfig
+        - TraceError
+        - TraceExporterType
+        - TraceProcessorType
+        - TraceSamplerType
         - add_context
         - get_context
         - instrument

--- a/docs/snippets/trace/component.py
+++ b/docs/snippets/trace/component.py
@@ -2,7 +2,7 @@ import asyncio
 
 from grelmicro import Grelmicro
 from grelmicro.log import Log
-from grelmicro.trace import Trace, TracingExporterType, instrument
+from grelmicro.trace import Trace, TraceExporterType, instrument
 
 
 @instrument
@@ -15,7 +15,7 @@ micro = Grelmicro(
         Log(),
         Trace(
             service_name="orders",
-            exporter=TracingExporterType.CONSOLE,
+            exporter=TraceExporterType.CONSOLE,
         ),
     ]
 )

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -116,14 +116,14 @@ configure()
 ```
 
 !!! warning "The default exporter expects a collector"
-    `Trace()` defaults to `TracingExporterType.OTLP_HTTP`, which sends spans to an OpenTelemetry collector or endpoint over OTLP HTTP. Without a reachable collector, spans are dropped. A bounded `shutdown_timeout` (default `5.0` seconds) caps the flush on exit, so a slow or unreachable collector cannot hang shutdown.
+    `Trace()` defaults to `TraceExporterType.OTLP_HTTP`, which sends spans to an OpenTelemetry collector or endpoint over OTLP HTTP. Without a reachable collector, spans are dropped. A bounded `shutdown_timeout` (default `5.0` seconds) caps the flush on exit, so a slow or unreachable collector cannot hang shutdown.
 
-    For local development with no collector, set `exporter=TracingExporterType.CONSOLE` to print spans to the console instead. Use `TracingExporterType.NONE` to disable export entirely.
+    For local development with no collector, set `exporter=TraceExporterType.CONSOLE` to print spans to the console instead. Use `TraceExporterType.NONE` to disable export entirely.
 
 ??? note "Provider lifecycle and exporters"
     The provider is installed on enter and restored to the prior global on exit, so sequential apps in tests do not stack providers.
 
-    `Trace()` reads `GREL_TRACE_*` environment variables (see `TracingConfig` for the full field set) or accepts the same fields as keyword arguments. The OTLP HTTP and gRPC exporters require their own packages (`opentelemetry-exporter-otlp-proto-http` or `opentelemetry-exporter-otlp-proto-grpc`) and are imported only when selected.
+    `Trace()` reads `GREL_TRACE_*` environment variables (see `TraceConfig` for the full field set) or accepts the same fields as keyword arguments. The OTLP HTTP and gRPC exporters require their own packages (`opentelemetry-exporter-otlp-proto-http` or `opentelemetry-exporter-otlp-proto-grpc`) and are imported only when selected.
 
 ??? note "Works with all logging backends"
     The tracing context is injected into all three logging backends (stdlib, loguru, structlog). Use whichever logger you prefer:

--- a/grelmicro/trace/__init__.py
+++ b/grelmicro/trace/__init__.py
@@ -9,21 +9,21 @@ from grelmicro.trace._context import add_context, get_context
 from grelmicro.trace._instrument import instrument
 from grelmicro.trace._span import span
 from grelmicro.trace.config import (
-    TracingConfig,
-    TracingExporterType,
-    TracingProcessorType,
-    TracingSamplerType,
+    TraceConfig,
+    TraceExporterType,
+    TraceProcessorType,
+    TraceSamplerType,
 )
-from grelmicro.trace.errors import TracingError, TracingSettingsValidationError
+from grelmicro.trace.errors import TraceError, TraceSettingsValidationError
 
 __all__ = [
     "Trace",
-    "TracingConfig",
-    "TracingError",
-    "TracingExporterType",
-    "TracingProcessorType",
-    "TracingSamplerType",
-    "TracingSettingsValidationError",
+    "TraceConfig",
+    "TraceError",
+    "TraceExporterType",
+    "TraceProcessorType",
+    "TraceSamplerType",
+    "TraceSettingsValidationError",
     "add_context",
     "get_context",
     "instrument",

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -149,7 +149,7 @@ class Trace:
             TraceConfig,
             Doc(
                 """
-                The pre-built tracing configuration.
+                The pre-built trace configuration.
 
                 Use this path when the configuration is assembled at
                 startup from a settings tree (for example YAML, Vault,

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -12,14 +12,14 @@ from typing_extensions import Doc
 from grelmicro._config import resolve_config
 from grelmicro.errors import DependencyNotFoundError
 from grelmicro.trace.config import (
-    TracingConfig,
-    TracingExporterType,
-    TracingProcessorType,
-    TracingSamplerType,
+    TraceConfig,
+    TraceExporterType,
+    TraceProcessorType,
+    TraceSamplerType,
 )
 from grelmicro.trace.errors import (
-    TracingError,
-    TracingSettingsValidationError,
+    TraceError,
+    TraceSettingsValidationError,
 )
 
 if TYPE_CHECKING:
@@ -77,7 +77,7 @@ class Trace:
             ),
         ] = "default",
         config: Annotated[
-            TracingConfig | None,
+            TraceConfig | None,
             Doc(
                 """
                 Pre-built configuration. When provided, individual kwargs
@@ -89,16 +89,16 @@ class Trace:
             str | None, Doc("Service name resource attribute.")
         ] = None,
         exporter: Annotated[
-            TracingExporterType | None, Doc("Span exporter.")
+            TraceExporterType | None, Doc("Span exporter.")
         ] = None,
         endpoint: Annotated[str | None, Doc("Exporter endpoint.")] = None,
         headers: Annotated[
             dict[str, str] | None, Doc("Exporter headers.")
         ] = None,
         processor: Annotated[
-            TracingProcessorType | None, Doc("Span processor.")
+            TraceProcessorType | None, Doc("Span processor.")
         ] = None,
-        sampler: Annotated[TracingSamplerType | None, Doc("Sampler.")] = None,
+        sampler: Annotated[TraceSamplerType | None, Doc("Sampler.")] = None,
         sample_ratio: Annotated[
             float | None, Doc("Sample ratio for `traceidratio` sampler.")
         ] = None,
@@ -138,7 +138,7 @@ class Trace:
             "shutdown_timeout": shutdown_timeout,
         }
         self._env_load = env_load
-        self._resolved: TracingConfig | None = None
+        self._resolved: TraceConfig | None = None
         self._provider: Any = None
         self._prior_provider: Any = None
 
@@ -146,7 +146,7 @@ class Trace:
     def from_config(
         cls,
         config: Annotated[
-            TracingConfig,
+            TraceConfig,
             Doc(
                 """
                 The pre-built tracing configuration.
@@ -164,7 +164,7 @@ class Trace:
             Doc("Registration name. Defaults to `'default'`."),
         ] = "default",
     ) -> Self:
-        """Construct a `Trace` from a pre-built `TracingConfig`."""
+        """Construct a `Trace` from a pre-built `TraceConfig`."""
         return cls(name=name, config=config)
 
     @property
@@ -173,8 +173,8 @@ class Trace:
         return self._name
 
     @property
-    def config(self) -> TracingConfig:
-        """Return the resolved `TracingConfig`.
+    def config(self) -> TraceConfig:
+        """Return the resolved `TraceConfig`.
 
         Raises:
             RuntimeError: If accessed before the component has been entered.
@@ -204,12 +204,12 @@ class Trace:
             raise DependencyNotFoundError(module="opentelemetry-api") from exc
 
         self._resolved = resolve_config(
-            TracingConfig,
+            TraceConfig,
             explicit=self._explicit_config,
             kwargs=self._kwargs,
             env_prefix="GREL_TRACE_",
             env_load=self._env_load,
-            error_type=TracingSettingsValidationError,
+            error_type=TraceSettingsValidationError,
         )
         # `opentelemetry.trace.set_tracer_provider()` refuses to replace an
         # already-installed provider, so `Trace` patches the private
@@ -223,7 +223,7 @@ class Trace:
                 "installed provider. Pin a compatible opentelemetry-api "
                 "release or open an issue against grelmicro."
             )
-            raise TracingError(msg)
+            raise TraceError(msg)
         self._prior_provider = trace._TRACER_PROVIDER  # type: ignore[attr-defined]  # noqa: SLF001
         self._provider = _build_provider(self._resolved)
         trace._TRACER_PROVIDER = self._provider  # type: ignore[attr-defined]  # noqa: SLF001
@@ -301,8 +301,8 @@ async def _run_with_timeout(fn: Any, timeout: float) -> bool:  # noqa: ANN401, A
     return finished
 
 
-def _build_provider(config: TracingConfig) -> Any:  # noqa: ANN401
-    """Build a `TracerProvider` from a `TracingConfig`."""
+def _build_provider(config: TraceConfig) -> Any:  # noqa: ANN401
+    """Build a `TracerProvider` from a `TraceConfig`."""
     try:
         from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
         from opentelemetry.sdk.trace import TracerProvider  # noqa: PLC0415
@@ -324,22 +324,22 @@ def _build_provider(config: TracingConfig) -> Any:  # noqa: ANN401
         resource_attrs["service.name"] = config.service_name
     resource = Resource.create(resource_attrs) if resource_attrs else None
 
-    if config.sampler == TracingSamplerType.ALWAYS_ON:
+    if config.sampler == TraceSamplerType.ALWAYS_ON:
         sampler = ALWAYS_ON
-    elif config.sampler == TracingSamplerType.ALWAYS_OFF:
+    elif config.sampler == TraceSamplerType.ALWAYS_OFF:
         sampler = ALWAYS_OFF
-    elif config.sampler == TracingSamplerType.TRACEIDRATIO:
+    elif config.sampler == TraceSamplerType.TRACEIDRATIO:
         sampler = TraceIdRatioBased(config.sample_ratio)
     else:
         sampler = ParentBased(ALWAYS_ON)
 
     provider = TracerProvider(resource=resource, sampler=sampler)
 
-    if config.exporter != TracingExporterType.NONE:
+    if config.exporter != TraceExporterType.NONE:
         exporter = _build_exporter(config)
         processor_cls = (
             BatchSpanProcessor
-            if config.processor == TracingProcessorType.BATCH
+            if config.processor == TraceProcessorType.BATCH
             else SimpleSpanProcessor
         )
         provider.add_span_processor(processor_cls(exporter))
@@ -347,16 +347,16 @@ def _build_provider(config: TracingConfig) -> Any:  # noqa: ANN401
     return provider
 
 
-def _build_exporter(config: TracingConfig) -> Any:  # noqa: ANN401
+def _build_exporter(config: TraceConfig) -> Any:  # noqa: ANN401
     """Build a span exporter for the configured exporter type."""
-    if config.exporter == TracingExporterType.CONSOLE:
+    if config.exporter == TraceExporterType.CONSOLE:
         from opentelemetry.sdk.trace.export import (  # noqa: PLC0415
             ConsoleSpanExporter,
         )
 
         return ConsoleSpanExporter()
 
-    if config.exporter == TracingExporterType.OTLP_HTTP:  # pragma: no cover
+    if config.exporter == TraceExporterType.OTLP_HTTP:  # pragma: no cover
         try:
             from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # noqa: PLC0415
                 OTLPSpanExporter,

--- a/grelmicro/trace/config.py
+++ b/grelmicro/trace/config.py
@@ -19,7 +19,7 @@ class _CaseInsensitiveEnum(StrEnum):
         return None
 
 
-class TracingExporterType(_CaseInsensitiveEnum):
+class TraceExporterType(_CaseInsensitiveEnum):
     """Span exporter selection."""
 
     OTLP_HTTP = "otlp-http"
@@ -28,14 +28,14 @@ class TracingExporterType(_CaseInsensitiveEnum):
     NONE = "none"
 
 
-class TracingProcessorType(_CaseInsensitiveEnum):
+class TraceProcessorType(_CaseInsensitiveEnum):
     """Span processor selection."""
 
     BATCH = "batch"
     SIMPLE = "simple"
 
 
-class TracingSamplerType(_CaseInsensitiveEnum):
+class TraceSamplerType(_CaseInsensitiveEnum):
     """Sampler selection."""
 
     ALWAYS_ON = "always_on"
@@ -44,8 +44,8 @@ class TracingSamplerType(_CaseInsensitiveEnum):
     TRACEIDRATIO = "traceidratio"
 
 
-class TracingConfig(BaseModel, frozen=True, extra="forbid"):
-    """Tracing Config."""
+class TraceConfig(BaseModel, frozen=True, extra="forbid"):
+    """Trace Config."""
 
     service_name: Annotated[
         str | None,
@@ -55,9 +55,9 @@ class TracingConfig(BaseModel, frozen=True, extra="forbid"):
         ),
     ] = None
     exporter: Annotated[
-        TracingExporterType,
+        TraceExporterType,
         Doc("Span exporter."),
-    ] = TracingExporterType.OTLP_HTTP
+    ] = TraceExporterType.OTLP_HTTP
     endpoint: Annotated[
         str | None,
         Doc(
@@ -73,13 +73,13 @@ class TracingConfig(BaseModel, frozen=True, extra="forbid"):
         ),
     ] = Field(default_factory=dict)
     processor: Annotated[
-        TracingProcessorType,
+        TraceProcessorType,
         Doc("Span processor."),
-    ] = TracingProcessorType.BATCH
+    ] = TraceProcessorType.BATCH
     sampler: Annotated[
-        TracingSamplerType,
+        TraceSamplerType,
         Doc("Sampler."),
-    ] = TracingSamplerType.PARENTBASED_ALWAYS_ON
+    ] = TraceSamplerType.PARENTBASED_ALWAYS_ON
     sample_ratio: Annotated[
         float,
         Doc("Sample ratio for `traceidratio` sampler."),

--- a/grelmicro/trace/errors.py
+++ b/grelmicro/trace/errors.py
@@ -3,9 +3,9 @@
 from grelmicro.errors import GrelmicroError, SettingsValidationError
 
 
-class TracingError(GrelmicroError):
+class TraceError(GrelmicroError):
     """Base tracing error."""
 
 
-class TracingSettingsValidationError(TracingError, SettingsValidationError):
-    """Tracing Settings Validation Error."""
+class TraceSettingsValidationError(TraceError, SettingsValidationError):
+    """Trace Settings Validation Error."""

--- a/grelmicro/trace/errors.py
+++ b/grelmicro/trace/errors.py
@@ -4,7 +4,7 @@ from grelmicro.errors import GrelmicroError, SettingsValidationError
 
 
 class TraceError(GrelmicroError):
-    """Base tracing error."""
+    """Base trace error."""
 
 
 class TraceSettingsValidationError(TraceError, SettingsValidationError):

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -612,20 +612,20 @@
       "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., shutdown_timeout=..., env_load=...)",
       ".from_config": "(config, *, name=...)"
     },
-    "TracingConfig": {
+    "TraceConfig": {
       "()": "(*, service_name=..., exporter=..., endpoint=..., headers=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., shutdown_timeout=...)"
     },
-    "TracingError": null,
-    "TracingExporterType": {
+    "TraceError": null,
+    "TraceExporterType": {
       "()": "(*values)"
     },
-    "TracingProcessorType": {
+    "TraceProcessorType": {
       "()": "(*values)"
     },
-    "TracingSamplerType": {
+    "TraceSamplerType": {
       "()": "(*values)"
     },
-    "TracingSettingsValidationError": {
+    "TraceSettingsValidationError": {
       "()": "(error)"
     },
     "add_context": {

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -10,45 +10,45 @@ from grelmicro import Component, ComponentAlreadyRegisteredError, Grelmicro
 from grelmicro.errors import SettingsValidationError
 from grelmicro.trace import (
     Trace,
-    TracingConfig,
-    TracingExporterType,
-    TracingSamplerType,
+    TraceConfig,
+    TraceExporterType,
+    TraceSamplerType,
 )
 from grelmicro.trace.errors import (
-    TracingError,
-    TracingSettingsValidationError,
+    TraceError,
+    TraceSettingsValidationError,
 )
 
 
 def test_tracing_config_accepts_case_insensitive_enums() -> None:
     """Enum fields accept any-case strings via `_missing_`."""
-    config = TracingConfig.model_validate(
+    config = TraceConfig.model_validate(
         {"exporter": "NONE", "sampler": "ALWAYS_OFF"}
     )
-    assert config.exporter == TracingExporterType.NONE
-    assert config.sampler == TracingSamplerType.ALWAYS_OFF
+    assert config.exporter == TraceExporterType.NONE
+    assert config.sampler == TraceSamplerType.ALWAYS_OFF
 
 
 def test_tracing_config_rejects_unknown_enum_value() -> None:
     """Enum fields reject values that no member matches."""
     with pytest.raises(ValueError, match="exporter"):
-        TracingConfig.model_validate({"exporter": "bogus"})
+        TraceConfig.model_validate({"exporter": "bogus"})
 
 
 def test_tracing_config_rejects_none_for_enum() -> None:
-    """`None` does not silently resolve to `TracingExporterType.NONE`."""
+    """`None` does not silently resolve to `TraceExporterType.NONE`."""
     with pytest.raises(ValueError, match="exporter"):
-        TracingConfig.model_validate({"exporter": None})
+        TraceConfig.model_validate({"exporter": None})
 
 
 def test_trace_satisfies_component_protocol() -> None:
     """`Trace` is a runtime-checkable `Component`."""
-    assert isinstance(Trace(exporter=TracingExporterType.NONE), Component)
+    assert isinstance(Trace(exporter=TraceExporterType.NONE), Component)
 
 
 def test_trace_default_kind_and_name() -> None:
     """Default kind is `trace` and default name is `default`."""
-    trace = Trace(exporter=TracingExporterType.NONE)
+    trace = Trace(exporter=TraceExporterType.NONE)
     assert trace.kind == "trace"
     assert trace.name == "default"
 
@@ -58,22 +58,22 @@ def test_trace_is_singleton() -> None:
     with pytest.raises(ComponentAlreadyRegisteredError, match="singleton"):
         Grelmicro(
             uses=[
-                Trace(exporter=TracingExporterType.NONE),
-                Trace(exporter=TracingExporterType.NONE, name="audit"),
+                Trace(exporter=TraceExporterType.NONE),
+                Trace(exporter=TraceExporterType.NONE, name="audit"),
             ]
         )
 
 
 def test_trace_name_is_read_only() -> None:
     """`Trace.name` is a read-only property."""
-    trace = Trace(exporter=TracingExporterType.NONE)
+    trace = Trace(exporter=TraceExporterType.NONE)
     with pytest.raises(AttributeError):
         trace.name = "other"  # ty: ignore[invalid-assignment]
 
 
 def test_trace_config_unavailable_before_enter() -> None:
     """`Trace.config` raises before the component has been entered."""
-    trace = Trace(exporter=TracingExporterType.NONE)
+    trace = Trace(exporter=TraceExporterType.NONE)
     with pytest.raises(RuntimeError, match="only available inside"):
         _ = trace.config
 
@@ -84,7 +84,7 @@ async def test_trace_installs_provider_on_enter() -> None:
     micro = Grelmicro(
         uses=[
             Trace(
-                exporter=TracingExporterType.NONE,
+                exporter=TraceExporterType.NONE,
                 service_name="test-svc",
             )
         ]
@@ -97,9 +97,9 @@ async def test_trace_installs_provider_on_enter() -> None:
 
 
 async def test_trace_accepts_prebuilt_config() -> None:
-    """`Trace(config=...)` uses the pre-built `TracingConfig` as-is."""
-    config = TracingConfig(
-        exporter=TracingExporterType.NONE, service_name="payments"
+    """`Trace(config=...)` uses the pre-built `TraceConfig` as-is."""
+    config = TraceConfig(
+        exporter=TraceExporterType.NONE, service_name="payments"
     )
     micro = Grelmicro(uses=[Trace(config=config)])
     async with micro:
@@ -108,8 +108,8 @@ async def test_trace_accepts_prebuilt_config() -> None:
 
 def test_trace_from_config_matches_config_kwarg() -> None:
     """`Trace.from_config(cfg)` matches `Trace(config=cfg)`."""
-    config = TracingConfig(
-        exporter=TracingExporterType.NONE, service_name="payments"
+    config = TraceConfig(
+        exporter=TraceExporterType.NONE, service_name="payments"
     )
     trace = Trace.from_config(config)
     assert trace._explicit_config is config
@@ -118,21 +118,21 @@ def test_trace_from_config_matches_config_kwarg() -> None:
 
 def test_trace_from_config_keeps_name() -> None:
     """`Trace.from_config(..., name=...)` keeps the registration name."""
-    config = TracingConfig(exporter=TracingExporterType.NONE)
+    config = TraceConfig(exporter=TraceExporterType.NONE)
     trace = Trace.from_config(config, name="audit")
     assert trace.name == "audit"
 
 
 def test_trace_provider_unavailable_before_enter() -> None:
     """`Trace.provider` raises before the component has been entered."""
-    trace = Trace(exporter=TracingExporterType.NONE)
+    trace = Trace(exporter=TraceExporterType.NONE)
     with pytest.raises(RuntimeError, match="only available inside"):
         _ = trace.provider
 
 
 async def test_trace_console_exporter() -> None:
     """`exporter=console` builds a console exporter pipeline."""
-    micro = Grelmicro(uses=[Trace(exporter=TracingExporterType.CONSOLE)])
+    micro = Grelmicro(uses=[Trace(exporter=TraceExporterType.CONSOLE)])
     async with micro:
         assert isinstance(micro.trace.provider, TracerProvider)
 
@@ -142,13 +142,13 @@ async def test_trace_always_off_sampler() -> None:
     micro = Grelmicro(
         uses=[
             Trace(
-                exporter=TracingExporterType.NONE,
-                sampler=TracingSamplerType.ALWAYS_OFF,
+                exporter=TraceExporterType.NONE,
+                sampler=TraceSamplerType.ALWAYS_OFF,
             )
         ]
     )
     async with micro:
-        assert micro.trace.config.sampler == TracingSamplerType.ALWAYS_OFF
+        assert micro.trace.config.sampler == TraceSamplerType.ALWAYS_OFF
 
 
 async def test_trace_always_on_sampler() -> None:
@@ -156,13 +156,13 @@ async def test_trace_always_on_sampler() -> None:
     micro = Grelmicro(
         uses=[
             Trace(
-                exporter=TracingExporterType.NONE,
-                sampler=TracingSamplerType.ALWAYS_ON,
+                exporter=TraceExporterType.NONE,
+                sampler=TraceSamplerType.ALWAYS_ON,
             )
         ]
     )
     async with micro:
-        assert micro.trace.config.sampler == TracingSamplerType.ALWAYS_ON
+        assert micro.trace.config.sampler == TraceSamplerType.ALWAYS_ON
 
 
 async def test_trace_sampler_ratio() -> None:
@@ -170,8 +170,8 @@ async def test_trace_sampler_ratio() -> None:
     micro = Grelmicro(
         uses=[
             Trace(
-                exporter=TracingExporterType.NONE,
-                sampler=TracingSamplerType.TRACEIDRATIO,
+                exporter=TraceExporterType.NONE,
+                sampler=TraceSamplerType.TRACEIDRATIO,
                 sample_ratio=0.25,
             )
         ]
@@ -196,7 +196,7 @@ async def test_trace_shutdown_timeout_logs_warning(
     micro = Grelmicro(
         uses=[
             Trace(
-                exporter=TracingExporterType.NONE,
+                exporter=TraceExporterType.NONE,
                 service_name="slow-svc",
                 shutdown_timeout=0.05,
             )
@@ -224,7 +224,7 @@ async def test_trace_shutdown_exception_logged_not_propagated(
         msg = "exporter broken"
         raise RuntimeError(msg)
 
-    micro = Grelmicro(uses=[Trace(exporter=TracingExporterType.NONE)])
+    micro = Grelmicro(uses=[Trace(exporter=TraceExporterType.NONE)])
     async with micro:
         micro.trace.provider.shutdown = _raise  # type: ignore[method-assign]
 
@@ -241,8 +241,8 @@ async def test_trace_raises_when_private_otel_global_missing(
 ) -> None:
     """A future OTel that drops `_TRACER_PROVIDER` surfaces a clear error."""
     monkeypatch.delattr(otel_trace, "_TRACER_PROVIDER", raising=False)
-    micro = Grelmicro(uses=[Trace(exporter=TracingExporterType.NONE)])
-    with pytest.raises(TracingError, match="_TRACER_PROVIDER"):
+    micro = Grelmicro(uses=[Trace(exporter=TraceExporterType.NONE)])
+    with pytest.raises(TraceError, match="_TRACER_PROVIDER"):
         async with micro:
             pass
 
@@ -250,15 +250,15 @@ async def test_trace_raises_when_private_otel_global_missing(
 async def test_trace_invalid_env_config_raises_settings_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Invalid env config raises a catchable `TracingSettingsValidationError`."""
+    """Invalid env config raises a catchable `TraceSettingsValidationError`."""
     monkeypatch.setenv("GREL_TRACE_EXPORTER", "bogus")
     micro = Grelmicro(uses=[Trace(env_load=True)])
-    with pytest.raises(TracingSettingsValidationError) as exc_info:
+    with pytest.raises(TraceSettingsValidationError) as exc_info:
         async with micro:
             pass
     assert isinstance(exc_info.value, SettingsValidationError)
 
 
 def test_trace_settings_error_is_settings_validation_error() -> None:
-    """`TracingSettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(TracingSettingsValidationError, SettingsValidationError)
+    """`TraceSettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(TraceSettingsValidationError, SettingsValidationError)


### PR DESCRIPTION
Closes #408. **Breaking** (clean cut, no shim).

The component is `Trace`, but its public symbols used the `Tracing` stem. Renamed all six to match:

- `TracingError` -> `TraceError`
- `TracingConfig` -> `TraceConfig`
- `TracingExporterType` -> `TraceExporterType`
- `TracingProcessorType` -> `TraceProcessorType`
- `TracingSamplerType` -> `TraceSamplerType`
- `TracingSettingsValidationError` -> `TraceSettingsValidationError`

Exact-identifier rename (never a substring sweep): the `tracing` concept word in module docstrings, the module name, and OTel references are untouched. `__all__` re-sorted. Class docstrings aligned to the `Trace` stem. API snapshot regenerated (6 names swapped, nothing else). `### Breaking` changelog entry added; the same-cycle `#401` Features bullet updated to `TraceSettingsValidationError`.

Migration: update imports of the renamed symbols.

Inspiration: OpenTelemetry names its namespace and types with the `trace` noun.