### PR TITLE
📝 Drop the project-status banner from the landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@
   <img alt="A FastAPI route protected by a grelmicro rate limiter and health check" src="docs/img/demo.gif" width="800">
 </p>
 
-> **Project status: 0.x.** The public API is feature-complete and guarded by a snapshot test, but it can still change between `0.x` minor releases while the toolkit settles. `pip install grelmicro` gets the latest release. A future `1.0` will mark the public API as stable. See the [versioning policy](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#about-grelmicro-versions).
-
 ______________________________________________________________________
 
 **Documentation**: [https://grelinfo.github.io/grelmicro/](https://grelinfo.github.io/grelmicro)

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,8 +27,6 @@
   <img alt="A FastAPI route protected by a grelmicro rate limiter and health check" src="img/demo.gif" width="800">
 </p>
 
-> **Project status: 0.x.** The public API is feature-complete and guarded by a snapshot test, but it can still change between `0.x` minor releases while the toolkit settles. `pip install grelmicro` gets the latest release. A future `1.0` will mark the public API as stable. See the [versioning policy](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#about-grelmicro-versions).
-
 ______________________________________________________________________
 
 **Documentation**: [https://grelinfo.github.io/grelmicro/](https://grelinfo.github.io/grelmicro)


### PR DESCRIPTION
Follows FastAPI: the README and docs homepage no longer carry a project-status banner. FastAPI ships `0.x` + `4 - Beta` with no status caveat on its landing, and so does grelmicro now. The versioning policy stays in CONTRIBUTING for anyone who wants the detail.