### PR TITLE
✨ Auto-disable Trace until configured and add first-class Basic auth

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* ✨ Auto-disable `Trace` until an endpoint is configured. The exporter now defaults to `TraceExporterType.AUTO`, which exports over OTLP HTTP when an endpoint is set (the `endpoint` argument, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or `OTEL_EXPORTER_OTLP_ENDPOINT`) and no-ops otherwise. Register `Trace()` unconditionally and it stays silent in dev, test, and CI instead of falling back to `localhost:4318`. ([#476](https://github.com/grelinfo/grelmicro/issues/476))
+* ✨ Add first-class HTTP Basic auth to `Trace`. Pass `basic_auth=(username, password)` or set `GREL_TRACE_BASIC_AUTH_USERNAME` and `GREL_TRACE_BASIC_AUTH_PASSWORD`, and the `Authorization: Basic` header is built and attached to the exporter directly, bypassing the fragile `OTEL_EXPORTER_OTLP_HEADERS` encoding. ([#476](https://github.com/grelinfo/grelmicro/issues/476))
+
 ## 1.0.0b3 - 2026-06-26
 
 ### Features

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -115,10 +115,23 @@ configure()
 --8<-- "trace/component.py"
 ```
 
-!!! warning "The default exporter expects a collector"
-    `Trace()` defaults to `TraceExporterType.OTLP_HTTP`, which sends spans to an OpenTelemetry collector or endpoint over OTLP HTTP. Without a reachable collector, spans are dropped. A bounded `shutdown_timeout` (default `5.0` seconds) caps the flush on exit, so a slow or unreachable collector cannot hang shutdown.
+!!! tip "Off until an endpoint is configured"
+    `Trace()` defaults to `TraceExporterType.AUTO`. It exports over OTLP HTTP when an endpoint is configured (the `endpoint` argument, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or `OTEL_EXPORTER_OTLP_ENDPOINT`) and otherwise no-ops. So you register `Trace()` unconditionally and it stays silent in dev, test, and CI instead of falling back to `localhost:4318`. A bounded `shutdown_timeout` (default `5.0` seconds) caps the flush on exit, so a slow or unreachable collector cannot hang shutdown.
 
-    For local development with no collector, set `exporter=TraceExporterType.CONSOLE` to print spans to the console instead. Use `TraceExporterType.NONE` to disable export entirely.
+    For local development, set `exporter=TraceExporterType.CONSOLE` to print spans to the console. Use `TraceExporterType.NONE` to force export off even when an endpoint is set.
+
+!!! note "Basic auth in one line"
+    Backends like OpenObserve want an `Authorization: Basic` header. Pass `basic_auth=(username, password)` and `Trace` builds and attaches it to the exporter:
+
+    ```python
+    Trace(
+        service_name="orders",
+        endpoint="https://obs.example.com/api/default/v1/traces",
+        basic_auth=("me@example.com", password),
+    )
+    ```
+
+    From the environment, set `GREL_TRACE_BASIC_AUTH_USERNAME` and `GREL_TRACE_BASIC_AUTH_PASSWORD` instead. The header is attached on the exporter directly, so it bypasses the `OTEL_EXPORTER_OTLP_HEADERS` encoding where base64 padding (`=`) can be mangled or dropped.
 
 ??? note "Provider lifecycle and exporters"
     The provider is installed on enter and restored to the prior global on exit, so sequential apps in tests do not stack providers.

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import threading
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
 
@@ -97,6 +98,19 @@ class Trace:
         headers: Annotated[
             dict[str, str] | None, Doc("Exporter headers.")
         ] = None,
+        basic_auth: Annotated[
+            tuple[str, str] | None,
+            Doc(
+                """
+                HTTP Basic auth credentials as a `(username, password)`
+                pair. grelmicro builds the `Authorization: Basic` header and
+                attaches it to the OTLP exporter directly, so it never goes
+                through the fragile `OTEL_EXPORTER_OTLP_HEADERS` encoding.
+                From the environment, set `GREL_TRACE_BASIC_AUTH_USERNAME`
+                and `GREL_TRACE_BASIC_AUTH_PASSWORD` instead.
+                """
+            ),
+        ] = None,
         processor: Annotated[
             TraceProcessorType | None, Doc("Span processor.")
         ] = None,
@@ -146,6 +160,9 @@ class Trace:
         ] = None,
     ) -> None:
         """Initialize the component (defer provider build until `__aenter__`)."""
+        if basic_auth is not None and len(basic_auth) != 2:  # noqa: PLR2004
+            msg = "basic_auth must be a (username, password) tuple."
+            raise TypeError(msg)
         self._name = name
         self._explicit_config = config
         self._kwargs = {
@@ -153,6 +170,8 @@ class Trace:
             "exporter": exporter,
             "endpoint": endpoint,
             "headers": headers,
+            "basic_auth_username": basic_auth[0] if basic_auth else None,
+            "basic_auth_password": basic_auth[1] if basic_auth else None,
             "processor": processor,
             "sampler": sampler,
             "sample_ratio": sample_ratio,
@@ -363,8 +382,9 @@ def _build_provider(config: TraceConfig) -> Any:  # noqa: ANN401
 
     provider = TracerProvider(resource=resource, sampler=sampler)
 
-    if config.exporter != TraceExporterType.NONE:
-        exporter = _build_exporter(config)
+    exporter_type = _resolve_exporter_type(config)
+    if exporter_type != TraceExporterType.NONE:
+        exporter = _build_exporter(config, exporter_type)
         processor_cls = (
             BatchSpanProcessor
             if config.processor == TraceProcessorType.BATCH
@@ -375,16 +395,39 @@ def _build_provider(config: TraceConfig) -> Any:  # noqa: ANN401
     return provider
 
 
-def _build_exporter(config: TraceConfig) -> Any:  # noqa: ANN401
-    """Build a span exporter for the configured exporter type."""
-    if config.exporter == TraceExporterType.CONSOLE:
+def _resolve_exporter_type(config: TraceConfig) -> TraceExporterType:
+    """Resolve the `auto` exporter against the configured endpoint.
+
+    `auto` becomes `otlp-http` when an endpoint is resolvable (the
+    `endpoint` field, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or
+    `OTEL_EXPORTER_OTLP_ENDPOINT`) and `none` otherwise. Any explicit
+    exporter is returned unchanged.
+    """
+    if config.exporter != TraceExporterType.AUTO:
+        return config.exporter
+    endpoint_configured = (
+        config.endpoint is not None
+        or bool(os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"))
+        or bool(os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"))
+    )
+    if endpoint_configured:
+        return TraceExporterType.OTLP_HTTP
+    return TraceExporterType.NONE
+
+
+def _build_exporter(
+    config: TraceConfig,
+    exporter_type: TraceExporterType,
+) -> Any:  # noqa: ANN401
+    """Build a span exporter for the resolved exporter type."""
+    if exporter_type == TraceExporterType.CONSOLE:
         from opentelemetry.sdk.trace.export import (  # noqa: PLC0415
             ConsoleSpanExporter,
         )
 
         return ConsoleSpanExporter()
 
-    if config.exporter == TraceExporterType.OTLP_HTTP:  # pragma: no cover
+    if exporter_type == TraceExporterType.OTLP_HTTP:  # pragma: no cover
         try:
             from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # noqa: PLC0415
                 OTLPSpanExporter,
@@ -393,12 +436,7 @@ def _build_exporter(config: TraceConfig) -> Any:  # noqa: ANN401
             raise DependencyNotFoundError(
                 module="opentelemetry-exporter-otlp-proto-http"
             ) from exc
-        kwargs: dict[str, Any] = {}
-        if config.endpoint is not None:
-            kwargs["endpoint"] = config.endpoint
-        if config.headers:
-            kwargs["headers"] = config.headers
-        return OTLPSpanExporter(**kwargs)
+        return OTLPSpanExporter(**_exporter_kwargs(config))
 
     try:  # pragma: no cover
         from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # noqa: PLC0415
@@ -408,11 +446,23 @@ def _build_exporter(config: TraceConfig) -> Any:  # noqa: ANN401
         raise DependencyNotFoundError(
             module="opentelemetry-exporter-otlp-proto-grpc"
         ) from exc
-    kwargs = {}  # pragma: no cover
-    if config.endpoint is not None:  # pragma: no cover
+    return OTLPSpanExporter(**_exporter_kwargs(config))  # pragma: no cover
+
+
+def _exporter_kwargs(config: TraceConfig) -> dict[str, Any]:
+    """Build the shared `endpoint`/`headers` kwargs for the OTLP exporters.
+
+    Merges any configured Basic-auth credentials into the headers as an
+    `Authorization: Basic` value, so the credentials ride on the exporter
+    rather than the env-parsed `OTEL_EXPORTER_OTLP_HEADERS`.
+    """
+    kwargs: dict[str, Any] = {}
+    if config.endpoint is not None:
         kwargs["endpoint"] = config.endpoint
-    if config.headers:  # pragma: no cover
-        kwargs["headers"] = config.headers
-    return OTLPSpanExporter(  # pragma: no cover
-        **kwargs,  # ty: ignore[invalid-argument-type]
-    )
+    headers = dict(config.headers)
+    authorization = config.authorization_header
+    if authorization is not None:
+        headers["Authorization"] = authorization
+    if headers:
+        kwargs["headers"] = headers
+    return kwargs

--- a/grelmicro/trace/config.py
+++ b/grelmicro/trace/config.py
@@ -1,9 +1,10 @@
 """Tracing Configuration."""
 
+from base64 import b64encode
 from enum import StrEnum
 from typing import Annotated, Self
 
-from pydantic import BaseModel, Field, PositiveFloat
+from pydantic import BaseModel, Field, PositiveFloat, model_validator
 from typing_extensions import Doc
 
 
@@ -22,6 +23,7 @@ class _CaseInsensitiveEnum(StrEnum):
 class TraceExporterType(_CaseInsensitiveEnum):
     """Span exporter selection."""
 
+    AUTO = "auto"
     OTLP_HTTP = "otlp-http"
     OTLP_GRPC = "otlp-grpc"
     CONSOLE = "console"
@@ -56,8 +58,15 @@ class TraceConfig(BaseModel, frozen=True, extra="forbid"):
     ] = None
     exporter: Annotated[
         TraceExporterType,
-        Doc("Span exporter."),
-    ] = TraceExporterType.OTLP_HTTP
+        Doc(
+            "Span exporter. The default `auto` resolves to `otlp-http` when "
+            "an endpoint is configured (the `endpoint` field, "
+            "`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or "
+            "`OTEL_EXPORTER_OTLP_ENDPOINT`) and to `none` otherwise, so an "
+            "unconfigured `Trace()` exports nothing instead of falling back "
+            "to `localhost:4318`."
+        ),
+    ] = TraceExporterType.AUTO
     endpoint: Annotated[
         str | None,
         Doc(
@@ -72,6 +81,22 @@ class TraceConfig(BaseModel, frozen=True, extra="forbid"):
             "when empty."
         ),
     ] = Field(default_factory=dict)
+    basic_auth_username: Annotated[
+        str | None,
+        Doc(
+            "HTTP Basic auth username for the OTLP exporter. Set together "
+            "with `basic_auth_password` to send an `Authorization: Basic` "
+            "header, built and attached on the exporter directly so it "
+            "bypasses the fragile `OTEL_EXPORTER_OTLP_HEADERS` encoding."
+        ),
+    ] = None
+    basic_auth_password: Annotated[
+        str | None,
+        Doc(
+            "HTTP Basic auth password for the OTLP exporter. Set together "
+            "with `basic_auth_username`."
+        ),
+    ] = None
     processor: Annotated[
         TraceProcessorType,
         Doc("Span processor."),
@@ -97,3 +122,37 @@ class TraceConfig(BaseModel, frozen=True, extra="forbid"):
             "shutdown past this deadline."
         ),
     ] = 5.0
+
+    @model_validator(mode="after")
+    def _check_basic_auth(self) -> Self:
+        """Require username and password together and guard header collisions."""
+        has_username = self.basic_auth_username is not None
+        has_password = self.basic_auth_password is not None
+        if has_username != has_password:
+            msg = (
+                "basic_auth_username and basic_auth_password must be set "
+                "together."
+            )
+            raise ValueError(msg)
+        if has_username and any(
+            key.lower() == "authorization" for key in self.headers
+        ):
+            msg = (
+                "basic_auth conflicts with an Authorization header already "
+                "set in headers. Use one or the other."
+            )
+            raise ValueError(msg)
+        return self
+
+    @property
+    def authorization_header(self) -> str | None:
+        """`Authorization: Basic` value from the credentials, or `None`.
+
+        Encodes `username:password` as base64 per RFC 7617. Returns `None`
+        when no Basic credentials are configured.
+        """
+        if self.basic_auth_username is None:
+            return None
+        raw = f"{self.basic_auth_username}:{self.basic_auth_password}"
+        token = b64encode(raw.encode()).decode("ascii")
+        return f"Basic {token}"

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -627,11 +627,11 @@
   },
   "grelmicro.trace": {
     "Trace": {
-      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., instrument=..., shutdown_timeout=..., env_load=...)",
+      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., basic_auth=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., instrument=..., shutdown_timeout=..., env_load=...)",
       ".from_config": "(config, *, name=...)"
     },
     "TraceConfig": {
-      "()": "(*, service_name=..., exporter=..., endpoint=..., headers=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., shutdown_timeout=...)"
+      "()": "(*, service_name=..., exporter=..., endpoint=..., headers=..., basic_auth_username=..., basic_auth_password=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., shutdown_timeout=...)"
     },
     "TraceError": null,
     "TraceExporterType": {

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from base64 import b64encode
+
 import pytest
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -14,6 +16,7 @@ from grelmicro.trace import (
     TraceExporterType,
     TraceSamplerType,
 )
+from grelmicro.trace._component import _exporter_kwargs, _resolve_exporter_type
 from grelmicro.trace.errors import (
     TraceError,
     TraceSettingsValidationError,
@@ -262,3 +265,139 @@ async def test_trace_invalid_env_config_raises_settings_error(
 def test_trace_settings_error_is_settings_validation_error() -> None:
     """`TraceSettingsValidationError` is a `SettingsValidationError`."""
     assert issubclass(TraceSettingsValidationError, SettingsValidationError)
+
+
+def test_exporter_defaults_to_auto() -> None:
+    """The exporter field defaults to `auto`."""
+    assert TraceConfig().exporter == TraceExporterType.AUTO
+
+
+def test_auto_exporter_resolves_none_without_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`auto` becomes `none` when no endpoint is configured."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    assert _resolve_exporter_type(TraceConfig()) == TraceExporterType.NONE
+
+
+def test_auto_exporter_resolves_otlp_http_with_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`auto` becomes `otlp-http` when the endpoint field is set."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    config = TraceConfig(endpoint="https://obs.example.com/v1/traces")
+    assert _resolve_exporter_type(config) == TraceExporterType.OTLP_HTTP
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"],
+)
+def test_auto_exporter_resolves_otlp_http_with_otel_env(
+    env_var: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`auto` honours the standard OTEL endpoint env vars."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    monkeypatch.setenv(env_var, "https://obs.example.com")
+    assert _resolve_exporter_type(TraceConfig()) == TraceExporterType.OTLP_HTTP
+
+
+def test_explicit_exporter_unchanged_without_endpoint() -> None:
+    """An explicit exporter is never downgraded by auto-resolution."""
+    config = TraceConfig(exporter=TraceExporterType.CONSOLE)
+    assert _resolve_exporter_type(config) == TraceExporterType.CONSOLE
+
+
+async def test_auto_exporter_enters_inert_without_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A default `Trace()` enters cleanly and exports nothing."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    micro = Grelmicro(uses=[Trace(service_name="orders")])
+    async with micro:
+        assert micro.trace.config.exporter == TraceExporterType.AUTO
+
+
+def test_basic_auth_header_is_base64_encoded() -> None:
+    """`authorization_header` encodes `username:password` per RFC 7617."""
+    config = TraceConfig(
+        basic_auth_username="me@example.com", basic_auth_password="s3cret"
+    )
+    expected = b64encode(b"me@example.com:s3cret").decode("ascii")
+    assert config.authorization_header == f"Basic {expected}"
+
+
+def test_basic_auth_header_none_when_unset() -> None:
+    """`authorization_header` is `None` without credentials."""
+    assert TraceConfig().authorization_header is None
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["basic_auth_username", "basic_auth_password"],
+)
+def test_basic_auth_requires_both_fields(field: str) -> None:
+    """Username and password must be set together."""
+    with pytest.raises(ValueError, match="must be set together"):
+        TraceConfig.model_validate({field: "value"})
+
+
+def test_basic_auth_conflicts_with_authorization_header() -> None:
+    """`basic_auth` plus an explicit Authorization header is rejected."""
+    with pytest.raises(ValueError, match="Authorization header"):
+        TraceConfig(
+            basic_auth_username="me",
+            basic_auth_password="secret",
+            headers={"authorization": "Bearer abc"},
+        )
+
+
+def test_exporter_kwargs_injects_authorization() -> None:
+    """`_exporter_kwargs` attaches the Basic header alongside other headers."""
+    config = TraceConfig(
+        endpoint="https://obs.example.com/v1/traces",
+        headers={"X-Org": "default"},
+        basic_auth_username="me",
+        basic_auth_password="secret",
+    )
+    kwargs = _exporter_kwargs(config)
+    assert kwargs["endpoint"] == "https://obs.example.com/v1/traces"
+    assert kwargs["headers"]["X-Org"] == "default"
+    assert kwargs["headers"]["Authorization"].startswith("Basic ")
+
+
+def test_exporter_kwargs_empty_without_endpoint_or_headers() -> None:
+    """`_exporter_kwargs` is empty when nothing is configured."""
+    assert _exporter_kwargs(TraceConfig()) == {}
+
+
+def test_trace_basic_auth_kwarg_splits_into_fields() -> None:
+    """`Trace(basic_auth=(u, p))` maps onto the two config fields."""
+    trace = Trace(exporter=TraceExporterType.NONE, basic_auth=("me", "secret"))
+    assert trace._kwargs["basic_auth_username"] == "me"
+    assert trace._kwargs["basic_auth_password"] == "secret"
+
+
+def test_trace_basic_auth_rejects_non_pair() -> None:
+    """`Trace(basic_auth=...)` requires a 2-tuple."""
+    with pytest.raises(TypeError, match="username, password"):
+        Trace(basic_auth=("only",))  # ty: ignore[invalid-argument-type]
+
+
+async def test_trace_basic_auth_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Credentials resolve from `GREL_TRACE_BASIC_AUTH_*`."""
+    monkeypatch.setenv("GREL_TRACE_BASIC_AUTH_USERNAME", "me@example.com")
+    monkeypatch.setenv("GREL_TRACE_BASIC_AUTH_PASSWORD", "s3cret")
+    micro = Grelmicro(
+        uses=[Trace(exporter=TraceExporterType.NONE, env_load=True)]
+    )
+    async with micro:
+        assert micro.trace.config.basic_auth_username == "me@example.com"
+        assert micro.trace.config.basic_auth_password == "s3cret"


### PR DESCRIPTION
Collapses the app-side `Trace` setup boilerplate from #476.

## Auto-disable when unconfigured
- New `TraceExporterType.AUTO`, now the default. Resolves to `otlp-http` when an endpoint is set (the `endpoint` argument, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or `OTEL_EXPORTER_OTLP_ENDPOINT`) and to `none` otherwise.
- An unconfigured `Trace()` enters cleanly and exports nothing instead of falling back to `localhost:4318`, so it is safe to register unconditionally in dev, test, and CI. An explicit `exporter=` is never downgraded.

## First-class HTTP Basic auth
- Code: `Trace(basic_auth=(username, password))`, the `requests`/`httpx` tuple idiom.
- Env: `GREL_TRACE_BASIC_AUTH_USERNAME` and `GREL_TRACE_BASIC_AUTH_PASSWORD`, the industry two-variable convention (OTel Collector, Alloy, Prometheus, libpq, Grafana).
- The `Authorization: Basic <base64(user:pass)>` header is built and attached to the exporter constructor directly, bypassing the fragile `OTEL_EXPORTER_OTLP_HEADERS` encoding where base64 padding gets mangled or dropped.
- A validator enforces username and password together and rejects a collision with an explicit `Authorization` header.

Both features are fully env-settable through the existing `GREL_TRACE_*` mechanism, so a 12-factor deploy needs no code config.

Closes #476.