### PR TITLE
✨ Add MemoryProvider for provider-direct Memory access

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,7 @@
 * ✨ Every component now raises a typed `*SettingsValidationError` for invalid configuration, rooted in the shared `SettingsValidationError` base. Adds `TraceSettingsValidationError`, `HealthSettingsValidationError`, `LogSettingsValidationError`, and `IdempotencySettingsValidationError`. Catch `SettingsValidationError` to handle any of them.
 * ✨ Cache adapters (`MemoryCacheAdapter`, `RedisCacheAdapter`, `PostgresCacheAdapter`, `SQLiteCacheAdapter`) now declare the `CacheBackend` protocol explicitly, matching the lock, circuit breaker, and rate limiter adapters.
 * ✨ Add `Log.from_config`, `Trace.from_config`, and `Metrics.from_config` to build each component from a pre-built config, matching the declarative path on every other pattern. The `config=` kwarg still works.
+* ✨ Add `MemoryProvider` so Memory has the same provider-direct surface (`memory.lock()`, `memory.cache()`, ...) as Redis, Postgres, and SQLite.
 
 ### Fixed
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -5,8 +5,8 @@ the native client (a Redis pool, an asyncpg pool, ...), and the lifecycle
 of both. Components like `Coordination`, `Cache`, and `RateLimiterRegistry` accept a
 Provider directly and use its matching adapter under the hood.
 
-Four providers ship today: `RedisProvider`, `ValkeyProvider`, `PostgresProvider`, and
-`SQLiteProvider`. More will follow.
+Five providers ship today: `RedisProvider`, `ValkeyProvider`, `PostgresProvider`,
+`SQLiteProvider`, and `MemoryProvider`. More will follow.
 
 ## Recommended shape
 
@@ -220,14 +220,14 @@ leader-election adapters touch one key per call and work on Cluster as is.
 
 Each Provider exposes factory methods that return its matching adapter:
 
-| Method                      | Returns                       | RedisProvider | ValkeyProvider | PostgresProvider | SQLiteProvider |
-|----------------------------|-------------------------------|:-------------:|:--------------:|:----------------:|:--------------:|
-| `.lock(**kwargs)`           | `LockBackend` implementation  |       ✓        |       ✓        |        ✓         |       ✓        |
-| `.schedule(**kwargs)`       | `ScheduleBackend` impl        |       ✓        |       ✓        |        ✓         |       ✓        |
-| `.leaderelection(**kwargs)` | `LeaderElectionBackend` impl  |       ✓        |       ✓        |        ✓         |      N/A       |
-| `.cache(**kwargs)`          | `CacheBackend` implementation |       ✓        |       ✓        |        ✓         |       ✓        |
-| `.ratelimiter(**kwargs)`    | `RateLimiterBackend` impl     |       ✓        |       ✓        |        ✓         |       ✓        |
-| `.circuitbreaker(**kwargs)` | `CircuitBreakerBackend` impl  |       ✓        |       ✓        |        ✓         |       ✓        |
+| Method                      | Returns                       | RedisProvider | ValkeyProvider | PostgresProvider | SQLiteProvider | MemoryProvider |
+|----------------------------|-------------------------------|:-------------:|:--------------:|:----------------:|:--------------:|:--------------:|
+| `.lock(**kwargs)`           | `LockBackend` implementation  |       ✓        |       ✓        |        ✓         |       ✓        |       ✓        |
+| `.schedule(**kwargs)`       | `ScheduleBackend` impl        |       ✓        |       ✓        |        ✓         |       ✓        |       ✓        |
+| `.leaderelection(**kwargs)` | `LeaderElectionBackend` impl  |       ✓        |       ✓        |        ✓         |      N/A       |       ✓        |
+| `.cache(**kwargs)`          | `CacheBackend` implementation |       ✓        |       ✓        |        ✓         |       ✓        |       ✓        |
+| `.ratelimiter(**kwargs)`    | `RateLimiterBackend` impl     |       ✓        |       ✓        |        ✓         |       ✓        |       ✓        |
+| `.circuitbreaker(**kwargs)` | `CircuitBreakerBackend` impl  |       ✓        |       ✓        |        ✓         |       ✓        |       ✓        |
 
 Factories that do not apply raise `NotImplementedError` with a message
 pointing to the right alternative. `Coordination(provider)`, `Cache(provider)`,
