### PR TITLE
💥 Two-verb CircuitBreaker manual control: isolate() / reset()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 Replace the six manual circuit-breaker control methods with two operator verbs. `isolate()` forces the breaker open until reset, `reset()` returns it to normal automatic operation starting `CLOSED`. Replace `transition_to_forced_open()` with `isolate()` and `restart()` with `reset()`. The remaining `transition_to_closed`, `transition_to_open`, `transition_to_half_open`, and `transition_to_forced_closed` are removed.
 * 💥 `CircuitBreakerMetrics` and `ErrorDetails` are now frozen slotted dataclasses instead of Pydantic models. Attribute access is unchanged, but they no longer offer `.model_dump()` or Pydantic validation. This matches `CircuitBreakerSnapshot` and `CacheInfo` (read-models are dataclasses, Pydantic is reserved for serialization boundaries).
 * 💥 `@cached` now folds concurrent misses of the same key in-process by default (`lock="local"` instead of `lock=False`). This removes a silent thundering-herd footgun at no I/O cost. Pass `lock=False` to restore the old behavior where every concurrent miss recomputes.
 * 💥 Move the backend protocols out of the public `abc` submodules into private `_protocol` modules (`clock`, `config`, `coordination`, `task`), matching `cache` and `resilience`. `VirtualClock` likewise moves to `clock/_virtual.py`. The protocols stay exported from each package, so import them from the package (`from grelmicro.coordination import LockBackend`) instead of `grelmicro.coordination.abc`.

--- a/docs/resilience/circuit-breaker.md
+++ b/docs/resilience/circuit-breaker.md
@@ -45,11 +45,19 @@ stateDiagram-v2
     | **FORCED_OPEN**   | Manual override that blocks every call.                            |
     | **FORCED_CLOSED** | Manual override that allows every call.                            |
 
+## Manual control
+
+Two operator verbs let you drive the breaker by hand.
+
+`await cb.isolate()` is the big red button. It forces the breaker open (`FORCED_OPEN`) and keeps it there, so every call is blocked until you reset. Use it to take a known-bad dependency out of rotation.
+
+`await cb.reset()` returns the breaker to normal automatic operation. It clears the counters and the last error, then moves to `CLOSED`. Use it to release an `isolate()` hold or to start fresh.
+
 ## Backend
 
 By default each replica keeps its own breaker state. A degraded downstream trips one replica's breaker without telling the others, and `error_threshold` errors must happen on every replica before the dependency stops being probed.
 
-Pass a shared `CircuitBreakerRegistry(redis_provider)` or `CircuitBreakerRegistry(postgres_provider)` to fan that state out. The first replica to trip the breaker opens it for the fleet, the `half_open_capacity` admission cap is enforced globally so probes never exceed the cap across replicas, and manual `transition_to_*` calls are visible everywhere.
+Pass a shared `CircuitBreakerRegistry(redis_provider)` or `CircuitBreakerRegistry(postgres_provider)` to fan that state out. The first replica to trip the breaker opens it for the fleet, the `half_open_capacity` admission cap is enforced globally so probes never exceed the cap across replicas, and manual `isolate()` and `reset()` calls are visible everywhere.
 
 !!! tip "Install"
     The Redis backend needs the `redis` extra and the Postgres backend needs the `postgres` extra: `pip install "grelmicro[redis]"` or `pip install "grelmicro[postgres]"`. See the [installation guide](../installation.md) for `uv` and `poetry`.
@@ -87,7 +95,7 @@ When the shared backend is unreachable, calls to the breaker raise the underlyin
     |---|---|---|
     | State scope | Per replica | Fleet-wide |
     | Half-open admission cap | Enforced per replica | Enforced globally |
-    | Manual `transition_to_*` | Visible to one replica | Visible to every replica |
+    | Manual `isolate()` / `reset()` | Visible to one replica | Visible to every replica |
     | `last_error` / `last_error_time` | Per replica | Per replica |
     | `total_error_count` / `total_success_count` | Per replica | Per replica |
 

--- a/grelmicro/resilience/circuitbreaker/__init__.py
+++ b/grelmicro/resilience/circuitbreaker/__init__.py
@@ -610,46 +610,33 @@ class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):
             last_error=self._map_last_error(),
         )
 
