### PR TITLE
✅ Raise the outbox Postgres integration test timeout

### DIFF
--- a/tests/outbox/test_postgres.py
+++ b/tests/outbox/test_postgres.py
@@ -26,7 +26,7 @@ from grelmicro.providers.postgres import PostgresProvider
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-pytestmark = [pytest.mark.timeout(5)]
+pytestmark = [pytest.mark.timeout(60)]
 
 URL = "postgresql://test_user:test_password@test_host:1234/test_db"
 


### PR DESCRIPTION
The outbox Postgres integration tests spin up a real container, which can take longer than the module's 5s timeout on a cold CI runner (as seen on the 0.29.0 release full tier for Python 3.14). Raise the module timeout to 60s, matching the other integration test modules.