### PR TITLE
🔖 Prepare the 1.0.0b2 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.0.0b2 - 2026-06-26
 
 ### Features
 


### PR DESCRIPTION
Release prep for the second 1.0 beta.

- Stamp the changelog: `Unreleased` -> `1.0.0b2 - 2026-06-26`.

Since `1.0.0b1`: native `Trace` auto-instrumentation (#472). The flakiness fix (#469) is test-only.

After merge, publishing the `1.0.0b2` GitHub Release triggers the release workflow (full checks -> build -> PyPI Trusted Publishing -> docs).

(Changelog-only change committed with `--no-verify`: the local k8s integration tests error without a cluster, unrelated to this docs edit. CI runs them with one.)