### PR TITLE
✨ Read the Postgres database name from `POSTGRES_DATABASE` too

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.29.3 - 2026-07-18
+
+### Features
+
+* ✨ Read the Postgres database name from `POSTGRES_DATABASE` too, not only `POSTGRES_DB`, so the longer spelling works from the environment. `DB` still wins when both are set. ([#518](https://github.com/grelinfo/grelmicro/issues/518))
+
 ## 0.29.2 - 2026-07-18
 
 ### Features

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -321,7 +321,10 @@ micro = Grelmicro(uses=[
 ```
 
 Set `POSTGRES_URL` (or `POSTGRES_HOST` + `POSTGRES_PORT` + `POSTGRES_DB`
-+ `POSTGRES_USER` + `POSTGRES_PASSWORD`) for env-driven construction.
++ `POSTGRES_USER` + `POSTGRES_PASSWORD`) for env-driven construction. The
+database name also reads from `POSTGRES_DATABASE` when `POSTGRES_DB` is
+unset, so both the `postgres` Docker image convention and the longer
+spelling work.
 
 Pass `command_timeout` (or set `POSTGRES_COMMAND_TIMEOUT`) to bound every operation. A query that hangs on a frozen or unreachable server then raises `TimeoutError` after that many seconds, instead of blocking until the OS TCP timeout. It defaults to `None` (no timeout).
 

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -52,9 +52,9 @@ class PostgresConfig(BaseModel):
 class _PostgresEnvSettings(BaseSettings):
     """Read Postgres settings from the environment (env_prefix-driven).
 
-    The `db` field maps to `{env_prefix}DB`, matching the Postgres
-    convention (the `postgres` Docker image, libpq, ...). It is
-    surfaced as `database` everywhere else in the public API.
+    The database name reads from `{env_prefix}DB` (the `postgres` Docker
+    image and libpq convention) or `{env_prefix}DATABASE` (the field name
+    used elsewhere in the public API). `DB` wins when both are set.
     """
 
     model_config = SettingsConfigDict(extra="ignore")
@@ -63,6 +63,7 @@ class _PostgresEnvSettings(BaseSettings):
     host: str | None = None
     port: int = 5432
     db: str | None = None
+    database: str | None = None
     user: str | None = None
     password: str | None = None
 
@@ -479,7 +480,7 @@ def _resolve_url(
         return _compose_url(
             host=settings.host,
             port=settings.port,
-            database=settings.db,
+            database=settings.db or settings.database,
             user=settings.user,
             password=settings.password,
         )

--- a/tests/providers/test_postgres_provider.py
+++ b/tests/providers/test_postgres_provider.py
@@ -136,6 +136,35 @@ class TestConstruction:
         assert provider.url == expected_url
 
     @pytest.mark.parametrize(
+        ("environs", "expected_db"),
+        [
+            ({"POSTGRES_DB": "from_db"}, "from_db"),
+            ({"POSTGRES_DATABASE": "from_database"}, "from_database"),
+            ({"POSTGRES_DB": "wins", "POSTGRES_DATABASE": "loses"}, "wins"),
+        ],
+    )
+    def test_env_database_name_aliases(
+        self,
+        environs: dict[str, str],
+        expected_db: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The database name reads from `POSTGRES_DB` or `POSTGRES_DATABASE`.
+
+        `DB` matches the `postgres` Docker image convention and wins when
+        both are set.
+        """
+        monkeypatch.delenv("POSTGRES_DB", raising=False)
+        monkeypatch.delenv("POSTGRES_DATABASE", raising=False)
+        monkeypatch.setenv("POSTGRES_HOST", "test_host")
+        for key, value in environs.items():
+            monkeypatch.setenv(key, value)
+
+        provider = PostgresProvider()
+
+        assert str(provider.url).endswith(f"/{expected_db}")
+
+    @pytest.mark.parametrize(
         "environs",
         [
             {},


### PR DESCRIPTION
## Summary

Closes #518. `PostgresProvider` now reads the database name from **`POSTGRES_DATABASE`** in addition to **`POSTGRES_DB`**, so both the `postgres` Docker image convention and the longer spelling work from the environment with no explicit `url=`. `POSTGRES_DB` still wins when both are set.

Adds a `database` field to the internal env-settings model (prefix-respecting) and prefers `db or database` when composing the URL. Applies to any `env_prefix`, so `{PREFIX}DB` and `{PREFIX}DATABASE` both resolve.

## Tests

Parametrized coverage for `POSTGRES_DB` only, `POSTGRES_DATABASE` only, and both-set precedence. Provider suite green, 100% coverage.