@@ -236,7 +236,8 @@ pointing to the right alternative. `Coordination(provider)`, `Cache(provider)`,
 ## Readiness check
 
 Every connection provider ships a built-in `check()` readiness probe: Redis and
-Valkey run `PING`, Postgres and SQLite run `SELECT 1`. A `HealthChecks` registers it as a
+Valkey run `PING`, Postgres and SQLite run `SELECT 1`, and Memory returns
+ready right away. A `HealthChecks` registers it as a
 `provider:{short_name}` check, one provider at a time with
 `health.add_provider(provider)` or for the whole app with
 `HealthChecks(auto_health=True)`. See [Health Checks](health.md#provider-readiness-checks).
@@ -382,18 +383,53 @@ Provider would access `provider.client` before the pool exists and raise
 `OutOfContextError`. `Grelmicro.__aenter__` warns on this ordering, but
 the correct fix is to list the Provider first.
 
-## Memory backends
+## Memory
 
-In-memory backends (`MemoryLockAdapter`, `MemoryCacheAdapter`,
-`MemoryRateLimiterAdapter`, `MemoryCircuitBreakerAdapter`) have no
-provider. Pass the adapter directly to its Component:
+`MemoryProvider` ships every factory: `.lock()`, `.leaderelection()`,
+`.schedule()`, `.cache()`, `.ratelimiter()`, and `.circuitbreaker()`. It owns no
+connection. State lives in process and disappears on restart, so it is for
+tests and single-process apps. Reach for Redis, Postgres, or SQLite for
+durable, distributed coordination.
 
 ```python
 from grelmicro import Grelmicro
-from grelmicro.resilience import CircuitBreakerRegistry
-from grelmicro.resilience.circuitbreaker.memory import MemoryCircuitBreakerAdapter
+from grelmicro.cache import Cache
+from grelmicro.coordination import Coordination
+from grelmicro.providers.memory import MemoryProvider
+from grelmicro.resilience import CircuitBreakerRegistry, RateLimiterRegistry
+
+memory = MemoryProvider()
 
 micro = Grelmicro(uses=[
-    CircuitBreakerRegistry(MemoryCircuitBreakerAdapter()),
+    memory,
+    Coordination(lock=memory.lock(), election=memory.leaderelection()),
+    Cache(memory.cache()),
+    RateLimiterRegistry(memory.ratelimiter()),
+    CircuitBreakerRegistry(memory.circuitbreaker()),
 ])
 ```
+
+Each factory hands back one cached adapter per kind, so the provider owns a
+single in-process store per kind. `memory.lock()` called twice returns the same
+backend, so a later call re-fetches the live store for a test or an
+introspection. Wire each kind into one component, the same way you would a Redis
+adapter. A lone `MemoryProvider` resolves every kind, so
+`uses=[memory, Coordination(memory)]` wires the lock, election, and schedule
+backends from it.
+
+To wire a single component, pass the provider straight in:
+
+```python
+from grelmicro import Grelmicro
+from grelmicro.coordination import Coordination
+from grelmicro.providers.memory import MemoryProvider
+
+memory = MemoryProvider()
+
+micro = Grelmicro(uses=[
+    Coordination(memory),
+])
+```
+
+You can still pass a raw adapter (`MemoryLockAdapter`, `MemoryCacheAdapter`, ...)
+to its Component when you do not want a provider.

--- a/grelmicro/providers/memory.py
+++ b/grelmicro/providers/memory.py
@@ -1,0 +1,144 @@
+"""Memory Provider."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar, Self
+
+from grelmicro.providers._base import Provider
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from grelmicro.cache.memory import MemoryCacheAdapter
+    from grelmicro.coordination.memory import (
+        MemoryLeaderElectionAdapter,
+        MemoryLockAdapter,
+        MemoryScheduleAdapter,
+    )
+    from grelmicro.resilience.circuitbreaker.memory import (
+        MemoryCircuitBreakerAdapter,
+    )
+    from grelmicro.resilience.ratelimiter.memory import (
+        MemoryRateLimiterAdapter,
+    )
+
+
+class MemoryProvider(Provider):
+    """In-process provider.
+
+    Gives Memory the same provider-direct surface as Redis, Postgres, and
+    SQLite. Each factory hands back one cached adapter per kind, so the
+    provider owns a single in-process store per kind instead of handing out
+    disconnected islands. `memory.lock()` called twice returns the same
+    `MemoryLockAdapter`, so a later call re-fetches the live store for a test
+    or an introspection. Wire each kind into one component, the same way you
+    would a Redis adapter. The provider owns no external resource: it stores
+    state in process and disappears on restart.
+
+    Use it for tests and single-process apps. Reach for a Redis, Postgres,
+    or SQLite provider for durable, distributed coordination.
+
+    ```python
+    from grelmicro import Grelmicro
+    from grelmicro.coordination import Coordination
+    from grelmicro.providers.memory import MemoryProvider
+
+    memory = MemoryProvider()
+    micro = Grelmicro(uses=[memory, Coordination(memory)])
+    ```
+
+    Read more in the [Providers](../providers.md) docs.
+    """
+
+    short_name: ClassVar[str] = "memory"
+
+    def __init__(self) -> None:
+        """Initialize the provider with empty per-kind adapter stores."""
+        self._lock: MemoryLockAdapter | None = None
+        self._leaderelection: MemoryLeaderElectionAdapter | None = None
+        self._schedule: MemoryScheduleAdapter | None = None
+        self._cache: MemoryCacheAdapter | None = None
+        self._ratelimiter: MemoryRateLimiterAdapter | None = None
+        self._circuitbreaker: MemoryCircuitBreakerAdapter | None = None
+
+    def __repr__(self) -> str:
+        """Return a representation of the provider."""
+        return "MemoryProvider()"
+
+    def lock(self, **kwargs: Any) -> MemoryLockAdapter:  # noqa: ANN401
+        """Return the shared `MemoryLockAdapter` for this provider."""
+        if self._lock is None:
+            from grelmicro.coordination.memory import (  # noqa: PLC0415
+                MemoryLockAdapter,
+            )
+
+            self._lock = MemoryLockAdapter(**kwargs)
+        return self._lock
+
+    def leaderelection(
+        self,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> MemoryLeaderElectionAdapter:
+        """Return the shared `MemoryLeaderElectionAdapter` for this provider."""
+        if self._leaderelection is None:
+            from grelmicro.coordination.memory import (  # noqa: PLC0415
+                MemoryLeaderElectionAdapter,
+            )
+
+            self._leaderelection = MemoryLeaderElectionAdapter(**kwargs)
+        return self._leaderelection
+
+    def schedule(self, **kwargs: Any) -> MemoryScheduleAdapter:  # noqa: ANN401
+        """Return the shared `MemoryScheduleAdapter` for this provider."""
+        if self._schedule is None:
+            from grelmicro.coordination.memory import (  # noqa: PLC0415
+                MemoryScheduleAdapter,
+            )
+
+            self._schedule = MemoryScheduleAdapter(**kwargs)
+        return self._schedule
+
+    def cache(self, **kwargs: Any) -> MemoryCacheAdapter:  # noqa: ANN401
+        """Return the shared `MemoryCacheAdapter` for this provider."""
+        if self._cache is None:
+            from grelmicro.cache.memory import (  # noqa: PLC0415
+                MemoryCacheAdapter,
+            )
+
+            self._cache = MemoryCacheAdapter(**kwargs)
+        return self._cache
+
+    def ratelimiter(self, **kwargs: Any) -> MemoryRateLimiterAdapter:  # noqa: ANN401
+        """Return the shared `MemoryRateLimiterAdapter` for this provider."""
+        if self._ratelimiter is None:
+            from grelmicro.resilience.ratelimiter.memory import (  # noqa: PLC0415
+                MemoryRateLimiterAdapter,
+            )
+
+            self._ratelimiter = MemoryRateLimiterAdapter(**kwargs)
+        return self._ratelimiter
+
+    def circuitbreaker(self, **kwargs: Any) -> MemoryCircuitBreakerAdapter:  # noqa: ANN401
+        """Return the shared `MemoryCircuitBreakerAdapter` for this provider."""
+        if self._circuitbreaker is None:
+            from grelmicro.resilience.circuitbreaker.memory import (  # noqa: PLC0415
+                MemoryCircuitBreakerAdapter,
+            )
+
+            self._circuitbreaker = MemoryCircuitBreakerAdapter(**kwargs)
+        return self._circuitbreaker
+
+    async def check(self) -> None:
+        """Report readiness. The in-process backend is always ready."""
+
+    async def __aenter__(self) -> Self:
+        """Open the provider. It owns no external resource."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the provider. It owns no external resource."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ redis = "grelmicro.providers.redis:RedisProvider"
 valkey = "grelmicro.providers.valkey:ValkeyProvider"
 postgres = "grelmicro.providers.postgres:PostgresProvider"
 sqlite = "grelmicro.providers.sqlite:SQLiteProvider"
+memory = "grelmicro.providers.memory:MemoryProvider"
 
 [project.entry-points."grelmicro.coordination.adapters"]
 memory = "grelmicro.coordination.memory:MemoryLockAdapter"

--- a/tests/providers/test_memory_provider.py
+++ b/tests/providers/test_memory_provider.py
@@ -1,0 +1,115 @@
+"""Tests for the Memory Provider."""
+
+import pytest
+
+from grelmicro.cache import Cache
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.coordination import Coordination
+from grelmicro.coordination.memory import (
+    MemoryLeaderElectionAdapter,
+    MemoryLockAdapter,
+    MemoryScheduleAdapter,
+)
+from grelmicro.providers.memory import MemoryProvider
+from grelmicro.resilience import CircuitBreakerRegistry, RateLimiterRegistry
+from grelmicro.resilience.circuitbreaker.memory import (
+    MemoryCircuitBreakerAdapter,
+)
+from grelmicro.resilience.ratelimiter.memory import MemoryRateLimiterAdapter
+
+
+def test_short_name() -> None:
+    """The provider carries the `memory` short name."""
+    assert MemoryProvider.short_name == "memory"
+
+
+def test_repr() -> None:
+    """`repr` shows the provider with no arguments."""
+    assert repr(MemoryProvider()) == "MemoryProvider()"
+
+
+def test_factories_return_adapters() -> None:
+    """The provider builds an adapter for every supported component."""
+    provider = MemoryProvider()
+    assert isinstance(provider.lock(), MemoryLockAdapter)
+    assert isinstance(provider.leaderelection(), MemoryLeaderElectionAdapter)
+    assert isinstance(provider.schedule(), MemoryScheduleAdapter)
+    assert isinstance(provider.cache(), MemoryCacheAdapter)
+    assert isinstance(provider.ratelimiter(), MemoryRateLimiterAdapter)
+    assert isinstance(provider.circuitbreaker(), MemoryCircuitBreakerAdapter)
+
+
+def test_factories_cache_one_adapter_per_kind() -> None:
+    """Each factory returns the same instance on repeated calls."""
+    provider = MemoryProvider()
+    assert provider.lock() is provider.lock()
+    assert provider.leaderelection() is provider.leaderelection()
+    assert provider.schedule() is provider.schedule()
+    assert provider.cache() is provider.cache()
+    assert provider.ratelimiter() is provider.ratelimiter()
+    assert provider.circuitbreaker() is provider.circuitbreaker()
+
+
+def test_unknown_kwarg_raises() -> None:
+    """A stray kwarg is forwarded and errors on first creation."""
+    provider = MemoryProvider()
+    with pytest.raises(TypeError):
+        provider.lock(bogus=1)
+
+
+async def test_handles_share_lock_state() -> None:
+    """Two handles from the same provider observe shared lock state."""
+    provider = MemoryProvider()
+    one = provider.lock()
+    two = provider.lock()
+    assert one is two
+    async with one:
+        assert await one.acquire(name="cart", token="w1", duration=10)
+        assert await two.locked(name="cart") is True
+        assert await two.owned(name="cart", token="w1") is True
+
+
+async def test_check_returns_none() -> None:
+    """`check` reports the in-process backend as ready."""
+    assert await MemoryProvider().check() is None
+
+
+async def test_context_manager_is_no_op() -> None:
+    """The provider enters and exits without owning a resource."""
+    provider = MemoryProvider()
+    async with provider as opened:
+        assert opened is provider
+    # Adapters are still cached after exit: the components own their lifecycle.
+    assert provider.lock() is provider.lock()
+
+
+def test_coordination_resolves_backends_from_provider() -> None:
+    """`Coordination(memory)` resolves lock, election, and schedule backends."""
+    provider = MemoryProvider()
+    coordination = Coordination(provider)
+    assert isinstance(coordination.lock_backend, MemoryLockAdapter)
+    assert isinstance(
+        coordination.election_backend, MemoryLeaderElectionAdapter
+    )
+    assert isinstance(coordination.schedule_backend, MemoryScheduleAdapter)
+
+
+def test_cache_resolves_backend_from_provider() -> None:
+    """`Cache(memory)` resolves a cache backend from the provider."""
+    provider = MemoryProvider()
+    cache = Cache(provider)
+    assert isinstance(cache.backend, MemoryCacheAdapter)
+
+
+def test_ratelimiter_registry_resolves_backend_from_provider() -> None:
+    """`RateLimiterRegistry(memory)` resolves a rate limiter backend."""
+    provider = MemoryProvider()
+    registry = RateLimiterRegistry(provider)
+    assert isinstance(registry.backend, MemoryRateLimiterAdapter)
+
+
+def test_circuitbreaker_registry_resolves_backend_from_provider() -> None:
+    """`CircuitBreakerRegistry(memory)` resolves a circuit breaker backend."""
+    provider = MemoryProvider()
+    registry = CircuitBreakerRegistry(provider)
+    assert isinstance(registry.backend, MemoryCircuitBreakerAdapter)


### PR DESCRIPTION
Closes #394.

Adds a first-class `MemoryProvider` so Memory has the same provider-direct surface as Redis, Postgres, and SQLite. No more reaching for raw `Memory*Adapter` classes.

```python
from grelmicro import Grelmicro
from grelmicro.coordination import Coordination
from grelmicro.providers.memory import MemoryProvider

memory = MemoryProvider()
micro = Grelmicro(uses=[memory, Coordination(memory)])
```

### What it does
* `MemoryProvider` mirrors the base `Provider` factory surface: `lock()`, `leaderelection()`, `schedule()`, `cache()`, `ratelimiter()`, `circuitbreaker()`, plus an always-ready `check()`.
* Each factory caches one adapter per kind, so the provider owns a single in-process store per kind instead of handing out disconnected islands. A repeated `memory.lock()` re-fetches the live store.
* Bare-provider resolution works like the others: `uses=[memory, Coordination(memory)]` wires lock, election, and schedule from it.
* Registered under the `grelmicro.providers` entry-point group as `memory`.

### Compatibility
Pure addition. The raw `Memory*Adapter` classes stay. `MemoryProvider` is not re-exported from `grelmicro.providers`, matching Redis/SQLite, so the public-API snapshot is unchanged.

### Tests & docs
* New `tests/providers/test_memory_provider.py`: factory types, per-kind caching, shared-state, bare-provider resolution for Coordination, Cache, and both resilience registries, no-op lifecycle.
* `docs/providers.md` gains a Memory provider section; changelog entry under Features.