### PR TITLE
🔖 Prepare the 0.28.1 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.28.1 - 2026-07-05
 
 ### Features
 


### PR DESCRIPTION
Dates the changelog for 0.28.1: the `Trace` auto-disable no-op ([#487](https://github.com/grelinfo/grelmicro/issues/487)), the `Metrics` overlapping-app guard fix, and the doc-staleness refresh.