-    async def restart(self) -> None:
-        """Restart the breaker, clearing all counts and resetting to CLOSED state."""
+    async def isolate(self) -> None:
+        """Force the breaker open and keep it open until reset.
+
+        The manual "big red button". Moves the breaker to
+        `FORCED_OPEN`, so every call is blocked with
+        `CircuitBreakerError` regardless of outcomes, until
+        [`reset`][grelmicro.resilience.CircuitBreaker.reset] returns it
+        to automatic operation.
+        """
+        await self._transition(
+            CircuitBreakerState.FORCED_OPEN, _TransitionCause.MANUAL
+        )
+
+    async def reset(self) -> None:
+        """Return the breaker to normal automatic operation.
+
+        Clears all counters and the last recorded error, then moves the
+        breaker to `CLOSED`. Use it to release an
+        [`isolate`][grelmicro.resilience.CircuitBreaker.isolate] hold or
+        to start fresh from a known state.
+        """
         self._total_error_count = 0
         self._total_success_count = 0
         self._last_error = None
         self._last_error_time = None
         await self._transition(
             CircuitBreakerState.CLOSED, _TransitionCause.RESTART
-        )
-
-    async def transition_to_closed(self) -> None:
-        """Transition the circuit breaker to CLOSED state."""
-        await self._transition(
-            CircuitBreakerState.CLOSED, _TransitionCause.MANUAL
-        )
-
-    async def transition_to_open(self, until: float | None = None) -> None:
-        """Transition the circuit breaker to OPEN state."""
-        await self._transition(
-            CircuitBreakerState.OPEN,
-            _TransitionCause.MANUAL,
-            cool_down=until,
-        )
-
-    async def transition_to_half_open(self) -> None:
-        """Transition the circuit breaker to HALF_OPEN state."""
-        await self._transition(
-            CircuitBreakerState.HALF_OPEN, _TransitionCause.MANUAL
-        )
-
-    async def transition_to_forced_open(self) -> None:
-        """Transition the circuit breaker to FORCED_OPEN state."""
-        await self._transition(
-            CircuitBreakerState.FORCED_OPEN, _TransitionCause.MANUAL
-        )
-
-    async def transition_to_forced_closed(self) -> None:
-        """Transition the circuit breaker to FORCED_CLOSED state."""
-        await self._transition(
-            CircuitBreakerState.FORCED_CLOSED, _TransitionCause.MANUAL
         )
 
     async def _transition(

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -27,6 +27,7 @@ from grelmicro.resilience.circuitbreaker import (
     CircuitBreakerMetrics,
     CircuitBreakerState,
     ErrorDetails,
+    _TransitionCause,
 )
 from grelmicro.resilience.circuitbreaker import memory as cb_memory_module
 from grelmicro.resilience.circuitbreaker.memory import (
@@ -65,18 +66,8 @@ def _cb_backend() -> MemoryCircuitBreakerAdapter:
 
 
 async def transition(cb: CircuitBreaker, state: CircuitBreakerState) -> None:
-    """Transition the circuit breaker to the specified state."""
-    match state:
-        case CircuitBreakerState.OPEN:
-            await cb.transition_to_open()
-        case CircuitBreakerState.HALF_OPEN:
-            await cb.transition_to_half_open()
-        case CircuitBreakerState.CLOSED:
-            await cb.transition_to_closed()
-        case CircuitBreakerState.FORCED_CLOSED:
-            await cb.transition_to_forced_closed()
-        case CircuitBreakerState.FORCED_OPEN:
-            await cb.transition_to_forced_open()
+    """Drive the circuit breaker into the specified state for white-box tests."""
+    await cb._transition(state, _TransitionCause.MANUAL)
 
 
 async def create_circuit(
@@ -829,15 +820,15 @@ async def test_circuit_metrics_with_call_not_permitted(
     )
 
 
-async def test_circuit_restart() -> None:
-    """Test circuit breaker restarts after forced open."""
+async def test_circuit_reset() -> None:
+    """Test circuit breaker resets to CLOSED after recorded calls."""
     # Arrange
     cb = CircuitBreaker("test")
     await generate_error(cb)
     await generate_success(cb)
 
     # Act
-    await cb.restart()
+    await cb.reset()
 
     # Assert
     assert cb.metrics() == CircuitBreakerMetrics(
@@ -852,15 +843,17 @@ async def test_circuit_restart() -> None:
     )
 
 
-async def test_circuit_restart_after_calls() -> None:
-    """Test circuit breaker restarts after recorded calls."""
+async def test_circuit_reset_after_isolate() -> None:
+    """Test reset returns to CLOSED and clears counts after isolate."""
     # Arrange
     cb = CircuitBreaker("test")
     await generate_error(cb)
     await generate_success(cb)
+    await cb.isolate()
+    assert cb.state == CircuitBreakerState.FORCED_OPEN
 
     # Act
-    await cb.restart()
+    await cb.reset()
 
     # Assert
     assert cb.state == CircuitBreakerState.CLOSED
@@ -876,6 +869,21 @@ async def test_circuit_restart_after_calls() -> None:
         consecutive_success_count=0,
         last_error=None,
     )
+
+
+async def test_circuit_isolate_blocks_calls() -> None:
+    """Test isolate forces the breaker open and blocks every call."""
+    # Arrange
+    cb = CircuitBreaker("test")
+
+    # Act
+    await cb.isolate()
+
+    # Assert
+    assert cb.state == CircuitBreakerState.FORCED_OPEN
+    with pytest.raises(CircuitBreakerError):
+        async with cb:
+            pytest.fail("Expected not reached")
 
 
 @pytest.mark.parametrize("from_state", ALL_STATES)
@@ -1223,49 +1231,32 @@ class TestSharedBackendIntegration:
         ]
         assert cb.last_error is sentinel_error
 
-    async def test_transition_to_open_calls_backend(self) -> None:
-        """`transition_to_open` forwards the desired state to the backend."""
+    async def test_isolate_calls_backend(self) -> None:
+        """`isolate` forwards FORCED_OPEN to the backend."""
         backend = _FakeSharedBackend()
         async with backend:
             cb = CircuitBreaker.consecutive_count(
                 "shared", backend=backend, reset_timeout=9.0
             )
-            await cb.transition_to_open()
+            await cb.isolate()
         assert backend.transition_calls == [
             {
                 "name": "shared",
-                "desired": CircuitBreakerState.OPEN,
+                "desired": CircuitBreakerState.FORCED_OPEN,
                 "cool_down": None,
             }
         ]
 
-    async def test_transition_to_open_with_until_passes_cool_down(
-        self,
-    ) -> None:
-        """`transition_to_open(until=X)` forwards X as cool_down."""
+    async def test_isolate_then_reset_call_backend(self) -> None:
+        """`isolate` then `reset` forward FORCED_OPEN then CLOSED."""
         backend = _FakeSharedBackend()
         async with backend:
             cb = CircuitBreaker("shared", backend=backend)
-            cool = 2.5
-            await cb.transition_to_open(until=cool)
-        assert backend.transition_calls[-1]["cool_down"] == cool
-
-    async def test_all_transitions_and_restart_call_backend(self) -> None:
-        """Every manual transition and `restart` forwards to the backend."""
-        backend = _FakeSharedBackend()
-        async with backend:
-            cb = CircuitBreaker("shared", backend=backend)
-            await cb.transition_to_closed()
-            await cb.transition_to_half_open()
-            await cb.transition_to_forced_open()
-            await cb.transition_to_forced_closed()
-            await cb.restart()
+            await cb.isolate()
+            await cb.reset()
         desired_states = [c["desired"] for c in backend.transition_calls]
         assert desired_states == [
-            CircuitBreakerState.CLOSED,
-            CircuitBreakerState.HALF_OPEN,
             CircuitBreakerState.FORCED_OPEN,
-            CircuitBreakerState.FORCED_CLOSED,
             CircuitBreakerState.CLOSED,
         ]
 

--- a/tests/resilience/test_stress.py
+++ b/tests/resilience/test_stress.py
@@ -17,6 +17,7 @@ from grelmicro.resilience import CircuitBreakerRegistry, RateLimiterRegistry
 from grelmicro.resilience.circuitbreaker import (
     CircuitBreaker,
     CircuitBreakerState,
+    _TransitionCause,
 )
 from grelmicro.resilience.circuitbreaker.memory import (
     MemoryCircuitBreakerAdapter,
@@ -90,11 +91,17 @@ async def test_circuit_breaker_churn() -> None:
         )
 
         for _ in range(CHURN_CYCLES):
-            await cb.transition_to_open()
+            await cb._transition(
+                CircuitBreakerState.OPEN, _TransitionCause.MANUAL
+            )
             assert cb.state is CircuitBreakerState.OPEN
-            await cb.transition_to_half_open()
+            await cb._transition(
+                CircuitBreakerState.HALF_OPEN, _TransitionCause.MANUAL
+            )
             assert cb.state is CircuitBreakerState.HALF_OPEN
-            await cb.transition_to_closed()
+            await cb._transition(
+                CircuitBreakerState.CLOSED, _TransitionCause.MANUAL
+            )
             assert cb.state is CircuitBreakerState.CLOSED
 
         assert cb.state is CircuitBreakerState.CLOSED


### PR DESCRIPTION
Closes #407. **Breaking** (clean cut).

The six public manual-control coroutines (`transition_to_closed/open/half_open/forced_open/forced_closed`, `restart`) are replaced by two operator verbs, matching Polly's `Isolate`/`Reset`:

```python
await cb.isolate()   # force OPEN (FORCED_OPEN), block all calls until reset
await cb.reset()     # return to normal automatic operation, start CLOSED
```

- `isolate()` = `_transition(FORCED_OPEN, MANUAL)`. `reset()` = the old `restart()` body (clear counts + last_error, transition to CLOSED).
- None of the six were used internally (the state machine drives `self._transition` directly), so they were removed, not internalized. `_transition` stays private.
- Tests cover isolate-blocks-calls, reset-clears, isolate-then-reset, backend notification. White-box state tests use `_transition`. Docs updated.

Migration: `transition_to_forced_open()` -> `isolate()`, `restart()` -> `reset()`. The other four manual transitions are removed (the breaker manages state automatically).