### PR TITLE
🔖 Prepare the 0.28.2 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.28.2 - 2026-07-05
 
 ### Fixed
 


### PR DESCRIPTION
Rename the changelog Unreleased section to 0.28.2 ahead of the release. All changes shipped in #494.