### PR TITLE
✅ Isolate the OTel global in the Trace auto-instrument span test

### DIFF
--- a/grelmicro/integrations/fastapi.py
+++ b/grelmicro/integrations/fastapi.py
@@ -46,9 +46,11 @@ _logger = logging.getLogger(__name__)
 def _instrument_app(app: "Starlette", micro: "Grelmicro") -> None:
     """Auto-instrument the FastAPI app per `Trace(instrument=...)`.
 
-    Runs at install time with no explicit `TracerProvider`. OTel's proxy
-    tracer resolves to the provider `Trace` installs during the lifespan, so
-    request spans land in grelmicro's pipeline. It is a no-op without
+    Runs at install time, before the app serves, because the framework builds
+    its middleware stack on first use and the request-span middleware must be
+    in place by then. With no explicit `TracerProvider`, OTel's proxy tracer
+    resolves to the provider `Trace` installs during the lifespan, so request
+    spans land in grelmicro's pipeline. It is a no-op without
     `opentelemetry-instrumentation-fastapi` installed.
     """
     from grelmicro.trace._autoinstrument import (  # noqa: PLC0415

--- a/tests/tracing/test_autoinstrument.py
+++ b/tests/tracing/test_autoinstrument.py
@@ -298,7 +298,7 @@ async def test_app_with_trace_no_providers() -> None:
 
 
 def test_install_instruments_fastapi_by_default() -> None:
-    """`micro.install(app)` instruments a FastAPI app by default."""
+    """`micro.install(app)` instruments a FastAPI app at install time."""
     app = FastAPI()
     Grelmicro(uses=[_none_trace()]).install(app)
     try:
@@ -331,6 +331,26 @@ def test_install_without_trace_skips_fastapi() -> None:
 # --- end-to-end span ---------------------------------------------------------
 
 
+@pytest.fixture
+def _isolate_tracer_provider() -> Iterator[None]:
+    """Give the test a clean OTel global so the proxy resolves deterministically.
+
+    `instrument_app` runs at install time with the proxy tracer, which
+    resolves the process-global provider at request time. Other tests in the
+    suite leave a provider in that global, so reset it to the default proxy
+    here and restore it after.
+    """
+    from opentelemetry import trace as otel_trace  # noqa: PLC0415
+
+    saved = otel_trace._TRACER_PROVIDER
+    otel_trace._TRACER_PROVIDER = None
+    try:
+        yield
+    finally:
+        otel_trace._TRACER_PROVIDER = saved
+
+
+@pytest.mark.usefixtures("_isolate_tracer_provider")
 def test_fastapi_request_produces_server_span() -> None:
     """A request through an instrumented app emits a SERVER span."""
     exporter = InMemorySpanExporter()
@@ -344,6 +364,8 @@ def test_fastapi_request_produces_server_span() -> None:
     micro.install(app)
     try:
         with TestClient(app) as client:
+            # The lifespan installed Trace's provider; the app's proxy tracer
+            # resolves to it, so capture spans from that exact provider.
             micro.trace.provider.add_span_processor(
                 SimpleSpanProcessor(exporter)
             )


### PR DESCRIPTION
The `1.0.0b2` release run failed on Python 3.12: `test_fastapi_request_produces_server_span` captured no SERVER span.

Root cause: the test relied on the ambient process-global OpenTelemetry tracer provider. `instrument_app` runs at install time with the proxy tracer (correct — the framework builds its middleware stack before the lifespan body, so it must be in place by then), and the proxy resolves the global at request time. Other tests in the full suite leave a provider in that global, so under random ordering the proxy occasionally resolved elsewhere and the span never reached the in-memory exporter.

Fix (test-only + a clarifying docstring):
- Add an OTel-global isolation fixture that resets `_TRACER_PROVIDER` to the default proxy for the test and restores it after, so the proxy resolves deterministically to grelmicro's provider.
- Expand the `_instrument_app` docstring to record why instrumentation must happen at install time, not in the lifespan.

The feature behavior is unchanged from #472. Verified 5/5 clean full unit suite under random ordering (3203 each); ruff + ty clean.