### PR TITLE
✨ Add RateLimiter.wait() and LeaderElection.lead()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,8 @@
 
 ### Features
 
+* ✨ Add `RateLimiter.wait()`, a blocking admission verb that waits until tokens are available then consumes them. It polls on the clock seam (so `VirtualClock` drives it in tests), waits as long as needed by default, and raises `RateLimitExceededError` once an optional `max_wait` budget is exceeded. A `cost` larger than the limit raises `ValueError` instead of waiting forever.
+* ✨ Add `LeaderElection.lead(func, *, repeat=False)`, which runs a coroutine only while the worker holds leadership and cancels it the instant leadership is lost, so no stale work outlives the lease. It returns the body's result if it finishes while still leader, or `None` if cancelled. Pass `repeat=True` to re-run after re-acquiring leadership.
 * ✨ Add `micro.install(app)`, one call that wires the lifecycle and per-handler ambient binding for Starlette, FastAPI, and FastStream. Pass `ambient=False` to skip the binding.
 * ✨ Accept a `timedelta` for the interval `seconds=`, like `@task.every(seconds=timedelta(minutes=2))`. A plain number of seconds still works.
 * ✨ Add a `key=` template to `@cached` for a stable, readable cache key rendered from the arguments, like `@cached(key="user:{user_id}")`. Pass `key_maker=` for the fully dynamic case. Passing both raises `TypeError`.

--- a/docs/coordination.md
+++ b/docs/coordination.md
@@ -337,6 +337,25 @@ it. The Memory backend needs no extra service, so this runs as-is:
 Only the leader runs `run_once_in_the_cluster`. Every other worker skips it until
 it becomes the leader.
 
+### Run only while leader
+
+`@tasks.every(..., leader=leader)` gates each tick. When you have one long-lived
+piece of work that should run for as long as you lead and stop the instant you do
+not, use `lead`:
+
+```python
+--8<-- "coordination/lead.py"
+```
+
+`lead` waits for leadership, runs the coroutine in a child task, and **cancels it
+the moment leadership is lost**, so no stale work outlives the lease. It returns
+the result if the body finishes while still leader, or `None` if it was cancelled.
+Pass `repeat=True` to re-run after re-acquiring leadership. Cancellation is
+cooperative: it lands at the body's next `await`, so pair it with
+`is_leader_confirmed_within` or a fencing token for writes that must never overlap
+a successor. The `LeaderElection` service must be running concurrently (added to
+`Tasks` above) to renew the lease and drive the leadership changes `lead` waits on.
+
 ### Independent backend
 
 Leader election is **not** a `Lock`. A `Lock` is short-lived mutual exclusion. A

--- a/docs/resilience/rate-limiter.md
+++ b/docs/resilience/rate-limiter.md
@@ -40,6 +40,16 @@ if not result:
 
 Use `acquire_or_raise` when a surrounding layer should turn the rejection into a response: it raises `RateLimitExceededError`, which is an `AdmissionError` (the shared base, exported from the top-level `grelmicro` package for every "turned away" rejection: rate limiter, bulkhead, open circuit breaker, non-blocking lock), so one `except AdmissionError` catches them all.
 
+### Waiting until allowed
+
+`wait` blocks until tokens are available, then consumes them. Use it to smooth a burst into the limit instead of rejecting it, for example when calling a rate-limited upstream:
+
+```python
+--8<-- "resilience/ratelimiter_wait.py"
+```
+
+It polls `acquire` on the clock seam, sleeping `retry_after` between attempts, so a denied call never consumes tokens. By default it waits as long as needed. Pass `max_wait` to bound the wait: it raises `RateLimitExceededError` once the budget would be exceeded. A `cost` larger than the limit raises `ValueError` instead of waiting forever.
+
 ### One fleet-wide limit
 
 When the limiter protects a service with one shared budget (no per-user or per-IP split), omit `key`. It defaults to `"default"`, and the limiter's own `name` already namespaces the bucket on the backend:

