### PR TITLE
✨ Make Trace a true no-op when the exporter auto-disables

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+* ✨ Make `Trace` a true no-op when the exporter auto-disables. With the default `auto` exporter and no endpoint, `Trace` installs no tracer provider, leaves the global untouched, runs no auto-instrumentation, and no longer counts against the single-active-app guard, so `Trace()` is safe to register unconditionally in dev, test, and CI. An explicit `exporter=none` still installs the provider. ([#487](https://github.com/grelinfo/grelmicro/issues/487))
+
 ### Fixed
 
 * 🐛 Block a second app that installs `Metrics` while one is active, matching `Log` and `Trace`. `Metrics` owns the process-global meter provider, so two overlapping apps would clobber it.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -116,9 +116,9 @@ configure()
 ```
 
 !!! tip "Off until an endpoint is configured"
-    `Trace()` defaults to `TraceExporterType.AUTO`. It exports over OTLP HTTP when an endpoint is configured (the `endpoint` argument, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or `OTEL_EXPORTER_OTLP_ENDPOINT`) and otherwise no-ops. So you register `Trace()` unconditionally and it stays silent in dev, test, and CI instead of falling back to `localhost:4318`. A bounded `shutdown_timeout` (default `5.0` seconds) caps the flush on exit, so a slow or unreachable collector cannot hang shutdown.
+    `Trace()` defaults to `TraceExporterType.AUTO`. It exports over OTLP HTTP when an endpoint is configured (the `endpoint` argument, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or `OTEL_EXPORTER_OTLP_ENDPOINT`) and otherwise auto-disables into a true no-op: it installs no tracer provider, leaves the global provider untouched, and runs no auto-instrumentation. So you register `Trace()` unconditionally and it stays silent in dev, test, and CI instead of falling back to `localhost:4318`, and it never conflicts with a second app. A bounded `shutdown_timeout` (default `5.0` seconds) caps the flush on exit, so a slow or unreachable collector cannot hang shutdown.
 
-    For local development, set `exporter=TraceExporterType.CONSOLE` to print spans to the console. Use `TraceExporterType.NONE` to force export off even when an endpoint is set.
+    For local development, set `exporter=TraceExporterType.CONSOLE` to print spans to the console. An explicit `TraceExporterType.NONE` is different from the auto-disable above: it still installs the provider so spans are created (and auto-instrumentation runs), they are just not exported. Leave the exporter on `AUTO` for the unconditional no-op.
 
 !!! note "Basic auth in one line"
     Backends like OpenObserve want an `Authorization: Basic` header. Pass `basic_auth=(username, password)` and `Trace` builds and attaches it to the exporter:

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -58,6 +58,20 @@ overlap freely, matching how web frameworks treat multiple app objects.
 """
 
 
+def _item_owns_global_state(item: object) -> bool:
+    """Return True if a registered item configures process-global state.
+
+    A kind in `_GLOBAL_STATE_KINDS` owns global state by default. An item may
+    refine this with an `owns_global_state()` method: an auto-disabled `Trace`
+    (default exporter, no endpoint) installs nothing, so it opts out and lets
+    overlapping apps carry it.
+    """
+    if getattr(item, "kind", None) not in _GLOBAL_STATE_KINDS:
+        return False
+    refine = getattr(item, "owns_global_state", None)
+    return bool(refine()) if callable(refine) else True
+
+
 _AMBIENT_KINDS = frozenset(
     {"coordination", "cache", "ratelimiter", "circuitbreaker"}
 )
@@ -763,10 +777,7 @@ class Grelmicro:
 
     def _owns_global_state(self) -> bool:
         """Return True if any registered item configures process-global state."""
-        return any(
-            getattr(item, "kind", None) in _GLOBAL_STATE_KINDS
-            for item in self._items
-        )
+        return any(_item_owns_global_state(item) for item in self._items)
 
     def _instrument_providers(self) -> None:
         """Auto-instrument active providers and used libraries per `Trace(instrument=...)`.
@@ -788,6 +799,10 @@ class Grelmicro:
             None,
         )
         if component is None:
+            return
+        if not cast("Trace", component).active:
+            # Auto-disabled Trace installs no provider, so there is nothing to
+            # bind auto-instrumentation to.
             return
         from grelmicro.trace._autoinstrument import (  # noqa: PLC0415
             KNOWN_FRAMEWORKS,

--- a/grelmicro/integrations/fastapi.py
+++ b/grelmicro/integrations/fastapi.py
@@ -65,6 +65,10 @@ def _instrument_app(app: "Starlette", micro: "Grelmicro") -> None:
     if component is None:
         return
     trace = cast("Trace", component)
+    if not trace.active:
+        # Auto-disabled Trace installs no provider, so request spans would go
+        # nowhere. Skip instrumentation until an exporter endpoint is set.
+        return
     directive = trace.instrument
     if not is_selected("fastapi", directive):
         return

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -236,28 +236,72 @@ class Trace:
         """Return the installed OTel `TracerProvider`.
 
         Raises:
-            RuntimeError: If accessed before the component has been entered.
+            RuntimeError: If accessed before the component has been entered,
+                or when the exporter auto-disables so no provider is installed.
         """
         if self._provider is None:
-            msg = "Trace.provider is only available inside `async with micro:`"
+            msg = (
+                "Trace.provider is only available inside `async with micro:` "
+                "and only when the exporter is active. An auto-disabled Trace "
+                "(default exporter with no endpoint) installs no provider."
+            )
             raise RuntimeError(msg)
         return self._provider
 
+    @property
+    def active(self) -> bool:
+        """Whether entering installs a `TracerProvider` for this app.
+
+        `False` when the exporter auto-disables: the default `auto` exporter
+        with no endpoint configured. An auto-disabled `Trace` is a no-op, so
+        it can be registered unconditionally in dev, test, and CI.
+        """
+        return not self._auto_disabled()
+
+    def owns_global_state(self) -> bool:
+        """Whether entering patches the process-global tracer provider.
+
+        Consulted by the app's single-active-app guard. An auto-disabled
+        `Trace` installs nothing, so overlapping apps may each carry one.
+        """
+        return self.active
+
+    def _auto_disabled(self) -> bool:
+        """Return True when the exporter was left `auto` and resolves to `none`."""
+        config = self._resolve()
+        return (
+            config.exporter is TraceExporterType.AUTO
+            and _resolve_exporter_type(config) is TraceExporterType.NONE
+        )
+
+    def _resolve(self) -> TraceConfig:
+        """Resolve the config once per open cycle (cleared on exit)."""
+        if self._resolved is None:
+            self._resolved = resolve_config(
+                TraceConfig,
+                explicit=self._explicit_config,
+                kwargs=self._kwargs,
+                env_prefix="GREL_TRACE_",
+                env_load=self._env_load,
+                error_type=TraceSettingsValidationError,
+            )
+        return self._resolved
+
     async def __aenter__(self) -> Self:
-        """Build the `TracerProvider` and install it as the global provider."""
+        """Build the `TracerProvider` and install it as the global provider.
+
+        When the exporter auto-disables (default `auto` exporter, no endpoint),
+        this is a true no-op: no provider is built, the process-global tracer
+        provider is left untouched, and auto-instrumentation is skipped.
+        """
+        config = self._resolve()
+        if not self.active:
+            return self
         try:
             from opentelemetry import trace  # noqa: PLC0415
         except ImportError as exc:  # pragma: no cover
             raise DependencyNotFoundError(module="opentelemetry-api") from exc
 
-        self._resolved = resolve_config(
-            TraceConfig,
-            explicit=self._explicit_config,
-            kwargs=self._kwargs,
-            env_prefix="GREL_TRACE_",
-            env_load=self._env_load,
-            error_type=TraceSettingsValidationError,
-        )
         # `opentelemetry.trace.set_tracer_provider()` refuses to replace an
         # already-installed provider, so `Trace` patches the private
         # `trace._TRACER_PROVIDER` global directly. A future OTel release
@@ -272,7 +316,7 @@ class Trace:
             )
             raise TraceError(msg)
         self._prior_provider = trace._TRACER_PROVIDER  # type: ignore[attr-defined]  # noqa: SLF001
-        self._provider = _build_provider(self._resolved)
+        self._provider = _build_provider(config)
         trace._TRACER_PROVIDER = self._provider  # type: ignore[attr-defined]  # noqa: SLF001
         return self
 
@@ -293,6 +337,12 @@ class Trace:
         exit. On timeout a warning is logged and the global provider is
         restored regardless.
         """
+        if self._provider is None:
+            # Auto-disabled on enter: nothing was installed, nothing to undo.
+            self._resolved = None
+            self._prior_provider = None
+            return None
+
         from opentelemetry import trace  # noqa: PLC0415
 
         try:
@@ -313,6 +363,7 @@ class Trace:
             trace._TRACER_PROVIDER = self._prior_provider  # type: ignore[attr-defined]  # noqa: SLF001
             self._provider = None
             self._prior_provider = None
+            self._resolved = None
         return None
 
 

--- a/tests/tracing/test_autoinstrument.py
+++ b/tests/tracing/test_autoinstrument.py
@@ -496,6 +496,17 @@ def test_install_without_trace_skips_fastapi() -> None:
     assert getattr(app, "_is_instrumented_by_opentelemetry", False) is False
 
 
+def test_install_skips_fastapi_when_trace_auto_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An auto-disabled `Trace` (no endpoint) skips FastAPI instrumentation."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    app = FastAPI()
+    Grelmicro(uses=[Trace()]).install(app)
+    assert getattr(app, "_is_instrumented_by_opentelemetry", False) is False
+
+
 # --- end-to-end span ---------------------------------------------------------
 
 

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -9,7 +9,7 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
 
 from grelmicro import Component, ComponentAlreadyRegisteredError, Grelmicro
-from grelmicro.errors import SettingsValidationError
+from grelmicro.errors import MultipleActiveAppsError, SettingsValidationError
 from grelmicro.trace import (
     Trace,
     TraceConfig,
@@ -315,12 +315,56 @@ def test_explicit_exporter_unchanged_without_endpoint() -> None:
 async def test_auto_exporter_enters_inert_without_endpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A default `Trace()` enters cleanly and exports nothing."""
+    """A default `Trace()` is a no-op: no provider installed, global untouched."""
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    prior = otel_trace.get_tracer_provider()
     micro = Grelmicro(uses=[Trace(service_name="orders")])
     async with micro:
         assert micro.trace.config.exporter == TraceExporterType.AUTO
+        assert micro.trace.active is False
+        assert otel_trace.get_tracer_provider() is prior
+    assert otel_trace.get_tracer_provider() is prior
+
+
+async def test_auto_disabled_provider_access_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`Trace.provider` reports the auto-disabled state clearly."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    micro = Grelmicro(uses=[Trace()])
+    async with micro:
+        with pytest.raises(RuntimeError, match="auto-disabled"):
+            _ = micro.trace.provider
+
+
+async def test_auto_disabled_traces_allow_overlapping_apps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-disabled `Trace` owns no global state, so two apps overlap freely."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    async with Grelmicro(uses=[Trace()]), Grelmicro(uses=[Trace()]):
+        pass  # no MultipleActiveAppsError
+
+
+async def test_active_trace_still_blocks_second_app() -> None:
+    """An active `Trace` (explicit exporter) still blocks an overlapping app."""
+    async with Grelmicro(uses=[Trace(exporter=TraceExporterType.CONSOLE)]):
+        with pytest.raises(MultipleActiveAppsError):
+            async with Grelmicro(
+                uses=[Trace(exporter=TraceExporterType.CONSOLE)]
+            ):
+                pass
+
+
+async def test_explicit_none_still_installs_provider() -> None:
+    """Explicit `exporter=none` keeps installing a provider (stays active)."""
+    micro = Grelmicro(uses=[Trace(exporter=TraceExporterType.NONE)])
+    async with micro:
+        assert micro.trace.active is True
+        assert isinstance(micro.trace.provider, TracerProvider)
 
 
 def test_basic_auth_header_is_base64_encoded() -> None:


### PR DESCRIPTION
Closes #487.

## Problem
With the default `auto` exporter and no endpoint, `Trace.__aenter__` still built the `TracerProvider`, patched the global `opentelemetry.trace._TRACER_PROVIDER`, and ran auto-instrumentation. Auto-disable only nulled the exporter, not the provider install. So `Trace` could not be registered unconditionally: in dev/test/CI it patched global state and clashed with `MultipleActiveAppsError` across app builds.

## Change
When the exporter resolves to `NONE` **because it was left `auto`** (no endpoint), `Trace` is now a true no-op:
- No `TracerProvider` built, global provider untouched.
- No auto-instrumentation (both the provider sweep and the FastAPI install path skip).
- Does not count against the single-active-app guard, so overlapping apps may each carry an auto-disabled `Trace`.
- Needs no `opentelemetry` import on the no-op path.

An explicit `exporter=none` is unchanged: it still installs a provider (spans created, not exported), preserving existing behavior and tests.

## Mechanism
`Trace.active` / `Trace.owns_global_state()` are config-derived, so the app guard (pre-enter), `micro.install` FastAPI instrumentation (install time), and the post-enter provider sweep all agree. `_GLOBAL_STATE_KINDS` membership is now refined per item via an optional `owns_global_state()`.

## Tests
Added coverage for: no provider installed + global untouched, overlapping auto-disabled apps allowed, active `Trace` still blocks a second app, explicit `none` still installs, `provider` access message, and FastAPI install skip.