### PR TITLE
💥 Default @cached to in-process stampede folding (lock=local)

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -292,19 +292,19 @@ Arguments not named in the template do not affect the key, so calls that differ 
 
 ### Stampede Protection
 
-A cache stampede (or "dog-pile") happens when many callers miss the same key at once and all recompute it together. Turn on `lock` to fold those misses into one execution, and add `early=` to refresh hot keys before they expire:
+A cache stampede (or "dog-pile") happens when many callers miss the same key at once and all recompute it together. By default `@cached` folds those misses in-process (`lock="local"`). Raise it to `lock=True` to fold across replicas, drop it to `lock=False` to opt out, and add `early=` to refresh hot keys before they expire:
 
 | Setting | What it does | Cost | Use when |
 |---|---|---|---|
-| `lock=False` (default) | no protection | none | misses are cheap or rare |
-| `lock=True` | fold concurrent misses, across replicas when a `Coordination` backend is configured | one backend acquire per cold miss | the common case |
-| `lock="local"` | fold misses in-process only, never touches a backend | free, no I/O | per-replica recompute is fine |
+| `lock="local"` (default) | fold misses in-process only, never touches a backend | free, no I/O | the common case |
+| `lock=True` | fold concurrent misses, across replicas when a `Coordination` backend is configured | one backend acquire per cold miss | you need cross-replica dedup |
+| `lock=False` | no protection, every concurrent miss recomputes | none | misses are cheap or rare |
 | `early=0.1` | probabilistic early refresh (XFetch) in the last 10% of the TTL | one background recompute per refresh | the hottest keys, where no caller should ever block |
 
-`lock=True` always dedups in-process first, so the backend is hit at most once per cold miss. `early=` works alongside either lock mode.
+`lock=True` always dedups in-process first, so the backend is hit at most once per cold miss. `early=` works alongside any lock mode.
 
 ```python
-@cached(cache)                  # default: no stampede protection
+@cached(cache)                  # default: in-process stampede folding
 async def get_user(user_id: int) -> dict:
     return await db.fetch_user(user_id)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 `@cached` now folds concurrent misses of the same key in-process by default (`lock="local"` instead of `lock=False`). This removes a silent thundering-herd footgun at no I/O cost. Pass `lock=False` to restore the old behavior where every concurrent miss recomputes.
 * 💥 Move the backend protocols out of the public `abc` submodules into private `_protocol` modules (`clock`, `config`, `coordination`, `task`), matching `cache` and `resilience`. `VirtualClock` likewise moves to `clock/_virtual.py`. The protocols stay exported from each package, so import them from the package (`from grelmicro.coordination import LockBackend`) instead of `grelmicro.coordination.abc`.
 * 💥 `reconfigure()` now raises `CoordinationSettingsValidationError` (a `SettingsValidationError`, still a `ValueError` subclass) instead of a bare `ValueError` when a new config would change the immutable `worker`. Catch `SettingsValidationError` or `GrelmicroError` to handle it.
 * 💥 Rename the `ExternalConfig` `interval` parameter to `reload_interval`, tying the knob to the `reload()` verb it controls. Update `ExternalConfig(interval=...)` to `reload_interval=`.

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -233,20 +233,19 @@ def cached(  # noqa: PLR0913, C901
             Protect against duplicate work when many callers miss the
             same key at once (the "dog-pile" effect).
 
-            - ``False`` (default): no protection. Every concurrent miss
-              runs the function.
+            - ``"local"`` (default): fold concurrent misses within the
+              worker through an in-process lock, with no backend round-trip
+              on a cold miss. Per-replica recompute is still possible.
             - ``True``: fold concurrent misses to one execution. When the
               active `Grelmicro` app has a lock backend, misses fold
               across replicas through it. Otherwise an in-process lock
               folds them within the worker. An in-process lock is always
               applied first, so the backend is hit once per cold miss.
-            - ``"local"``: force the in-process lock only, even when a
-              lock backend is configured. Use when per-replica recompute
-              is acceptable and you want no backend round-trip on a cold
-              miss.
+            - ``False``: no protection. Every concurrent miss runs the
+              function.
             """,
         ),
-    ] = False,
+    ] = "local",
     early: Annotated[
         float | None,
         Doc(

--- a/tests/cache/test_cached_mutations.py
+++ b/tests/cache/test_cached_mutations.py
@@ -407,19 +407,41 @@ class TestDistributedComputePath:
 
 
 class TestLockDefault:
-    """Pin that `lock` defaults to False (no folding) for `@cached`."""
+    """Pin that `lock` defaults to `"local"` (in-process folding)."""
 
-    async def test_default_lock_does_not_fold_concurrent_misses(self) -> None:
-        """With no `lock` argument, concurrent misses each run the function.
+    async def test_default_lock_folds_concurrent_misses(self) -> None:
+        """With no `lock` argument, concurrent misses fold to one call.
 
-        A `lock=True` default would fold them to one call, so the count of
-        two pins the `False` default.
+        The default is `"local"`, an in-process lock that coalesces a
+        burst of misses within the worker, so the count is one.
         """
         cache = _make_cache()
         calls = 0
         barrier = asyncio.Event()
 
         @cached(cache)
+        async def fetch(x: int) -> int:
+            nonlocal calls
+            calls += 1
+            await barrier.wait()
+            return x * 2
+
+        task_a = asyncio.create_task(fetch(5))
+        task_b = asyncio.create_task(fetch(5))
+        await asyncio.sleep(0.05)
+        barrier.set()
+        await task_a
+        await task_b
+
+        assert calls == 1
+
+    async def test_lock_false_does_not_fold_concurrent_misses(self) -> None:
+        """`lock=False` opts out: every concurrent miss runs the function."""
+        cache = _make_cache()
+        calls = 0
+        barrier = asyncio.Event()
+
+        @cached(cache, lock=False)
         async def fetch(x: int) -> int:
             nonlocal calls
             calls += 1


### PR DESCRIPTION
Closes #414. **Breaking** (default behavior change).

`@cached` now defaults to `lock="local"` instead of `lock=False`, so a burst of concurrent misses of the same key folds to one execution within the worker, at no backend I/O cost. This removes a silent thundering-herd footgun.

```python
@cached(cache)              # now: in-process folding (lock="local")
@cached(cache, lock=False)  # opt out: every concurrent miss recomputes
@cached(cache, lock=True)   # fold across replicas via a Coordination backend
```

Tests: the default now folds (1 call), `lock=False` opts out (2 calls). Docs + changelog updated. Snapshot unaffected (defaults are normalized).

Migration: pass `lock=False` if you relied on every concurrent miss recomputing.

Inspiration: Caffeine `AsyncLoadingCache`, async-lru.