--- a/docs/snippets/coordination/lead.py
+++ b/docs/snippets/coordination/lead.py
@@ -1,0 +1,25 @@
+import asyncio
+
+from grelmicro import Grelmicro
+from grelmicro.coordination import Coordination
+from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
+from grelmicro.task import Tasks
+
+tasks = Tasks()
+micro = Grelmicro(
+    uses=[Coordination(election=MemoryLeaderElectionAdapter()), tasks]
+)
+
+leader = micro.coordination.leaderelection("worker")
+tasks.add_task(leader)
+
+
+async def emit_metrics() -> None:
+    while True:  # cancelled the instant leadership is lost
+        print("leader heartbeat")
+        await asyncio.sleep(10)
+
+
+async def run() -> None:
+    # Runs only while leader, re-running after any re-acquisition.
+    await leader.lead(emit_metrics, repeat=True)

--- a/docs/snippets/resilience/ratelimiter_wait.py
+++ b/docs/snippets/resilience/ratelimiter_wait.py
@@ -1,0 +1,13 @@
+from grelmicro.resilience import RateLimiter
+
+api_limiter = RateLimiter.token_bucket("api", capacity=100, refill_rate=10)
+
+
+async def serve(user_id: str) -> None:
+    # Block until a token frees up, then proceed.
+    await api_limiter.wait(key=user_id)
+
+
+async def serve_bounded(user_id: str) -> None:
+    # Give up after 2 seconds, raising RateLimitExceededError.
+    await api_limiter.wait(key=user_id, cost=3, max_wait=2.0)

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -1,7 +1,8 @@
 """Leader Election."""
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
+from contextlib import suppress
 from logging import getLogger
 from time import monotonic
 from types import TracebackType
@@ -538,6 +539,80 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
                     )
             except TimeoutError:
                 pass
