### PR TITLE
👷 Path-filter CI jobs and add a single CI Green gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,49 @@ concurrency:
 env:
     UV_FROZEN: 1
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          # A workflow change re-runs every tier. Code includes the snippet
+          # and README tests, which live under tests/ and run in the test job.
+          filters: |
+            code:
+              - 'grelmicro/**'
+              - 'tests/**'
+              - 'examples/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.python-version'
+              - '.github/workflows/**'
+            docs:
+              - 'docs/**'
+              - 'mkdocs.yml'
+              - 'README.md'
+              - '.github/workflows/**'
+
   lint:
     name: Lint
+    needs: changes
+    # Path filtering applies to pull requests only. Pushes, the nightly
+    # schedule, and manual dispatch always run, so a mis-filtered PR is still
+    # covered once it lands on main.
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -41,6 +82,8 @@ jobs:
 
   docs:
     name: Docs
+    needs: changes
+    if: ${{ needs.changes.outputs.docs == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -80,6 +123,8 @@ jobs:
 
   tests:
     name: Tests
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
     # PRs and pushes to main run the light tier (unit, Python 3.12). The
     # nightly schedule and manual dispatch run the full tier (matrix, slow,
     # integration, demo). Release runs the full tier before publishing.
@@ -90,3 +135,26 @@ jobs:
       contents: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  check:
+    name: CI Green
+    # Single aggregation gate: branch protection needs only this check. It
+    # passes when every job either succeeded or was legitimately path-skipped,
+    # and fails if any job failed. `always()` so it still reports when an
+    # upstream job is skipped.
+    if: ${{ always() }}
+    needs:
+      - changes
+      - lint
+      - docs
+      - workflow-lint
+      - tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Require all jobs to pass
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: lint, docs, tests


### PR DESCRIPTION
Addresses the remaining best-practice gaps in #391 (the P1 concurrency + per-job timeouts were already in place from #392).

Adopts FastAPI's CI pattern, security-conscious:

### Path-filtering (skip irrelevant jobs on PRs)
A `changes` job (`dorny/paths-filter`, SHA-pinned) classifies each PR as touching `code` and/or `docs`. The `lint`/`tests` jobs run only on code changes, `docs` only on doc changes. A docs-only PR no longer spins up the test tier, and a code-only PR skips the strict docs build.

**Safety:** filtering applies to `pull_request` only. `push` to main, the nightly `schedule`, and `workflow_dispatch` always run every job, so a mis-filtered PR is still fully covered the moment it lands on `main`. A workflow change re-runs every tier. `zizmor` (workflow security lint) stays always-on.

### Single `CI Green` aggregation gate
A `check` job (`re-actors/alls-green`, SHA-pinned) passes when every job either succeeded or was legitimately path-skipped, and fails if any job failed. This lets branch protection require one check (`CI Green`) without a skipped job hanging as a pending required status (the native-`paths` gotcha).

### Notes
- New actions are SHA-pinned with version comments, matching the rest of the workflows. `zizmor` reports no findings.
- The release path is unchanged: `release.yml` still runs the full tier (`reusable-tests` with `full: true`) before publishing.
- Not done here (they are a repo setting / separate scope): enabling "Require approval for first-time contributors" under Settings → Actions (the highest-leverage fork-PR guard, maintainer-only), and the P3 scorecard push-trigger trim.