### PR TITLE
🔖 Prepare the 0.29.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.29.0 - 2026-07-18
 
 ### Features
 


### PR DESCRIPTION
Flip the changelog Unreleased heading to 0.29.0 for the transactional outbox feature release.