+
+    async def lead[T](
+        self,
+        func: Annotated[
+            Callable[..., Awaitable[T]],
+            Doc("Coroutine function to run only while this worker leads."),
+        ],
+        /,
+        *args: object,
+        repeat: Annotated[
+            bool,
+            Doc(
+                "Re-run `func` after re-acquiring leadership instead of"
+                " returning once leadership is lost."
+            ),
+        ] = False,
+    ) -> T | None:
+        """Run `func(*args)` only while this worker holds leadership.
+
+        Waits for leadership, then runs `func(*args)` in a child task.
+        The moment leadership is lost the task is cancelled, so no stale
+        work outlives the lease. This is the difference from a plain
+        `if is_leader():` check, which keeps running until the next poll.
+
+        Returns `func`'s result if it finishes while still leader, or
+        `None` if leadership was lost first and the body was cancelled.
+        With `repeat=True`, waits to re-acquire and runs `func` again
+        instead of returning, looping until the surrounding scope is
+        cancelled.
+
+        Requires the `LeaderElection` service to be running concurrently
+        (wired through `Tasks`, or run as a task), since it renews the
+        lease and drives the leadership changes `lead` waits on.
+
+        Any exception raised by `func` propagates out of `lead`.
+
+        Cancellation is cooperative: it takes effect at the body's next
+        `await`. Pair with `is_leader_confirmed_within` or a fencing
+        token for writes that must never overlap a successor.
+
+        ```python
+        async def emit_metrics() -> None:
+            while True:
+                await push_snapshot()
+                await asyncio.sleep(10)
+
+        await election.lead(emit_metrics, repeat=True)
+        ```
+        """
+        while True:
+            result = await self._lead_once(func, *args)
+            if not repeat:
+                return result
+
+    async def _lead_once[T](
+        self, func: Callable[..., Awaitable[T]], *args: object
+    ) -> T | None:
+        """Wait for leadership, run `func` once, cancel it if leadership ends."""
+        await self.wait_for_leader()
+        work: asyncio.Future[T] = asyncio.ensure_future(func(*args))
+        loss = asyncio.ensure_future(self.wait_lose_leader())
+        try:
+            await asyncio.wait(
+                {work, loss}, return_when=asyncio.FIRST_COMPLETED
+            )
+            if work.done():
+                return work.result()
+            return None
+        finally:
+            for task in (work, loss):
+                if not task.done():
+                    task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await task
 
     async def __call__(
         self,

--- a/grelmicro/resilience/ratelimiter/__init__.py
+++ b/grelmicro/resilience/ratelimiter/__init__.py
@@ -11,6 +11,8 @@ from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro
 from grelmicro._config import Reconfigurable, default_env_prefix
+from grelmicro.clock import monotonic as clock_monotonic
+from grelmicro.clock import sleep as clock_sleep
 from grelmicro.metrics import _emit
 from grelmicro.resilience._protocol import (
     RateLimiterBackend,
@@ -50,6 +52,10 @@ def __getattr__(name: str) -> object:
 
 
 logger = logging.getLogger(__name__)
+
+_MIN_POLL_INTERVAL = 0.005
+"""Floor for the `wait` poll sleep, avoiding a busy-loop on a zero or
+coarse `retry_after` from a distributed backend."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -548,6 +554,74 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
                 self._log_fail_open(key, exc)
                 return
             raise
+
+    async def wait(
+        self,
+        *,
+        key: Annotated[
+            str,
+            Doc(
+                "Identifier for rate limiting"
+                " (e.g. IP address, user ID, session)."
+                " Defaults to `default` for the single-bucket case."
+                " The limiter's `name` already namespaces the backend"
+                " key, so the default bucket is `name:default`."
+            ),
+        ] = "default",
+        cost: Annotated[
+            int,
+            Doc("Number of tokens to consume."),
+        ] = 1,
+        max_wait: Annotated[
+            float | None,
+            Doc(
+                "Maximum number of seconds to wait before giving up."
+                " `None` (the default) waits indefinitely."
+            ),
+        ] = None,
+    ) -> RateLimitResult:
+        """Wait until tokens are available, then consume them.
+
+        Polls `acquire` on the clock seam, sleeping `retry_after`
+        between attempts, until the request is admitted. A denied
+        `acquire` consumes nothing, so retrying is safe.
+
+        With `max_wait` set, gives up once the budget would be exceeded
+        and raises `RateLimitExceededError`. The default waits forever:
+
+        ```python
+        await limiter.wait(key="user-1")
+        result = await limiter.wait(key="user-1", cost=3, max_wait=2.0)
+        ```
+
+        The wait runs on the clock seam, so `VirtualClock` drives it in
+        tests without real sleeping.
+
+        Returns:
+            The allowed RateLimitResult once tokens are consumed.
+
+        Raises:
+            ValueError: If `cost` is not between 1 and the algorithm's
+                limit/capacity. Guards the otherwise unsatisfiable wait
+                when `cost` exceeds capacity.
+            RateLimitExceededError: If `max_wait` elapses before the
+                request is admitted.
+        """
+        _validate_cost(cost, _config_limit(self._state.config))
+        deadline = None if max_wait is None else clock_monotonic() + max_wait
+        while True:
+            result = await self.acquire(key=key, cost=cost)
+            if result.allowed:
+                return result
+            delay = result.retry_after
+            if deadline is not None:
+                remaining = deadline - clock_monotonic()
+                if remaining <= 0 or delay > remaining:
+                    raise RateLimitExceededError(
+                        key=key,
+                        retry_after=result.retry_after,
+                    )
+            await clock_sleep(max(delay, _MIN_POLL_INTERVAL))
 
     async def _apply_reconfigure(
         self,

--- a/tests/coordination/test_leaderelection.py
+++ b/tests/coordination/test_leaderelection.py
@@ -3,6 +3,7 @@
 import asyncio
 import math
 from asyncio import Event, sleep
+from contextlib import suppress
 
 import pytest
 from pydantic import ValidationError
@@ -942,3 +943,164 @@ async def test_leaderelection_backend_out_of_context() -> None:
         OutOfContextError, match="LeaderElection\\('out-of-context'\\)"
     ):
         _ = election.backend
+
+
+# --- lead() ------------------------------------------------------------------
+
+
+@pytest.fixture
+def stable_leader(backend: LeaderElectionBackend) -> LeaderElection:
+    """Return a leader whose lease never lapses, so loss is driven manually.
+
+    Lease and renew deadline are large enough that `is_leader()` stays
+    `True` after a manual `_update_state(is_leader=True)`, letting each
+    `lead()` test control loss explicitly with no renew-loop racing.
+    """
+    config = LeaderElectionConfig(
+        worker="worker_lead",
+        lease_duration=100,
+        renew_deadline=90,
+        retry_interval=1,
+        error_interval=30,
+        backend_timeout=5,
+    )
+    return LeaderElection.from_config(LEADER_NAME, config, backend=backend)
+
+
+async def test_lead_runs_while_leader_and_returns_result(
+    stable_leader: LeaderElection,
+) -> None:
+    """`lead` runs the body while leader and returns its result."""
+    await stable_leader._update_state(
+        is_leader=True, reason_if_no_more_leader=""
+    )
+
+    async def work() -> str:
+        return "done"
+
+    assert await stable_leader.lead(work) == "done"
+
+
+async def test_lead_passes_positional_args(
+    stable_leader: LeaderElection,
+) -> None:
+    """`lead` forwards positional arguments to the body."""
+    await stable_leader._update_state(
+        is_leader=True, reason_if_no_more_leader=""
+    )
+
+    async def add(left: int, right: int) -> int:
+        return left + right
+
+    left, right = 2, 3
+    assert await stable_leader.lead(add, left, right) == left + right
+
+
+async def test_lead_propagates_body_exception(
+    stable_leader: LeaderElection,
+) -> None:
+    """An exception raised by the body propagates out of `lead`."""
+    await stable_leader._update_state(
+        is_leader=True, reason_if_no_more_leader=""
+    )
+
+    async def boom() -> None:
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        await stable_leader.lead(boom)
+
+
+async def test_lead_waits_for_leadership_before_running(
+    stable_leader: LeaderElection,
+) -> None:
+    """`lead` blocks until leadership is acquired, then runs the body."""
+    started = Event()
+
+    async def work() -> str:
+        started.set()
+        return "ran"
+
+    async with asyncio.TaskGroup() as tg:
+        task = tg.create_task(stable_leader.lead(work))
+        await sleep(0)
+        assert not started.is_set()  # not leader yet
+
+        await stable_leader._update_state(
+            is_leader=True, reason_if_no_more_leader=""
+        )
+        assert await task == "ran"
+
+    assert started.is_set()
+
+
+async def test_lead_cancels_body_on_leadership_loss(
+    stable_leader: LeaderElection,
+) -> None:
+    """Losing leadership cancels the in-flight body and returns `None`."""
+    await stable_leader._update_state(
+        is_leader=True, reason_if_no_more_leader=""
+    )
+    started = Event()
+    cancelled = Event()
+
+    async def work() -> None:
+        started.set()
+        try:
+            await sleep(100)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async with asyncio.TaskGroup() as tg:
+        task = tg.create_task(stable_leader.lead(work))
+        await started.wait()
+
+        await stable_leader._update_state(
+            is_leader=False, reason_if_no_more_leader="lost"
+        )
+        assert await task is None
+
+    assert cancelled.is_set()
+
+
+async def test_lead_repeat_reruns_after_reacquire(
+    stable_leader: LeaderElection,
+) -> None:
+    """With `repeat=True` the body re-runs after leadership is re-acquired."""
+    await stable_leader._update_state(
+        is_leader=True, reason_if_no_more_leader=""
+    )
+    runs = 0
+    running = Event()
+
+    async def work() -> None:
+        nonlocal runs
+        runs += 1
+        running.set()
+        await sleep(100)
+
+    first_run, second_run = 1, 2
+    task = asyncio.ensure_future(stable_leader.lead(work, repeat=True))
+    try:
+        await running.wait()
+        assert runs == first_run
+
+        # Lose leadership: the body is cancelled and lead loops back.
+        await stable_leader._update_state(
+            is_leader=False, reason_if_no_more_leader="lost"
+        )
+        running.clear()
+        await sleep(0)
+
+        # Re-acquire: the body runs a second time.
+        await stable_leader._update_state(
+            is_leader=True, reason_if_no_more_leader=""
+        )
+        await running.wait()
+        assert runs == second_run
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task

--- a/tests/resilience/test_ratelimiter_wait.py
+++ b/tests/resilience/test_ratelimiter_wait.py
@@ -1,0 +1,104 @@
+"""Tests for `RateLimiter.wait`, the blocking admission verb.
+
+The wait loop sleeps on the clock seam, so a `VirtualClock` drives the
+refill without real waiting.
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from grelmicro import Grelmicro
+from grelmicro.clock import VirtualClock
+from grelmicro.resilience import RateLimiterRegistry
+from grelmicro.resilience.errors import RateLimitExceededError
+from grelmicro.resilience.ratelimiter import RateLimiter
+from grelmicro.resilience.ratelimiter.memory import MemoryRateLimiterAdapter
+
+pytestmark = [pytest.mark.timeout(1)]
+
+CAPACITY = 1
+REFILL_RATE = 1.0
+
+
+@pytest.fixture
+async def _backend() -> AsyncGenerator[MemoryRateLimiterAdapter]:
+    """Open the in-memory backend inside an active `Grelmicro` app."""
+    backend = MemoryRateLimiterAdapter()
+    async with Grelmicro(uses=[RateLimiterRegistry(backend)]):
+        yield backend
+
+
+@pytest.fixture
+def limiter(_backend: MemoryRateLimiterAdapter) -> RateLimiter:
+    """Return a token-bucket limiter with one token, refilling at 1 tps."""
+    return RateLimiter.token_bucket(
+        "wait-tb", capacity=CAPACITY, refill_rate=REFILL_RATE
+    )
+
+
+async def test_wait_returns_immediately_when_allowed(
+    limiter: RateLimiter,
+) -> None:
+    """A request within budget is admitted on the first attempt."""
+    result = await limiter.wait()
+    assert result.allowed
+
+
+async def test_wait_blocks_until_refill(
+    clock: VirtualClock, limiter: RateLimiter
+) -> None:
+    """A drained limiter blocks on the clock seam until a token refills."""
+    assert await limiter.allow()  # drain the single token
+
+    task = asyncio.create_task(limiter.wait())
+    await asyncio.sleep(0)
+    assert not task.done()  # suspended on the refill sleep
+
+    await clock.advance(1.0)
+    result = await task
+    assert result.allowed
+
+
+async def test_wait_succeeds_within_max_wait_budget(
+    clock: VirtualClock, limiter: RateLimiter
+) -> None:
+    """A `max_wait` larger than the refill delay waits, then succeeds."""
+    assert await limiter.allow()  # drain the single token
+
+    task = asyncio.create_task(limiter.wait(max_wait=5.0))
+    await asyncio.sleep(0)
+    assert not task.done()  # suspended within the budget
+
+    await clock.advance(1.0)
+    result = await task
+    assert result.allowed
+
+
+async def test_wait_raises_when_cost_exceeds_capacity(
+    limiter: RateLimiter,
+) -> None:
+    """An unsatisfiable cost raises instead of waiting forever."""
+    with pytest.raises(ValueError, match="cost must be between"):
+        await limiter.wait(cost=CAPACITY + 1)
+
+
+async def test_wait_raises_when_max_wait_budget_exceeded(
+    limiter: RateLimiter,
+) -> None:
+    """`max_wait` shorter than the refill delay raises immediately."""
+    assert await limiter.allow()  # drain the single token
+
+    with pytest.raises(RateLimitExceededError):
+        await limiter.wait(max_wait=0.5)  # refill needs ~1s
+
+
+async def test_wait_max_wait_zero_is_single_attempt(
+    limiter: RateLimiter,
+) -> None:
+    """`max_wait=0` makes a single attempt and raises when denied."""
+    assert await limiter.allow()  # drain the single token
+
+    with pytest.raises(RateLimitExceededError):
+        await limiter.wait(max_wait=0.0)


### PR DESCRIPTION
Pulls in the two deferred Top-10 ergonomics before the 1.0 announcement. Both are additive, market-researched, and API-approved.

## RateLimiter.wait()

Blocking admission verb: waits until tokens are available, then consumes them.

- Polls `acquire` on the clock seam (so `VirtualClock` drives it in tests), sleeping `retry_after` between attempts. A denied `acquire` consumes nothing, so retrying is safe.
- `max_wait=None` (default) waits as long as needed. When set, raises `RateLimitExceededError` once the budget would be exceeded.
- A `cost` larger than the limit raises `ValueError` instead of waiting forever.

Precedent: Go `x/time/rate.Wait`, Guava `acquire`, resilience4j `acquirePermission(timeout)`.

## LeaderElection.lead(func, *, repeat=False)

Runs a coroutine only while the worker holds leadership, and cancels it the instant leadership is lost, so no stale work outlives the lease.

- Returns the body's result if it finishes while still leader, or `None` if cancelled.
- `repeat=True` re-runs after re-acquiring leadership.
- Callback form (not `async with`): pure asyncio cannot cancel an `async with` body, so the callback form is the only one that delivers real cancel-on-loss. Reuses `wait_for_leader`/`wait_lose_leader` + `asyncio.wait(FIRST_COMPLETED)`.

Precedent: Kubernetes client-go `OnStartedLeading(ctx)` (cancel-on-loss), kazoo `Election.run`.

## Tests and docs

- 11 new tests (6 `lead`, 5 `wait`), 100% coverage on both.
- Verified runnable snippets + docs sections + changelog entries.
- Full suite green; ruff, ty, and mkdocs --strict clean.