### PR TITLE
✨ Guard against missing ambient binding and add check_ambient_binding

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+* ✨ Fail fast on a missing ambient binding. `micro.install(app, ambient=False)` now warns at startup when ambient-resolving components are registered (it raises `AmbientBindingError` under `Grelmicro(strict=True)`), and the new `micro.check_ambient_binding(app)` returns whether the binding middleware is wired so a test can catch a forgotten `micro.install(app)` before it 500s on the first request. ([#471](https://github.com/grelinfo/grelmicro/issues/471))
 * ✨ Auto-disable `Trace` until an endpoint is configured. The exporter now defaults to `TraceExporterType.AUTO`, which exports over OTLP HTTP when an endpoint is set (the `endpoint` argument, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or `OTEL_EXPORTER_OTLP_ENDPOINT`) and no-ops otherwise. Register `Trace()` unconditionally and it stays silent in dev, test, and CI instead of falling back to `localhost:4318`. ([#476](https://github.com/grelinfo/grelmicro/issues/476))
 * ✨ Add first-class HTTP Basic auth to `Trace`. Pass `basic_auth=(username, password)` or set `GREL_TRACE_BASIC_AUTH_USERNAME` and `GREL_TRACE_BASIC_AUTH_PASSWORD`, and the `Authorization: Basic` header is built and attached to the exporter directly, bypassing the fragile `OTEL_EXPORTER_OTLP_HEADERS` encoding. ([#476](https://github.com/grelinfo/grelmicro/issues/476))
 

--- a/docs/resilience/rate-limiter.md
+++ b/docs/resilience/rate-limiter.md
@@ -164,6 +164,16 @@ Use **Redis** in production when you already run Redis and want the lowest-laten
 !!! tip
     The rate limiter uses the same backend registry pattern as the synchronization primitives. See [Backend Architecture](../architecture/backends.md) for details.
 
+!!! note "Coming from 0.x: register a backend, then `install` the app"
+    In 0.x you opened a global backend in the lifespan (`async with RedisRateLimiterBackend(...)`). In 1.0 you register a `RateLimiterRegistry` on the app and wire the app with `micro.install(app)`:
+
+    ```python
+    micro = Grelmicro(uses=[RateLimiterRegistry(RedisRateLimiterAdapter())])
+    micro.install(app)  # opens the registry AND binds it per request
+    ```
+
+    `install` is the important part. A module-level `RateLimiter("auth")` resolves its backend from the active app per request, which only works when `install` adds its middleware. Open `async with micro:` in a hand-written lifespan without `install` and the app starts up healthy, then raises `OutOfContextError` on the first rate-limited request. See [Wiring an App](../wiring.md) for the guard and the `micro.check_ambient_binding(app)` test helper.
+
 ## Result fields
 
 `RateLimitResult` is the same across algorithms and carries everything needed for HTTP rate limit headers. The `HTTP header` column shows the [RFC 9211](https://www.rfc-editor.org/rfc/rfc9211.html) name first and the legacy `X-RateLimit-*` name second. Pick whichever convention your API already uses.

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -64,6 +64,20 @@ when your handlers always pass an explicit `backend=` and do not need it:
 micro.install(app, ambient=False)
 ```
 
+!!! warning "Always call `install`, never hand-wire the lifespan alone"
+    A request handler runs in its own task, so it only resolves ambient backends
+    when `install` adds the middleware. If you open `async with micro:` in a
+    hand-written lifespan but forget `install` (or pass `ambient=False`), the app
+    starts up healthy and then every ambient call raises `OutOfContextError` on
+    the first request that hits it. `install(ambient=False)` warns at startup when
+    ambient components are registered (it raises under `Grelmicro(strict=True)`),
+    and you can assert the wiring in a test before it ships:
+
+    ```python
+    def test_ambient_binding_is_wired() -> None:
+        assert micro.check_ambient_binding(app)
+    ```
+
 ## FastStream
 
 The same call wires a FastStream app:

--- a/grelmicro/__init__.py
+++ b/grelmicro/__init__.py
@@ -1,6 +1,7 @@
 """grelmicro is a lightweight framework/toolkit which is ideal for building async microservices in Python."""  # noqa: E501
 
 from grelmicro._app import (
+    AmbientBindingError,
     AmbiguousProviderError,
     ComponentAlreadyRegisteredError,
     ComponentNotRegisteredError,
@@ -24,6 +25,7 @@ from grelmicro.errors import (
 __all__ = [
     "AdapterNotRegisteredError",
     "AdmissionError",
+    "AmbientBindingError",
     "AmbiguousProviderError",
     "Component",
     "ComponentAlreadyRegisteredError",

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -57,6 +57,18 @@ shared global out of order, so the second is blocked. Apps without them
 overlap freely, matching how web frameworks treat multiple app objects.
 """
 
+
+_AMBIENT_KINDS = frozenset(
+    {"coordination", "cache", "ratelimiter", "circuitbreaker"}
+)
+"""Component kinds whose patterns resolve their backend through `current()`.
+
+A `Lock`, `@cached`, `RateLimiter`, or `CircuitBreaker` that omits `backend=`
+looks up the active app per call. Inside a request handler that only works
+when `GrelmicroMiddleware` binds the app per request (see
+`Grelmicro.check_ambient_binding`).
+"""
+
 _active_bulkhead: ContextVar[Mapping[tuple[str, str], Component]] = ContextVar(
     "grelmicro_active_bulkhead"
 )
@@ -643,6 +655,98 @@ class Grelmicro:
         )
         raise TypeError(msg)
 
+    def _ambient_component_labels(self) -> list[str]:
+        """Return sorted `kind:name` labels of registered ambient components."""
+        return sorted(
+            f"{component.kind}:{component.name}"
+            for component in self._by_key.values()
+            if component.kind in _AMBIENT_KINDS
+        )
+
+    def _on_ambient_disabled(self) -> None:
+        """Warn or raise when `install(ambient=False)` leaves patterns unbound.
+
+        Called by an integration's `install` when the per-request binding is
+        skipped. With ambient-resolving components registered, patterns that
+        omit `backend=` would raise `OutOfContextError` on every request.
+        Reported as a `UserWarning`, or as `AmbientBindingError` when the app
+        was built with `strict=True`, matching the warn-or-raise policy of the
+        provider-lifecycle check.
+        """
+        labels = self._ambient_component_labels()
+        if not labels:
+            return
+        import warnings  # noqa: PLC0415
+
+        msg = (
+            f"install(app, ambient=False) skips the per-request binding, but "
+            f"these components resolve their backend ambiently: "
+            f"{', '.join(labels)}. A pattern that omits backend= will raise "
+            f"OutOfContextError on every request. Keep ambient=True (the "
+            f"default) or pass backend= explicitly at each call site."
+        )
+        if self._strict:
+            raise AmbientBindingError(msg)
+        warnings.warn(msg, UserWarning, stacklevel=3)
+
+    def check_ambient_binding(
+        self,
+        app: Annotated[  # noqa: ANN401
+            Any,
+            Doc("A Starlette, FastAPI, or FastStream application."),
+        ],
+    ) -> bool:
+        """Return whether ambient pattern resolution is wired for `app`.
+
+        Returns `True` when this app registers no ambient-resolving components
+        (nothing needs binding) or when the binding middleware is installed on
+        `app` by `micro.install(app)`. Returns `False` when ambient components
+        are registered but the middleware is missing, so a `Lock(...)`,
+        `@cached`, `RateLimiter...`, or `CircuitBreaker(...)` that omits
+        `backend=` would raise `OutOfContextError` on every request.
+
+        Call it in a test to catch a forgotten `micro.install(app)` before it
+        reaches production, where the failure only surfaces on the first
+        affected request:
+
+        ```python
+        def test_ambient_binding_is_wired() -> None:
+            assert micro.check_ambient_binding(app)
+        ```
+
+        Raises:
+            TypeError: If `app` is not a recognized Starlette, FastAPI, or
+                FastStream application and ambient components are registered.
+        """
+        if not self._ambient_component_labels():
+            return True
+        if hasattr(app, "add_middleware") and hasattr(
+            getattr(app, "router", None), "lifespan_context"
+        ):
+            from grelmicro.integrations.fastapi import (  # noqa: PLC0415
+                GrelmicroMiddleware,
+            )
+
+            return any(
+                getattr(mw, "cls", None) is GrelmicroMiddleware
+                for mw in getattr(app, "user_middleware", ())
+            )
+        if hasattr(app, "broker") and hasattr(app, "after_shutdown"):
+            from grelmicro.integrations.faststream import (  # noqa: PLC0415
+                _GrelmicroBrokerMiddleware,
+            )
+
+            return any(
+                isinstance(mw, type)
+                and issubclass(mw, _GrelmicroBrokerMiddleware)
+                for mw in getattr(app.broker, "middlewares", ())
+            )
+        msg = (
+            f"check_ambient_binding does not support {type(app).__name__!r}. "
+            f"Supported frameworks are Starlette, FastAPI, and FastStream."
+        )
+        raise TypeError(msg)
+
     def _bind_current(self) -> Any:  # noqa: ANN401
         """Set this app as `current()` for the running task, return a reset token.
 
@@ -999,6 +1103,10 @@ class NoActiveAppError(GrelmicroError, LookupError):
 
 class LifecycleOrderError(GrelmicroError, ValueError):
     """Raised when `Grelmicro(strict=True)` detects misordered provider/component lifecycles."""
+
+
+class AmbientBindingError(GrelmicroError, RuntimeError):
+    """Raised when `strict=True` and `install(ambient=False)` leaves ambient patterns unbound."""
 
 
 class AmbiguousProviderError(GrelmicroError, ValueError):

--- a/grelmicro/integrations/fastapi.py
+++ b/grelmicro/integrations/fastapi.py
@@ -198,6 +198,8 @@ def install(
     app.router.lifespan_context = lifespan
     if ambient:
         app.add_middleware(GrelmicroMiddleware, micro=micro)
+    else:
+        micro._on_ambient_disabled()  # noqa: SLF001
     _instrument_app(app, micro)
 
 

--- a/grelmicro/integrations/faststream.py
+++ b/grelmicro/integrations/faststream.py
@@ -85,3 +85,5 @@ def install(
             {"micro": micro},
         )
         app.broker.add_middleware(middleware)  # ty: ignore[unresolved-attribute]
+    else:
+        micro._on_ambient_disabled()  # noqa: SLF001

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -4,6 +4,7 @@
       "()": "(kind, short_name, available)"
     },
     "AdmissionError": null,
+    "AmbientBindingError": null,
     "AmbiguousProviderError": null,
     "Component": {
       "()": "(*args, **kwargs)"

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.status import HTTP_200_OK
 
-from grelmicro import Grelmicro
+from grelmicro import AmbientBindingError, Grelmicro
 from grelmicro.errors import OutOfContextError
 from grelmicro.integrations.fastapi import GrelmicroMiddleware
 from grelmicro.resilience import RateLimiter, RateLimiterRegistry
@@ -149,7 +149,8 @@ def test_install_wires_lifecycle_and_ambient_binding() -> None:
 
 def test_install_ambient_false_skips_middleware() -> None:
     """`ambient=False` opens micro but does not bind it per request."""
-    app = _build_installed_app(ambient=False)
+    with pytest.warns(UserWarning, match="ambient=False"):
+        app = _build_installed_app(ambient=False)
     with TestClient(app) as client, pytest.raises(OutOfContextError):
         client.get("/limited")
 
@@ -170,3 +171,55 @@ def test_install_rejects_unknown_app() -> None:
     micro = Grelmicro()
     with pytest.raises(TypeError, match="Starlette, FastAPI, and FastStream"):
         micro.install(object())
+
+
+def test_install_ambient_false_no_warning_without_ambient_components(
+    recwarn: pytest.WarningsRecorder,
+) -> None:
+    """`ambient=False` is silent when no ambient components are registered."""
+    micro = Grelmicro()
+    app = FastAPI()
+    micro.install(app, ambient=False)
+    assert not [w for w in recwarn if issubclass(w.category, UserWarning)]
+
+
+def test_install_ambient_false_strict_raises() -> None:
+    """`strict=True` turns the ambient-binding warning into an error."""
+    micro = Grelmicro(
+        strict=True,
+        uses=[RateLimiterRegistry(MemoryRateLimiterAdapter())],
+    )
+    app = FastAPI()
+    with pytest.raises(AmbientBindingError, match="ratelimiter:default"):
+        micro.install(app, ambient=False)
+
+
+def test_check_ambient_binding_true_when_installed() -> None:
+    """`check_ambient_binding` is True once the middleware is wired."""
+    micro = Grelmicro(uses=[RateLimiterRegistry(MemoryRateLimiterAdapter())])
+    app = FastAPI()
+    micro.install(app)
+    assert micro.check_ambient_binding(app) is True
+
+
+def test_check_ambient_binding_false_without_middleware() -> None:
+    """`check_ambient_binding` is False when the middleware was never wired."""
+    micro = Grelmicro(uses=[RateLimiterRegistry(MemoryRateLimiterAdapter())])
+    app = FastAPI()
+    # The footgun: micro opened in a hand-written lifespan, install never
+    # called, so no GrelmicroMiddleware was added.
+    assert micro.check_ambient_binding(app) is False
+
+
+def test_check_ambient_binding_true_without_ambient_components() -> None:
+    """Nothing needs binding, so the check passes regardless of middleware."""
+    micro = Grelmicro()
+    app = FastAPI()
+    assert micro.check_ambient_binding(app) is True
+
+
+def test_check_ambient_binding_rejects_unknown_app() -> None:
+    """`check_ambient_binding` raises for an unsupported app with ambient components."""
+    micro = Grelmicro(uses=[RateLimiterRegistry(MemoryRateLimiterAdapter())])
+    with pytest.raises(TypeError, match="Starlette, FastAPI, and FastStream"):
+        micro.check_ambient_binding(object())

--- a/tests/test_faststream.py
+++ b/tests/test_faststream.py
@@ -13,7 +13,7 @@ faststream_redis = pytest.importorskip("faststream.redis")
 from faststream import FastStream  # noqa: E402
 from faststream.redis import RedisBroker, TestRedisBroker  # noqa: E402
 
-from grelmicro import Grelmicro  # noqa: E402
+from grelmicro import AmbientBindingError, Grelmicro  # noqa: E402
 from grelmicro.resilience import RateLimiter, RateLimiterRegistry  # noqa: E402
 from grelmicro.resilience.ratelimiter.memory import (  # noqa: E402
     MemoryRateLimiterAdapter,
@@ -81,9 +81,34 @@ async def test_install_ambient_false_still_opens_lifecycle() -> None:
         opened.append(bool(micro.components))
         return True
 
-    micro.install(app, ambient=False)
+    with pytest.warns(UserWarning, match="ambient=False"):
+        micro.install(app, ambient=False)
 
     async with TestRedisBroker(broker), _running(app):
         await broker.request("ping", "limited")
 
     assert opened == [True]
+
+
+def test_install_ambient_false_strict_raises() -> None:
+    """`strict=True` turns the ambient-binding warning into an error."""
+    micro = Grelmicro(
+        strict=True, uses=[RateLimiterRegistry(MemoryRateLimiterAdapter())]
+    )
+    with pytest.raises(AmbientBindingError, match="ratelimiter:default"):
+        micro.install(FastStream(RedisBroker()), ambient=False)
+
+
+def test_check_ambient_binding_true_when_installed() -> None:
+    """`check_ambient_binding` is True once the broker middleware is wired."""
+    micro = Grelmicro(uses=[RateLimiterRegistry(MemoryRateLimiterAdapter())])
+    app = FastStream(RedisBroker())
+    micro.install(app)
+    assert micro.check_ambient_binding(app) is True
+
+
+def test_check_ambient_binding_false_without_middleware() -> None:
+    """`check_ambient_binding` is False when the broker middleware is absent."""
+    micro = Grelmicro(uses=[RateLimiterRegistry(MemoryRateLimiterAdapter())])
+    app = FastStream(RedisBroker())
+    assert micro.check_ambient_binding(app) is False


### PR DESCRIPTION
Closes #471.

Migrating from 0.x, it is easy to port `async with micro:` into a FastAPI lifespan but forget `micro.install(app)` (or pass `ambient=False`). The app boots healthy and then every ambient `RateLimiter`/`Lock`/`@cached`/`CircuitBreaker` call raises `OutOfContextError` on the first request that hits it. It slips past suites that stub limiters and only surfaces in e2e.

## What this does

**Precise startup guard.** `micro.install(app, ambient=False)` now warns when ambient-resolving components (`coordination`, `cache`, `ratelimiter`, `circuitbreaker`) are registered, naming them. Under `Grelmicro(strict=True)` it raises the new `AmbientBindingError`, reusing the warn-or-raise policy of the provider-lifecycle check.

**CI-catchable test helper.** `micro.check_ambient_binding(app) -> bool` returns whether the binding is wired (`True` when no ambient components exist or the middleware is present, `False` when it was never wired). Supports FastAPI/Starlette and FastStream; raises `TypeError` on an unknown app. Drop `assert micro.check_ambient_binding(app)` in a test to catch the misconfiguration before production.

**Migration close-out (docs).** `wiring.md` gains a warning box (always call `install`, never hand-wire the lifespan alone) with the helper snippet; `rate-limiter.md` gains a "Coming from 0.x" note mapping the old lifespan-backend pattern to `RateLimiterRegistry` + `micro.install(app)`.

## What this deliberately does NOT do

No magic "resolve to the sole active app" fallback. Research (Flask errors rather than guessing; OTel/logging/sentry/ddtrace all prefer one registered instance and complain about extras; hazards under mounted sub-apps, threaded workers, concurrent tests) plus the existing tests that assert the strict no-middleware behavior all point against it. The explicit-binding model stays canonical; this makes its one footgun loud and testable.

`AmbientBindingError` is exported from `grelmicro`. No breaking changes; the guard is additive and `strict`-gated.