### PR TITLE
⬆️ Use httpx2 in the test suite

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Internal
 
 * ✅ Treat warnings as errors in the test suite and close the FastAPI health test client cleanly. ([#526](https://github.com/grelinfo/grelmicro/pull/526))
+* ⬆️ Adopt `httpx2` in the test suite so Starlette's `TestClient` stops warning about httpx v1. ([#527](https://github.com/grelinfo/grelmicro/pull/527))
 
 ## 0.29.5 - 2026-07-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ dev = [
     "pre-commit>=4.0.1",
     "fastapi>=0.115.5",
     "fastapi-cli>=0.0.5",
+    "httpx2>=2.7.0",
     "faststream>=0.7.0",
     "freezegun>=1.5.2",
     "ty>=0.0.13",
@@ -351,9 +352,6 @@ markers = """
 """
 filterwarnings = [
     "error",
-    # Starlette's TestClient warns that httpx v1 is deprecated in favour of
-    # httpx2. Import-time and third-party, not driven by our code.
-    "ignore:Using .httpx. with .starlette.testclient. is deprecated:Warning",
     # testcontainers' own deprecation banners, not driven by our code.
     "ignore:The @wait_container_is_ready decorator is deprecated:DeprecationWarning:testcontainers",
     "ignore:The wait_for_logs function with string or callable predicates is deprecated:DeprecationWarning",

--- a/tests/test_asgi_frameworks.py
+++ b/tests/test_asgi_frameworks.py
@@ -6,7 +6,7 @@ import json
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
-import httpx
+import httpx2
 import pytest
 from litestar import Litestar, get
 from litestar.middleware import DefineMiddleware
@@ -71,8 +71,8 @@ async def test_starlette_middleware_binds_app_inside_request_handler() -> None:
     """A Starlette handler resolves the ambient backend when the middleware is present."""
     app, micro = _build_starlette_app(with_middleware=True)
     async with micro:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
             transport=transport, base_url="http://testserver"
         ) as client:
             response = await client.get("/limited")
@@ -85,8 +85,8 @@ async def test_starlette_without_middleware_handler_misses_ambient_backend() -> 
 ):
     """Without the middleware, the Starlette handler hits the ambient-miss guard."""
     app, _micro = _build_starlette_app(with_middleware=False)
-    transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(
+    transport = httpx2.ASGITransport(app=app)
+    async with httpx2.AsyncClient(
         transport=transport, base_url="http://testserver"
     ) as client:
         with pytest.raises(OutOfContextError):

--- a/uv.lock
+++ b/uv.lock
@@ -605,6 +605,7 @@ dev = [
     { name = "fastapi-cli" },
     { name = "faststream" },
     { name = "freezegun" },
+    { name = "httpx2" },
     { name = "hypothesis" },
     { name = "lightkube" },
     { name = "litestar" },
@@ -688,6 +689,7 @@ dev = [
     { name = "fastapi-cli", specifier = ">=0.0.5" },
     { name = "faststream", specifier = ">=0.7.0" },
     { name = "freezegun", specifier = ">=1.5.2" },
+    { name = "httpx2", specifier = ">=2.7.0" },
     { name = "hypothesis", specifier = ">=6.100.0" },
     { name = "lightkube", specifier = ">=0.15.0" },
     { name = "litestar", specifier = ">=2.24.0" },
@@ -840,6 +842,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/fe/6a3f9f1a8bb8733326140737446aaf72fddb8b54b8f202302f5c84960613/httpcore2-2.7.0.tar.gz", hash = "sha256:6dc0fedf329a52a990930a5579edfebaea81118ea700ea0dd7de2b5e5be49efc", size = 65593, upload-time = "2026-07-14T20:40:01.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/6c/62e2e279e63fc4f7a5ee841ef13175a8bbc613f258e9dcc186e9de803a42/httpcore2-2.7.0-py3-none-any.whl", hash = "sha256:1452f589fe23f55b44546cd884294c41a29330af902bc0b71a761fd52d18f92b", size = 81506, upload-time = "2026-07-14T20:39:58.053Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -908,6 +923,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/f8/a6bc80313a9e93c888fa10534dfce2ad76ff86911b6f485777ce6de6a073/httpx_ws-0.9.0-py3-none-any.whl", hash = "sha256:71640d2fb1bf9a225775015b33cd755cfd4c5f7e21c885192fe3adc4c387b248", size = 15759, upload-time = "2026-03-28T14:11:11.887Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4a/129b2e21b90ac2985d3928d96792bccc39bc6dfe796c5eee2d8ec06d4105/httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07", size = 94487, upload-time = "2026-07-14T20:40:02.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/b8/c341bba6411bdfda786020343c47a75ef472f6085caf82391b142b1a3ad9/httpx2-2.7.0-py3-none-any.whl", hash = "sha256:ed2a2719c696789e09493bd8e2bec3d8bd925cc6e26b68389ec25ade132f7bf4", size = 90234, upload-time = "2026-07-14T20:39:59.531Z" },
 ]
 
 [[package]]
@@ -2602,6 +2633,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/7a/c519db0aba5024f86e71e9631810bfdd6866ed2c8695bd7fa34b90e7ef59/textual-8.2.7.tar.gz", hash = "sha256:658f568ff81e30ed43890c3e07520390e5cf1b4763822006e060656b0a88f105", size = 1859249, upload-time = "2026-05-19T10:52:49.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/f5/c1e18bc0707300a0e90204343abbf7d7acd6fb7ebe03a6d4893b99a234b8/textual-8.2.7-py3-none-any.whl", hash = "sha256:4caaa13a90bc4cf9c6c862c067ccd34fe84e9c161710a2a907a8026313b6bd73", size = 731129, upload-time = "2026-05-19T10:52:51.773Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts [httpx2](https://github.com/pydantic/httpx2) (the httpx 2.x line, now maintained under the Pydantic org) in the test suite. Starlette's `TestClient` prefers httpx2 and warns when it falls back to httpx v1, so installing httpx2 makes `TestClient` use it and removes the deprecation.

This is a **test/dev-only** change. grelmicro does not depend on httpx at runtime (the `httpx.HTTPError` references in the resilience docs are examples), so there is no impact on the public API or on users.

## Changes

- Add `httpx2` to the dev dependency group.
- Port `tests/test_asgi_frameworks.py` from `httpx` to `httpx2` (`ASGITransport`, `AsyncClient` are API-compatible for this usage).
- Drop the now-unneeded `filterwarnings` ignore for the Starlette httpx-v1 deprecation, since it no longer fires.

Note: FastAPI, Starlette, and Litestar still require httpx v1 transitively, so it stays in the lock alongside httpx2 until they adopt httpx2 upstream.

## Verification

- Full pre-commit gate passes with warnings still treated as errors: unit, integration, 100% coverage, and `mkdocs build --strict`.
- Confirmed Starlette `TestClient` emits no deprecation warning with httpx2 installed.