### PR TITLE
💥 Rename Logging* symbols to Log*

### DIFF
--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -105,7 +105,7 @@ We keep `self._config` as the single source of truth. If a future profile shows 
 | `RateLimitFilterConfig` | `grelmicro.log` |
 | `DuplicateFilterConfig` | `grelmicro.log` |
 | `HealthChecksConfig` | `grelmicro.health` |
-| `LoggingConfig` | `grelmicro.log` |
+| `LogConfig` | `grelmicro.log` |
 
 Each is a `BaseModel, frozen=True, extra="forbid"`. Field docs live in `Annotated[T, Doc("...")]` blocks and surface in IDEs and the API reference.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Breaking
 
 * 💥 Rename the `Trace` component symbols to the `Trace` stem so they match the component name. `TracingConfig`, `TracingError`, `TracingExporterType`, `TracingProcessorType`, `TracingSamplerType`, and `TracingSettingsValidationError` become `TraceConfig`, `TraceError`, `TraceExporterType`, `TraceProcessorType`, `TraceSamplerType`, and `TraceSettingsValidationError`. Update imports.
+* 💥 Rename the `Log` component symbols to the `Log` stem so they match the component name. `LoggingConfig`, `LoggingError`, `LoggingBackendType`, `LoggingFormatType`, `LoggingLevelType`, `LoggingSerializerType`, `LoggingTimeZoneType`, and `LoggingSettingsValidationError` become `LogConfig`, `LogError`, `LogBackendType`, `LogFormatType`, `LogLevelType`, `LogSerializerType`, `LogTimeZoneType`, and `LogSettingsValidationError`. Update imports.
 * 💥 Rename the concrete leader election adapters to the `*Adapter` suffix every other pattern already uses. `MemoryLeaderElectionBackend`, `RedisLeaderElectionBackend`, `PostgresLeaderElectionBackend`, and `KubernetesLeaderElectionBackend` become `MemoryLeaderElectionAdapter`, `RedisLeaderElectionAdapter`, `PostgresLeaderElectionAdapter`, and `KubernetesLeaderElectionAdapter`. The `LeaderElectionBackend` protocol keeps its name (protocol stays `*Backend`, concrete stays `*Adapter`). Update direct imports and constructions.
 
 ### Features
@@ -13,7 +14,7 @@
 * ✨ Add a `key=` template to `@cached` for a stable, readable cache key rendered from the arguments, like `@cached(key="user:{user_id}")`. Pass `key_maker=` for the fully dynamic case. Passing both raises `TypeError`.
 * ✨ Type `FireInfo.outcome` as the new `FireOutcome` `StrEnum` (`SUCCESS`, `ERROR`, `SKIPPED`). String comparisons like `outcome == "success"` still work.
 * ✨ Add `Idempotency.run(key, factory)`, a one-call helper that runs an operation once and replays its response. It takes a sync or async factory and mirrors `TTLCache.get_or_set`.
-* ✨ Every component now raises a typed `*SettingsValidationError` for invalid configuration, rooted in the shared `SettingsValidationError` base. Adds `TraceSettingsValidationError`, `HealthSettingsValidationError`, `LoggingSettingsValidationError`, and `IdempotencySettingsValidationError`. Catch `SettingsValidationError` to handle any of them.
+* ✨ Every component now raises a typed `*SettingsValidationError` for invalid configuration, rooted in the shared `SettingsValidationError` base. Adds `TraceSettingsValidationError`, `HealthSettingsValidationError`, `LogSettingsValidationError`, and `IdempotencySettingsValidationError`. Catch `SettingsValidationError` to handle any of them.
 * ✨ Cache adapters (`MemoryCacheAdapter`, `RedisCacheAdapter`, `PostgresCacheAdapter`, `SQLiteCacheAdapter`) now declare the `CacheBackend` protocol explicitly, matching the lock, circuit breaker, and rate limiter adapters.
 * ✨ Add `Log.from_config`, `Trace.from_config`, and `Metrics.from_config` to build each component from a pre-built config, matching the declarative path on every other pattern. The `config=` kwarg still works.
 

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -12,8 +12,9 @@
         - ErrorDict
         - JSONRecordDict
         - Log
-        - LoggingConfig
-        - LoggingError
+        - LogConfig
+        - LogError
+        - LogSettingsValidationError
         - RateLimitFilter
         - RateLimitFilterConfig
         - configure

--- a/grelmicro/log/__init__.py
+++ b/grelmicro/log/__init__.py
@@ -13,39 +13,39 @@ from grelmicro.log._ratelimit import (
     RateLimitFilterConfig,
 )
 from grelmicro.log.config import (
-    LoggingBackendType,
-    LoggingConfig,
-    LoggingFormatType,
-    LoggingLevelType,
-    LoggingSerializerType,
-    LoggingTimeZoneType,
+    LogBackendType,
+    LogConfig,
+    LogFormatType,
+    LogLevelType,
+    LogSerializerType,
+    LogTimeZoneType,
 )
