### PR TITLE
🐛 Close audit backlog: lifecycle, idempotency, and API ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,17 +118,14 @@ async def ping() -> dict[str, str]:
 
 That is the whole thing. Pick a primitive, name it, give it a backend, call it. The memory adapter says per-process on purpose. Swap to a fleet-wide backend later by composing it inside `Grelmicro(uses=[RateLimiterRegistry(redis)])` as shown below.
 
-### Lifespan with one provider and one component
+### FastAPI with one provider and one component
 
-To make the rate limiter fleet-wide, wrap it in a `Grelmicro` container with one provider and one component, bind it to FastAPI's lifespan, and add the middleware so request handlers see the app.
+To make the rate limiter fleet-wide, wrap it in a `Grelmicro` container with one provider and one component, then install it into FastAPI.
 
 ```python
-from contextlib import asynccontextmanager
-
 from fastapi import FastAPI
 
 from grelmicro import Grelmicro
-from grelmicro.integrations.fastapi import GrelmicroMiddleware
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience import (
     RateLimitExceededError,
@@ -141,15 +138,8 @@ micro = Grelmicro(uses=[RateLimiterRegistry(redis)])
 
 api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
 
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    async with micro:
-        yield
-
-
-app = FastAPI(lifespan=lifespan)
-app.add_middleware(GrelmicroMiddleware, micro=micro)
+app = FastAPI()
+micro.install(app)
 
 
 @app.get("/ping")
@@ -161,7 +151,7 @@ async def ping() -> dict[str, str]:
     return {"status": "ok"}
 ```
 
-Adding more primitives is the same shape: one extra entry in `uses=[...]`. The full demo below shows what that looks like.
+Adding more primitives is the same shape: one extra entry in `uses=[...]`. `micro.install(app)` opens the app on startup, closes it on shutdown, and lets request handlers resolve backends without passing `backend=`.
 
 ### FastAPI integration
 
@@ -175,7 +165,6 @@ from fastapi import FastAPI, HTTPException, Request
 
 from grelmicro import Grelmicro
 from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
-from grelmicro.integrations.fastapi import GrelmicroMiddleware
 from grelmicro.health import HealthChecks
 from grelmicro.log import configure as configure_logging
 from grelmicro.providers.redis import RedisProvider
@@ -217,16 +206,15 @@ cb = CircuitBreaker("my-service")
 api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
 
 
-# === FastAPI lifespan and middleware ===
+# === FastAPI ===
 @asynccontextmanager
 async def lifespan(app):
     configure_logging()
-    async with micro:
-        yield
+    yield
 
 
 app = FastAPI(lifespan=lifespan)
-app.add_middleware(GrelmicroMiddleware, micro=micro)
+micro.install(app)
 
 
 # --- Cache: avoid redundant database queries ---

--- a/docs/architecture/api-conventions.md
+++ b/docs/architecture/api-conventions.md
@@ -1,0 +1,51 @@
+# API Conventions
+
+The public API follows a few constructor and factory rules so a new primitive
+feels like the existing ones. Follow them when you add a pattern or component.
+
+## Patterns take a positional `name`
+
+A pattern is the object user code calls directly, such as `Lock`,
+`CircuitBreaker`, or a `RateLimiter` built from a factory. Its first argument is
+a positional `name` that identifies the instance and drives its config prefix:
+
+```python
+Lock("cart")
+CircuitBreaker("payments")
+RateLimiter.sliding_window("api", limit=100, window=60)
+```
+
+The name comes first because it is the one argument every call sets. Everything
+else (`backend=`, tuning fields) is keyword-only with a default.
+
+## Components take the provider first, `name` keyword-only
+
+A component or registry is app-level wiring passed to `uses=`, such as
+`Coordination`, `Cache`, or `RateLimiterRegistry`. Its first positional is the
+provider or backend it wraps. The registration `name` is keyword-only and
+defaults to `"default"`:
+
+```python
+Coordination(redis)
+Cache(redis)
+RateLimiterRegistry(redis, name="api")
+```
+
+Most apps register one component per kind, so the default name keeps the common
+case silent. Name a second instance only when two of the same kind coexist.
+
+## Algorithms use factory classmethods
+
+When a pattern has more than one algorithm, expose each as an explicit factory
+classmethod rather than a `kind=` argument. The classmethod names the algorithm
+and takes only the fields that algorithm needs:
+
+```python
+RateLimiter.sliding_window("api", limit=100, window=60)
+RateLimiter.token_bucket("api", rate=10, capacity=20)
+CircuitBreaker.consecutive_count("payments", error_threshold=5)
+```
+
+The bare constructor stays available for a pre-assembled config object (from
+YAML or a `pydantic-settings` tree), but the factory is the path most callers
+take.

--- a/docs/architecture/coordination.md
+++ b/docs/architecture/coordination.md
@@ -32,6 +32,8 @@ This design provides the following guarantees:
 - **Idempotent**: The same async task (or thread) always produces the same deterministic token, so the backend accepts a re-acquire and extends the lease.
 - **Isolation**: Different lock instances have different worker identities, so their tokens never collide even when used from the same task or thread.
 
+`TaskLock` appends a per-handle nonce to its token (for example `{worker}:task:{task_id}:0.a1b2c3d4`). The nonce joins a process-local counter with random bytes, so it is unique across handles and unguessable. This keeps an untrusted in-process caller from forging another handle's ownership token, which matters when the same process loads untrusted plugins.
+
 ## Lock Name and Backend Key
 
 Each coordination primitive automatically prefixes the user-provided `name` with a type-specific namespace to form the backend key:

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -10,6 +10,7 @@ This section documents the internal design decisions and guarantees of grelmicro
 - **[Plugins](plugins.md)**: Entry-point groups that let third-party packages register Providers and Adapters.
 - **[Multiple apps](multiple-apps.md)**: When two `Grelmicro` apps can run concurrently, and why `Log`, `Trace`, and `Metrics` are the exception.
 - **[Decorators](decorators.md)**: Which decorators take the bare `@deco` form, which require `@deco(...)`, and which wrap sync functions.
