### PR TITLE
💥 Rename @task.interval to @task.every

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,19 +269,19 @@ async def protected():
 
 
 # --- Interval Task: run locally on every worker ---
-@tasks.interval(seconds=5)
+@tasks.every(seconds=5)
 def heartbeat():
     logger.info("heartbeat")
 
 
 # --- Distributed Task: run once per interval across all workers ---
-@tasks.interval(seconds=60, lock=TaskLock(lease_duration=300))
+@tasks.every(seconds=60, lock=TaskLock(lease_duration=300))
 def cleanup():
     logger.info("cleanup")
 
 
 # --- Leader-gated Task: only the leader executes ---
-@tasks.interval(seconds=10, leader=leader)
+@tasks.every(seconds=10, leader=leader)
 def leader_only_task():
     logger.info("leader task")
 ```

--- a/docs/architecture/decorators.md
+++ b/docs/architecture/decorators.md
@@ -7,7 +7,7 @@ grelmicro decorators follow one rule, so you never have to guess whether to add 
 A decorator supports the bare `@deco` form only when every option has a default. When it needs an argument to mean anything, you always call it with parentheses.
 
 - **Bare or parametrized.** `@measure` and `@instrument` work with no arguments and also accept options, so both `@measure` and `@measure(name="checkout")` are valid.
-- **Parametrized only.** `@retry`, `@fallback`, `@cached`, and `@interval` need an argument (the retry condition, the fallback value, the cache, the interval), so they are always called with parentheses.
+- **Parametrized only.** `@retry`, `@fallback`, `@cached`, and `@every` need an argument (the retry condition, the fallback value, the cache, the interval), so they are always called with parentheses.
 
 `@shield` is the one bare-first decorator with named presets: use `@shield` for the default, or `@shield.api(...)` / `@shield.internal(...)` / `@shield.slow(...)` for tuned profiles.
 
@@ -23,4 +23,4 @@ Every decorator wraps both `def` and `async def` functions, except `@shield`, wh
 | `@retry(...)` | | ✓ | ✓ | ✓ |
 | `@fallback(...)` | | ✓ | ✓ | ✓ |
 | `@cached(...)` | | ✓ | ✓ | ✓ |
-| `@interval(...)` | | ✓ | ✓ | ✓ |
+| `@every(...)` | | ✓ | ✓ | ✓ |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,8 +4,9 @@
 
 ### Breaking
 
+* 💥 Rename the recurring-task decorator from `@task.interval(seconds=...)` to `@task.every(seconds=...)`, pairing it with `@task.cron(...)` as a verb-form family. The `seconds=` keyword is unchanged. Update your call sites.
 * 💥 Move the framework integration modules into `grelmicro.integrations`. `grelmicro.fastapi` becomes `grelmicro.integrations.fastapi`, so `GrelmicroMiddleware` is now `from grelmicro.integrations.fastapi import GrelmicroMiddleware`, and the new FastStream wiring lives at `grelmicro.integrations.faststream`.
-* 💥 Collapse the four `@task.interval` lock passthroughs into one typed `lock=TaskLock(...)`. The `lease_duration`, `min_hold_duration`, `backend`, and `worker` parameters are removed. Pass a `TaskLock` instead, like `@task.interval(seconds=60, lock=TaskLock(lease_duration=300))`. The lock keeps its default `"default"` name and is re-stamped to the task name, so you never repeat it. The lock's settings are authoritative. `leader=` and `sync=` stay separate, self-documenting parameters.
+* 💥 Collapse the four `@task.every` lock passthroughs into one typed `lock=TaskLock(...)`. The `lease_duration`, `min_hold_duration`, `backend`, and `worker` parameters are removed. Pass a `TaskLock` instead, like `@task.every(seconds=60, lock=TaskLock(lease_duration=300))`. The lock keeps its default `"default"` name and is re-stamped to the task name, so you never repeat it. The lock's settings are authoritative. `leader=` and `sync=` stay separate, self-documenting parameters.
 * 💥 `HealthChecks` now namespaces its env vars per instance: the default instance keeps `GREL_HEALTH_*`, but a named instance reads `GREL_HEALTH_{NAME_UPPER}_*` (matching `Lock`, `CircuitBreaker`, and the other named components). Update env vars for any named `HealthChecks`.
 * 💥 Replace the six manual circuit-breaker control methods with two operator verbs. `isolate()` forces the breaker open until reset, `reset()` returns it to normal automatic operation starting `CLOSED`. Replace `transition_to_forced_open()` with `isolate()` and `restart()` with `reset()`. The remaining `transition_to_closed`, `transition_to_open`, `transition_to_half_open`, and `transition_to_forced_closed` are removed.
 * 💥 `CircuitBreakerMetrics` and `ErrorDetails` are now frozen slotted dataclasses instead of Pydantic models. Attribute access is unchanged, but they no longer offer `.model_dump()` or Pydantic validation. This matches `CircuitBreakerSnapshot` and `CacheInfo` (read-models are dataclasses, Pydantic is reserved for serialization boundaries).
@@ -24,7 +25,7 @@
 ### Features
 
 * ✨ Add `micro.install(app)`, one call that wires the lifecycle and per-handler ambient binding for Starlette, FastAPI, and FastStream. Pass `ambient=False` to skip the binding.
-* ✨ Accept a `timedelta` for the interval `seconds=`, like `@task.interval(seconds=timedelta(minutes=2))`. A plain number of seconds still works.
+* ✨ Accept a `timedelta` for the interval `seconds=`, like `@task.every(seconds=timedelta(minutes=2))`. A plain number of seconds still works.
 * ✨ Add a `key=` template to `@cached` for a stable, readable cache key rendered from the arguments, like `@cached(key="user:{user_id}")`. Pass `key_maker=` for the fully dynamic case. Passing both raises `TypeError`.
 * ✨ Type `FireInfo.outcome` as the new `FireOutcome` `StrEnum` (`SUCCESS`, `ERROR`, `SKIPPED`). String comparisons like `outcome == "success"` still work.
 * ✨ Add `Idempotency.run(key, factory)`, a one-call helper that runs an operation once and replays its response. It takes a sync or async factory and mirrors `TTLCache.get_or_set`.

--- a/docs/coordination.md
+++ b/docs/coordination.md
@@ -306,7 +306,7 @@ async with task_lock:
 
 !!! tip
     For scheduled tasks, prefer the
-    [`interval()` decorator with `lock=TaskLock(...)`](task.md#distributed-lock),
+    [`every()` decorator with `lock=TaskLock(...)`](task.md#distributed-lock),
     which re-stamps the lock with the task name automatically.
 
 !!! warning

--- a/docs/index.md
+++ b/docs/index.md
@@ -269,19 +269,19 @@ async def protected():
 
 
 # --- Interval Task: run locally on every worker ---
-@tasks.interval(seconds=5)
+@tasks.every(seconds=5)
 def heartbeat():
     logger.info("heartbeat")
 
 
 # --- Distributed Task: run once per interval across all workers ---
-@tasks.interval(seconds=60, lock=TaskLock(lease_duration=300))
+@tasks.every(seconds=60, lock=TaskLock(lease_duration=300))
 def cleanup():
     logger.info("cleanup")
 
 
 # --- Leader-gated Task: only the leader executes ---
-@tasks.interval(seconds=10, leader=leader)
+@tasks.every(seconds=10, leader=leader)
 def leader_only_task():
     logger.info("leader task")
 ```