-from grelmicro.log.errors import LoggingError, LoggingSettingsValidationError
+from grelmicro.log.errors import LogError, LogSettingsValidationError
 from grelmicro.log.types import ErrorDict, JSONRecordDict
 
 
 def configure(
     *,
     backend: Annotated[
-        LoggingBackendType | None,
+        LogBackendType | None,
         Doc(
             "Logging backend (`stdlib`, `loguru`, `structlog`). Default: `stdlib`."
         ),
     ] = None,
     level: Annotated[
-        LoggingLevelType | None,
+        LogLevelType | None,
         Doc("Log level threshold. Default: `INFO`."),
     ] = None,
     format: Annotated[  # noqa: A002
-        LoggingFormatType | str | None,
+        LogFormatType | str | None,
         Doc("Log format. Default: `AUTO`."),
     ] = None,
     timezone: Annotated[
-        LoggingTimeZoneType | None,  # ty: ignore[invalid-type-form]
+        LogTimeZoneType | None,  # ty: ignore[invalid-type-form]
         Doc("IANA timezone for timestamps. Default: `UTC`."),
     ] = None,
     json_serializer: Annotated[
-        LoggingSerializerType | None,
+        LogSerializerType | None,
         Doc("JSON serializer. Default: `stdlib`."),
     ] = None,
     caller_enabled: Annotated[
@@ -72,14 +72,14 @@ def configure(
             "Pass True or False to override."
         ),
     ] = None,
-) -> LoggingConfig:
+) -> LogConfig:
     """Configure logging with the selected backend.
 
     Two paths:
 
     - Programmatic: pass any of the per-field kwargs. Unset fields
       resolve from `GREL_LOG_*` env vars (when `env_load=True`),
-      then from `LoggingConfig` defaults.
+      then from `LogConfig` defaults.
     - Environmental: omit all kwargs. `GREL_LOG_*` env vars populate
       every field.
 
@@ -87,14 +87,14 @@ def configure(
     [`configure_with`][grelmicro.log.configure_with].
 
     Returns:
-        The applied `LoggingConfig`. Snapshot of what was resolved.
+        The applied `LogConfig`. Snapshot of what was resolved.
 
     Raises:
         DependencyNotFoundError: If the selected backend module is not installed.
-        LoggingSettingsValidationError: If configuration is invalid.
+        LogSettingsValidationError: If configuration is invalid.
     """
     config = resolve_config(
-        LoggingConfig,
+        LogConfig,
         explicit=None,
         kwargs={
             "backend": backend,
@@ -107,7 +107,7 @@ def configure(
         },
         env_prefix="GREL_LOG_",
         env_load=env_load,
-        error_type=LoggingSettingsValidationError,
+        error_type=LogSettingsValidationError,
     )
     _apply(config)
     return config
@@ -115,7 +115,7 @@ def configure(
 
 def configure_with(
     config: Annotated[
-        LoggingConfig,
+        LogConfig,
         Doc(
             """
             Pre-built logging configuration.
@@ -126,11 +126,11 @@ def configure_with(
             """
         ),
     ],
-) -> LoggingConfig:
-    """Configure logging from a pre-built `LoggingConfig`.
+) -> LogConfig:
+    """Configure logging from a pre-built `LogConfig`.
 
     Returns:
-        The same `LoggingConfig`, for symmetry with `configure`.
+        The same `LogConfig`, for symmetry with `configure`.
     """
     _apply(config)
     return config
@@ -142,9 +142,9 @@ __all__ = [
     "ErrorDict",
     "JSONRecordDict",
     "Log",
-    "LoggingConfig",
-    "LoggingError",
-    "LoggingSettingsValidationError",
+    "LogConfig",
+    "LogError",
+    "LogSettingsValidationError",
     "RateLimitFilter",
     "RateLimitFilterConfig",
     "configure",

--- a/grelmicro/log/_apply.py
+++ b/grelmicro/log/_apply.py
@@ -1,15 +1,15 @@
 """Backend dispatcher for logging configuration."""
 
-from grelmicro.log.config import LoggingBackendType, LoggingConfig
+from grelmicro.log.config import LogBackendType, LogConfig
 
 
-def apply(config: LoggingConfig) -> None:
+def apply(config: LogConfig) -> None:
     """Dispatch to the selected backend with the resolved config."""
-    if config.backend == LoggingBackendType.STRUCTLOG:
+    if config.backend == LogBackendType.STRUCTLOG:
         from grelmicro.log._structlog import (  # noqa: PLC0415
             configure as _configure,
         )
-    elif config.backend == LoggingBackendType.STDLIB:
+    elif config.backend == LogBackendType.STDLIB:
         from grelmicro.log._stdlib import (  # noqa: PLC0415
             configure as _configure,
         )

--- a/grelmicro/log/_component.py
+++ b/grelmicro/log/_component.py
@@ -11,14 +11,14 @@ from typing_extensions import Doc
 from grelmicro._config import resolve_config
 from grelmicro.log._apply import apply as _apply
 from grelmicro.log.config import (
-    LoggingBackendType,
-    LoggingConfig,
-    LoggingFormatType,
-    LoggingLevelType,
-    LoggingSerializerType,
-    LoggingTimeZoneType,
+    LogBackendType,
+    LogConfig,
+    LogFormatType,
+    LogLevelType,
+    LogSerializerType,
+    LogTimeZoneType,
 )
-from grelmicro.log.errors import LoggingSettingsValidationError
+from grelmicro.log.errors import LogSettingsValidationError
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -73,7 +73,7 @@ class Log:
             ),
         ] = "default",
         config: Annotated[
-            LoggingConfig | None,
+            LogConfig | None,
             Doc(
                 """
                 Pre-built configuration. When provided, individual kwargs
@@ -82,21 +82,21 @@ class Log:
             ),
         ] = None,
         backend: Annotated[
-            LoggingBackendType | None,
+            LogBackendType | None,
             Doc("Logging backend (`stdlib`, `loguru`, `structlog`)."),
         ] = None,
         level: Annotated[
-            LoggingLevelType | None, Doc("Log level threshold.")
+            LogLevelType | None, Doc("Log level threshold.")
         ] = None,
         format: Annotated[  # noqa: A002
-            LoggingFormatType | str | None, Doc("Log format.")
+            LogFormatType | str | None, Doc("Log format.")
         ] = None,
         timezone: Annotated[
-            LoggingTimeZoneType | None,  # ty: ignore[invalid-type-form]
+            LogTimeZoneType | None,  # ty: ignore[invalid-type-form]
             Doc("IANA timezone for timestamps."),
         ] = None,
         json_serializer: Annotated[
-            LoggingSerializerType | None, Doc("JSON serializer.")
+            LogSerializerType | None, Doc("JSON serializer.")
         ] = None,
         caller_enabled: Annotated[
             bool | None,
@@ -126,7 +126,7 @@ class Log:
             "otel_enabled": otel_enabled,
         }
         self._env_load = env_load
