### PR TITLE
✅ Treat warnings as errors in the test suite

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+* ✅ Treat warnings as errors in the test suite and close the FastAPI health test client cleanly. ([#526](https://github.com/grelinfo/grelmicro/pull/526))
+
 ## 0.29.5 - 2026-07-18
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -350,8 +350,19 @@ markers = """
     stress: mark a test as a stress or endurance test (heavy load, opt-in via -m stress)
 """
 filterwarnings = [
-    # testcontainers' own deprecation banner, not driven by our code.
+    "error",
+    # Starlette's TestClient warns that httpx v1 is deprecated in favour of
+    # httpx2. Import-time and third-party, not driven by our code.
+    "ignore:Using .httpx. with .starlette.testclient. is deprecated:Warning",
+    # testcontainers' own deprecation banners, not driven by our code.
     "ignore:The @wait_container_is_ready decorator is deprecated:DeprecationWarning:testcontainers",
+    "ignore:The wait_for_logs function with string or callable predicates is deprecated:DeprecationWarning",
+    # Sockets and event loops from TestClient and `asyncio.run` are torn down at
+    # garbage-collection time, so the interpreter reports them non-deterministically
+    # after the owning test ends. This is test-harness noise: grelmicro creates no
+    # event loops of its own and drives every backend through async context managers.
+    "ignore::ResourceWarning",
+    "ignore::pytest.PytestUnraisableExceptionWarning",
 ]
 
 testpaths = "tests"

--- a/tests/test_health_router.py
+++ b/tests/test_health_router.py
@@ -2,6 +2,7 @@
 
 import importlib
 import sys
+from collections.abc import Iterator
 from unittest.mock import patch
 
 import pytest
@@ -38,9 +39,10 @@ def app(registry: HealthChecks) -> FastAPI:
 
 
 @pytest.fixture
-def client(app: FastAPI) -> TestClient:
+def client(app: FastAPI) -> Iterator[TestClient]:
     """Test client for the FastAPI app."""
-    return TestClient(app)
+    with TestClient(app) as client:
+        yield client
 
 
 # ---------- /livez ----------


### PR DESCRIPTION
Enables `filterwarnings = ["error", ...]` so the test suite fails on any warning, satisfying the OpenSSF Best Practices `warnings_strict` criterion. This complements the existing strict linting (`ruff` with `select = ["ALL"]`), type checking (`ty`), and `mkdocs build --strict`.

## What was warning

All surfaced warnings were third-party or test-harness noise, not grelmicro runtime issues:

- **Starlette `TestClient`** warns at import that `httpx` v1 is deprecated in favour of `httpx2`. Third-party, ignored by message.
- **testcontainers** deprecation banners (`@wait_container_is_ready`, `wait_for_logs`). Third-party, ignored by message.
- **`ResourceWarning`** for sockets and event loops from `TestClient` and `asyncio.run`, surfaced non-deterministically at garbage-collection time. grelmicro creates no event loops of its own and drives every backend through async context managers, so these are harness artifacts. Ignored with an explanatory comment to avoid flaky CI.

Also makes the health-router `client` fixture context-managed so it closes its transport and portal cleanly.

## Verification

- Unit suite passes deterministically with warnings as errors (two runs, 3370 passed).
- Full pre-commit gate passes: unit, integration, 100% coverage, and `mkdocs build --strict`.