+- **[API Conventions](api-conventions.md)**: Constructor and factory rules: positional `name` on patterns, keyword-only `name` on components, factory classmethods for algorithms.
 - **[Coordination](coordination.md)**: Worker identity, token generation, lock design, and cleanup strategy.
 - **[Kubernetes Backend](kubernetes.md)**: Lease resources, optimistic concurrency, and name sanitization.
 - **[SQLite Backend](sqlite.md)**: WAL mode.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -246,6 +246,9 @@ Literal tags with no `{...}` pass through unchanged. Tags work the same across M
 --8<-- "cache/tags.py"
 ```
 
+!!! warning "Keep keys and tags bounded"
+    Every distinct key and tag is stored. On the memory backend the tag-to-key map grows with cardinality and is not evicted until the tagged entries expire. Deriving keys or tags straight from untrusted input (a raw user id, a full URL, a free-text field) lets a caller inflate memory or backend storage without limit. Map untrusted values onto a bounded set first, such as a hash bucket or an allowlist, and prefer a short shared tag plus one per-entity tag over a fresh tag per request.
+
 ## @cached Decorator
 
 The `@cached` decorator automatically caches function results. It works with both sync and async functions.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,20 +4,20 @@
 
 ### Fixed
 
-* 🐛 Make idempotency storage atomic. The fingerprint guard is now written before the response and outlives it, so a failed guard write can never leave a response that a different payload could replay.
-* 🐛 Guard the process-global active-app registry with a lock so two apps starting concurrently cannot both enter and clobber each other's `Log`/`Trace`/`Metrics` state. The second raises `MultipleActiveAppsError`.
-* 🐛 Roll back an opened `Grelmicro` app when a later FastStream startup hook fails, so a failed startup no longer leaves the app open and registered.
-* 🐛 Export `SQLiteCircuitBreakerAdapter` from `grelmicro.resilience`, matching the other circuit breaker adapters.
+* 🐛 Make idempotency storage atomic. The fingerprint guard is now written before the response and outlives it, so a failed guard write can never leave a response that a different payload could replay. ([#494](https://github.com/grelinfo/grelmicro/issues/494))
+* 🐛 Guard the process-global active-app registry with a lock so two apps starting concurrently cannot both enter and clobber each other's `Log`/`Trace`/`Metrics` state. The second raises `MultipleActiveAppsError`. ([#494](https://github.com/grelinfo/grelmicro/issues/494))
+* 🐛 Roll back an opened `Grelmicro` app when a later FastStream startup hook fails, so a failed startup no longer leaves the app open and registered. ([#494](https://github.com/grelinfo/grelmicro/issues/494))
+* 🐛 Export `SQLiteCircuitBreakerAdapter` from `grelmicro.resilience`, matching the other circuit breaker adapters. ([#494](https://github.com/grelinfo/grelmicro/issues/494))
 
 ### Security
 
-* 🔒 Make the `TaskLock` token nonce unpredictable (a process-local counter joined with random bytes) so an untrusted in-process caller cannot forge another handle's ownership token.
+* 🔒 Make the `TaskLock` token nonce unpredictable (a process-local counter joined with random bytes) so an untrusted in-process caller cannot forge another handle's ownership token. ([#494](https://github.com/grelinfo/grelmicro/issues/494))
 
 ### Docs
 
-* 📝 Point every ambient-miss `OutOfContextError` at `micro.install(app)`, and switch the README and first-steps examples to the one-call `micro.install(app)` form.
-* 📝 Add a first-use mental model, an operator defaults reference, an API conventions page, an adapter import policy, and decision tables for rate limiter methods and task entry points.
-* 📝 Warn that `/healthz` always returns each check's `error` string, and that cache keys and tags derived from untrusted input must stay bounded.
+* 📝 Point every ambient-miss `OutOfContextError` at `micro.install(app)`, and switch the README and first-steps examples to the one-call `micro.install(app)` form. ([#494](https://github.com/grelinfo/grelmicro/issues/494))
+* 📝 Add a first-use mental model, an operator defaults reference, an API conventions page, an adapter import policy, and decision tables for rate limiter methods and task entry points. ([#494](https://github.com/grelinfo/grelmicro/issues/494))
+* 📝 Warn that `/healthz` always returns each check's `error` string, and that cache keys and tags derived from untrusted input must stay bounded. ([#494](https://github.com/grelinfo/grelmicro/issues/494))
 
 ## 0.28.1 - 2026-07-05
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* 🐛 Make idempotency storage atomic. The fingerprint guard is now written before the response and outlives it, so a failed guard write can never leave a response that a different payload could replay.
+* 🐛 Guard the process-global active-app registry with a lock so two apps starting concurrently cannot both enter and clobber each other's `Log`/`Trace`/`Metrics` state. The second raises `MultipleActiveAppsError`.
+* 🐛 Roll back an opened `Grelmicro` app when a later FastStream startup hook fails, so a failed startup no longer leaves the app open and registered.
+* 🐛 Export `SQLiteCircuitBreakerAdapter` from `grelmicro.resilience`, matching the other circuit breaker adapters.
+
+### Security
+
+* 🔒 Make the `TaskLock` token nonce unpredictable (a process-local counter joined with random bytes) so an untrusted in-process caller cannot forge another handle's ownership token.
+
+### Docs
+
+* 📝 Point every ambient-miss `OutOfContextError` at `micro.install(app)`, and switch the README and first-steps examples to the one-call `micro.install(app)` form.
+* 📝 Add a first-use mental model, an operator defaults reference, an API conventions page, an adapter import policy, and decision tables for rate limiter methods and task entry points.
+* 📝 Warn that `/healthz` always returns each check's `error` string, and that cache keys and tags derived from untrusted input must stay bounded.
+
 ## 0.28.1 - 2026-07-05
 
 ### Features

--- a/docs/config.md
+++ b/docs/config.md
@@ -73,6 +73,38 @@ a field out of the constructor to let the deployment set it.
 
 Each pattern page lists its own fields and the exact variable names.
 
+### Defaults reference
+
+The most important defaults for operators. All times are in seconds. Override
+any of them with the pattern prefix above plus the field name, uppercased.
+
+| Pattern | Field | Default |
+|---|---|---|
+| `Lock` | `lease_duration` | `60` |
+| `Lock` | `retry_interval` | `0.1` |
+| `TaskLock` | `lease_duration` | `60` |
+| `TaskLock` | `min_hold_duration` | `1` |
+| `LeaderElection` | `lease_duration` | `15` |
+| `LeaderElection` | `renew_deadline` | `10` |
+| `LeaderElection` | `retry_interval` | `2` |
+| `LeaderElection` | `backend_timeout` | `5` |
+| `TTLCache` | `ttl` | `60` |
+| `RateLimiter` | `fail_open` | `False` |
+| `CircuitBreaker` | `error_threshold` | `5` |
+| `CircuitBreaker` | `success_threshold` | `2` |
+| `CircuitBreaker` | `reset_timeout` | `30` |
+| `Retry` | `attempts` | `3` |
+| `Retry` | `backoff.base_delay` | `0.1` |
+| `Retry` | `backoff.max_delay` | `30` |
+| `Bulkhead` | `max_concurrent` | `None` (unbounded) |
+| `HealthChecks` | `timeout` | `5` |
+| `HealthChecks` | `cache_ttl` | `1` |
+| `Idempotency` | `ttl` | `86400` (1 day) |
+
+`TTLCache` and `Idempotency` set their `ttl` in code, not from the environment.
+`Timeout.seconds`, `Fallback.when`, and `Fallback.default` are required and have
+no default.
+
 ## Advanced
 
 The kwargs-and-env path covers most apps. When you need more, the

--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -12,6 +12,14 @@ pip install grelmicro
 See the [installation guide](installation.md) for `uv`, `poetry`, and the
 backend extras.
 
+## Mental model
+
+- **Pattern**: the object your app calls, such as `Lock("cart")` or `RateLimiter.sliding_window("api", ...)`.
+- **Provider**: owns a connection, such as `RedisProvider`.
+- **Component or Registry**: registers a backend on the app.
+- **Adapter**: the concrete backend implementation. Providers usually hide it.
+- **Ambient binding**: `micro.install(app)` lets request and message handlers find the current `Grelmicro` app.
+
 ## Your first app
 
 Guard a shared resource with a distributed `Lock`. The memory backend keeps the
@@ -61,4 +69,4 @@ async def get_user(user_id: int) -> dict:
 ## Next
 
 You built a pattern and wired it into an app. Next, [wire a real app](wiring.md)
-with a Redis provider and the FastAPI middleware.
+with a Redis provider and `micro.install(app)`.

--- a/docs/health.md
+++ b/docs/health.md
@@ -220,6 +220,9 @@ With details enabled, each check entry includes a `details` field:
 }
 ```
 
