### PR TITLE
👷 Gate the workflow-lint job on workflow path changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -51,6 +52,8 @@ jobs:
               - 'docs/**'
               - 'mkdocs.yml'
               - 'README.md'
+              - '.github/workflows/**'
+            workflows:
               - '.github/workflows/**'
 
   lint:
@@ -108,6 +111,11 @@ jobs:
 
   workflow-lint:
     name: Workflow Lint
+    needs: changes
+    # zizmor only analyzes workflow files, so its result cannot change unless
+    # they do. Path filtering applies to pull requests only; pushes, the
+    # nightly schedule, and manual dispatch always run it.
+    if: ${{ needs.changes.outputs.workflows == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -157,4 +165,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: lint, docs, tests
+          allowed-skips: lint, docs, workflow-lint, tests


### PR DESCRIPTION
Part of #391 (reduce CI minutes).

`workflow-lint` (zizmor) was the last CI job with no `needs` and no path filter, so it ran on every pull request even when nothing under `.github/` changed. zizmor only analyzes workflow files, so its result cannot change unless they do.

This gates the job on a new `workflows` path filter in the existing `changes` job, mirroring the pattern already used for `lint`, `docs`, and `tests`. Pushes, the nightly schedule, and manual dispatch still always run it, and a mis-filtered PR is caught on merge to `main`. `workflow-lint` is added to the `CI Green` allowed-skips so a path-skip does not leave the gate pending.

Saves a runner on the majority of PRs (most do not touch workflows). Validated locally: `zizmor` clean, YAML parses.

### Deliberately scoped out
The other open #391 items were evaluated and left as the maintainer already reasoned: the scorecard push trigger and `lint --all-extras` trade negligible minutes for security cadence and type coverage, and dependabot auto-merge is intentionally not extended to the `github-actions` ecosystem (auto-merging action bumps is a supply-chain risk). Separately, `release.yml` could move docs deploy from `mkdocs gh-deploy` to the official Pages OIDC action for a security win, but that is out of this issue's scope and touches the release path, so it is left for a deliberate follow-up.