--- a/docs/snippets/coordination/quickstart.py
+++ b/docs/snippets/coordination/quickstart.py
@@ -12,6 +12,6 @@ leader = micro.coordination.leaderelection("worker")
 tasks.add_task(leader)
 
 
-@tasks.interval(seconds=10, leader=leader)
+@tasks.every(seconds=10, leader=leader)
 async def run_once_in_the_cluster() -> None:
     print("only the leader runs this")

--- a/docs/snippets/simple_fastapi_app.py
+++ b/docs/snippets/simple_fastapi_app.py
@@ -69,18 +69,18 @@ async def protected():
 
 
 # --- Interval Task: run locally on every worker ---
-@tasks.interval(seconds=5)
+@tasks.every(seconds=5)
 def heartbeat():
     logger.info("heartbeat")
 
 
 # --- Distributed Task: run once per interval across all workers ---
-@tasks.interval(seconds=60, lock=TaskLock(lease_duration=300))
+@tasks.every(seconds=60, lock=TaskLock(lease_duration=300))
 def cleanup():
     logger.info("cleanup")
 
 
 # --- Leader-gated Task: only the leader executes ---
-@tasks.interval(seconds=10, leader=leader_election)
+@tasks.every(seconds=10, leader=leader_election)
 def leader_only_task():
     logger.info("leader task")

