### PR TITLE
💥 Namespace HealthChecks env vars per instance

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 `HealthChecks` now namespaces its env vars per instance: the default instance keeps `GREL_HEALTH_*`, but a named instance reads `GREL_HEALTH_{NAME_UPPER}_*` (matching `Lock`, `CircuitBreaker`, and the other named components). Update env vars for any named `HealthChecks`.
 * 💥 Replace the six manual circuit-breaker control methods with two operator verbs. `isolate()` forces the breaker open until reset, `reset()` returns it to normal automatic operation starting `CLOSED`. Replace `transition_to_forced_open()` with `isolate()` and `restart()` with `reset()`. The remaining `transition_to_closed`, `transition_to_open`, `transition_to_half_open`, and `transition_to_forced_closed` are removed.
 * 💥 `CircuitBreakerMetrics` and `ErrorDetails` are now frozen slotted dataclasses instead of Pydantic models. Attribute access is unchanged, but they no longer offer `.model_dump()` or Pydantic validation. This matches `CircuitBreakerSnapshot` and `CacheInfo` (read-models are dataclasses, Pydantic is reserved for serialization boundaries).
 * 💥 `@cached` now folds concurrent misses of the same key in-process by default (`lock="local"` instead of `lock=False`). This removes a silent thundering-herd footgun at no I/O cost. Pass `lock=False` to restore the old behavior where every concurrent miss recomputes.

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -13,7 +13,11 @@ from pydantic import BaseModel, NonNegativeFloat, PositiveFloat
 from typing_extensions import Doc
 
 from grelmicro._async import is_async_callable
-from grelmicro._config import Reconfigurable, resolve_config
+from grelmicro._config import (
+    Reconfigurable,
+    default_env_prefix,
+    resolve_config,
+)
 from grelmicro.health._models import (
     CheckResult,
     HealthReport,
@@ -138,8 +142,9 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
 
                 Default: 5.0. When unset and env reads are enabled (see ``env_load`` and
                 ``GREL_ENV_LOAD``), resolves from the
-                environment variable ``GREL_HEALTH_TIMEOUT`` if
-                present, otherwise falls back to the
+                environment variable ``GREL_HEALTH_TIMEOUT`` (or
+                ``GREL_HEALTH_{NAME_UPPER}_TIMEOUT`` for a named instance)
+                if present, otherwise falls back to the
                 ``HealthChecksConfig`` default.
                 """
             ),
@@ -152,8 +157,9 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
 
                 Default: 1.0. When unset and env reads are enabled (see ``env_load`` and
                 ``GREL_ENV_LOAD``), resolves from the
-                environment variable ``GREL_HEALTH_CACHE_TTL`` if
-                present, otherwise falls back to the
+                environment variable ``GREL_HEALTH_CACHE_TTL`` (or
+                ``GREL_HEALTH_{NAME_UPPER}_CACHE_TTL`` for a named instance)
+                if present, otherwise falls back to the
                 ``HealthChecksConfig`` default.
                 """
             ),
@@ -164,7 +170,8 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
                 """
                 Override the auto-derived environment variable prefix.
 
-                Default: ``GREL_HEALTH_``.
+                Default: ``GREL_HEALTH_`` for the default instance,
+                ``GREL_HEALTH_{NAME_UPPER}_`` for a named one.
                 """
             ),
         ] = None,
@@ -198,7 +205,7 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
             HealthChecksConfig,
             explicit=None,
             kwargs={"timeout": timeout, "cache_ttl": cache_ttl},
-            env_prefix=env_prefix or "GREL_HEALTH_",
+            env_prefix=env_prefix or default_env_prefix("HEALTH", name),
             env_load=env_load,
             error_type=HealthSettingsValidationError,
         )

--- a/tests/health/test_checks_config.py
+++ b/tests/health/test_checks_config.py
@@ -47,6 +47,16 @@ def test_environmental_path_reads_grel_prefixed_env(
     assert registry._config.cache_ttl == CACHE_TTL_ENV
 
 
+def test_named_instance_reads_name_segmented_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A named instance reads ``GREL_HEALTH_{NAME}_*``, not the bare prefix."""
+    monkeypatch.setenv("GREL_HEALTH_TIMEOUT", str(TIMEOUT_KWARG))
+    monkeypatch.setenv("GREL_HEALTH_API_TIMEOUT", str(TIMEOUT_ENV))
+    registry = HealthChecks(name="api")
+    assert registry._config.timeout == TIMEOUT_ENV
+
+
 def test_kwargs_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Caller kwargs win over env vars."""
     monkeypatch.setenv("GREL_HEALTH_TIMEOUT", str(TIMEOUT_ENV))


### PR DESCRIPTION
Closes #418. **Breaking** for named instances (the default instance is unchanged).

`HealthChecks` used a flat `GREL_HEALTH_` prefix regardless of name. It now uses the shared `default_env_prefix("HEALTH", name)` helper, matching `Lock`, `CircuitBreaker`, and the other named components:

```
GREL_HEALTH_TIMEOUT          # default instance (unchanged)
GREL_HEALTH_API_TIMEOUT      # HealthChecks(name="api")
```

The default instance keeps `GREL_HEALTH_*`, so existing setups are unaffected. Only a named `HealthChecks` now reads the name-segmented prefix. Docstrings updated, named-instance test added. Snapshot unaffected.

Migration: update env vars for any named `HealthChecks` instance.