### PR TITLE
🔖 Prepare the 1.0.0b1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <img alt="A FastAPI route protected by a grelmicro rate limiter and health check" src="docs/img/demo.gif" width="800">
 </p>
 
-> **Project status: 1.0 alpha.** The 1.0 line is feature-complete and its public API is frozen behind a snapshot guard. Prereleases install explicitly: `pip install --pre grelmicro` (stable installs stay on 0.27 until `1.0.0` final). Breaking changes can still land between alphas if testing finds a flaw. After `1.0.0`, standard semver applies. See the [versioning policy](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#about-grelmicro-versions).
+> **Project status: 1.0 beta.** The 1.0 line is feature-complete and its public API is frozen behind a snapshot guard. Prereleases install explicitly: `pip install --pre grelmicro` (stable installs stay on 0.27 until `1.0.0` final). Breaking changes can still land between betas if testing finds a flaw. After `1.0.0`, standard semver applies. See the [versioning policy](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#about-grelmicro-versions).
 
 ______________________________________________________________________
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.0.0b1 - 2026-06-25
 
 ### Breaking
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@
   <img alt="A FastAPI route protected by a grelmicro rate limiter and health check" src="img/demo.gif" width="800">
 </p>
 
-> **Project status: 1.0 alpha.** The 1.0 line is feature-complete and its public API is frozen behind a snapshot guard. Prereleases install explicitly: `pip install --pre grelmicro` (stable installs stay on 0.27 until `1.0.0` final). Breaking changes can still land between alphas if testing finds a flaw. After `1.0.0`, standard semver applies. See the [versioning policy](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#about-grelmicro-versions).
+> **Project status: 1.0 beta.** The 1.0 line is feature-complete and its public API is frozen behind a snapshot guard. Prereleases install explicitly: `pip install --pre grelmicro` (stable installs stay on 0.27 until `1.0.0` final). Breaking changes can still land between betas if testing finds a flaw. After `1.0.0`, standard semver applies. See the [versioning policy](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#about-grelmicro-versions).
 
 ______________________________________________________________________
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,13 +2,28 @@
 
 Post-1.0 items planned for future releases. All are purely additive. No dates are promised.
 
+## Next
+
+The first post-1.0 cycle: small, high-demand, additive.
+
+- **Rate-limit response headers**: a helper that renders the `RateLimit-*` and `X-RateLimit-*` headers (RFC 9211) from a `RateLimitResult`, pairing with the limiter and `wait()`.
+- **Named cron helpers**: `@tasks.daily(at=...)`, `@tasks.hourly()`, and `@tasks.weekly()` over the existing cron engine, for schedules a stranger reads at a glance.
+- **FastAPI Idempotency-Key integration**: map the Idempotency pattern onto the HTTP `Idempotency-Key` header in the FastAPI integration.
+- **Circuit breaker state-change callbacks**: `on_open`, `on_half_open`, and `on_close` hooks so an operator can react to a trip, not only observe it in metrics.
+- **Observability depth**: metric exemplars and lock-acquire latency.
+
+## Later
+
+Demand-gated. Built when a concrete need shows up.
+
 - **Fleet-wide retry budgets**: cap the retry-to-call ratio across replicas through distributed backends.
 - **Request hedging on Shield**: fire a backup attempt after a latency threshold, take the fastest, cancel the loser.
 - **Distributed `Semaphore`, then read-write locks**: new classes on `LockBackend`. No hooks needed.
 - **Adaptive `Bulkhead`**: the CUBIC machinery inside Shield, exposed as `Bulkhead.adaptive()`.
 - **Deadline propagation**: a contextvar deadline that `Timeout`, `Retry`, and `Shield` respect.
+- **Resilience composition**: a horizontal `compose()` for assembling a policy list at runtime, plus slow-call rate as a trip input to the failure-rate breaker.
 - **Framework depth**: `Depends()` helpers, an ASGI per-route rate-limit middleware, Litestar and FastStream integration.
-- **Observability depth**: provider pool metrics, lock acquire latency, metric exemplars.
+- **Provider pool metrics**: connection-pool gauges per provider.
 - **More backends**: MySQL/MariaDB, MongoDB, etcd/ZooKeeper.
 - **Multi-window rate limits and task pause/resume**: additive features with lower urgency.
 - **Uniform admission guard**: a `@guard(on_reject=...)` decorator over the shared `AdmissionError` base (was issue #356).


### PR DESCRIPTION
Release prep for the first 1.0 beta.

- Stamp the changelog: `Unreleased` -> `1.0.0b1 - 2026-06-25`.
- Move the project status from **1.0 alpha** to **1.0 beta** in the README and docs landing page.
- Triage the post-1.0 roadmap into **Next** (rate-limit headers, named cron helpers, FastAPI Idempotency-Key, circuit breaker callbacks, observability exemplars + lock-acquire latency) and **Later** buckets. Nothing dropped.

After merge, publishing the `1.0.0b1` GitHub Release triggers the release workflow (full checks -> build -> PyPI Trusted Publishing -> docs).