### PR TITLE
🔖 Prepare the 0.29.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ______________________________________________________________________
 
 ## Why grelmicro
 
-grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, and fully tested.
+grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, the transactional outbox, logging, health checks, and task scheduling. Async-first, type-safe, and fully tested.
 
 It is built for any Python application that coordinates work across processes, workers, or replicas. The same primitives serve microservices, a modular monolith, or a self-contained system, and fit naturally into containerized and Kubernetes deployments.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.29.4 - 2026-07-18
+
+### Internal
+
+* ⬆️ Bump the Python dependency group (including `redis` 8.0.1, `pytest`, `ruff`, and `ty` 0.0.58), the GitHub Actions, and the pre-commit hooks. ([#514](https://github.com/grelinfo/grelmicro/pull/514), [#510](https://github.com/grelinfo/grelmicro/pull/510), [#488](https://github.com/grelinfo/grelmicro/pull/488))
+* 🚨 Adapt to `ty` 0.0.58: type the `Component` protocol's `name` as a read-only property and trim stale `ty: ignore` directives.
+
 ## 0.29.3 - 2026-07-18
 
 ### Features

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@
 * ⬆️ Bump the Python dependency group (including `redis` 8.0.1, `pytest`, `ruff`, and `ty` 0.0.58), the GitHub Actions, and the pre-commit hooks. ([#514](https://github.com/grelinfo/grelmicro/pull/514), [#510](https://github.com/grelinfo/grelmicro/pull/510), [#488](https://github.com/grelinfo/grelmicro/pull/488))
 * 🚨 Adapt to `ty` 0.0.58: type the `Component` protocol's `name` as a read-only property and trim stale `ty: ignore` directives.
 
+### Docs
+
+* 📝 List the transactional outbox among the modules in the README intro.
+
 ## 0.29.3 - 2026-07-18
 
 ### Features

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ ______________________________________________________________________
 
 ## Why grelmicro
 
-grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, logging, health checks, and task scheduling. Async-first, type-safe, and fully tested.
+grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, the transactional outbox, logging, health checks, and task scheduling. Async-first, type-safe, and fully tested.
 
 It is built for any Python application that coordinates work across processes, workers, or replicas. The same primitives serve microservices, a modular monolith, or a self-contained system, and fit naturally into containerized and Kubernetes deployments.
 


### PR DESCRIPTION
## Summary

Cuts **0.29.4** with the merged dependency bumps, plus a small docs fix.

- **Internal:** bump the Python dependency group (`redis` 8.0.1, `pytest`, `ruff`, `ty` 0.0.58, ...), GitHub Actions, and pre-commit hooks (#514, #510, #488). Adapts to `ty` 0.0.58 (Component protocol `name` as read-only property; trimmed stale `ty: ignore`).
- **Docs:** the "Why grelmicro" intro sampler was missing the transactional outbox — added it (README + regenerated `index.md`).

No API changes. Changelog under `## 0.29.4`.