### PR TITLE
✨ Add native auto-instrumentation to Trace

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* ✨ Add native auto-instrumentation to `Trace`. `Trace(instrument=...)` traces incoming FastAPI requests and Redis and Postgres calls against the app's tracer provider, no per-handler decoration. On by default, a no-op until the new `instrumentation` extra is installed. Pass `False`, a name or list to select, or a `{name: False}` map to exclude. Redis attaches per-client, asyncpg is patched process-wide, and Valkey and SQLite stay on `@instrument`.
+
 ## 1.0.0b1 - 2026-06-25
 
 ### Breaking

--- a/docs/snippets/trace/autoinstrument.py
+++ b/docs/snippets/trace/autoinstrument.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+
+from grelmicro import Grelmicro
+from grelmicro.providers.postgres import PostgresProvider
+from grelmicro.providers.redis import RedisProvider
+from grelmicro.trace import Trace
+
+micro = Grelmicro(
+    uses=[
+        Trace(service_name="payments-api"),  # instrument=True is the default
+        RedisProvider("redis://cache"),
+        PostgresProvider("postgresql://db/payments"),
+    ]
+)
+
+app = FastAPI()
+micro.install(app)  # the FastAPI app is instrumented too

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -145,3 +145,42 @@ configure()
     ```
 
     All produce the same JSON output with tracing context included.
+
+## Automatic instrumentation
+
+`@instrument` traces your own functions. To trace incoming HTTP requests and database or cache calls without touching every handler, `Trace` auto-instruments the providers and the FastAPI app it runs with.
+
+Install the instrumentor packages alongside the OpenTelemetry SDK:
+
+```bash
+pip install "grelmicro[opentelemetry,instrumentation]"
+```
+
+You can instead install a single `opentelemetry-instrumentation-*` package (for example `opentelemetry-instrumentation-redis`) to trace only that backend.
+
+Then `Trace` does the rest. Request spans wrap each handler, and Redis and Postgres spans nest under them, all bound to the app's tracer provider:
+
+```python
+--8<-- "trace/autoinstrument.py"
+```
+
+`instrument` is on by default and degrades to a no-op when an instrumentor package is absent, so it does nothing until you install the extras. Redis attaches to the exact client the provider owns. Postgres patches asyncpg for the whole process, because asyncpg has no per-pool hook, so every asyncpg connection is traced.
+
+Select what to instrument:
+
+```python
+Trace(instrument=False)                   # nothing (the @instrument decorator still works)
+Trace(instrument=["redis", "fastapi"])    # only the named targets, an unknown name raises
+Trace(instrument={"redis": False})        # every active target except the named ones
+```
+
+What is covered:
+
+| Target | Spans | Notes |
+|---|---|---|
+| FastAPI | Incoming HTTP requests | wired by `micro.install(app)`, FastAPI apps only |
+| Redis | Cache and lock commands | per-client, cluster included |
+| Postgres (asyncpg) | Queries | patches asyncpg process-wide |
+| Valkey, SQLite | None | Not auto-instrumented yet. Use `@instrument` for these. |
+
+Under a FastStream app, the provider spans (Redis, Postgres) are produced, but FastStream message spans are not auto-instrumented yet. Use `@instrument` for handler spans.

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -8,7 +8,7 @@ from contextlib import (
     asynccontextmanager,
 )
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Annotated, Any, Self
+from typing import TYPE_CHECKING, Annotated, Any, Self, cast
 
 from typing_extensions import Doc
 
@@ -664,6 +664,41 @@ class Grelmicro:
             for item in self._items
         )
 
+    def _instrument_providers(self) -> None:
+        """Auto-instrument active providers per the `Trace(instrument=...)` set.
+
+        Runs after every item is open, so provider clients exist and the
+        `TracerProvider` is installed. The framework integration instruments
+        itself separately in `micro.install(app)`.
+        """
+        component = next(
+            (
+                item
+                for item in self.components
+                if getattr(item, "kind", None) == "trace"
+            ),
+            None,
+        )
+        providers = self.providers
+        if component is None or not providers:
+            return
+        from grelmicro.trace._autoinstrument import (  # noqa: PLC0415
+            KNOWN_FRAMEWORKS,
+            instrument_providers,
+            uninstrument_providers,
+            validate_directive,
+        )
+
+        trace = cast("Trace", component)
+        directive = trace.instrument
+        known = {provider.short_name for provider in providers}
+        validate_directive(directive, known | KNOWN_FRAMEWORKS)
+        instrumented = instrument_providers(
+            providers, trace.provider, directive
+        )
+        if instrumented and self._exit_stack is not None:  # pragma: no branch
+            self._exit_stack.callback(uninstrument_providers, instrumented)
+
     async def __aenter__(self) -> Self:
         """Open every registered item in registration order.
 
@@ -689,6 +724,7 @@ class Grelmicro:
         try:
             for item in self._items:
                 await self._exit_stack.enter_async_context(item)
+            self._instrument_providers()
         except BaseException:
             _active_apps.remove(self)
             _current_micro.reset(self._token)

--- a/grelmicro/integrations/fastapi.py
+++ b/grelmicro/integrations/fastapi.py
@@ -1,7 +1,8 @@
 """FastAPI integration: middleware, install helper, and health router."""
 
+import logging
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, cast
 
 from pydantic import BaseModel
 from typing_extensions import Doc
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
     from starlette.applications import Starlette
 
     from grelmicro import Grelmicro
+    from grelmicro.trace._component import Trace
 
     Scope = MutableMapping[str, Any]
     Message = MutableMapping[str, Any]
@@ -37,6 +39,52 @@ __all__ = [
     "health_router",
     "install",
 ]
+
+_logger = logging.getLogger(__name__)
+
+
+def _instrument_app(app: "Starlette", micro: "Grelmicro") -> None:
+    """Auto-instrument the FastAPI app per `Trace(instrument=...)`.
+
+    Runs at install time with no explicit `TracerProvider`. OTel's proxy
+    tracer resolves to the provider `Trace` installs during the lifespan, so
+    request spans land in grelmicro's pipeline. It is a no-op without
+    `opentelemetry-instrumentation-fastapi` installed.
+    """
+    from grelmicro.trace._autoinstrument import (  # noqa: PLC0415
+        explicit_names,
+        is_selected,
+    )
+
+    component = next(
+        (c for c in micro.components if getattr(c, "kind", None) == "trace"),
+        None,
+    )
+    if component is None:
+        return
+    trace = cast("Trace", component)
+    directive = trace.instrument
+    if not is_selected("fastapi", directive):
+        return
+    try:
+        from fastapi import FastAPI  # noqa: PLC0415
+    except ImportError:  # pragma: no cover
+        return
+    if not isinstance(app, FastAPI):
+        return
+    try:
+        from opentelemetry.instrumentation.fastapi import (  # noqa: PLC0415
+            FastAPIInstrumentor,
+        )
+    except ImportError:  # pragma: no cover
+        names = explicit_names(directive)
+        if names is not None and "fastapi" in names:
+            _logger.warning(
+                "Trace named 'fastapi' for instrumentation but "
+                "opentelemetry-instrumentation-fastapi is not installed."
+            )
+        return
+    FastAPIInstrumentor.instrument_app(app)
 
 
 class GrelmicroMiddleware:
@@ -148,6 +196,7 @@ def install(
     app.router.lifespan_context = lifespan
     if ambient:
         app.add_middleware(GrelmicroMiddleware, micro=micro)
+    _instrument_app(app, micro)
 
 
 _NO_STORE_HEADERS = {"Cache-Control": "no-store"}

--- a/grelmicro/providers/_base.py
+++ b/grelmicro/providers/_base.py
@@ -141,3 +141,19 @@ class Provider(AbstractAsyncContextManager["Provider"]):
             f"Register a custom check with health.check(...) instead."
         )
         raise NotImplementedError(msg)
+
+    def instrument(self, tracer_provider: Any) -> bool:  # noqa: ANN401, ARG002
+        """Attach OpenTelemetry instrumentation for this Provider's client.
+
+        Called by `Trace(instrument=...)` after the app is open, with the
+        app's `TracerProvider`. Returns whether instrumentation is in effect.
+        The default returns `True`: a Provider with no native client to trace
+        (such as Memory) has nothing to attach and that is not a failure.
+        Subclasses override to attach the matching instrumentor, preferring
+        per-instance attachment, and return `False` when the instrumentor
+        package is absent so a named-but-uninstrumented target can warn.
+        """
+        return True
+
+    def uninstrument(self) -> None:
+        """Reverse `instrument`. The default is a no-op."""

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -96,6 +96,7 @@ class PostgresProvider(Provider):
     """
 
     short_name: ClassVar[str] = "postgres"
+    _asyncpg_instrumented: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -305,6 +306,37 @@ class PostgresProvider(Provider):
     async def check(self) -> None:
         """Run `SELECT 1` to prove the pool can serve a connection."""
         await self.client.fetchval("SELECT 1")
+
+    def instrument(self, tracer_provider: Any) -> bool:  # noqa: ANN401
+        """Attach the asyncpg OpenTelemetry instrumentor.
+
+        asyncpg has no per-pool API, so this patches `asyncpg.Connection` once
+        per process. The class-level guard keeps a second Postgres provider
+        from double-instrumenting. Returns `False` when
+        `opentelemetry-instrumentation-asyncpg` is not installed.
+        """
+        if PostgresProvider._asyncpg_instrumented:
+            return True
+        try:
+            from opentelemetry.instrumentation.asyncpg import (  # noqa: PLC0415
+                AsyncPGInstrumentor,
+            )
+        except ImportError:  # pragma: no cover
+            return False
+        AsyncPGInstrumentor().instrument(tracer_provider=tracer_provider)
+        PostgresProvider._asyncpg_instrumented = True
+        return True
+
+    def uninstrument(self) -> None:
+        """Reverse the process-wide asyncpg patch."""
+        if not PostgresProvider._asyncpg_instrumented:
+            return
+        from opentelemetry.instrumentation.asyncpg import (  # noqa: PLC0415
+            AsyncPGInstrumentor,
+        )
+
+        AsyncPGInstrumentor().uninstrument()
+        PostgresProvider._asyncpg_instrumented = False
 
     async def __aenter__(self) -> Self:
         """Open the asyncpg pool when the provider owns it."""

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -446,6 +446,32 @@ class RedisProvider(Provider):
         """`PING` Redis to prove the connection is reachable."""
         await self._client.ping()
 
+    def instrument(self, tracer_provider: Any) -> bool:  # noqa: ANN401
+        """Attach the Redis OpenTelemetry instrumentor to this client.
+
+        Uses per-instance `instrument_client`, so only this provider's client
+        is traced, not every Redis client in the process. Returns `False` when
+        `opentelemetry-instrumentation-redis` is not installed.
+        """
+        try:
+            from opentelemetry.instrumentation.redis import (  # noqa: PLC0415
+                RedisInstrumentor,
+            )
+        except ImportError:  # pragma: no cover
+            return False
+        self._instrumentor = RedisInstrumentor()
+        self._instrumentor.instrument_client(
+            self._client, tracer_provider=tracer_provider
+        )
+        return True
+
+    def uninstrument(self) -> None:
+        """Detach the Redis instrumentor from this client."""
+        instrumentor = getattr(self, "_instrumentor", None)
+        if instrumentor is not None:
+            instrumentor.uninstrument_client(self._client)
+            self._instrumentor = None
+
     async def __aenter__(self) -> Self:
         """Open the provider. The client is already constructed eagerly."""
         return self

--- a/grelmicro/providers/valkey.py
+++ b/grelmicro/providers/valkey.py
@@ -142,6 +142,15 @@ class ValkeyProvider(RedisProvider):
         """Whether the underlying client is a Valkey Cluster client."""
         return isinstance(self._client, self._cluster_class)
 
+    def instrument(self, tracer_provider: Any) -> bool:  # noqa: ANN401, ARG002
+        """Report that Valkey has no OpenTelemetry instrumentor.
+
+        The Redis instrumentor patches `redis.*`, not `valkey.*`, so it does
+        not trace valkey-py. Returns `False` so a named valkey target warns.
+        Use the `@instrument` decorator for valkey spans.
+        """
+        return False
+
     @classmethod
     def from_config(
         cls,

--- a/grelmicro/trace/_autoinstrument.py
+++ b/grelmicro/trace/_autoinstrument.py
@@ -1,0 +1,146 @@
+"""Auto-instrumentation wiring for the `Trace` component.
+
+`Trace(instrument=...)` selects which active providers and framework
+integrations attach their OpenTelemetry instrumentation against the app's
+`TracerProvider`. The selection directive is resolved here; the actual
+attachment lives on each `Provider.instrument` and in the framework
+integrations. A missing `opentelemetry-instrumentation-*` package degrades to a
+no-op (silent under the default, a warning when the target was named).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from grelmicro.providers._base import Provider
+
+_logger = logging.getLogger(__name__)
+
+InstrumentDirective = bool | str | Sequence[str] | Mapping[str, bool]
+"""`True`/`False`, a single name, an allow-list, or an all-with-overrides map."""
+
+KNOWN_FRAMEWORKS = frozenset({"fastapi"})
+"""Framework integration names valid in an `instrument` directive."""
+
+
+def explicit_names(directive: InstrumentDirective) -> set[str] | None:
+    """Return the names named in the directive, or `None` for a bool."""
+    if isinstance(directive, bool):
+        return None
+    if isinstance(directive, str):
+        return {directive}
+    if isinstance(directive, Mapping):
+        return {str(key) for key in directive}
+    return set(directive)
+
+
+def validate_directive(directive: InstrumentDirective, known: set[str]) -> None:
+    """Raise if the directive names a target outside `known`.
+
+    The allow-list, single-name, and map forms are strict: a name that matches
+    no active provider or known framework is almost always a typo, so it fails
+    loudly instead of silently instrumenting the wrong set. A map value that is
+    not a bool is rejected the same way, so a mistaken options dict cannot be
+    silently treated as "include".
+
+    Raises:
+        TraceSettingsValidationError: If the directive names an unknown target
+            or maps a name to a non-bool value.
+    """
+    from grelmicro.trace.errors import (  # noqa: PLC0415
+        TraceSettingsValidationError,
+    )
+
+    if isinstance(directive, Mapping):
+        bad_values = sorted(
+            key
+            for key, value in directive.items()
+            if not isinstance(value, bool)
+        )
+        if bad_values:
+            msg = (
+                f"Trace(instrument=...) maps {bad_values} to non-bool values. "
+                f"Map a name to True or False."
+            )
+            raise TraceSettingsValidationError(msg)
+    names = explicit_names(directive)
+    if names is None:
+        return
+    unknown = names - known
+    if unknown:
+        msg = (
+            f"Trace(instrument=...) names unknown targets "
+            f"{sorted(unknown)}. Known targets are {sorted(known)}."
+        )
+        raise TraceSettingsValidationError(msg)
+
+
+def is_selected(name: str, directive: InstrumentDirective) -> bool:
+    """Return whether `name` is selected by the directive.
+
+    - `True`/`False`: all or nothing.
+    - single name (`str`): selected only when it matches.
+    - allow-list (`Sequence`): selected only when listed.
+    - all-with-overrides (`Mapping`): selected unless mapped to `False`.
+    """
+    if isinstance(directive, bool):
+        return directive
+    if isinstance(directive, str):
+        return name == directive
+    if isinstance(directive, Mapping):
+        return directive.get(name, True) is not False
+    return name in directive
+
+
+def instrument_providers(
+    providers: Sequence[Provider],
+    tracer_provider: Any,  # noqa: ANN401
+    directive: InstrumentDirective,
+) -> list[Provider]:
+    """Instrument each selected provider; return the ones instrumented.
+
+    A provider whose `instrument` raises is logged and skipped, so one broken
+    instrumentor never blocks app startup. A selected provider that reports it
+    could not attach (its instrumentor package is absent) warns only when the
+    directive named it explicitly, so the default-on path stays quiet until the
+    extras are installed.
+    """
+    named = explicit_names(directive)
+    instrumented: list[Provider] = []
+    for provider in providers:
+        if not is_selected(provider.short_name, directive):
+            continue
+        try:
+            attached = provider.instrument(tracer_provider)
+        except Exception:  # noqa: BLE001
+            _logger.warning(
+                "Failed to auto-instrument provider '%s'",
+                provider.short_name,
+                exc_info=True,
+            )
+            continue
+        if attached:
+            instrumented.append(provider)
+        elif named is not None and provider.short_name in named:
+            _logger.warning(
+                "Trace named '%s' for instrumentation but no instrumentor "
+                "attached. Install its opentelemetry-instrumentation-* package.",
+                provider.short_name,
+            )
+    return instrumented
+
+
+def uninstrument_providers(providers: Sequence[Provider]) -> None:
+    """Reverse `instrument_providers` for the given providers."""
+    for provider in providers:
+        try:
+            provider.uninstrument()
+        except Exception:  # noqa: BLE001
+            _logger.warning(
+                "Failed to un-instrument provider '%s'",
+                provider.short_name,
+                exc_info=True,
+            )

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -25,6 +25,8 @@ from grelmicro.trace.errors import (
 if TYPE_CHECKING:
     from types import TracebackType
 
+    from grelmicro.trace._autoinstrument import InstrumentDirective
+
 
 _logger = logging.getLogger(__name__)
 
@@ -105,6 +107,26 @@ class Trace:
         resource_attributes: Annotated[
             dict[str, str] | None, Doc("Extra resource attributes.")
         ] = None,
+        instrument: Annotated[
+            InstrumentDirective,
+            Doc(
+                """
+                Auto-instrumentation selection for active providers and the
+                FastAPI app, bound to this app's tracer provider. `True` (the
+                default) instruments every active provider plus the FastAPI
+                app. A missing `opentelemetry-instrumentation-*` package is a
+                no-op, so default-on does nothing until the extras are
+                installed.
+
+                - `False`: instrument nothing (the `@instrument` decorator
+                  still works).
+                - `"redis"` or `["redis", "fastapi"]`: instrument only the
+                  named targets. An unknown name raises.
+                - `{"redis": False}`: instrument every active target except
+                  the named ones.
+                """
+            ),
+        ] = True,
         shutdown_timeout: Annotated[
             float | None,
             Doc(
@@ -138,6 +160,7 @@ class Trace:
             "shutdown_timeout": shutdown_timeout,
         }
         self._env_load = env_load
+        self._instrument = instrument
         self._resolved: TraceConfig | None = None
         self._provider: Any = None
         self._prior_provider: Any = None
@@ -171,6 +194,11 @@ class Trace:
     def name(self) -> str:
         """Return the registration name."""
         return self._name
+
+    @property
+    def instrument(self) -> InstrumentDirective:
+        """Return the auto-instrumentation selection directive."""
+        return self._instrument
 
     @property
     def config(self) -> TraceConfig:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,11 @@ opentelemetry = [
     "opentelemetry-exporter-prometheus>=0.41b0",
     "prometheus-client>=0.19.0",
 ]
+instrumentation = [
+    "opentelemetry-instrumentation-fastapi>=0.41b0",
+    "opentelemetry-instrumentation-redis>=0.41b0",
+    "opentelemetry-instrumentation-asyncpg>=0.41b0",
+]
 structlog = [
     "structlog>=24.1.0",
     "orjson>=3.10.11",
@@ -182,6 +187,9 @@ dev = [
     "opentelemetry-exporter-otlp-proto-http>=1.20.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
     "opentelemetry-exporter-prometheus>=0.41b0",
+    "opentelemetry-instrumentation-fastapi>=0.41b0",
+    "opentelemetry-instrumentation-redis>=0.41b0",
+    "opentelemetry-instrumentation-asyncpg>=0.41b0",
     "prometheus-client>=0.19.0",
     "structlog>=24.1.0",
     "aiosqlite>=0.20.0",

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -627,7 +627,7 @@
   },
   "grelmicro.trace": {
     "Trace": {
-      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., shutdown_timeout=..., env_load=...)",
+      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., instrument=..., shutdown_timeout=..., env_load=...)",
       ".from_config": "(config, *, name=...)"
     },
     "TraceConfig": {

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -27,6 +27,7 @@ _SNIPPETS_DIR = Path(__file__).resolve().parent.parent / "docs" / "snippets"
 # (logging / tracing setup). Compiled and built by MkDocs, not run here.
 _COMPILE_ONLY = {
     "trace/component.py",
+    "trace/autoinstrument.py",
     "log/component.py",
 }
 

--- a/tests/tracing/test_autoinstrument.py
+++ b/tests/tracing/test_autoinstrument.py
@@ -1,0 +1,354 @@
+"""Tests for `Trace(instrument=...)` auto-instrumentation.
+
+Covers the selection logic, the per-provider instrument hooks, the app-level
+provider pass, the FastAPI install pass, and an end-to-end request span.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import SpanKind
+from starlette.applications import Starlette
+from starlette.status import HTTP_200_OK
+
+from grelmicro import Grelmicro
+from grelmicro.providers.memory import MemoryProvider
+from grelmicro.providers.postgres import PostgresProvider
+from grelmicro.providers.redis import RedisProvider
+from grelmicro.providers.valkey import ValkeyProvider
+from grelmicro.trace import Trace, TraceExporterType
+from grelmicro.trace._autoinstrument import (
+    InstrumentDirective,
+    instrument_providers,
+    is_selected,
+    uninstrument_providers,
+    validate_directive,
+)
+from grelmicro.trace.errors import TraceSettingsValidationError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+REDIS_URL = "redis://localhost:6379/0"
+PG_URL = "postgresql://localhost:5432/db"
+
+
+def _none_trace(*, instrument: InstrumentDirective = True) -> Trace:
+    """Return a `Trace` with no exporter (no real OTLP connection)."""
+    return Trace(exporter=TraceExporterType.NONE, instrument=instrument)
+
+
+# --- selection logic ---------------------------------------------------------
+
+
+def test_is_selected_bool() -> None:
+    """A bool selects all or nothing."""
+    assert is_selected("redis", directive=True) is True
+    assert is_selected("redis", directive=False) is False
+
+
+def test_is_selected_allow_list() -> None:
+    """An allow-list selects only listed names."""
+    assert is_selected("redis", directive=["redis", "fastapi"]) is True
+    assert is_selected("postgres", directive=["redis"]) is False
+
+
+def test_is_selected_single_name_string() -> None:
+    """A bare string is a single-name allow-list, not a char sequence."""
+    assert is_selected("redis", directive="redis") is True
+    assert is_selected("postgres", directive="redis") is False
+
+
+def test_is_selected_map_is_all_except() -> None:
+    """A map selects all except names mapped to `False`."""
+    assert is_selected("redis", directive={"redis": False}) is False
+    assert is_selected("postgres", directive={"redis": False}) is True
+    assert is_selected("redis", directive={"redis": True}) is True
+
+
+def test_validate_directive_allows_bool_and_known_names() -> None:
+    """A bool needs no validation; known names and a single string pass."""
+    validate_directive(directive=True, known={"redis"})
+    validate_directive(["redis"], known={"redis", "fastapi"})
+    validate_directive("redis", known={"redis"})
+    validate_directive({"redis": False}, known={"redis"})
+
+
+def test_validate_directive_rejects_unknown_names() -> None:
+    """An unknown name in a string, list, or map raises (typo guard)."""
+    with pytest.raises(TraceSettingsValidationError, match="unknown targets"):
+        validate_directive("typo", known={"redis"})
+    with pytest.raises(TraceSettingsValidationError, match="unknown targets"):
+        validate_directive(["reddis"], known={"redis"})
+    with pytest.raises(TraceSettingsValidationError, match="unknown targets"):
+        validate_directive({"typo": False}, known={"redis"})
+
+
+def test_validate_directive_rejects_non_bool_map_values() -> None:
+    """A map value that is not a bool raises, so options are not swallowed."""
+    with pytest.raises(TraceSettingsValidationError, match="non-bool"):
+        validate_directive({"redis": {"opt": 1}}, known={"redis"})  # ty: ignore[invalid-argument-type]
+
+
+# --- orchestration with spy providers ----------------------------------------
+
+
+class _SpyProvider:
+    short_name = "spy"
+
+    def __init__(self, *, attaches: bool = True) -> None:
+        self._attaches = attaches
+        self.tracer_provider: object | None = None
+        self.uninstrumented = False
+
+    def instrument(self, tracer_provider: object) -> bool:
+        self.tracer_provider = tracer_provider
+        return self._attaches
+
+    def uninstrument(self) -> None:
+        self.uninstrumented = True
+
+
+def test_instrument_providers_selected_and_reversible() -> None:
+    """A selected provider is instrumented and later un-instrumented."""
+    provider = _SpyProvider()
+    tracer_provider = object()
+    out = instrument_providers([provider], tracer_provider, directive=True)  # ty: ignore[invalid-argument-type]
+    assert out == [provider]
+    assert provider.tracer_provider is tracer_provider
+
+    uninstrument_providers(out)
+    assert provider.uninstrumented is True
+
+
+def test_instrument_providers_skips_unselected() -> None:
+    """An unselected provider is left untouched."""
+    provider = _SpyProvider()
+    assert instrument_providers([provider], object(), directive=False) == []  # ty: ignore[invalid-argument-type]
+    assert provider.tracer_provider is None
+
+
+def test_instrument_providers_warns_on_explicit_miss(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A named provider that cannot attach warns; not added to the result."""
+    provider = _SpyProvider(attaches=False)
+    caplog.set_level("WARNING")
+    assert instrument_providers([provider], object(), directive=["spy"]) == []  # ty: ignore[invalid-argument-type]
+    assert "no instrumentor" in caplog.text
+
+
+def test_instrument_providers_silent_on_default_miss(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A default-on provider that cannot attach stays quiet (no warning)."""
+    provider = _SpyProvider(attaches=False)
+    caplog.set_level("WARNING")
+    assert instrument_providers([provider], object(), directive=True) == []  # ty: ignore[invalid-argument-type]
+    assert caplog.text == ""
+
+
+def test_instrument_providers_swallows_instrument_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A provider whose instrument raises is logged and skipped."""
+
+    class _Boom:
+        short_name = "boom"
+
+        def instrument(self, tracer_provider: object) -> bool:  # noqa: ARG002
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    caplog.set_level("WARNING")
+    assert instrument_providers([_Boom()], object(), directive=True) == []  # ty: ignore[invalid-argument-type]
+    assert "Failed to auto-instrument" in caplog.text
+
+
+def test_uninstrument_providers_swallows_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A provider whose uninstrument raises is logged, not propagated."""
+
+    class _Boom:
+        short_name = "boom"
+
+        def uninstrument(self) -> None:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    caplog.set_level("WARNING")
+    uninstrument_providers([_Boom()])  # ty: ignore[invalid-argument-type]
+    assert "Failed to un-instrument" in caplog.text
+
+
+# --- per-provider hooks ------------------------------------------------------
+
+
+def test_redis_provider_instrument_and_uninstrument() -> None:
+    """Redis attaches a per-instance instrumentor and detaches it."""
+    redis = RedisProvider(REDIS_URL)
+    assert redis.instrument(TracerProvider()) is True
+    assert redis._instrumentor is not None
+    redis.uninstrument()
+    assert redis._instrumentor is None
+
+
+def test_redis_uninstrument_without_instrument_is_noop() -> None:
+    """Un-instrumenting a never-instrumented Redis provider is a no-op."""
+    RedisProvider(REDIS_URL).uninstrument()
+
+
+def test_valkey_provider_instrument_reports_unsupported() -> None:
+    """Valkey has no OTel instrumentor, so instrument returns False."""
+    valkey = ValkeyProvider(REDIS_URL)
+    assert valkey.instrument(TracerProvider()) is False
+    assert getattr(valkey, "_instrumentor", None) is None
+
+
+def test_memory_provider_instrument_is_noop_success() -> None:
+    """The base reports success (nothing to trace is not a failure)."""
+    memory = MemoryProvider()
+    assert memory.instrument(TracerProvider()) is True
+    memory.uninstrument()
+
+
+@pytest.fixture
+def _clean_asyncpg() -> Iterator[None]:
+    """Guarantee the global asyncpg patch is reverted after the test."""
+    PostgresProvider._asyncpg_instrumented = False
+    yield
+    if PostgresProvider._asyncpg_instrumented:
+        PostgresProvider(PG_URL).uninstrument()
+
+
+@pytest.mark.usefixtures("_clean_asyncpg")
+def test_postgres_provider_global_patch_guarded() -> None:
+    """Asyncpg patches once process-wide; a second provider does not re-patch."""
+    first = PostgresProvider(PG_URL)
+    assert first.instrument(TracerProvider()) is True
+    assert PostgresProvider._asyncpg_instrumented is True
+
+    assert PostgresProvider(PG_URL).instrument(TracerProvider()) is True
+    assert PostgresProvider._asyncpg_instrumented is True
+
+    first.uninstrument()
+    assert PostgresProvider._asyncpg_instrumented is False
+    first.uninstrument()  # already reverted -> no-op
+
+
+# --- app-level provider pass -------------------------------------------------
+
+
+async def test_app_instruments_providers_by_default() -> None:
+    """A provider under a `Trace` is instrumented on enter, reversed on exit."""
+    redis = RedisProvider(REDIS_URL)
+    async with Grelmicro(uses=[_none_trace(), redis]):
+        assert redis._instrumentor is not None
+    assert redis._instrumentor is None
+
+
+async def test_app_instrument_false_skips() -> None:
+    """`instrument=False` instruments nothing."""
+    redis = RedisProvider(REDIS_URL)
+    async with Grelmicro(uses=[_none_trace(instrument=False), redis]):
+        assert getattr(redis, "_instrumentor", None) is None
+
+
+async def test_app_allow_list_excludes_unlisted_provider() -> None:
+    """An allow-list naming only a framework leaves providers untouched."""
+    redis = RedisProvider(REDIS_URL)
+    async with Grelmicro(uses=[_none_trace(instrument=["fastapi"]), redis]):
+        assert getattr(redis, "_instrumentor", None) is None
+
+
+async def test_app_unknown_target_raises() -> None:
+    """An unknown instrument target fails app startup."""
+    redis = RedisProvider(REDIS_URL)
+    micro = Grelmicro(uses=[_none_trace(instrument=["bogus"]), redis])
+    with pytest.raises(TraceSettingsValidationError, match="unknown targets"):
+        async with micro:
+            pass
+
+
+async def test_app_without_trace_does_not_instrument() -> None:
+    """No `Trace` component means no provider instrumentation."""
+    redis = RedisProvider(REDIS_URL)
+    async with Grelmicro(uses=[redis]):
+        assert getattr(redis, "_instrumentor", None) is None
+
+
+async def test_app_with_trace_no_providers() -> None:
+    """A `Trace` with no providers enters cleanly."""
+    async with Grelmicro(uses=[_none_trace()]):
+        pass
+
+
+# --- FastAPI install pass ----------------------------------------------------
+
+
+def test_install_instruments_fastapi_by_default() -> None:
+    """`micro.install(app)` instruments a FastAPI app by default."""
+    app = FastAPI()
+    Grelmicro(uses=[_none_trace()]).install(app)
+    try:
+        assert app._is_instrumented_by_opentelemetry is True  # ty: ignore[unresolved-attribute]
+    finally:
+        FastAPIInstrumentor.uninstrument_app(app)
+
+
+def test_install_instrument_false_skips_fastapi() -> None:
+    """`instrument=False` leaves the FastAPI app un-instrumented."""
+    app = FastAPI()
+    Grelmicro(uses=[_none_trace(instrument=False)]).install(app)
+    assert getattr(app, "_is_instrumented_by_opentelemetry", False) is False
+
+
+def test_install_skips_plain_starlette() -> None:
+    """A non-FastAPI Starlette app is skipped (FastAPI instrumentor only)."""
+    app = Starlette()
+    Grelmicro(uses=[_none_trace()]).install(app)
+    assert getattr(app, "_is_instrumented_by_opentelemetry", False) is False
+
+
+def test_install_without_trace_skips_fastapi() -> None:
+    """No `Trace` component means no FastAPI instrumentation."""
+    app = FastAPI()
+    Grelmicro(uses=[]).install(app)
+    assert getattr(app, "_is_instrumented_by_opentelemetry", False) is False
+
+
+# --- end-to-end span ---------------------------------------------------------
+
+
+def test_fastapi_request_produces_server_span() -> None:
+    """A request through an instrumented app emits a SERVER span."""
+    exporter = InMemorySpanExporter()
+    micro = Grelmicro(uses=[_none_trace()])
+    app = FastAPI()
+
+    @app.get("/ping")
+    def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    micro.install(app)
+    try:
+        with TestClient(app) as client:
+            micro.trace.provider.add_span_processor(
+                SimpleSpanProcessor(exporter)
+            )
+            assert client.get("/ping").status_code == HTTP_200_OK
+        spans = exporter.get_finished_spans()
+        assert any(span.kind is SpanKind.SERVER for span in spans)
+    finally:
+        FastAPIInstrumentor.uninstrument_app(app)

--- a/uv.lock
+++ b/uv.lock
@@ -48,6 +48,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -481,6 +490,11 @@ dependencies = [
 faststream = [
     { name = "faststream" },
 ]
+instrumentation = [
+    { name = "opentelemetry-instrumentation-asyncpg" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-redis" },
+]
 kubernetes = [
     { name = "lightkube" },
 ]
@@ -532,6 +546,9 @@ dev = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-exporter-prometheus" },
+    { name = "opentelemetry-instrumentation-asyncpg" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-redis" },
     { name = "opentelemetry-sdk" },
     { name = "orjson" },
     { name = "pre-commit" },
@@ -576,6 +593,9 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'opentelemetry'", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'opentelemetry'", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-prometheus", marker = "extra == 'opentelemetry'", specifier = ">=0.41b0" },
+    { name = "opentelemetry-instrumentation-asyncpg", marker = "extra == 'instrumentation'", specifier = ">=0.41b0" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'instrumentation'", specifier = ">=0.41b0" },
+    { name = "opentelemetry-instrumentation-redis", marker = "extra == 'instrumentation'", specifier = ">=0.41b0" },
     { name = "opentelemetry-sdk", marker = "extra == 'opentelemetry'", specifier = ">=1.20.0" },
     { name = "orjson", marker = "extra == 'standard'", specifier = ">=3.10.11" },
     { name = "orjson", marker = "extra == 'structlog'", specifier = ">=3.10.11" },
@@ -589,7 +609,7 @@ requires-dist = [
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'standard'", specifier = ">=0.21.0" },
     { name = "valkey", marker = "extra == 'valkey'", specifier = ">=6" },
 ]
-provides-extras = ["standard", "faststream", "postgres", "redis", "sqlite", "kubernetes", "opentelemetry", "structlog", "valkey", "yaml"]
+provides-extras = ["standard", "faststream", "postgres", "redis", "sqlite", "kubernetes", "opentelemetry", "instrumentation", "structlog", "valkey", "yaml"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -607,6 +627,9 @@ dev = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-prometheus", specifier = ">=0.41b0" },
+    { name = "opentelemetry-instrumentation-asyncpg", specifier = ">=0.41b0" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.41b0" },
+    { name = "opentelemetry-instrumentation-redis", specifier = ">=0.41b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "orjson", specifier = ">=3.10.11" },
     { name = "pre-commit", specifier = ">=4.0.1" },
@@ -1438,31 +1461,31 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.42.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.42.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/9c/216acfeaedadf2e1937f4373929b20f73197c5c4a2546d4f584b7fa63813/opentelemetry_exporter_otlp_proto_common-1.42.1.tar.gz", hash = "sha256:04f1f01fb597c4249dfcd7f8b861c902c2102369d376d9d346ff38de4469a2ee", size = 21433, upload-time = "2026-05-21T16:32:55.526Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/43/2375e7612e1121a4518c17603b6e0b03ad94f565aafad53f464dc5be2bf6/opentelemetry_exporter_otlp_proto_common-1.42.1-py3-none-any.whl", hash = "sha256:f48d395ab815b444da118868977e9798ea354c25737d5cf39578ae894011c140", size = 17327, upload-time = "2026-05-21T16:32:33.387Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.42.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1473,14 +1496,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/87/ca7fc790dfdbcf4f9e9aab14a39ef1b7508ead13707e283de0b3131478d2/opentelemetry_exporter_otlp_proto_grpc-1.42.1.tar.gz", hash = "sha256:975c4461f167dd8ed8857d68d3b6b25f3d272eab896f6a9470d0f5b90e2faf15", size = 27140, upload-time = "2026-05-21T16:32:56.162Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/1d/6336453716ca0a240d4417d19e6d5b77a5e7163e5670ec4f7ec4d3ede7bf/opentelemetry_exporter_otlp_proto_grpc-1.43.0.tar.gz", hash = "sha256:1b3e0627daa9bc21884d4a13946807c255eb558bfe5bdd543dffb6f4c9faee0d", size = 27213, upload-time = "2026-06-24T15:20:00.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/2b/28ba5b128f47fe8c3bab541000d6feb4b5a9bd26623ca013406f01c0fb60/opentelemetry_exporter_otlp_proto_grpc-1.42.1-py3-none-any.whl", hash = "sha256:0ae1177e2038b18a929b3098215243631ef91136cba26b7e2b12790ceb7e87cc", size = 19617, upload-time = "2026-05-21T16:32:34.278Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/74/2700b5d5c946bf2dba87073fce3dfc198c46bc92ea3d5693f54bc51c90b1/opentelemetry_exporter_otlp_proto_grpc-1.43.0-py3-none-any.whl", hash = "sha256:6a10d1feacffffda19acacbf277b736094b1e2f4dbb98c90ccb2c6e1962e2ec6", size = 19626, upload-time = "2026-06-24T15:19:42.233Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.42.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1491,62 +1514,147 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/32/826bfa1d80ecea24f47808de03cd4a0d13c17ecc07712f45123f0f61e4ac/opentelemetry_exporter_otlp_proto_http-1.42.1.tar.gz", hash = "sha256:bf142a21035d7571ac3a09cb2e5639f49886f243972883cfe777ed3bf02b734d", size = 25406, upload-time = "2026-05-21T16:32:56.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/96/82cb223a1502f0787d4bbff12907f5f8d870a50731febcd5818d93ef9555/opentelemetry_exporter_otlp_proto_http-1.42.1-py3-none-any.whl", hash = "sha256:00a16da1b312a1d6c7233d600d557c91df71125af73020f3b9a7765bd699d59d", size = 21793, upload-time = "2026-05-21T16:32:35.277Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-prometheus"
-version = "0.63b1"
+version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/2a/dfeddff262b12eff0c72f4ad9e258aab8889f48c4dc1417a0377a13bc427/opentelemetry_exporter_prometheus-0.63b1.tar.gz", hash = "sha256:31902e22c89431058a95b6dcdb644f9309f226aa4872cc755f0a780d2895e97f", size = 15234, upload-time = "2026-05-21T16:32:57.797Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/b3/f778f705289ea5f1c54589ae4494d318c9cede052f18ca33979fda0ef016/opentelemetry_exporter_prometheus-0.64b0.tar.gz", hash = "sha256:96fec79be9527cb9dc994d7e663051df35161eb936fe2d41954725e4595abbc1", size = 16405, upload-time = "2026-06-24T15:20:02.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/ec/d7c7435e9000fb69837cf7753b7cbbbdeb5d0585203daf1b6ebf8fa93e02/opentelemetry_exporter_prometheus-0.63b1-py3-none-any.whl", hash = "sha256:0efd00aa6b1939345ddcc6de141b83ebffa2b4401a37a68f880e54217602701d", size = 12466, upload-time = "2026-05-21T16:32:36.622Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/dd/d95db7ac5bec037b3dcc8ea6fe64cd5dc4bc87017d2e06e7410318e85dc0/opentelemetry_exporter_prometheus-0.64b0-py3-none-any.whl", hash = "sha256:9979a15f8d007d442bc7a6e16f4cbde5e8e0c5e99689887ceb5f33da251f0655", size = 13031, upload-time = "2026-06-24T15:19:44.159Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/97/02fe6e1c8b1ffac42d0b429c18080edb24e0e0d18c86612edf72b5752382/opentelemetry_instrumentation-0.64b0.tar.gz", hash = "sha256:b47d528dead6271d7743114417eb67fc915bd9258111c48dbf9a4951d2efa88d", size = 41935, upload-time = "2026-06-24T15:19:12.951Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/0c/cb9fe342de5299c7af24582eb7d788661cc53a1c4b904da92309caaa9417/opentelemetry_instrumentation-0.64b0-py3-none-any.whl", hash = "sha256:133ab7ffca796557aec059bf6be3190a34b6dea987f25be3d9409e230cbdad8b", size = 35880, upload-time = "2026-06-24T15:18:17.277Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/0c/71c696fccb86d37af383ea1604af4729fabad0af2fabaf203e4c79c1e859/opentelemetry_instrumentation_asgi-0.64b0.tar.gz", hash = "sha256:4dd3eee566a4303f8e6b9b84f2a0a7abc57a6640df768926c68a3868bf5b2090", size = 26136, upload-time = "2026-06-24T15:19:17.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/20/218b65a63d847a7ed28d1bea84c39234689160b74480b8702272e37f4240/opentelemetry_instrumentation_asgi-0.64b0-py3-none-any.whl", hash = "sha256:e0840b66e15303a9254b0540946010bd008aa0504f4d89b8e1b7fb63490a36f0", size = 15906, upload-time = "2026-06-24T15:18:23.107Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asyncpg"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/6b/890ba6ecb920c9bb1912a01b9d1c04255a9b38592bb43cdd4baa1b82eced/opentelemetry_instrumentation_asyncpg-0.64b0.tar.gz", hash = "sha256:1a10887fa3dd1eee68cd939340967f767558c42eb108fddd03b00c1235a4c8e6", size = 9710, upload-time = "2026-06-24T15:19:18.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/6d/987109d9a05fcb71755570aa040b155f6c47472a8af8c2a99a8280993f4f/opentelemetry_instrumentation_asyncpg-0.64b0-py3-none-any.whl", hash = "sha256:c7633818b74327bf2b79c5d8b8722e58e183f0adb13c6bf8fe1d0ba3b6f7ac5a", size = 9430, upload-time = "2026-06-24T15:18:26.234Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/a1/52282e2cc5c08f4df13b087896d9907258fe2ff4f34035d3b21aa92684c3/opentelemetry_instrumentation_fastapi-0.64b0.tar.gz", hash = "sha256:05f75149929e433c1630de381688e650bf651c1e1cce7f9a7b649a807dac8a98", size = 26236, upload-time = "2026-06-24T15:19:27.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/2d/4f48dc2d6f289f2febc5b871940dbea9f3b04ab9186d23342581b49cb984/opentelemetry_instrumentation_fastapi-0.64b0-py3-none-any.whl", hash = "sha256:43cbbfb2d3079dc81104478a2950ae93ac6d0e90a5020fa3987a236f8f2bdef1", size = 13263, upload-time = "2026-06-24T15:18:38.553Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-redis"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/89/9b556b53faf2b5a23f2bb844e087e6577704129bd5964decc3fb9d7a1309/opentelemetry_instrumentation_redis-0.64b0.tar.gz", hash = "sha256:c37e194c1e8ff59944d5c2f18014ee18f244a103958b1f2482099525ae9099f9", size = 17045, upload-time = "2026-06-24T15:19:38.281Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/f2/96cd02f91303ea0d387aa46c615365877875ca47f9796e9fb1503ec1e0e6/opentelemetry_instrumentation_redis-0.64b0-py3-none-any.whl", hash = "sha256:5458a541986f665b9d7e641421fa5d0c286f1813b452faab6f84503823719d52", size = 14642, upload-time = "2026-06-24T15:18:54.141Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.42.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/55/63eac3e1089b768ba014091fdd2ae8a9a440c821ef5e2b786909c94c8836/opentelemetry_proto-1.42.1.tar.gz", hash = "sha256:c6a51e6b4f05ae63565f3a113217f3d2bfaec68f78c02d7a6c85f9010d1cfca6", size = 45839, upload-time = "2026-05-21T16:33:03.937Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/9d/171c02c84a76940b7e601805b3bb536985aded9168fbcc9ba52f0a730fa2/opentelemetry_proto-1.42.1-py3-none-any.whl", hash = "sha256:dedb74cba2886c59c7789b227a7a670613025a07489040050aedff6e5c0fb43c", size = 71782, upload-time = "2026-05-21T16:32:44.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.42.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/6b/4287766cfbde577ae2272e8884abac325aeaac0d64f41c61d5b8cc595105/opentelemetry_sdk-1.42.1-py3-none-any.whl", hash = "sha256:083cd4bbfaa5aa7b5a9e552430d9951219967cfb27aa61feb13a77aba1fc839d", size = 170907, upload-time = "2026-05-21T16:32:45.894Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.63b1"
+version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/7a/7fe66f5f3682b1dd47d88cc4e11f1c6c0966b737de2d16671146e23c39a5/opentelemetry_semantic_conventions-0.63b1-py3-none-any.whl", hash = "sha256:dfe5ef4dee82586b746f522b818ceb298d00b3d59f660042bd79404bff8d0682", size = 203713, upload-time = "2026-05-21T16:32:47.016Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/1b/1029a805fd7242f7dfce91633b244c3b14a94d703232878f71e01ce862b1/opentelemetry_util_http-0.64b0.tar.gz", hash = "sha256:8a86a220dbfc56d736f47f1e5c4e7932a21fcf69052312e1bcf166444dc79322", size = 11102, upload-time = "2026-06-24T15:19:48.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/c7/5f8ec5b30546f2dc22cd5fc5759bce2ab5be6e89a2e710a405ac9ef64ed3/opentelemetry_util_http-0.64b0-py3-none-any.whl", hash = "sha256:c1e5350d25507c1afcd6076cf9ac062485a0a4f79cd9971366996fd3056bacdb", size = 8204, upload-time = "2026-06-24T15:19:09.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements #470. `Trace(instrument=...)` auto-instruments active providers and the FastAPI app with OpenTelemetry, so incoming requests and Redis/Postgres calls produce spans with no per-handler decoration. Post-1.0, Next bucket.

## Design (two seams, one config hub)

grelmicro owns its instrumentation targets as concrete instances, so "instrument everything active" is safe (no global monkeypatch of code it doesn't own).

- **Providers self-instrument**: a `Provider.instrument(tracer_provider) -> bool` hook. The app's `__aenter__` walks `micro.providers` after everything is open and reverses it on exit. Redis attaches per-instance (`instrument_client`); asyncpg patches process-wide (guarded once); Valkey reports unsupported; Memory is a no-op.
- **FastAPI self-instruments**: `micro.install(app)` calls `FastAPIInstrumentor.instrument_app`; OTel's proxy tracer resolves to grelmicro's provider once `Trace` installs it during the lifespan.

## API

```python
Trace(instrument: bool | str | Sequence[str] | Mapping[str, bool] = True)
```

- `True` (default) instruments everything active; a missing `opentelemetry-instrumentation-*` package is a no-op, so default-on does nothing until the new `instrumentation` extra is installed.
- `False` disables; `"redis"` / `["redis", "fastapi"]` select; `{"redis": False}` excludes.
- An unknown name raises `TraceSettingsValidationError`. A named-but-uninstrumented target warns.

## Coverage

Redis, asyncpg (process-wide), FastAPI request spans. Valkey and SQLite have no OTel package yet and stay on `@instrument`. FastStream provider spans work; message spans are a follow-up.

## Tests / quality

- 29 tests including an end-to-end FastAPI request -> SERVER span; `_autoinstrument` at 100% coverage.
- Two adversarial reviews applied (dropped an inert options form, tightened framework validation, fixed the install/extra docs, typed the validation error to match every other component).
- ruff, ty, mkdocs --strict, public-API snapshot all clean. New `instrumentation` extra; docs + verified snippet + changelog added.