+!!! warning "The `error` field is always returned"
+    `show_details` strips only the `details` field. Each failing check still reports its `error` string, even on a public `/healthz`. Keep check error messages safe for the endpoint audience: raise `HealthError` with a short, non-sensitive message and put diagnostics in `details`, which stays hidden by default. To hide error strings too, gate the whole endpoint with `healthz_dependencies`.
+
 #### `show_details` vs `healthz_dependencies`
 
 Two independent gates sit in front of `/healthz`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,17 +118,14 @@ async def ping() -> dict[str, str]:
 
 That is the whole thing. Pick a primitive, name it, give it a backend, call it. The memory adapter says per-process on purpose. Swap to a fleet-wide backend later by composing it inside `Grelmicro(uses=[RateLimiterRegistry(redis)])` as shown below.
 
-### Lifespan with one provider and one component
+### FastAPI with one provider and one component
 
-To make the rate limiter fleet-wide, wrap it in a `Grelmicro` container with one provider and one component, bind it to FastAPI's lifespan, and add the middleware so request handlers see the app.
+To make the rate limiter fleet-wide, wrap it in a `Grelmicro` container with one provider and one component, then install it into FastAPI.
 
 ```python
-from contextlib import asynccontextmanager
-
 from fastapi import FastAPI
 
 from grelmicro import Grelmicro
-from grelmicro.integrations.fastapi import GrelmicroMiddleware
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience import (
     RateLimitExceededError,
@@ -141,15 +138,8 @@ micro = Grelmicro(uses=[RateLimiterRegistry(redis)])
 
 api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
 
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    async with micro:
-        yield
-
-
-app = FastAPI(lifespan=lifespan)
-app.add_middleware(GrelmicroMiddleware, micro=micro)
+app = FastAPI()
+micro.install(app)
 
 
 @app.get("/ping")
@@ -161,7 +151,7 @@ async def ping() -> dict[str, str]:
     return {"status": "ok"}
 ```
 
-Adding more primitives is the same shape: one extra entry in `uses=[...]`. The full demo below shows what that looks like.
+Adding more primitives is the same shape: one extra entry in `uses=[...]`. `micro.install(app)` opens the app on startup, closes it on shutdown, and lets request handlers resolve backends without passing `backend=`.
 
 ### FastAPI integration
 
@@ -175,7 +165,6 @@ from fastapi import FastAPI, HTTPException, Request
 
 from grelmicro import Grelmicro
 from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
-from grelmicro.integrations.fastapi import GrelmicroMiddleware
 from grelmicro.health import HealthChecks
 from grelmicro.log import configure as configure_logging
 from grelmicro.providers.redis import RedisProvider
@@ -217,16 +206,15 @@ cb = CircuitBreaker("my-service")
 api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
 
 
-# === FastAPI lifespan and middleware ===
+# === FastAPI ===
 @asynccontextmanager
 async def lifespan(app):
     configure_logging()
-    async with micro:
-        yield
+    yield
 
 
 app = FastAPI(lifespan=lifespan)
-app.add_middleware(GrelmicroMiddleware, micro=micro)
+micro.install(app)
 
 
 # --- Cache: avoid redundant database queries ---

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -36,6 +36,16 @@ Components dispatch to the Provider's factory methods (`provider.lock()`,
 (`RedisLockAdapter`, `RedisCacheAdapter`, `RedisRateLimiterAdapter`) stay
 public as escape hatches but rarely appear in user code.
 
+!!! note "Import policy: prefer Providers over concrete adapters"
+    App code should import a Provider and pass it to Components and Registries,
+    not import concrete adapter classes. The Provider owns the connection and
+    hands each Component the right adapter, so one URL change swaps every
+    backend at once. Import an adapter directly only for an escape hatch: a
+    bespoke client the factory does not build, or a per-process Memory backend
+    in a test. Adapters live in their backend submodule
+    (`grelmicro.resilience.circuitbreaker.sqlite`) and the top-level package
+    re-exports them (`from grelmicro.resilience import SQLiteCircuitBreakerAdapter`).
+
 !!! tip "Listing the Provider is optional"
     A Provider held by a Component is discovered and lifecycled for you, so
     you can drop the top-level entry and let the Components carry it:

