### PR TITLE
📝 Refresh stale docs and guard Metrics against overlapping apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? S
 | [**Resilience**](https://grelinfo.github.io/grelmicro/resilience/) | [Circuit Breaker](https://grelinfo.github.io/grelmicro/resilience/circuit-breaker/) and [Rate Limiter](https://grelinfo.github.io/grelmicro/resilience/rate-limiter/) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |
 | [**Logging**](https://grelinfo.github.io/grelmicro/logging/) | 12-factor logging with JSON, LOGFMT, TEXT, or PRETTY output, structured error rendering, and OpenTelemetry trace context. |
 | [**Tracing**](https://grelinfo.github.io/grelmicro/tracing/) | Unified instrumentation. `@instrument` creates OpenTelemetry spans and enriches log records with structured context. |
+| [**Metrics**](https://grelinfo.github.io/grelmicro/metrics/) | OpenTelemetry metrics with a `@measure` decorator, a Prometheus `/metrics` router, and built-in instrumentation across components. |
 | [**Health**](https://grelinfo.github.io/grelmicro/health/) | Health check registry with concurrent runners and FastAPI liveness / readiness integration. |
+| [**Configuration**](https://grelinfo.github.io/grelmicro/config/) | `ExternalConfig` reconfigures live components from a mounted ConfigMap, Secret, or `.env` / JSON / YAML / TOML file. |
 
 ## Installation
 

--- a/docs/architecture/coordination.md
+++ b/docs/architecture/coordination.md
@@ -4,12 +4,12 @@ This page documents the internal design of the [Coordination primitives](../coor
 
 ## Worker Identity
 
-By default, each coordination primitive (`Lock`, `TaskLock`, `LeaderElection`) generates a unique **worker identity** at instantiation using `token_hex(4)` (8 random hex characters, 32 bits of entropy) when no explicit `worker` parameter is provided.
+By default, each coordination primitive (`Lock`, `TaskLock`, `LeaderElection`) generates a unique **worker identity** at instantiation using `token_hex(8)` (16 random hex characters, 64 bits of entropy) when no explicit `worker` parameter is provided.
 
 This provides uniqueness across:
 
-- **Multiple processes** (e.g., `uvicorn --workers N`): Each worker process imports the application independently, so `token_hex(4)` is called separately per process with independent randomness.
-- **Multiple instances** within the same process: Each `Lock(...)` or `TaskLock(...)` call generates its own `token_hex(4)`, producing a different worker identity.
+- **Multiple processes** (e.g., `uvicorn --workers N`): Each worker process imports the application independently, so `token_hex(8)` is called separately per process with independent randomness.
+- **Multiple instances** within the same process: Each `Lock(...)` or `TaskLock(...)` call generates its own `token_hex(8)`, producing a different worker identity.
 
 !!! warning "Pre-fork servers"
     If the ASGI server uses a pre-fork model (forking after the application is loaded), worker identities generated before the fork will be duplicated across child processes. Uvicorn does **not** pre-fork. It spawns workers via `subprocess.Popen`, so each worker imports the application independently. If using a pre-fork server, pass an explicit `worker` identity to avoid collisions.

--- a/docs/architecture/tracing.md
+++ b/docs/architecture/tracing.md
@@ -2,7 +2,7 @@
 
 ## Context Stack
 
-The tracing module uses a `contextvars`-based context stack defined in `grelmicro/_context.py`. This low-level module is shared by both `logging` and `tracing` so that neither depends on the other.
+The tracing module uses a `contextvars`-based context stack defined in `grelmicro/_context.py`. This low-level module is shared by both `log` and `trace` so that neither depends on the other.
 
 Each `@instrument` call or `span()` block pushes a new frame with its fields. Logging backends merge all active frames into the JSON record.
 
@@ -28,8 +28,8 @@ This follows the same pattern used by OpenTelemetry Python for `Context` propaga
 
 ```
 grelmicro/_context.py    <- owns ContextVar (no dependencies)
-    ├── logging/         <- imports _context (merge into log records)
-    └── tracing/         <- imports _context (push/pop spans, add_context)
+    ├── log/             <- imports _context (merge into log records)
+    └── trace/           <- imports _context (push/pop spans, add_context)
 ```
 
-The `_context` module has no imports from `logging` or `tracing`, preventing circular dependencies and allowing users to configure logging without loading the tracing module.
+The `_context` module has no imports from `log` or `trace`, preventing circular dependencies and allowing users to configure logging without loading the tracing module.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -356,7 +356,7 @@ A flaky upstream then degrades to slightly stale data instead of an error storm.
 | `key_maker` | `Callable` | `None` | Custom key generation function. Receives `(func, args, kwargs)`. Mutually exclusive with `key`. |
 | `skip` | `Callable` | `None` | Predicate receiving the result. Returns `True` to skip caching. |
 | `typed` | `bool` | `False` | Cache arguments of different types separately. |
-| `lock` | `True`, `False`, or `"local"` | `False` | Concurrent-miss (stampede) protection. |
+| `lock` | `True`, `False`, or `"local"` | `"local"` | Concurrent-miss (stampede) protection. |
 | `early` | `float` in `[0, 1)` | `None` | Probabilistic early refresh in the late TTL window. |
 | `stale_ttl` | `float` | `None` | Serve-stale-on-error budget in seconds. Serve the last good value for this long past the TTL when a recompute fails. |
 | `tags` | `Sequence[str]` | `()` | Tags to attach to each result. Templates like `"user:{user_id}"` fill in from the arguments. Invalidate with `cache.delete_tags(...)`. |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,7 +6,7 @@ The [roadmap](https://github.com/grelinfo/grelmicro/issues/124) carries the live
 
 ## Vocabulary
 
-- **Pattern**: user-facing class. `Lock`, `LeaderElection`, `TaskLock`, `TTLCache`, `RateLimiter`, `CircuitBreaker`, `Retry`, `Bulkhead`, `Fallback`, `Timeout`.
+- **Pattern**: user-facing class. `Lock`, `LeaderElection`, `TaskLock`, `TTLCache`, `RateLimiter`, `CircuitBreaker`, `Idempotency`, `Retry`, `Bulkhead`, `Fallback`, `Timeout`, `Shield`.
 - **Adapter**: concrete implementation of a Backend Protocol. `RedisLockAdapter`, `PostgresLockAdapter`, `MemoryCacheAdapter`, `SQLiteLockAdapter`, `KubernetesLockAdapter`, and so on.
 - **Backend**: the Protocol class an Adapter satisfies. `LockBackend`, `LeaderElectionBackend`, `CacheBackend`, `RateLimiterBackend`, `CircuitBreakerBackend`.
 - **Provider**: vendor configuration plus native client, shared by Adapters that talk to the same service. `RedisProvider`, `PostgresProvider`, `SQLiteProvider`. Memory and Kubernetes Adapters do not use a Provider.
@@ -15,19 +15,21 @@ See [Backends and Adapters](architecture/backends.md) for the full model.
 
 ## Matrix
 
-| Pattern             | Memory                                                         | Redis                                                          | Postgres                                                       | SQLite                                                         | Kubernetes |
-| ------------------- | :------------------------------------------------------------: | :------------------------------------------------------------: | :------------------------------------------------------------: | :------------------------------------------------------------: | :--------: |
-| `Lock`              | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | ✅         |
-| `TaskLock`          | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | ✅         |
-| `LeaderElection`    | ✅                                                             | ✅                                                             | ✅                                                             | N/A                                                            | ✅         |
-| `Schedule` (cron)   | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | N/A        |
-| `TTLCache`          | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | N/A        |
-| `RateLimiter`       | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | N/A        |
-| `CircuitBreaker`    | ✅                                                             | ✅                                                             | ✅                                                             | ✅                                                             | N/A        |
-| `Retry`             | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
-| `Bulkhead`          | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
-| `Fallback`          | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
-| `Timeout`           | ✅                                                             | N/A                                                            | N/A                                                            | N/A                                                            | N/A        |
+| Pattern | Memory | Redis | Postgres | SQLite | Kubernetes |
+| --- | :---: | :---: | :---: | :---: | :---: |
+| `Lock` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `TaskLock` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `LeaderElection` | ✅ | ✅ | ✅ | N/A | ✅ |
+| `@tasks.cron` | ✅ | ✅ | ✅ | ✅ | N/A |
+| `TTLCache` | ✅ | ✅ | ✅ | ✅ | N/A |
+| `Idempotency` | ✅ | ✅ | ✅ | ✅ | N/A |
+| `RateLimiter` | ✅ | ✅ | ✅ | ✅ | N/A |
+| `CircuitBreaker` | ✅ | ✅ | ✅ | ✅ | N/A |
+| `Retry` | ✅ | N/A | N/A | N/A | N/A |
+| `Bulkhead` | ✅ | N/A | N/A | N/A | N/A |
+| `Fallback` | ✅ | N/A | N/A | N/A | N/A |
+| `Timeout` | ✅ | N/A | N/A | N/A | N/A |
+| `Shield` | ✅ | N/A | N/A | N/A | N/A |
 
 Legend:
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* 🐛 Block a second app that installs `Metrics` while one is active, matching `Log` and `Trace`. `Metrics` owns the process-global meter provider, so two overlapping apps would clobber it.
+
+### Docs
+
+* 📝 Refresh stale docs: the optional-extras table, the capability matrix, the module lists, the `@cached` `lock` default, and the `DuplicateFilter` `ttl` field.
+
 ## 0.28.0 - 2026-06-28
 
 ### Breaking

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -43,11 +43,15 @@ What you get from a single import:
 | Cache decorator + TTL store | `Cache`, `TTLCache[T]`, `@cached` | Redis, Memory, Postgres, SQLite |
 | Rate limiter | `RateLimiter` (token bucket, sliding window) | Redis, Memory, Postgres, SQLite |
 | Circuit breaker | `CircuitBreaker` | Redis, Memory, Postgres, SQLite |
+| Idempotency | `Idempotency`, `@idempotent` | Redis, Memory, Postgres, SQLite |
 | Retry | `Retry`, `@retry` | n/a (in-process) |
+| In-process resilience | `Bulkhead`, `Fallback`, `Timeout`, `Shield` | n/a (in-process) |
 | Health checks | `HealthChecks` + `/livez` `/readyz` `/healthz` router | n/a |
-| Scheduled tasks | `Tasks`, `TaskRouter`, `@interval`, `@cron` | n/a |
+| Scheduled tasks | `Tasks`, `TaskRouter`, `@every`, `@cron` | n/a |
 | Structured logging | `grelmicro.log` (JSON, LOGFMT, PRETTY, AUTO) | n/a |
 | Tracing | `grelmicro.trace` (`@instrument`, `span`, `add_context`) | OpenTelemetry |
+| Metrics | `Metrics`, `@measure`, `metrics_router` | OpenTelemetry, Prometheus |
+| Externalized config | `ExternalConfig` | ConfigMap, Secret, .env, JSON, YAML, TOML |
 
 All of them share:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,9 @@ Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? S
 | [**Resilience**](https://grelinfo.github.io/grelmicro/resilience/) | [Circuit Breaker](https://grelinfo.github.io/grelmicro/resilience/circuit-breaker/) and [Rate Limiter](https://grelinfo.github.io/grelmicro/resilience/rate-limiter/) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |
 | [**Logging**](https://grelinfo.github.io/grelmicro/logging/) | 12-factor logging with JSON, LOGFMT, TEXT, or PRETTY output, structured error rendering, and OpenTelemetry trace context. |
 | [**Tracing**](https://grelinfo.github.io/grelmicro/tracing/) | Unified instrumentation. `@instrument` creates OpenTelemetry spans and enriches log records with structured context. |
+| [**Metrics**](https://grelinfo.github.io/grelmicro/metrics/) | OpenTelemetry metrics with a `@measure` decorator, a Prometheus `/metrics` router, and built-in instrumentation across components. |
 | [**Health**](https://grelinfo.github.io/grelmicro/health/) | Health check registry with concurrent runners and FastAPI liveness / readiness integration. |
+| [**Configuration**](https://grelinfo.github.io/grelmicro/config/) | `ExternalConfig` reconfigures live components from a mounted ConfigMap, Secret, or `.env` / JSON / YAML / TOML file. |
 
 ## Installation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,11 +40,14 @@ grelmicro is modular. Install only the extras you need.
 | `standard` | `orjson` for fast JSON serialization. `uvloop` for a faster event loop. Activate with `uvloop.run(main())`. | `orjson` everywhere. `uvloop` only on Linux/macOS CPython (skipped on Windows and PyPy). |
 | `redis` | `redis-py` for the Redis backends. | All platforms. |
 | `valkey` | `valkey-py` for the Valkey backends. | All platforms. |
-| `postgres` | `asyncpg` for the PostgreSQL sync backend. | All platforms. |
-| `sqlite` | `aiosqlite` for the SQLite sync backend. | All platforms. |
-| `kubernetes` | `lightkube` for the Kubernetes Lease sync backend. | All platforms. |
-| `opentelemetry` | OpenTelemetry API and SDK for tracing integration. | All platforms. |
+| `postgres` | `asyncpg` for the PostgreSQL backends. | All platforms. |
+| `sqlite` | `aiosqlite` for the SQLite backends. | All platforms. |
+| `kubernetes` | `lightkube` for the Kubernetes Lease backend. | All platforms. |
+| `faststream` | `faststream` for the FastStream integration. | All platforms. |
+| `opentelemetry` | OpenTelemetry API and SDK for the `Trace` and `Metrics` components. | All platforms. |
+| `instrumentation` | OpenTelemetry instrumentation packages (FastAPI, Redis, asyncpg) for `Trace(instrument=...)`. | All platforms. |
 | `structlog` | `structlog` as an alternative logging backend. | All platforms. |
+| `yaml` | `pyyaml` for YAML sources in `ExternalConfig`. | All platforms. |
 
 === "pip"
     ```bash
@@ -54,8 +57,11 @@ grelmicro is modular. Install only the extras you need.
     pip install "grelmicro[postgres]"
     pip install "grelmicro[sqlite]"
     pip install "grelmicro[kubernetes]"
+    pip install "grelmicro[faststream]"
     pip install "grelmicro[opentelemetry]"
+    pip install "grelmicro[instrumentation]"
     pip install "grelmicro[structlog]"
+    pip install "grelmicro[yaml]"
     ```
 
 === "uv"
@@ -66,8 +72,11 @@ grelmicro is modular. Install only the extras you need.
     uv add "grelmicro[postgres]"
     uv add "grelmicro[sqlite]"
     uv add "grelmicro[kubernetes]"
+    uv add "grelmicro[faststream]"
     uv add "grelmicro[opentelemetry]"
+    uv add "grelmicro[instrumentation]"
     uv add "grelmicro[structlog]"
+    uv add "grelmicro[yaml]"
     ```
 
 === "poetry"
@@ -78,8 +87,11 @@ grelmicro is modular. Install only the extras you need.
     poetry add "grelmicro[postgres]"
     poetry add "grelmicro[sqlite]"
     poetry add "grelmicro[kubernetes]"
+    poetry add "grelmicro[faststream]"
     poetry add "grelmicro[opentelemetry]"
+    poetry add "grelmicro[instrumentation]"
     poetry add "grelmicro[structlog]"
+    poetry add "grelmicro[yaml]"
     ```
 
 Combine multiple extras in one call, for example `pip install "grelmicro[redis,valkey,opentelemetry,structlog]"`.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -336,10 +336,10 @@ logger.addFilter(DuplicateFilter(key_mode="rendered"))
 logger.addFilter(DuplicateFilter(key=lambda r: (r.name, r.exc_info)))
 ```
 
-Set `ttl_seconds` to re-emit a burst of `allowed_repetitions` records every window during sustained floods, so operators continue to receive periodic reminders:
+Set `ttl` to re-emit a burst of `allowed_repetitions` records every window during sustained floods, so operators continue to receive periodic reminders:
 
 ```python
-logger.addFilter(DuplicateFilter(allowed_repetitions=5, ttl_seconds=300))
+logger.addFilter(DuplicateFilter(allowed_repetitions=5, ttl=300))
 ```
 
 State is in-process only. There is no cross-process sharing and no explicit reset API: construct a new filter if you need to wipe counters.

--- a/docs/reference/health.md
+++ b/docs/reference/health.md
@@ -15,4 +15,4 @@
         - HealthChecksConfig
         - HealthReport
         - HealthStatus
-        - get_health_checks
+        - HealthSettingsValidationError

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -49,8 +49,8 @@ whose `Log`/`Trace` would clobber the active app's global-state snapshots.
 """
 
 
-_GLOBAL_STATE_KINDS = frozenset({"log", "trace"})
-"""Component kinds that own process-global state (root logger, tracer).
+_GLOBAL_STATE_KINDS = frozenset({"log", "trace", "metrics"})
+"""Component kinds that own process-global state (root logger, tracer, meter).
 
 Two overlapping apps that each register one of these would restore the
 shared global out of order, so the second is blocked. Apps without them

--- a/grelmicro/coordination/_base.py
+++ b/grelmicro/coordination/_base.py
@@ -32,7 +32,7 @@ class BaseLockConfig(BaseModel, frozen=True, extra="forbid"):
         Doc("""
             The worker identity.
 
-            By default, a UUIDv1 is generated.
+            By default, a random 16-character hex token is generated.
             """),
         Field(default_factory=generate_worker_id),
     ]

--- a/grelmicro/coordination/lock.py
+++ b/grelmicro/coordination/lock.py
@@ -156,7 +156,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
                 """
                 The worker identity.
 
-                By default, a UUIDv1 is generated.
+                By default, a random 16-character hex token is generated.
                 """,
             ),
         ] = None,

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -828,6 +828,20 @@ async def test_global_app_overlaps_plain_app() -> None:
         pass
 
 
+class _MetricsComponent(_RecordingComponent):
+    """Stands in for `Metrics`, which installs the process-global meter."""
+
+    kind: ClassVar[str] = "metrics"
+
+
+async def test_second_metrics_app_is_blocked() -> None:
+    """`Metrics` owns the process-global meter, so a second app is blocked."""
+    async with Grelmicro(uses=[_MetricsComponent()]):
+        with pytest.raises(MultipleActiveAppsError):
+            async with Grelmicro(uses=[_MetricsComponent()]):
+                pass
+
+
 async def test_sequential_global_apps_are_allowed() -> None:
     """Two global-state apps opened one after another are fine."""
     async with Grelmicro(uses=[_GlobalComponent()]):


### PR DESCRIPTION
Follows a full audit of every doc page against the current API (0.28.0). CI-tested snippets were already correct; the drift was in prose, tables, and feature lists.

## Docs fixed
- **installation.md**: optional-extras table was missing `faststream`, `instrumentation`, `yaml`; corrected the stale "PostgreSQL sync backend" wording.
- **capabilities.md**: added `Idempotency` and `Shield` to the pattern list and matrix; relabeled the `Schedule` row to `@tasks.cron` (no `Schedule` class exists).
- **comparison.md**: `@interval` -> `@every`; added Idempotency, in-process resilience, Metrics, and Externalized config rows.
- **index.md / README.md**: added Metrics and Configuration to the Modules table.
- **cache.md**: `@cached` `lock` default was `False`, actually `"local"`.
- **logging.md**: `DuplicateFilter` field `ttl_seconds` -> `ttl`.
- **architecture/coordination.md**: worker id is `token_hex(8)` (64 bits), not `token_hex(4)` (32 bits).
- **architecture/tracing.md**: package names `logging`/`tracing` -> `log`/`trace`.
- **reference/health.md**: dropped nonexistent `get_health_checks`, added `HealthSettingsValidationError`.
- Source docstrings: `worker` default said "UUIDv1", actually a random hex token.

## Bug fixed
- `Metrics` installs the process-global OTel meter provider but was missing from `_GLOBAL_STATE_KINDS`, so two overlapping apps each installing `Metrics` were not blocked (unlike `Log`/`Trace`) and would clobber the global. Added `"metrics"` to the guard, matching the documented behavior, with a regression test.