### PR TITLE
💥 Raise typed error on reconfigure worker-change rejection

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 `reconfigure()` now raises `CoordinationSettingsValidationError` (a `SettingsValidationError`, still a `ValueError` subclass) instead of a bare `ValueError` when a new config would change the immutable `worker`. Catch `SettingsValidationError` or `GrelmicroError` to handle it.
 * 💥 Rename the `ExternalConfig` `interval` parameter to `reload_interval`, tying the knob to the `reload()` verb it controls. Update `ExternalConfig(interval=...)` to `reload_interval=`.
 * 💥 Rename the log dedup `ttl_seconds` field to `ttl`, matching the bare-noun duration convention used everywhere else (the cache `ttl`, lock durations). Update `DuplicateFilter(ttl_seconds=...)` and `DedupConfig` to `ttl=`.
 * 💥 Rename the `Trace` component symbols to the `Trace` stem so they match the component name. `TracingConfig`, `TracingError`, `TracingExporterType`, `TracingProcessorType`, `TracingSamplerType`, and `TracingSettingsValidationError` become `TraceConfig`, `TraceError`, `TraceExporterType`, `TraceProcessorType`, `TraceSamplerType`, and `TraceSettingsValidationError`. Update imports.

--- a/grelmicro/coordination/_base.py
+++ b/grelmicro/coordination/_base.py
@@ -11,6 +11,7 @@ from typing_extensions import Doc
 from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination._tokens import generate_worker_id
 from grelmicro.coordination.abc import LockPrimitive
+from grelmicro.coordination.errors import CoordinationSettingsValidationError
 
 # Seam for randomness in retry jitter. Tests pin it to a fixed value.
 _random = random.random
@@ -43,11 +44,11 @@ def assert_worker_unchanged(
     """Reject a reconfigure that would change the immutable `worker` field."""
     if new.worker != current.worker:
         msg = (
-            f"reconfigure cannot change worker "
+            f"the worker is immutable and cannot change "
             f"({current.worker!r} -> {new.worker!r}). "
             f"Reuse the existing worker on the new config."
         )
-        raise ValueError(msg)
+        raise CoordinationSettingsValidationError(msg)
 
 
 class BaseLock(LockPrimitive, Protocol):

--- a/tests/coordination/test_leaderelection.py
+++ b/tests/coordination/test_leaderelection.py
@@ -11,6 +11,7 @@ from pytest_mock import MockerFixture
 import grelmicro.coordination._base as base_module
 import grelmicro.coordination.leaderelection as le_module
 from grelmicro.coordination.abc import LeaderElectionBackend
+from grelmicro.coordination.errors import CoordinationSettingsValidationError
 from grelmicro.coordination.leaderelection import (
     LeaderElection,
     LeaderElectionConfig,
@@ -672,7 +673,9 @@ async def test_leader_reconfigure_rejects_worker_change(
         update={"worker": "other-worker"},
     )
 
-    with pytest.raises(ValueError, match="cannot change worker"):
+    with pytest.raises(
+        CoordinationSettingsValidationError, match="worker is immutable"
+    ):
         await leader_election.reconfigure(new_config)
 
 

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -14,6 +14,7 @@ import grelmicro.coordination.lock as lock_module
 from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination.abc import LockBackend
 from grelmicro.coordination.errors import (
+    CoordinationSettingsValidationError,
     LockAcquireError,
     LockLockedCheckError,
     LockNotOwnedError,
@@ -864,7 +865,9 @@ async def test_reconfigure_rejects_worker_change(lock: Lock) -> None:
     """Changing `worker` is not allowed because the token identity is live."""
     new_config = lock.config.model_copy(update={"worker": "other-worker"})
 
-    with pytest.raises(ValueError, match="cannot change worker"):
+    with pytest.raises(
+        CoordinationSettingsValidationError, match="worker is immutable"
+    ):
         await lock.reconfigure(new_config)
 
     assert lock.config.worker != "other-worker"

--- a/tests/coordination/test_tasklock.py
+++ b/tests/coordination/test_tasklock.py
@@ -13,6 +13,7 @@ from pytest_mock import MockerFixture
 from grelmicro.coordination._tokens import generate_task_token
 from grelmicro.coordination.abc import LockBackend
 from grelmicro.coordination.errors import (
+    CoordinationSettingsValidationError,
     LockAcquireError,
     LockLockedCheckError,
     LockNotOwnedError,
@@ -749,7 +750,9 @@ async def test_tasklock_reconfigure_rejects_worker_change(
     )
     new_config = task_lock.config.model_copy(update={"worker": WORKER_2})
 
-    with pytest.raises(ValueError, match="cannot change worker"):
+    with pytest.raises(
+        CoordinationSettingsValidationError, match="worker is immutable"
+    ):
         await task_lock.reconfigure(new_config)
 
 


### PR DESCRIPTION
Closes #412. **Breaking** (error type), but `ValueError`-compatible.

`assert_worker_unchanged` raised a bare builtin `ValueError` when a reconfigure tried to change the immutable `worker`, which escaped both `except GrelmicroError` and the settings-error handlers. It now raises `CoordinationSettingsValidationError`, which roots in `GrelmicroError` and `SettingsValidationError` (and is still a `ValueError` subclass, so existing `except ValueError` keeps working).

Message reworded to read cleanly under the settings-validation framing ("the worker is immutable and cannot change ..."). The three worker-change reconfigure tests now assert the typed error.

Migration: optional. `except ValueError` still catches it; prefer `except SettingsValidationError`.