-        self._resolved: LoggingConfig | None = None
+        self._resolved: LogConfig | None = None
         self._snapshot_handlers: list[logging.Handler] | None = None
         self._snapshot_level: int | None = None
 
@@ -134,7 +134,7 @@ class Log:
     def from_config(
         cls,
         config: Annotated[
-            LoggingConfig,
+            LogConfig,
             Doc(
                 """
                 The pre-built logging configuration.
@@ -152,7 +152,7 @@ class Log:
             Doc("Registration name. Defaults to `'default'`."),
         ] = "default",
     ) -> Self:
-        """Construct a `Log` from a pre-built `LoggingConfig`."""
+        """Construct a `Log` from a pre-built `LogConfig`."""
         return cls(name=name, config=config)
 
     @property
@@ -161,8 +161,8 @@ class Log:
         return self._name
 
     @property
-    def config(self) -> LoggingConfig:
-        """Return the resolved `LoggingConfig`.
+    def config(self) -> LogConfig:
+        """Return the resolved `LogConfig`.
 
         Raises:
             RuntimeError: If accessed before the component has been entered.
@@ -179,12 +179,12 @@ class Log:
             self._snapshot_handlers = list(root.handlers)
             self._snapshot_level = root.level
             self._resolved = resolve_config(
-                LoggingConfig,
+                LogConfig,
                 explicit=self._explicit_config,
                 kwargs=self._kwargs,
                 env_prefix="GREL_LOG_",
                 env_load=self._env_load,
-                error_type=LoggingSettingsValidationError,
+                error_type=LogSettingsValidationError,
             )
             _apply(self._resolved)
         return self

--- a/grelmicro/log/_dedup.py
+++ b/grelmicro/log/_dedup.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, PositiveFloat, PositiveInt
 from typing_extensions import Doc
 
 from grelmicro._config import resolve_config
-from grelmicro.log.errors import LoggingSettingsValidationError
+from grelmicro.log.errors import LogSettingsValidationError
 
 KeyMode = Literal["rendered", "template"]
 
@@ -198,7 +198,7 @@ class DuplicateFilter(Filter):
             },
             env_prefix=env_prefix or "GREL_DUPLICATE_FILTER_",
             env_load=env_load,
-            error_type=LoggingSettingsValidationError,
+            error_type=LogSettingsValidationError,
         )
         Filter.__init__(self)
         self._setup(config, key)

--- a/grelmicro/log/_loguru.py
+++ b/grelmicro/log/_loguru.py
@@ -15,7 +15,7 @@ from grelmicro.log._shared import (
     render_pretty_lines,
     render_text_line,
 )
-from grelmicro.log.config import LoggingConfig, LoggingFormatType
+from grelmicro.log.config import LogConfig, LogFormatType
 from grelmicro.log.types import ErrorDict
 
 try:
@@ -235,7 +235,7 @@ def _make_pretty_formatter(
     return _formatter
 
 
-def configure(config: LoggingConfig | None = None) -> None:
+def configure(config: LogConfig | None = None) -> None:
     """Configure logging with loguru.
 
     Simple twelve-factor app logging configuration that logs to stdout.
@@ -263,19 +263,19 @@ def configure(config: LoggingConfig | None = None) -> None:
     needs_logfmt = False
     needs_localtime = False
 
-    if log_format == LoggingFormatType.JSON or (
+    if log_format == LogFormatType.JSON or (
         isinstance(log_format, str) and log_format.strip() == JSON_FORMAT
     ):
         log_format = _json_formatter
         needs_json = True
-    elif log_format == LoggingFormatType.LOGFMT:
+    elif log_format == LogFormatType.LOGFMT:
         log_format = _logfmt_formatter
         needs_logfmt = True
-    elif log_format == LoggingFormatType.PRETTY:
+    elif log_format == LogFormatType.PRETTY:
         log_format = _make_pretty_formatter(
             timezone, caller_enabled=caller, colors=colors
         )
-    elif log_format == LoggingFormatType.TEXT:
+    elif log_format == LogFormatType.TEXT:
         log_format = _make_text_formatter(
             timezone, caller_enabled=caller, colors=colors
         )

--- a/grelmicro/log/_ratelimit.py
+++ b/grelmicro/log/_ratelimit.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, PositiveFloat, PositiveInt
 from typing_extensions import Doc
 
 from grelmicro._config import resolve_config
-from grelmicro.log.errors import LoggingSettingsValidationError
+from grelmicro.log.errors import LogSettingsValidationError
 from grelmicro.resilience import MemoryTokenBucket
 
 KeyMode = Literal["logger", "level", "global", "template", "rendered"]
@@ -222,7 +222,7 @@ class RateLimitFilter(Filter):
             },
             env_prefix=env_prefix or "GREL_RATE_LIMIT_FILTER_",
             env_load=env_load,
-            error_type=LoggingSettingsValidationError,
+            error_type=LogSettingsValidationError,
         )
         Filter.__init__(self)
         self._setup(config, key)

--- a/grelmicro/log/_shared.py
+++ b/grelmicro/log/_shared.py
@@ -12,11 +12,11 @@ from zoneinfo import ZoneInfo
 from grelmicro._config import resolve_config
 from grelmicro.errors import DependencyNotFoundError
 from grelmicro.log.config import (
-    LoggingConfig,
-    LoggingFormatType,
-    LoggingSerializerType,
+    LogConfig,
+    LogFormatType,
+    LogSerializerType,
 )
-from grelmicro.log.errors import LoggingSettingsValidationError
+from grelmicro.log.errors import LogSettingsValidationError
 
 try:
     from opentelemetry import trace
@@ -319,29 +319,25 @@ def render_pretty_lines(
 
 
 def _resolve_format(
-    log_format: LoggingFormatType | str,
-) -> LoggingFormatType | str:
+    log_format: LogFormatType | str,
+) -> LogFormatType | str:
     """Resolve AUTO format based on TTY and color environment detection."""
-    if log_format == LoggingFormatType.AUTO:
-        return (
-            LoggingFormatType.TEXT
-            if should_colorize()
-            else LoggingFormatType.JSON
-        )
+    if log_format == LogFormatType.AUTO:
+        return LogFormatType.TEXT if should_colorize() else LogFormatType.JSON
     return log_format
 
 
 class LoadedSettings(NamedTuple):
     """Validated logging settings."""
 
-    settings: LoggingConfig
+    settings: LogConfig
     timezone: tzinfo
-    resolved_format: LoggingFormatType | str
+    resolved_format: LogFormatType | str
     json_dumps: Callable[[Mapping[str, Any]], str]
     colors: bool
 
 
-def load_settings(settings: LoggingConfig | None = None) -> LoadedSettings:
+def load_settings(settings: LogConfig | None = None) -> LoadedSettings:
     """Validate and prepare runtime values from a logging config.
 
     When `settings` is `None`, reads `GREL_LOG_*` environment
@@ -349,19 +345,19 @@ def load_settings(settings: LoggingConfig | None = None) -> LoadedSettings:
 
     Raises:
         DependencyNotFoundError: If orjson or OpenTelemetry is enabled but not installed.
-        LoggingSettingsValidationError: If environment variables are invalid.
+        LogSettingsValidationError: If environment variables are invalid.
     """
     if settings is None:
         settings = resolve_config(
-            LoggingConfig,
+            LogConfig,
             explicit=None,
             kwargs={},
             env_prefix="GREL_LOG_",
-            error_type=LoggingSettingsValidationError,
+            error_type=LogSettingsValidationError,
         )
 
     json_dumps: Callable[[Mapping[str, Any]], str]
-    if settings.json_serializer == LoggingSerializerType.ORJSON:
+    if settings.json_serializer == LogSerializerType.ORJSON:
         if not has_orjson():
             raise DependencyNotFoundError(module="orjson")
         json_dumps = json_dumps_str
@@ -375,7 +371,7 @@ def load_settings(settings: LoggingConfig | None = None) -> LoadedSettings:
     resolved_format = _resolve_format(settings.format)
     colors = (
         should_colorize()
-        if resolved_format in (LoggingFormatType.TEXT, LoggingFormatType.PRETTY)
+        if resolved_format in (LogFormatType.TEXT, LogFormatType.PRETTY)
         else False
     )
 

--- a/grelmicro/log/_stdlib.py
+++ b/grelmicro/log/_stdlib.py
@@ -15,7 +15,7 @@ from grelmicro.log._shared import (
     render_pretty_lines,
     render_text_line,
 )
-from grelmicro.log.config import LoggingConfig, LoggingFormatType
+from grelmicro.log.config import LogConfig, LogFormatType
 from grelmicro.log.types import ErrorDict
 
 _STANDARD_LOG_RECORD_ATTRS = frozenset(
@@ -197,7 +197,7 @@ class _PrettyFormatter(_BaseFormatter):
         return render_pretty_lines(self._record(record), colors=self.colors)
 
 
-def configure(config: LoggingConfig | None = None) -> None:
+def configure(config: LogConfig | None = None) -> None:
     """Configure logging with stdlib.
 
     Simple twelve-factor app logging configuration that logs to stdout.
@@ -221,18 +221,18 @@ def configure(config: LoggingConfig | None = None) -> None:
     otel = settings.otel_enabled
 
     formatter: logging.Formatter
-    if resolved_format == LoggingFormatType.JSON:
+    if resolved_format == LogFormatType.JSON:
         formatter = _JSONFormatter(
             timezone=timezone,
             json_dumps=json_dumps,
             caller_enabled=caller,
             otel_enabled=otel,
         )
-    elif resolved_format == LoggingFormatType.LOGFMT:
+    elif resolved_format == LogFormatType.LOGFMT:
         formatter = _LogfmtFormatter(
             timezone=timezone, caller_enabled=caller, otel_enabled=otel
         )
-    elif resolved_format == LoggingFormatType.PRETTY:
+    elif resolved_format == LogFormatType.PRETTY:
         formatter = _PrettyFormatter(
             timezone=timezone,
             caller_enabled=caller,

--- a/grelmicro/log/_structlog.py
+++ b/grelmicro/log/_structlog.py
@@ -15,9 +15,9 @@ from grelmicro.log._shared import (
     render_text_line,
 )
 from grelmicro.log.config import (
-    LoggingConfig,
-    LoggingFormatType,
-    LoggingSerializerType,
+    LogConfig,
+    LogFormatType,
+    LogSerializerType,
 )
 from grelmicro.log.types import ErrorDict
 
@@ -193,7 +193,7 @@ def _make_pretty_renderer(*, colors: bool) -> Processor:
     return processor
 
 
-def configure(config: LoggingConfig | None = None) -> None:
+def configure(config: LogConfig | None = None) -> None:
     """Configure logging with structlog.
 
     Simple twelve-factor app logging configuration that logs to stdout.
@@ -237,9 +237,9 @@ def configure(config: LoggingConfig | None = None) -> None:
     if settings.otel_enabled:
         processors.append(_add_otel_context)
 
-    if resolved_format == LoggingFormatType.JSON:
+    if resolved_format == LogFormatType.JSON:
         processors.append(_build_flat_record)
-        if settings.json_serializer == LoggingSerializerType.ORJSON:
+        if settings.json_serializer == LogSerializerType.ORJSON:
             import orjson  # noqa: PLC0415
 
             processors.append(
@@ -253,10 +253,10 @@ def configure(config: LoggingConfig | None = None) -> None:
                 structlog.processors.JSONRenderer(default=json_default)
             )
             logger_factory = structlog.PrintLoggerFactory(file=sys.stdout)
-    elif resolved_format == LoggingFormatType.LOGFMT:
+    elif resolved_format == LogFormatType.LOGFMT:
         processors.append(_render_logfmt)
         logger_factory = structlog.PrintLoggerFactory(file=sys.stdout)
-    elif resolved_format == LoggingFormatType.PRETTY:
+    elif resolved_format == LogFormatType.PRETTY:
         processors.append(_make_pretty_renderer(colors=colors))
         logger_factory = structlog.PrintLoggerFactory(file=sys.stdout)
     else:

--- a/grelmicro/log/config.py
+++ b/grelmicro/log/config.py
@@ -26,8 +26,8 @@ class _CaseInsensitiveEnum(StrEnum):
         return None
 
 
-class LoggingLevelType(_CaseInsensitiveEnum):
-    """Logging Level Enum."""
+class LogLevelType(_CaseInsensitiveEnum):
+    """Log Level Enum."""
 
     DEBUG = "DEBUG"
     INFO = "INFO"
@@ -36,8 +36,8 @@ class LoggingLevelType(_CaseInsensitiveEnum):
     CRITICAL = "CRITICAL"
 
 
-class LoggingFormatType(_CaseInsensitiveEnum):
-    """Logging Format Enum."""
+class LogFormatType(_CaseInsensitiveEnum):
+    """Log Format Enum."""
 
     AUTO = "AUTO"
     JSON = "JSON"
@@ -46,15 +46,15 @@ class LoggingFormatType(_CaseInsensitiveEnum):
     PRETTY = "PRETTY"
 
 
-class LoggingBackendType(_CaseInsensitiveEnum):
-    """Logging Backend Enum."""
+class LogBackendType(_CaseInsensitiveEnum):
+    """Log Backend Enum."""
 
     LOGURU = "loguru"
     STRUCTLOG = "structlog"
     STDLIB = "stdlib"
 
 
-class LoggingSerializerType(_CaseInsensitiveEnum):
+class LogSerializerType(_CaseInsensitiveEnum):
     """JSON Serializer Enum."""
 
     STDLIB = "stdlib"
@@ -62,34 +62,34 @@ class LoggingSerializerType(_CaseInsensitiveEnum):
 
 
 @timezone_name_settings(strict=False)
-class LoggingTimeZoneType(TimeZoneName):
+class LogTimeZoneType(TimeZoneName):
     """Timezone name."""
 
 
-class LoggingConfig(BaseModel, frozen=True, extra="forbid"):
-    """Logging Config."""
+class LogConfig(BaseModel, frozen=True, extra="forbid"):
+    """Log Config."""
 
     backend: Annotated[
-        LoggingBackendType,
+        LogBackendType,
         Doc("Logging backend implementation."),
-    ] = LoggingBackendType.STDLIB
+    ] = LogBackendType.STDLIB
     level: Annotated[
-        LoggingLevelType,
+        LogLevelType,
         Doc("Log level threshold."),
-    ] = LoggingLevelType.INFO
+    ] = LogLevelType.INFO
     format: Annotated[
-        LoggingFormatType | str,
+        LogFormatType | str,
         Doc("Log format. Built-in option or a custom template string."),
         Field(union_mode="left_to_right"),
-    ] = LoggingFormatType.AUTO
+    ] = LogFormatType.AUTO
     timezone: Annotated[
-        LoggingTimeZoneType,  # ty: ignore[invalid-type-form]
+        LogTimeZoneType,  # ty: ignore[invalid-type-form]
         Doc("IANA timezone for timestamps."),
-    ] = LoggingTimeZoneType("UTC")
+    ] = LogTimeZoneType("UTC")
     json_serializer: Annotated[
-        LoggingSerializerType,
+        LogSerializerType,
         Doc("JSON serializer used for structured output."),
-    ] = LoggingSerializerType.STDLIB
+    ] = LogSerializerType.STDLIB
     caller_enabled: Annotated[
         bool,
         Doc("Include caller (function and line) in log records."),

--- a/grelmicro/log/errors.py
+++ b/grelmicro/log/errors.py
@@ -3,9 +3,9 @@
 from grelmicro.errors import GrelmicroError, SettingsValidationError
 
 
-class LoggingError(GrelmicroError):
-    """Base logging error."""
+class LogError(GrelmicroError):
+    """Base log error."""
 
 
-class LoggingSettingsValidationError(LoggingError, SettingsValidationError):
-    """Logging Settings Validation Error."""
+class LogSettingsValidationError(LogError, SettingsValidationError):
+    """Log Settings Validation Error."""

--- a/grelmicro/log/uvicorn.py
+++ b/grelmicro/log/uvicorn.py
@@ -11,7 +11,7 @@ from grelmicro.log._shared import (
     render_text_line,
 )
 from grelmicro.log._stdlib import _STANDARD_LOG_RECORD_ATTRS, _BaseFormatter
-from grelmicro.log.config import LoggingFormatType
+from grelmicro.log.config import LogFormatType
 
 if TYPE_CHECKING:
     import logging
@@ -49,13 +49,13 @@ class UvicornFormatter(_UvicornBaseFormatter):
         )
 
         match resolved_format:
-            case LoggingFormatType.LOGFMT:
+            case LogFormatType.LOGFMT:
                 self._format_record = logfmt_dumps
-            case LoggingFormatType.PRETTY:
+            case LogFormatType.PRETTY:
                 self._format_record = lambda r: render_pretty_lines(
                     r, colors=colors
                 )
-            case LoggingFormatType.TEXT:
+            case LogFormatType.TEXT:
                 self._format_record = lambda r: render_text_line(
                     r, colors=colors
                 )

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -227,11 +227,11 @@
       "()": "(*, name=..., config=..., backend=..., level=..., format=..., timezone=..., json_serializer=..., caller_enabled=..., otel_enabled=..., env_load=...)",
       ".from_config": "(config, *, name=...)"
     },
-    "LoggingConfig": {
+    "LogConfig": {
       "()": "(*, backend=..., level=..., format=..., timezone=..., json_serializer=..., caller_enabled=..., otel_enabled=...)"
     },
-    "LoggingError": null,
-    "LoggingSettingsValidationError": {
+    "LogError": null,
+    "LogSettingsValidationError": {
       "()": "(error)"
     },
     "RateLimitFilter": {

--- a/tests/logging/test_backends.py
+++ b/tests/logging/test_backends.py
@@ -15,7 +15,7 @@ from loguru import logger as loguru_logger
 
 from grelmicro._json import json_default
 from grelmicro.errors import DependencyNotFoundError
-from grelmicro.log import LoggingSettingsValidationError, configure
+from grelmicro.log import LogSettingsValidationError, configure
 from grelmicro.log._shared import (
     _logfmt_format_value,
     get_otel_trace_context,
@@ -218,7 +218,7 @@ class TestConfigureLoggingLevel:
 
         # Act / Assert
         with pytest.raises(
-            LoggingSettingsValidationError,
+            LogSettingsValidationError,
             match=(
                 r"Input should be 'DEBUG', 'INFO', 'WARNING', "
                 r"'ERROR' or 'CRITICAL'"
@@ -484,7 +484,7 @@ class TestLoadSettings:
         monkeypatch.setenv("GREL_LOG_LEVEL", "INVALID")
 
         # Act / Assert
-        with pytest.raises(LoggingSettingsValidationError):
+        with pytest.raises(LogSettingsValidationError):
             load_settings()
 
 

--- a/tests/logging/test_component.py
+++ b/tests/logging/test_component.py
@@ -7,8 +7,8 @@ import logging
 import pytest
 
 from grelmicro import Component, ComponentAlreadyRegisteredError, Grelmicro
-from grelmicro.log import Log, LoggingConfig
-from grelmicro.log.config import LoggingLevelType
+from grelmicro.log import Log, LogConfig
+from grelmicro.log.config import LogLevelType
 
 
 def test_log_satisfies_component_protocol() -> None:
@@ -47,15 +47,15 @@ async def test_log_resolves_config_on_enter(
     reset_stdlib: None,  # noqa: ARG001
 ) -> None:
     """Entering the app resolves the config and configures logging."""
-    micro = Grelmicro(uses=[Log(level=LoggingLevelType.DEBUG)])
+    micro = Grelmicro(uses=[Log(level=LogLevelType.DEBUG)])
     async with micro:
-        assert micro.log.config.level == LoggingLevelType.DEBUG
+        assert micro.log.config.level == LogLevelType.DEBUG
         assert logging.getLogger().level == logging.DEBUG
 
 
 async def test_log_accepts_prebuilt_config(reset_stdlib: None) -> None:  # noqa: ARG001
-    """`Log(config=...)` uses the pre-built `LoggingConfig` as-is."""
-    config = LoggingConfig(level=LoggingLevelType.WARNING)
+    """`Log(config=...)` uses the pre-built `LogConfig` as-is."""
+    config = LogConfig(level=LogLevelType.WARNING)
     micro = Grelmicro(uses=[Log(config=config)])
     async with micro:
         assert micro.log.config is config
@@ -63,7 +63,7 @@ async def test_log_accepts_prebuilt_config(reset_stdlib: None) -> None:  # noqa:
 
 def test_log_from_config_matches_config_kwarg() -> None:
     """`Log.from_config(cfg)` matches `Log(config=cfg)`."""
-    config = LoggingConfig(level=LoggingLevelType.WARNING)
+    config = LogConfig(level=LogLevelType.WARNING)
     log = Log.from_config(config)
     assert log._explicit_config is config
     assert log.name == "default"
@@ -71,7 +71,7 @@ def test_log_from_config_matches_config_kwarg() -> None:
 
 def test_log_from_config_keeps_name() -> None:
     """`Log.from_config(..., name=...)` keeps the registration name."""
-    config = LoggingConfig()
+    config = LogConfig()
     log = Log.from_config(config, name="audit")
     assert log.name == "audit"
 
@@ -85,7 +85,7 @@ async def test_log_restores_root_handlers_on_exit(
     root.addHandler(sentinel)
     before = list(root.handlers)
     root.setLevel(logging.WARNING)
-    micro = Grelmicro(uses=[Log(level=LoggingLevelType.DEBUG)])
+    micro = Grelmicro(uses=[Log(level=LogLevelType.DEBUG)])
     async with micro:
         assert sentinel not in root.handlers
     assert root.handlers == before

--- a/tests/logging/test_dedup.py
+++ b/tests/logging/test_dedup.py
@@ -9,7 +9,7 @@ from freezegun import freeze_time
 
 from grelmicro.log import (
     DuplicateFilter,
-    LoggingSettingsValidationError,
+    LogSettingsValidationError,
     configure,
 )
 from grelmicro.log._dedup import _key_by_rendered
@@ -333,8 +333,8 @@ def test_explicit_key_callable_overrides_mode() -> None:
 
 
 def test_invalid_key_mode_rejected() -> None:
-    """Unknown ``key_mode`` values raise a LoggingSettingsValidationError."""
-    with pytest.raises(LoggingSettingsValidationError, match="key_mode"):
+    """Unknown ``key_mode`` values raise a LogSettingsValidationError."""
+    with pytest.raises(LogSettingsValidationError, match="key_mode"):
         DuplicateFilter(key_mode="bogus")  # ty: ignore[invalid-argument-type]
 
 
@@ -414,8 +414,8 @@ def test_ttl_none_disables_time_expiry() -> None:
 
 @pytest.mark.parametrize("bad_ttl", [0, -0.5, -1])
 def test_non_positive_ttl_rejected(bad_ttl: float) -> None:
-    """Non-positive ``ttl_seconds`` values raise a LoggingSettingsValidationError."""
-    with pytest.raises(LoggingSettingsValidationError, match="greater than 0"):
+    """Non-positive ``ttl_seconds`` values raise a LogSettingsValidationError."""
+    with pytest.raises(LogSettingsValidationError, match="greater than 0"):
         DuplicateFilter(ttl_seconds=bad_ttl)
 
 
@@ -424,8 +424,8 @@ def test_non_positive_ttl_rejected(bad_ttl: float) -> None:
     [(0, 10), (-1, 10), (10, 0), (10, -5)],
 )
 def test_invalid_config_rejected(allowed: int, cache: int) -> None:
-    """Non-positive config values raise a LoggingSettingsValidationError."""
-    with pytest.raises(LoggingSettingsValidationError, match="greater than 0"):
+    """Non-positive config values raise a LogSettingsValidationError."""
+    with pytest.raises(LogSettingsValidationError, match="greater than 0"):
         DuplicateFilter(allowed_repetitions=allowed, cache_size=cache)
 
 

--- a/tests/logging/test_log_config.py
+++ b/tests/logging/test_log_config.py
@@ -4,23 +4,23 @@ import pytest
 
 from grelmicro.errors import SettingsValidationError
 from grelmicro.log import (
-    LoggingConfig,
-    LoggingSettingsValidationError,
+    LogConfig,
+    LogSettingsValidationError,
     configure,
     configure_with,
 )
-from grelmicro.log.config import LoggingBackendType, LoggingLevelType
+from grelmicro.log.config import LogBackendType, LogLevelType
 
 
 def test_configure_returns_resolved_config(
     monkeypatch: pytest.MonkeyPatch,
     reset_backend: None,  # noqa: ARG001
 ) -> None:
-    """`configure()` returns the `LoggingConfig` it applied."""
+    """`configure()` returns the `LogConfig` it applied."""
     monkeypatch.delenv("GREL_LOG_LEVEL", raising=False)
-    cfg = configure(level=LoggingLevelType.DEBUG)
-    assert isinstance(cfg, LoggingConfig)
-    assert cfg.level == LoggingLevelType.DEBUG
+    cfg = configure(level=LogLevelType.DEBUG)
+    assert isinstance(cfg, LogConfig)
+    assert cfg.level == LogLevelType.DEBUG
 
 
 def test_configure_kwargs_override_env(
@@ -29,8 +29,8 @@ def test_configure_kwargs_override_env(
 ) -> None:
     """Caller kwargs win over `GREL_LOG_*` env vars."""
     monkeypatch.setenv("GREL_LOG_LEVEL", "WARNING")
-    cfg = configure(level=LoggingLevelType.DEBUG)
-    assert cfg.level == LoggingLevelType.DEBUG
+    cfg = configure(level=LogLevelType.DEBUG)
+    assert cfg.level == LogLevelType.DEBUG
 
 
 def test_configure_reads_env_when_kwargs_unset(
@@ -41,8 +41,8 @@ def test_configure_reads_env_when_kwargs_unset(
     monkeypatch.setenv("GREL_LOG_LEVEL", "ERROR")
     monkeypatch.setenv("GREL_LOG_BACKEND", "stdlib")
     cfg = configure()
-    assert cfg.level == LoggingLevelType.ERROR
-    assert cfg.backend == LoggingBackendType.STDLIB
+    assert cfg.level == LogLevelType.ERROR
+    assert cfg.backend == LogBackendType.STDLIB
 
 
 def test_configure_env_load_false_ignores_env(
@@ -52,30 +52,30 @@ def test_configure_env_load_false_ignores_env(
     """`env_load=False` skips env reading entirely."""
     monkeypatch.setenv("GREL_LOG_LEVEL", "ERROR")
     cfg = configure(env_load=False)
-    assert cfg.level == LoggingLevelType.INFO  # default
+    assert cfg.level == LogLevelType.INFO  # default
 
 
 def test_configure_invalid_level_raises_settings_error(
     monkeypatch: pytest.MonkeyPatch,
     reset_backend: None,  # noqa: ARG001
 ) -> None:
-    """Invalid env values raise a catchable `LoggingSettingsValidationError`."""
+    """Invalid env values raise a catchable `LogSettingsValidationError`."""
     monkeypatch.setenv("GREL_LOG_LEVEL", "BOGUS")
-    with pytest.raises(LoggingSettingsValidationError) as exc_info:
+    with pytest.raises(LogSettingsValidationError) as exc_info:
         configure()
     assert isinstance(exc_info.value, SettingsValidationError)
 
 
 def test_logging_settings_error_is_settings_validation_error() -> None:
-    """`LoggingSettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(LoggingSettingsValidationError, SettingsValidationError)
+    """`LogSettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(LogSettingsValidationError, SettingsValidationError)
 
 
 def test_configure_with_returns_passed_config(
     reset_backend: None,  # noqa: ARG001
 ) -> None:
-    """`configure_with(cfg)` returns the same `LoggingConfig` for symmetry."""
-    cfg = LoggingConfig(level=LoggingLevelType.WARNING)
+    """`configure_with(cfg)` returns the same `LogConfig` for symmetry."""
+    cfg = LogConfig(level=LogLevelType.WARNING)
     returned = configure_with(cfg)
     assert returned is cfg
 
@@ -86,6 +86,6 @@ def test_configure_with_bypasses_env(
 ) -> None:
     """`configure_with(cfg)` ignores env vars and uses the passed config as-is."""
     monkeypatch.setenv("GREL_LOG_LEVEL", "ERROR")
-    cfg = LoggingConfig(level=LoggingLevelType.WARNING)
+    cfg = LogConfig(level=LogLevelType.WARNING)
     returned = configure_with(cfg)
-    assert returned.level == LoggingLevelType.WARNING
+    assert returned.level == LogLevelType.WARNING

--- a/tests/logging/test_ratelimit.py
+++ b/tests/logging/test_ratelimit.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic import ValidationError
 
 from grelmicro.log import (
-    LoggingSettingsValidationError,
+    LogSettingsValidationError,
     RateLimitFilter,
     RateLimitFilterConfig,
 )
@@ -79,9 +79,9 @@ def test_config_property_is_frozen() -> None:
     ],
 )
 def test_invalid_config(capacity: int, refill_rate: float, cost: float) -> None:
-    """Test non-positive values raise LoggingSettingsValidationError."""
+    """Test non-positive values raise LogSettingsValidationError."""
     # Act & Assert
-    with pytest.raises(LoggingSettingsValidationError, match="greater than"):
+    with pytest.raises(LogSettingsValidationError, match="greater than"):
         RateLimitFilter(capacity=capacity, refill_rate=refill_rate, cost=cost)
 
 


### PR DESCRIPTION
Closes #423. **Breaking** (clean cut, no shim). Parallel to the Trace rename (#408).

The component is `Log`, but its public symbols used the `Logging` stem. Renamed all eight to match:

`LoggingConfig`->`LogConfig`, `LoggingError`->`LogError`, `LoggingSettingsValidationError`->`LogSettingsValidationError`, `LoggingBackendType`->`LogBackendType`, `LoggingFormatType`->`LogFormatType`, `LoggingLevelType`->`LogLevelType`, `LoggingSerializerType`->`LogSerializerType`, `LoggingTimeZoneType`->`LogTimeZoneType`.

Exact-identifier rename (never a substring sweep): the `logging` concept word, the stdlib `logging` module, and prose are untouched. Class docstrings aligned to the `Log` stem. `__all__` re-sorted. The three `LogTimeZoneType` annotations keep their `# ty: ignore[invalid-type-form]` (needed under whole-project ty). API snapshot updated for the three top-level exports (the enum types live in `grelmicro.log.config`, not the package `__all__`).

Migration: update imports of the renamed symbols.