--- a/docs/resilience/rate-limiter.md
+++ b/docs/resilience/rate-limiter.md
@@ -20,6 +20,15 @@ Load a backend, build a limiter with a factory classmethod, then call `acquire`:
 
 ### Checking the limit
 
+Pick the call by what you need:
+
+| Need | Method | Why |
+|---|---|---|
+| Just branch yes or no | `allow()` | Smallest code. |
+| Build HTTP 429 headers | `acquire()` | Keeps `retry_after`, `remaining`, and `reset_after`. |
+| Let a shared handler map rejections | `acquire_or_raise()` | Raises `RateLimitExceededError`, an `AdmissionError`. |
+| Smooth work instead of rejecting | `wait()` | Sleeps until admitted, with optional `max_wait`. |
+
 The simplest form is a boolean:
 
 ```python

--- a/docs/snippets/coordination/postgres.py
+++ b/docs/snippets/coordination/postgres.py
@@ -1,6 +1,8 @@
+import os
+
 from grelmicro import Grelmicro
 from grelmicro.coordination import Coordination
 from grelmicro.providers.postgres import PostgresProvider
 
-postgres = PostgresProvider("postgresql://user:password@localhost:5432/db")
+postgres = PostgresProvider(os.environ["POSTGRES_URL"])
 micro = Grelmicro(uses=[Coordination(postgres)])

--- a/docs/task.md
+++ b/docs/task.md
@@ -39,6 +39,16 @@ The `Tasks` class is the main entry point to manage tasks. The recommended way t
 
 `Grelmicro.use(item)` (or the `uses=` constructor kwarg) accepts any async context manager and lifecycles it with the app. The caller keeps the reference and uses the manager directly.
 
+Choose the entry point by the job:
+
+| Need | Use |
+|---|---|
+| Simple recurring function | `@tasks.every(...)` |
+| Group tasks across modules | `TaskRouter` |
+| Add an object that already implements the task protocol | `tasks.add_task(...)` |
+| Run at most once across replicas | `@tasks.every(..., lock=TaskLock(...))` |
+| Run only on the leader | `@tasks.every(..., leader=leader_election)` |
+
 Start it standalone using the application lifespan:
 
 === "FastAPI"

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -8,6 +8,7 @@ from contextlib import (
     asynccontextmanager,
 )
 from contextvars import ContextVar
+from threading import Lock as ThreadLock
 from typing import TYPE_CHECKING, Annotated, Any, Self, cast
 
 from typing_extensions import Doc
@@ -47,6 +48,9 @@ Unlike `_current_micro` (per asyncio task), this is a single process-global
 list so `Grelmicro.__aenter__` can refuse to open a second overlapping app
 whose `Log`/`Trace` would clobber the active app's global-state snapshots.
 """
+
+_active_apps_lock = ThreadLock()
+"""Serializes the process-global active app guard and reservation."""
 
 
 _GLOBAL_STATE_KINDS = frozenset({"log", "trace", "metrics"})
@@ -284,7 +288,7 @@ class Grelmicro:
         Raises:
             ComponentAlreadyRegisteredError: A different component is already
                 registered under the same `(kind, name)` key. Plain async
-                context managers do not raise; they are appended.
+                context managers do not raise. They are appended.
         """
         # A bare class (no parens) is instantiated with no arguments, in the
         # spirit of FastAPI's `Depends(dep)`: pass the reference, the framework
@@ -851,28 +855,36 @@ class Grelmicro:
         """
         if self._exit_stack is not None:
             raise OutOfContextError(self, "__aenter__")
-        if (
-            not self._allow_multiple
-            and self._owns_global_state()
-            and any(app._owns_global_state() for app in _active_apps)  # noqa: SLF001
-        ):
-            raise MultipleActiveAppsError
-        self._discover_shared_providers()
-        self._warn_unlifecycled_providers()
-        self._resolve_provider_sharing()
-        self._exit_stack = AsyncExitStack()
-        await self._exit_stack.__aenter__()
-        self._token = _current_micro.set(self)
-        _active_apps.append(self)
+        with _active_apps_lock:
+            if (
+                not self._allow_multiple
+                and self._owns_global_state()
+                and any(
+                    app._owns_global_state()  # noqa: SLF001
+                    for app in _active_apps
+                )
+            ):
+                raise MultipleActiveAppsError
+            _active_apps.append(self)
         try:
+            self._discover_shared_providers()
+            self._warn_unlifecycled_providers()
+            self._resolve_provider_sharing()
+            self._exit_stack = AsyncExitStack()
+            await self._exit_stack.__aenter__()
+            self._token = _current_micro.set(self)
             for item in self._items:
                 await self._exit_stack.enter_async_context(item)
             self._instrument_providers()
         except BaseException:
-            _active_apps.remove(self)
-            _current_micro.reset(self._token)
+            with _active_apps_lock:
+                if self in _active_apps:  # pragma: no branch
+                    _active_apps.remove(self)
+            if self._token is not None:
+                _current_micro.reset(self._token)
             self._token = None
-            await self._exit_stack.__aexit__(*_sys_exc_info_or_none())
+            if self._exit_stack is not None:
+                await self._exit_stack.__aexit__(*_sys_exc_info_or_none())
             self._exit_stack = None
             raise
         return self
@@ -894,8 +906,9 @@ class Grelmicro:
             if self._token is not None:  # pragma: no branch
                 _current_micro.reset(self._token)
                 self._token = None
-            if self in _active_apps:  # pragma: no branch
-                _active_apps.remove(self)
+            with _active_apps_lock:
+                if self in _active_apps:  # pragma: no branch
+                    _active_apps.remove(self)
             self._exit_stack = None
 
     def _discover_shared_providers(self) -> None:

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -196,8 +196,8 @@ class TTLCache(Generic[T]):
             OutOfContextError: No backend resolved in this scope. Pass
                 `backend=` (a `MemoryCacheAdapter()` for a per-process
                 cache), register a `Cache` Component, or run the call
-                under the app context (for FastAPI, add
-                `GrelmicroMiddleware`).
+                inside `async with micro:` or after
+                `micro.install(app)`.
         """
         if self._backend is not None:
             return self._backend
@@ -213,8 +213,8 @@ class TTLCache(Generic[T]):
             msg = (
                 "TTLCache resolved no backend. Pass backend= "
                 "(MemoryCacheAdapter() for a per-process cache), register "
-                "a Cache component, or run the call under the app context "
-                "(for FastAPI add GrelmicroMiddleware)."
+                "a Cache component, or run the call inside `async with micro:` "
+                "or after `micro.install(app)`."
             )
             raise OutOfContextError(msg) from None
         return cache.backend

--- a/grelmicro/coordination/_tokens.py
+++ b/grelmicro/coordination/_tokens.py
@@ -24,12 +24,16 @@ def generate_task_token(worker: UUID | str, nonce: str = "") -> str:
 
 
 def generate_token_nonce() -> str:
-    """Generate a unique token nonce suffix (e.g., ':0', ':1').
+    """Generate a unique, unpredictable token nonce suffix.
+
+    Combines a process-local counter with random bytes (e.g. ':0.a1b2c3d4').
+    The counter is unique across handles in the same process and the random
+    part is unguessable.
 
     Thread-safe: ``next()`` on ``itertools.count`` is a single C-level
     operation protected by the GIL.
     """
-    return f":{next(_guard_counter)}"
+    return f":{next(_guard_counter)}.{token_hex(8)}"
 
 
 def generate_thread_token(

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -436,8 +436,8 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
             OutOfContextError: No backend resolved in this scope. Pass
                 `backend=` (a `MemoryLeaderElectionAdapter()` for a
                 per-process election), register a `Coordination`
-                Component, or run the call under the app context (for
-                FastAPI, add `GrelmicroMiddleware`).
+                Component, or run the call inside `async with micro:` or
+                after `micro.install(app)`.
         """
         if self._backend is not None:
             return self._backend
@@ -456,8 +456,7 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
                 f"LeaderElection({self._name!r}) resolved no backend. Pass "
                 f"backend= (MemoryLeaderElectionAdapter() for a per-process "
                 f"election), register a Coordination component, or run the "
-                f"call under the app context (for FastAPI add "
-                f"GrelmicroMiddleware)."
+                f"call inside `async with micro:` or after `micro.install(app)`."
             )
             raise OutOfContextError(msg) from None
         return coordination.election_backend

--- a/grelmicro/coordination/lock.py
+++ b/grelmicro/coordination/lock.py
@@ -340,8 +340,8 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             OutOfContextError: No backend resolved in this scope. Pass
                 `backend=` (a `MemoryLockAdapter()` for a per-process
                 lock), register a `Coordination` Component, or run the
-                call under the app context (for FastAPI, add
-                `GrelmicroMiddleware`).
+                call inside `async with micro:` or after
+                `micro.install(app)`.
         """
         if self._backend is not None:
             return self._backend
@@ -359,8 +359,8 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
             msg = (
                 f"Lock({self._name!r}) resolved no backend. Pass backend= "
                 f"(MemoryLockAdapter() for a per-process lock), register a "
-                f"Coordination component, or run the call under the app "
-                f"context (for FastAPI add GrelmicroMiddleware)."
+                f"Coordination component, or run the call inside "
+                f"`async with micro:` or after `micro.install(app)`."
             )
             raise OutOfContextError(msg) from None
         return coordination.lock_backend

--- a/grelmicro/coordination/tasklock.py
+++ b/grelmicro/coordination/tasklock.py
@@ -302,8 +302,8 @@ class TaskLock(Reconfigurable[TaskLockConfig], LockPrimitive):
             OutOfContextError: No backend resolved in this scope. Pass
                 `backend=` (a `MemoryLockAdapter()` for a per-process
                 lock), register a `Coordination` Component, or run the
-                call under the app context (for FastAPI, add
-                `GrelmicroMiddleware`).
+                call inside `async with micro:` or after
+                `micro.install(app)`.
         """
         if self._backend is not None:
             return self._backend
@@ -321,8 +321,8 @@ class TaskLock(Reconfigurable[TaskLockConfig], LockPrimitive):
             msg = (
                 f"TaskLock({self._name!r}) resolved no backend. Pass "
                 f"backend= (MemoryLockAdapter() for a per-process lock), "
-                f"register a Coordination component, or run the call under "
-                f"the app context (for FastAPI add GrelmicroMiddleware)."
+                f"register a Coordination component, or run the call inside "
+                f"`async with micro:` or after `micro.install(app)`."
             )
             raise OutOfContextError(msg) from None
         return coordination.lock_backend

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -114,8 +114,8 @@ class _Block(Generic[T]):
         Raises:
             OutOfContextError: No cache backend resolved in this scope.
                 Pass `cache=`, register a `Cache` Component, or run the
-                call under the app context (for FastAPI, add
-                `GrelmicroMiddleware`).
+                call inside `async with micro:` or after
+                `micro.install(app)`.
         """
         from grelmicro._app import (  # noqa: PLC0415
             ComponentNotRegisteredError,
@@ -135,8 +135,8 @@ class _Block(Generic[T]):
             msg = (
                 f"Idempotency({self._idempotency.name!r}) resolved no "
                 f"cache backend. Pass cache=, register a Cache "
-                f"component, or run the call under the app context (for "
-                f"FastAPI add GrelmicroMiddleware)."
+                f"component, or run the call inside `async with micro:` or "
+                f"after `micro.install(app)`."
             )
             raise OutOfContextError(msg) from None
         if replay is not _SENTINEL:
@@ -545,10 +545,11 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
         """Store the response and the optional fingerprint under `ttl`."""
         scoped = self._scoped(key)
         ttl = self._config.ttl
-        await self._cache.set(scoped, response, ttl)
         if fingerprint is not None:
+            # Store the guard first so a response never outlives its check.
             await self._cache._get_backend().set(  # noqa: SLF001
                 key=f"{_CACHE_PREFIX}:{scoped}{_FINGERPRINT_SUFFIX}",
                 value=fingerprint.encode(),
-                ttl=ttl,
+                ttl=ttl + 1,
             )
+        await self._cache.set(scoped, response, ttl)

--- a/grelmicro/integrations/faststream.py
+++ b/grelmicro/integrations/faststream.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import sys
 from typing import TYPE_CHECKING, Annotated, Any, cast
 
 from faststream import BaseMiddleware
@@ -136,6 +137,20 @@ def install(
     @app.after_shutdown
     async def _close_micro() -> None:
         await micro.__aexit__(None, None, None)
+
+    original_start = app.start
+
+    async def _start_with_micro_rollback(
+        **run_extra_options: Any,  # noqa: ANN401
+    ) -> None:
+        try:
+            await original_start(**run_extra_options)
+        except BaseException:
+            if micro._exit_stack is not None:  # noqa: SLF001
+                await micro.__aexit__(*sys.exc_info())
+            raise
+
+    app.start = _start_with_micro_rollback  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
     if ambient:
         middleware = type(

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -123,6 +123,9 @@ if TYPE_CHECKING:
     from grelmicro.resilience.circuitbreaker.redis import (
         RedisCircuitBreakerAdapter,
     )
+    from grelmicro.resilience.circuitbreaker.sqlite import (
+        SQLiteCircuitBreakerAdapter,
+    )
     from grelmicro.resilience.fallback import (
         Fallback,
         FallbackConfig,
@@ -213,6 +216,7 @@ __all__ = [
     "RetryBackoffConfig",
     "RetryConfig",
     "RetryStrategy",
+    "SQLiteCircuitBreakerAdapter",
     "SQLiteRateLimiterAdapter",
     "Shield",
     "ShieldConfig",
@@ -264,6 +268,10 @@ _LAZY: dict[str, tuple[str, str]] = {
     "RedisCircuitBreakerAdapter": (
         "grelmicro.resilience.circuitbreaker.redis",
         "RedisCircuitBreakerAdapter",
+    ),
+    "SQLiteCircuitBreakerAdapter": (
+        "grelmicro.resilience.circuitbreaker.sqlite",
+        "SQLiteCircuitBreakerAdapter",
     ),
     # Rate limiter
     "RateLimiter": ("grelmicro.resilience.ratelimiter", "RateLimiter"),

--- a/grelmicro/resilience/circuitbreaker/__init__.py
+++ b/grelmicro/resilience/circuitbreaker/__init__.py
@@ -423,8 +423,8 @@ class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):
             OutOfContextError: No backend resolved in this scope. Pass
                 `backend=` (a `MemoryCircuitBreakerAdapter()` for a
                 per-replica breaker), register a `CircuitBreakerRegistry`
-                Component, or run the call under the app context (for
-                FastAPI, add `GrelmicroMiddleware`).
+                Component, or run the call inside `async with micro:` or
+                after `micro.install(app)`.
         """
         if self._backend is not None:
             return self._backend
@@ -443,8 +443,8 @@ class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):
                 f"CircuitBreaker({self._name!r}) resolved no backend. Pass "
                 f"backend= (MemoryCircuitBreakerAdapter() for a per-replica "
                 f"breaker), register a CircuitBreakerRegistry component, or run "
-                f"the call under the app context (for FastAPI add "
-                f"GrelmicroMiddleware)."
+                f"the call inside `async with micro:` or after "
+                f"`micro.install(app)`."
             )
             raise OutOfContextError(msg) from None
         return component.backend

--- a/grelmicro/resilience/ratelimiter/__init__.py
+++ b/grelmicro/resilience/ratelimiter/__init__.py
@@ -197,8 +197,8 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
             OutOfContextError: No backend resolved in this scope. Pass
                 `backend=` (a `MemoryRateLimiterAdapter()` for a
                 per-process limiter), register a `RateLimiterRegistry`
-                Component, or run the call under the app context (for
-                FastAPI, add `GrelmicroMiddleware`).
+                Component, or run the call inside `async with micro:` or
+                after `micro.install(app)`.
         """
         if self._backend is not None:
             return self._backend
@@ -217,8 +217,7 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
                 f"RateLimiter({self._name!r}) resolved no backend. Pass "
                 f"backend= (MemoryRateLimiterAdapter() for a per-process "
                 f"limiter), register a RateLimiterRegistry component, or run the "
-                f"call under the app context (for FastAPI add "
-                f"GrelmicroMiddleware)."
+                f"call inside `async with micro:` or after `micro.install(app)`."
             )
             raise OutOfContextError(msg) from None
         return component.backend

--- a/grelmicro/task/_cron.py
+++ b/grelmicro/task/_cron.py
@@ -377,8 +377,8 @@ class CronTask(Task):
         Raises:
             OutOfContextError: An app is running but no `Coordination`
                 component is registered. Pass `backend=`, register a
-                `Coordination` Component, or run the call under the app
-                context (for FastAPI, add `GrelmicroMiddleware`).
+                `Coordination` Component, or run the call inside
+                `async with micro:` or after `micro.install(app)`.
         """
         if self._backend is not None:
             return self._backend
@@ -399,8 +399,8 @@ class CronTask(Task):
             msg = (
                 f"Cron task {self.name!r} resolved no schedule backend. "
                 f"Pass backend=, register a Coordination component, or run "
-                f"the call under the app context (for FastAPI add "
-                f"GrelmicroMiddleware)."
+                f"the call inside `async with micro:` or after "
+                f"`micro.install(app)`."
             )
             raise OutOfContextError(msg) from None
         return coordination.schedule_backend

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
     - architecture/plugins.md
     - architecture/multiple-apps.md
     - architecture/decorators.md
+    - architecture/api-conventions.md
     - architecture/sync-from-thread.md
     - architecture/coordination.md
     - architecture/graceful-shutdown.md

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -460,6 +460,9 @@
     "RetryStrategy": {
       "()": "(*args, **kwargs)"
     },
+    "SQLiteCircuitBreakerAdapter": {
+      "()": "(*, provider=..., env_prefix=..., prefix=..., table_name=..., auto_migrate=...)"
+    },
     "SQLiteRateLimiterAdapter": {
       "()": "(*, provider=..., env_prefix=..., prefix=..., table_name=..., auto_migrate=...)"
     },

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import asyncio
 import logging
 from time import monotonic
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 from grelmicro import Grelmicro
 from grelmicro._config import reconfigurable_instances, reconfigure_all
@@ -244,6 +248,44 @@ class TestSingleFlight:
 class TestFingerprint:
     """Test payload fingerprint match and conflict."""
 
+    async def test_fingerprint_write_failure_stores_no_response(
+        self,
+    ) -> None:
+        """A failed fingerprint write must not leave a replayable response."""
+
+        class FailingFingerprintBackend(MemoryCacheAdapter):
+            fail_fingerprint_writes = True
+
+            async def set(
+                self,
+                *,
+                key: str,
+                value: bytes,
+                ttl: float,
+                tags: Sequence[str] = (),
+            ) -> None:
+                if self.fail_fingerprint_writes and key.endswith("\x1ffp"):
+                    msg = "fingerprint write failed before storage"
+                    raise RuntimeError(msg)
+                await super().set(key=key, value=value, ttl=ttl, tags=tags)
+
+        backend = FailingFingerprintBackend()
+        cache = TTLCache(ttl=3600, backend=backend, serializer=JsonSerializer())
+        idem = Idempotency("charge", ttl=3600, cache=cache)
+
+        with pytest.raises(RuntimeError, match="fingerprint write failed"):
+            async with idem("key-1", fingerprint="abc") as op:
+                op.store({"status": "old"})
+
+        backend.fail_fingerprint_writes = False
+        async with idem("key-1", fingerprint="xyz") as op:
+            assert op.replayed is False
+            op.store({"status": "fresh"})
+
+        async with idem("key-1", fingerprint="xyz") as op:
+            assert op.replayed is True
+            assert op.response == {"status": "fresh"}
+
     async def test_fingerprint_match_replays(self, cache: TTLCache) -> None:
         """A replay with the same fingerprint returns the stored response."""
         idem = Idempotency("charge", ttl=3600, cache=cache)
@@ -451,7 +493,7 @@ class TestBackendResolution:
         """No explicit cache and no active app raises out of context."""
         idem = Idempotency("charge", ttl=3600)
 
-        with pytest.raises(OutOfContextError, match="GrelmicroMiddleware"):
+        with pytest.raises(OutOfContextError, match=r"micro\.install"):
             async with idem("key-1"):
                 pass
 
@@ -561,7 +603,7 @@ class TestCoverageGaps:
         micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
         idem = Idempotency("charge", ttl=3600, cache=idem_cache)
 
-        # Patch _replay to raise on the third call (first two return _SENTINEL;
+        # Patch _replay to raise on the third call. First two return _SENTINEL,
         # the third happens after the distributed lock is acquired).
         # Three calls: before try, inside try before distributed lock, after lock.
         _RAISE_AFTER = 3  # noqa: N806
@@ -581,7 +623,7 @@ class TestCoverageGaps:
         async with micro:
             with pytest.raises(RuntimeError, match="cache error after lock"):
                 async with idem("key-err"):
-                    pass  # never reached; enter raises
+                    pass  # never reached because enter raises
 
     async def test_reconfigure_all_type_error_is_logged_not_raised(
         self, cache: TTLCache, caplog: pytest.LogCaptureFixture

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -221,7 +221,7 @@ def test_circuit_raises_out_of_context_on_ambient_miss_with_active_component() -
     # `Context.run` executes `resolve` in a context where `_current_micro`
     # is unset, so `Grelmicro.current()` raises and the ambient-miss guard
     # fires even though the autouse app is active in the process.
-    with pytest.raises(OutOfContextError, match="add GrelmicroMiddleware"):
+    with pytest.raises(OutOfContextError, match=r"micro\.install"):
         contextvars.Context().run(resolve)
 
 

--- a/tests/resilience/test_errors.py
+++ b/tests/resilience/test_errors.py
@@ -103,6 +103,7 @@ def test_resilience_module_exports() -> None:
         "RetryBackoffConfig",
         "RetryConfig",
         "RetryStrategy",
+        "SQLiteCircuitBreakerAdapter",
         "SQLiteRateLimiterAdapter",
         "Shield",
         "ShieldConfig",

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -376,7 +376,7 @@ async def test_acquire_raises_out_of_context_when_component_active() -> None:
             # visible here, mimicking a FastAPI handler.
             _ = rl.backend
 
-        with pytest.raises(OutOfContextError, match="add GrelmicroMiddleware"):
+        with pytest.raises(OutOfContextError, match=r"micro\.install"):
             contextvars.Context().run(resolve)
 
 

--- a/tests/test_faststream.py
+++ b/tests/test_faststream.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 import pytest
 
@@ -30,6 +30,22 @@ if TYPE_CHECKING:
     from grelmicro.trace._autoinstrument import InstrumentDirective
 
 pytestmark = [pytest.mark.timeout(5)]
+
+
+class _RecordingComponent:
+    kind = "rec"
+    name = "default"
+
+    def __init__(self) -> None:
+        self.entered = 0
+        self.exited = 0
+
+    async def __aenter__(self) -> Self:
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        self.exited += 1
 
 
 @asynccontextmanager
@@ -174,6 +190,49 @@ async def test_install_ambient_false_still_opens_lifecycle() -> None:
         await broker.request("ping", "limited")
 
     assert opened == [True]
+
+
+async def test_install_closes_micro_when_later_startup_hook_fails() -> None:
+    """A later startup failure rolls back an opened micro app."""
+    component = _RecordingComponent()
+    broker = RedisBroker()
+    app = FastStream(broker)
+    micro = Grelmicro(uses=[component])
+    micro.install(app)
+
+    @app.on_startup
+    async def fail_after_micro_open() -> None:
+        msg = "later startup failed"
+        raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="later startup failed"):
+        await app.start()
+
+    assert component.entered == 1
+    assert component.exited == 1
+
+
+async def test_install_leaves_micro_closed_when_startup_fails_before_open() -> (
+    None
+):
+    """A startup failure before micro opens leaves nothing to roll back."""
+    component = _RecordingComponent()
+    broker = RedisBroker()
+    app = FastStream(broker)
+    micro = Grelmicro(uses=[component])
+
+    @app.on_startup
+    async def fail_before_micro_open() -> None:
+        msg = "early startup failed"
+        raise RuntimeError(msg)
+
+    micro.install(app)
+
+    with pytest.raises(RuntimeError, match="early startup failed"):
+        await app.start()
+
+    assert component.entered == 0
+    assert component.exited == 0
 
 
 def test_install_ambient_false_strict_raises() -> None:

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -76,7 +76,7 @@ class _RaisingComponent(_RecordingComponent):
 class _RecordingLockAdapter:
     """A `LockBackend` that borrows a provider it does not own.
 
-    Only the lifecycle hooks run in these tests; the lock methods are
+    Only the lifecycle hooks run in these tests. The lock methods are
     stubs present to satisfy the `LockBackend` protocol.
     """
 
@@ -113,7 +113,7 @@ class _RecordingLockAdapter:
 class _RecordingElectionAdapter:
     """A `LeaderElectionBackend` that borrows a provider it does not own.
 
-    Only the lifecycle hooks run in these tests; the election methods are
+    Only the lifecycle hooks run in these tests. The election methods are
     stubs present to satisfy the `LeaderElectionBackend` protocol.
     """
 
@@ -444,7 +444,7 @@ class _RecordingContext:
 
 
 def test_use_plain_context_manager_returns_none() -> None:
-    """`.use()` on a plain async context manager returns None; caller keeps the reference."""
+    """`.use()` on a plain async context manager returns None. Caller keeps the reference."""
     micro = Grelmicro()
     item = _RecordingContext(log=[], label="x")
     assert micro.use(item) is None
@@ -515,7 +515,7 @@ def test_runtime_type_hints_resolve_without_loading_submodules() -> None:
 
     hints = get_type_hints(Grelmicro)
     # Property names show up via class-level resolution under
-    # `from __future__ import annotations`; the call must not raise.
+    # `from __future__ import annotations` is active. The call must not raise.
     assert isinstance(hints, dict)
 
 
@@ -802,12 +802,53 @@ class _GlobalComponent(_RecordingComponent):
     kind: ClassVar[str] = "log"
 
 
+class _BlockingGlobalComponent(_GlobalComponent):
+    """Global component that pauses startup after the app slot is reserved."""
+
+    def __init__(
+        self, *, entered: asyncio.Event, release: asyncio.Event
+    ) -> None:
+        super().__init__()
+        self._entered = entered
+        self._release = release
+
+    async def __aenter__(self) -> Self:
+        self._entered.set()
+        await self._release.wait()
+        return await super().__aenter__()
+
+
 async def test_second_global_app_is_blocked() -> None:
     """A second app owning global state, while one is active, is blocked."""
     async with Grelmicro(uses=[_GlobalComponent()]):
         with pytest.raises(MultipleActiveAppsError):
             async with Grelmicro(uses=[_GlobalComponent()]):
                 pass
+
+
+async def test_concurrent_global_app_startup_is_blocked() -> None:
+    """A global-state app is reserved before startup reaches its first await."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    started = asyncio.Event()
+    stop = asyncio.Event()
+    micro = Grelmicro(
+        uses=[_BlockingGlobalComponent(entered=entered, release=release)]
+    )
+
+    async def run_micro() -> None:
+        async with micro:
+            started.set()
+            await stop.wait()
+
+    task = asyncio.create_task(run_micro())
+    await entered.wait()
+    with pytest.raises(MultipleActiveAppsError):
+        await Grelmicro(uses=[_GlobalComponent()]).__aenter__()
+    release.set()
+    await started.wait()
+    stop.set()
+    await task
 
 
 async def test_apps_without_global_state_overlap_freely() -> None:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -153,3 +153,40 @@ def test_every_exported_symbol_resolves(module_name: str) -> None:
         assert getattr(module, name, None) is not None, (
             f"{module_name}.{name} is listed in __all__ but does not resolve"
         )
+
+
+# Adapter families that must stay symmetric on the top-level package. Each
+# tuple is ``(package, base_name, [backend, ...])``. Every backend the package
+# ships must export a ``{Backend}{base_name}`` symbol from ``__all__``, so a
+# documented adapter can never silently drop off the public surface (as the
+# SQLite circuit breaker adapter once did).
+_ADAPTER_FAMILIES = [
+    (
+        "grelmicro.resilience",
+        "CircuitBreakerAdapter",
+        ["Memory", "Redis", "Postgres", "SQLite"],
+    ),
+    (
+        "grelmicro.resilience",
+        "RateLimiterAdapter",
+        ["Memory", "Redis", "Postgres", "SQLite"],
+    ),
+]
+
+
+@pytest.mark.parametrize(("package", "base", "backends"), _ADAPTER_FAMILIES)
+def test_adapter_family_export_parity(
+    package: str, base: str, backends: list[str]
+) -> None:
+    """Every backend in an adapter family is exported from the package."""
+    module = importlib.import_module(package)
+    exported = set(module.__all__)
+    for backend in backends:
+        symbol = f"{backend}{base}"
+        assert symbol in exported, (
+            f"{package} exports other {base} backends but is missing "
+            f"{symbol}. Add it to __all__ and the lazy import map."
+        )
+        assert getattr(module, symbol, None) is not None, (
+            f"{package}.{symbol} is listed in __all__ but does not resolve"
+        )

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -41,6 +41,9 @@ _ENV = {
     "resilience/timeout_environmental.py": {
         "GREL_TIMEOUT_DB_SECONDS": "2.0",
     },
+    "coordination/postgres.py": {
+        "POSTGRES_URL": "postgresql://user:password@localhost:5432/db",
+    },
 }
 
 _ALL = sorted(


### PR DESCRIPTION
Closes the aggregated audit backlog. All 17 findings addressed, full validation baseline green (3471 tests, ruff, ty, strict docs build).

## Fixed
- **Idempotency atomic storage**: write the fingerprint guard before the response (`ttl + 1`), so a failed guard write never leaves a replayable response.
- **Active-app lifecycle lock**: guard the process-global registry so two apps starting concurrently cannot both enter and clobber `Log`/`Trace`/`Metrics` state. The second raises `MultipleActiveAppsError`.
- **FastStream startup rollback**: close an opened `micro` when a later startup hook fails, so a failed startup no longer leaves the app open and registered.
- **SQLite circuit breaker export**: `from grelmicro.resilience import SQLiteCircuitBreakerAdapter` now works, matching the other adapters.

## Security
- Make the `TaskLock` token nonce unpredictable (process-local counter joined with random bytes), hardening same-process untrusted-plugin scenarios.

## Docs and API ergonomics
- Point every ambient-miss `OutOfContextError` at `micro.install(app)`; switch README and first-steps to the one-call form.
- Add a first-use mental model, an operator defaults reference, an API conventions page, an adapter import policy, and decision tables for rate limiter methods and task entry points.
- Warn that `/healthz` always returns each check's `error` string, and that cache keys and tags from untrusted input must stay bounded.

## Tests
- Partial-persistence idempotency regression, concurrent global-app startup guard, FastStream failed-startup rollback (both before and after micro opens), and an adapter-family export-parity guard.