### PR TITLE
💥 Convert CircuitBreakerMetrics and ErrorDetails to frozen dataclasses

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 `CircuitBreakerMetrics` and `ErrorDetails` are now frozen slotted dataclasses instead of Pydantic models. Attribute access is unchanged, but they no longer offer `.model_dump()` or Pydantic validation. This matches `CircuitBreakerSnapshot` and `CacheInfo` (read-models are dataclasses, Pydantic is reserved for serialization boundaries).
 * 💥 `@cached` now folds concurrent misses of the same key in-process by default (`lock="local"` instead of `lock=False`). This removes a silent thundering-herd footgun at no I/O cost. Pass `lock=False` to restore the old behavior where every concurrent miss recomputes.
 * 💥 Move the backend protocols out of the public `abc` submodules into private `_protocol` modules (`clock`, `config`, `coordination`, `task`), matching `cache` and `resilience`. `VirtualClock` likewise moves to `clock/_virtual.py`. The protocols stay exported from each package, so import them from the package (`from grelmicro.coordination import LockBackend`) instead of `grelmicro.coordination.abc`.
 * 💥 `reconfigure()` now raises `CoordinationSettingsValidationError` (a `SettingsValidationError`, still a `ValueError` subclass) instead of a bare `ValueError` when a new config would change the immutable `worker`. Catch `SettingsValidationError` or `GrelmicroError` to handle it.

--- a/grelmicro/resilience/circuitbreaker/__init__.py
+++ b/grelmicro/resilience/circuitbreaker/__init__.py
@@ -14,7 +14,6 @@ from inspect import iscoroutinefunction
 from logging import getLogger
 from typing import TYPE_CHECKING, Annotated, Any, Self
 
-from pydantic import BaseModel, PositiveFloat, PositiveInt
 from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro
@@ -35,7 +34,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from types import TracebackType
 
-    from pydantic import Discriminator
+    from pydantic import Discriminator, PositiveFloat, PositiveInt
 
     from grelmicro._types import LogLevel
     from grelmicro.resilience._protocol import (
@@ -138,7 +137,8 @@ class CircuitBreakerState(StrEnum):
     """Circuit is forced closed for an indefinite time, calls are allowed."""
 
 
-class ErrorDetails(BaseModel, frozen=True, extra="forbid"):
+@dataclass(frozen=True, slots=True)
+class ErrorDetails:
     """Details about an error recorded by the circuit breaker."""
 
     time: datetime
@@ -146,7 +146,8 @@ class ErrorDetails(BaseModel, frozen=True, extra="forbid"):
     msg: str
 
 
-class CircuitBreakerMetrics(BaseModel, frozen=True, extra="forbid"):
+@dataclass(frozen=True, slots=True)
+class CircuitBreakerMetrics:
     """Circuit breaker metrics."""
 
     name: str

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -304,7 +304,7 @@
       "()": "(*, name, last_error_time=..., last_error=...)"
     },
     "CircuitBreakerMetrics": {
-      "()": "(*, name, state, active_calls, total_error_count, total_success_count, consecutive_error_count, consecutive_success_count, last_error)"
+      "()": "(name, state, active_calls, total_error_count, total_success_count, consecutive_error_count, consecutive_success_count, last_error)"
     },
     "CircuitBreakerRegistry": {
       "()": "(source, *, name=...)"
@@ -325,7 +325,7 @@
       "()": "(*, kind=..., delay=...)"
     },
     "ErrorDetails": {
-      "()": "(*, time, type, msg)"
+      "()": "(time, type, msg)"
     },
     "ExponentialBackoff": {
       "()": "(*, kind=..., base_delay=..., max_delay=..., jitter=...)"
@@ -519,7 +519,7 @@
       "()": "(*, name, last_error_time=..., last_error=...)"
     },
     "CircuitBreakerMetrics": {
-      "()": "(*, name, state, active_calls, total_error_count, total_success_count, consecutive_error_count, consecutive_success_count, last_error)"
+      "()": "(name, state, active_calls, total_error_count, total_success_count, consecutive_error_count, consecutive_success_count, last_error)"
     },
     "CircuitBreakerState": {
       "()": "(*values)"
@@ -528,7 +528,7 @@
       "()": "(*, kind=..., ignore_exceptions=..., error_threshold=..., success_threshold=..., reset_timeout=..., half_open_capacity=..., log_level=...)"
     },
     "ErrorDetails": {
-      "()": "(*, time, type, msg)"
+      "()": "(time, type, msg)"
     }
   },
   "grelmicro.resilience.ratelimiter": {


### PR DESCRIPTION
Closes #409. **Breaking** (read-model type).

`CircuitBreakerMetrics` and `ErrorDetails` were Pydantic models inside a component whose sibling read-model (`CircuitBreakerSnapshot`) is a frozen dataclass. Converted both to `@dataclass(frozen=True, slots=True)`.

- Attribute access is unchanged. They no longer offer `.model_dump()` or Pydantic validation (the breaker builds them with already-correct types).
- Establishes the rule: in-process read-models are frozen slotted dataclasses, Pydantic is reserved for serialization boundaries (configs). Matches `CircuitBreakerSnapshot` and `CacheInfo`.
- `BaseModel` import dropped (no Pydantic model left in the file); `PositiveFloat`/`PositiveInt` moved to `TYPE_CHECKING`. API snapshot updated.

Migration: drop `.model_dump()` on these; use attribute access (or `dataclasses.asdict`).