--- a/docs/snippets/single_file_app.py
+++ b/docs/snippets/single_file_app.py
@@ -47,12 +47,12 @@ leader_election = LeaderElection(
 task.add_task(leader_election)
 
 
-@task.interval(seconds=1)
+@task.every(seconds=1)
 def sync_func_with_no_param():
     typer.echo("sync_with_no_param")
 
 
-@task.interval(seconds=2)
+@task.every(seconds=2)
 async def async_func_with_no_param():
     typer.echo("async_with_no_param")
 
@@ -61,7 +61,7 @@ def sync_dependency():
     return "sync_dependency"
 
 
-@task.interval(seconds=3)
+@task.every(seconds=3)
 def sync_func_with_sync_dependency(
     sync_dependency: Annotated[str, Depends(sync_dependency)],
 ):
@@ -72,26 +72,26 @@ async def async_dependency():
     yield "async_with_async_dependency"
 
 
-@task.interval(seconds=4)
+@task.every(seconds=4)
 async def async_func_with_async_dependency(
     async_dependency: Annotated[str, Depends(async_dependency)],
 ):
     typer.echo(async_dependency)
 
 
-@task.interval(seconds=15, sync=leased_lock_10sec)
+@task.every(seconds=15, sync=leased_lock_10sec)
 def sync_func_with_leased_lock_10sec():
     typer.echo("sync_func_with_leased_lock_10sec")
     time.sleep(9)
 
 
-@task.interval(seconds=15, sync=leased_lock_10sec)
+@task.every(seconds=15, sync=leased_lock_10sec)
 async def async_func_with_leased_lock_10sec():
     typer.echo("async_func_with_leased_lock_10sec")
     await asyncio.sleep(9)
 
 
-@task.interval(seconds=15, sync=leased_lock_5sec)
+@task.every(seconds=15, sync=leased_lock_5sec)
 def sync_func_with_sync_dependency_and_leased_lock_5sec(
     sync_dependency: Annotated[str, Depends(sync_dependency)],
 ):
@@ -99,7 +99,7 @@ def sync_func_with_sync_dependency_and_leased_lock_5sec(
     time.sleep(4)
 
 
-@task.interval(seconds=15, sync=leased_lock_5sec)
+@task.every(seconds=15, sync=leased_lock_5sec)
 async def async_func_with_async_dependency_and_leased_lock_5sec(
     async_dependency: Annotated[str, Depends(async_dependency)],
 ):
@@ -107,13 +107,13 @@ async def async_func_with_async_dependency_and_leased_lock_5sec(
     await asyncio.sleep(4)
 
 
-@task.interval(seconds=15, sync=leader_election)
+@task.every(seconds=15, sync=leader_election)
 def sync_func_with_leader_election():
     typer.echo("sync_func_with_leader_election")
     time.sleep(30)
 
 
-@task.interval(seconds=15, sync=leader_election)
+@task.every(seconds=15, sync=leader_election)
 async def async_func_with_leader_election():
     typer.echo("async_func_with_leader_election")
     await asyncio.sleep(30)

--- a/docs/snippets/task/graceful_shutdown.py
+++ b/docs/snippets/task/graceful_shutdown.py
@@ -9,7 +9,7 @@ from grelmicro.task import Tasks
 tasks = Tasks(shutdown_timeout=25)
 
 
-@tasks.interval(seconds=5)
+@tasks.every(seconds=5)
 async def heartbeat() -> None:
     """Run periodic work; finishes the current run before shutdown."""
 

--- a/docs/snippets/task/interval_leader.py
+++ b/docs/snippets/task/interval_leader.py
@@ -7,6 +7,6 @@ task = Tasks()
 task.add_task(leader)
 
 
-@task.interval(seconds=60, leader=leader)
+@task.every(seconds=60, leader=leader)
 async def cleanup():
     print("Running cleanup...")

--- a/docs/snippets/task/interval_lock.py
+++ b/docs/snippets/task/interval_lock.py
@@ -4,6 +4,6 @@ from grelmicro.task import Tasks
 task = Tasks()
 
 
-@task.interval(seconds=60, lock=TaskLock(lease_duration=300))
+@task.every(seconds=60, lock=TaskLock(lease_duration=300))
 async def cleanup():
     print("Running cleanup...")

--- a/docs/snippets/task/interval_lock_custom.py
+++ b/docs/snippets/task/interval_lock_custom.py
@@ -4,7 +4,7 @@ from grelmicro.task import Tasks
 task = Tasks()
 
 
-@task.interval(
+@task.every(
     seconds=60,
     lock=TaskLock(lease_duration=300, min_hold_duration=30),
 )

--- a/docs/snippets/task/interval_lock_resource.py
+++ b/docs/snippets/task/interval_lock_resource.py
@@ -5,8 +5,6 @@ task = Tasks()
 resource_lock = Lock("shared-resource")
 
 
-@task.interval(
-    seconds=60, lock=TaskLock(lease_duration=300), sync=resource_lock
-)
+@task.every(seconds=60, lock=TaskLock(lease_duration=300), sync=resource_lock)
 async def cleanup():
     print("Running cleanup...")

--- a/docs/snippets/task/interval_manager.py
+++ b/docs/snippets/task/interval_manager.py
@@ -3,6 +3,6 @@ from grelmicro.task import Tasks
 task = Tasks()
 
 
-@task.interval(seconds=5)
+@task.every(seconds=5)
 async def my_task():
     print("Hello, World!")

--- a/docs/snippets/task/interval_router.py
+++ b/docs/snippets/task/interval_router.py
@@ -3,6 +3,6 @@ from grelmicro.task import TaskRouter
 task = TaskRouter()
 
 
-@task.interval(seconds=5)
+@task.every(seconds=5)
 async def my_task():
     print("Hello, World!")

--- a/docs/snippets/task/leaderelection.py
+++ b/docs/snippets/task/leaderelection.py
@@ -7,7 +7,7 @@ task = Tasks()
 task.add_task(leader)
 
 
-@task.interval(seconds=5)
+@task.every(seconds=5)
 async def my_task():
     if leader.is_leader():
         print("Hello from the leader!")

--- a/docs/snippets/task/lock.py
+++ b/docs/snippets/task/lock.py
@@ -4,7 +4,7 @@ from grelmicro.task import Tasks
 task = Tasks()
 
 
-@task.interval(seconds=5)
+@task.every(seconds=5)
 async def my_task():
     async with Lock("shared-resource"):
         print("Hello, World!")

--- a/docs/snippets/task/router.py
+++ b/docs/snippets/task/router.py
@@ -4,7 +4,7 @@ from grelmicro.task import TaskRouter
 router = TaskRouter()
 
 
-@router.interval(seconds=5)
+@router.every(seconds=5)
 async def my_task():
     print("Hello, World!")
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -10,7 +10,7 @@ A simple scheduler that runs tasks periodically. Use it for lightweight recurrin
 
 ## Quick start
 
-Register a `Tasks` instance with a `Grelmicro` app, then schedule a task with the `interval` decorator:
+Register a `Tasks` instance with a `Grelmicro` app, then schedule a task with the `every` decorator:
 
 ```python
 from grelmicro import Grelmicro
@@ -19,7 +19,7 @@ from grelmicro.task import Tasks
 tasks = Tasks()
 micro = Grelmicro(uses=[tasks])
 
-@tasks.interval(seconds=5)
+@tasks.every(seconds=5)
 async def cleanup() -> None:
     ...
 
@@ -28,7 +28,7 @@ async with micro:
 ```
 
 !!! warning "Per-process by default"
-    `Tasks` runs schedules **in the local process only**. Every process that boots a `Tasks` instance runs its own copy of every registered task. To run a task at most once across the fleet, gate it with [`TaskLock`](coordination.md#task-lock) or [`LeaderElection`](coordination.md#leader-election). Without one of those, a 3-replica deployment runs the same `@tasks.interval(...)` three times per tick.
+    `Tasks` runs schedules **in the local process only**. Every process that boots a `Tasks` instance runs its own copy of every registered task. To run a task at most once across the fleet, gate it with [`TaskLock`](coordination.md#task-lock) or [`LeaderElection`](coordination.md#leader-election). Without one of those, a 3-replica deployment runs the same `@tasks.every(...)` three times per tick.
 
 !!! note
     This is not a replacement for full task queues such as Celery, taskiq, or APScheduler. It is small, simple, and safe for running tasks in a distributed system.
@@ -56,7 +56,7 @@ Start it standalone using the application lifespan:
 
 ## Interval Task
 
-Use the `interval` decorator to run a task at a fixed interval:
+Use the `every` decorator to run a task at a fixed interval:
 
 !!! note
     The interval specifies the waiting time between task executions. Ensure that the task execution duration is considered to meet deadlines effectively.
@@ -218,7 +218,7 @@ from grelmicro.task import FireInfo, Tasks
 
 tasks = Tasks()
 
-@tasks.interval(seconds=60)
+@tasks.every(seconds=60)
 async def cleanup() -> None:
     ...
 

--- a/examples/fastapi-demo/app.py
+++ b/examples/fastapi-demo/app.py
@@ -133,13 +133,13 @@ async def update_ledger(amount: int) -> dict:
 
 
 # --- Leader-gated task: only the elected leader runs the sweep ---
-@tasks.interval(seconds=10, leader=leader)
+@tasks.every(seconds=10, leader=leader)
 def nightly_sweep() -> None:
     # Leader-election Pattern: runs on exactly one replica.
     logger.info("nightly sweep (leader only)")
 
 
 # --- Local interval task: runs on every replica ---
-@tasks.interval(seconds=5)
+@tasks.every(seconds=5)
 def heartbeat() -> None:
     logger.info("heartbeat")

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -91,7 +91,7 @@ class Grelmicro:
         tasks,
     ])
 
-    @tasks.interval(seconds=5)
+    @tasks.every(seconds=5)
     async def cleanup(): ...
 
     async with micro:

--- a/grelmicro/task/_interval.py
+++ b/grelmicro/task/_interval.py
@@ -27,7 +27,7 @@ logger = getLogger("grelmicro.task")
 class IntervalTask(Task):
     """Interval Task.
 
-    Use the `Tasks.interval()` or `TaskRouter.interval()` decorator instead
+    Use the `Tasks.every()` or `TaskRouter.every()` decorator instead
     of creating IntervalTask objects directly.
 
     Supports three modes:

--- a/grelmicro/task/router.py
+++ b/grelmicro/task/router.py
@@ -57,7 +57,7 @@ class TaskRouter:
 
         self._tasks.append(task)
 
-    def interval(
+    def every(
         self,
         *,
         seconds: Annotated[
@@ -129,7 +129,7 @@ class TaskRouter:
         [Callable[..., Any | Awaitable[Any]]],
         Callable[..., Any | Awaitable[Any]],
     ]:
-        """Decorate function to add it as an interval task.
+        """Decorate a function to run it on a fixed interval.
 
         Supports three modes:
 

--- a/tests/task/test_router.py
+++ b/tests/task/test_router.py
@@ -70,9 +70,9 @@ def test_router_interval() -> None:
     sync = Lock(backend=MemoryLockAdapter(), name="testlock")
 
     # Act
-    router.interval(name="test1", seconds=10, sync=sync)(test1)
-    router.interval(name="test2", seconds=20)(test2)
-    router.interval(seconds=10)(test3)
+    router.every(name="test1", seconds=10, sync=sync)(test1)
+    router.every(name="test2", seconds=20)(test2)
+    router.every(seconds=10)(test3)
 
     # Assert
     assert len(router.tasks) == task_count
@@ -94,8 +94,8 @@ def test_router_interval_with_timedelta() -> None:
     seconds = 5
 
     # Act
-    router.interval(seconds=interval)(test1)
-    router.interval(seconds=seconds)(test2)
+    router.every(seconds=interval)(test1)
+    router.every(seconds=seconds)(test2)
 
     # Assert
     assert isinstance(router.tasks[0], IntervalTask)
@@ -110,9 +110,9 @@ def test_router_interval_name_generation() -> None:
     router = TaskRouter()
 
     # Act
-    router.interval(seconds=10)(test1)
-    router.interval(seconds=10)(SimpleClass.static_method)
-    router.interval(seconds=10)(SimpleClass.method)
+    router.every(seconds=10)(test1)
+    router.every(seconds=10)(SimpleClass.static_method)
+    router.every(seconds=10)(SimpleClass.method)
 
     # Assert
     assert router.tasks[0].name == "tests.task.samples:test1"
@@ -131,24 +131,24 @@ def test_router_interval_name_generation_error() -> None:
     # Act
     with pytest.raises(FunctionTypeError, match="nested function"):
 
-        @router.interval(seconds=10)
+        @router.every(seconds=10)
         def nested_function() -> None:
             pass
 
     with pytest.raises(FunctionTypeError, match="lambda"):
-        router.interval(seconds=10)(lambda _: None)
+        router.every(seconds=10)(lambda _: None)
 
     with pytest.raises(FunctionTypeError, match="method"):
-        router.interval(seconds=10)(test_instance.method)
+        router.every(seconds=10)(test_instance.method)
 
     with pytest.raises(FunctionTypeError, match=re.escape("partial()")):
-        router.interval(seconds=10)(partial(test1))
+        router.every(seconds=10)(partial(test1))
 
     with pytest.raises(
         FunctionTypeError,
         match="callable without __module__ or __qualname__ attribute",
     ):
-        router.interval(seconds=10)(object())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        router.every(seconds=10)(object())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
 
 def test_router_interval_with_lock() -> None:
@@ -158,7 +158,7 @@ def test_router_interval_with_lock() -> None:
     router = TaskRouter()
 
     # Act
-    router.interval(
+    router.every(
         seconds=60,
         lock=TaskLock(backend=backend, lease_duration=300),
     )(test1)
@@ -180,7 +180,7 @@ def test_router_interval_with_lock_default_name_restamped() -> None:
     router = TaskRouter()
 
     # Act
-    router.interval(
+    router.every(
         name="cleanup",
         seconds=60,
         lock=TaskLock(backend=backend, lease_duration=300),
@@ -201,7 +201,7 @@ def test_router_interval_with_lock_explicit_name_honored() -> None:
     router = TaskRouter()
 
     # Act
-    router.interval(
+    router.every(
         name="cleanup",
         seconds=60,
         lock=TaskLock("shared", backend=backend, lease_duration=300),
@@ -223,7 +223,7 @@ def test_router_interval_with_lock_and_custom_least() -> None:
     router = TaskRouter()
 
     # Act
-    router.interval(
+    router.every(
         seconds=60,
         lock=TaskLock(
             backend=backend,
@@ -252,7 +252,7 @@ def test_router_interval_lease_less_than_seconds_raises() -> None:
         ValueError,
         match="lease_duration must be greater than or equal to seconds",
     ):
-        router.interval(
+        router.every(
             seconds=60,
             lock=TaskLock(backend=backend, lease_duration=10),
         )(test1)

--- a/tests/task/test_tasks.py
+++ b/tests/task/test_tasks.py
@@ -211,7 +211,7 @@ async def test_tasks_drains_cooperative_task_without_cancel() -> None:
 
     _drain_events.clear()
     tasks = Tasks(auto_start=False, shutdown_timeout=5)
-    tasks.interval(seconds=0.01)(_drain_work)
+    tasks.every(seconds=0.01)(_drain_work)
 
     async with tasks:
         await tasks.start()
@@ -228,7 +228,7 @@ async def test_tasks_interval_wakes_promptly_on_stop() -> None:
     import asyncio  # noqa: PLC0415
 
     tasks = Tasks(auto_start=False, shutdown_timeout=5)
-    tasks.interval(seconds=3600)(_noop_work)  # would otherwise sleep an hour
+    tasks.every(seconds=3600)(_noop_work)  # would otherwise sleep an hour
 
     async with asyncio.timeout(
         2


### PR DESCRIPTION
Closes #413.

Renames the recurring-task decorator from `@task.interval(...)` to `@task.every(...)`, pairing it with `@task.cron(...)` as a verb-form decorator family. `@every` is the dominant readable form (robfig/cron `@every 1h30m`, Rocketry `every`).

```python
@task.every(seconds=5)
@task.every(seconds=timedelta(minutes=2))
```

* Clean pre-1.0 rename: no alias, no deprecation. The `seconds=` keyword and the full signature (`name`, `lock`, `leader`, `sync`) are unchanged.
* 51 call sites updated across code, tests, docs, snippets, README, and the demo example.
* Private internals (`grelmicro/task/_interval.py`, `IntervalTask`) keep their names.
* `every` is an instance method, so the public-API snapshot is unchanged.