### PR TITLE
🏷️ Preserve the decorated function's type through @health.check

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+* 🏷️ Preserve the decorated function's type through `@health.check`, so awaiting an async check directly type-checks without `# type: ignore`. ([#499](https://github.com/grelinfo/grelmicro/issues/499))
+
 ### Internal
 
 * ✅ Treat warnings as errors in the test suite and close the FastAPI health test client cleanly. ([#526](https://github.com/grelinfo/grelmicro/pull/526))

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -346,7 +346,7 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
         )
         self._entries = dict(sorted(self._entries.items()))
 
-    def check(
+    def check[FuncT: HealthCheckFunc](
         self,
         name: Annotated[str, Doc("Unique name identifying this check.")],
         *,
@@ -358,8 +358,12 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
             PositiveFloat | None,
             Doc("Per-check timeout override."),
         ] = None,
-    ) -> Callable[[HealthCheckFunc], HealthCheckFunc]:
+    ) -> Callable[[FuncT], FuncT]:
         """Decorate an async function to register it as a health check.
+
+        Registration is a side effect: the function is returned unchanged
+        with its original signature, so ``await``-ing it directly (for
+        example in a unit test) type-checks as usual.
 
         Example:
             >>> @registry.check("database")
@@ -367,7 +371,7 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
             ...     return None
         """
 
-        def decorator(func: HealthCheckFunc) -> HealthCheckFunc:
+        def decorator(func: FuncT) -> FuncT:
             self.add(name, func, critical=critical, timeout=timeout)
             return func
 

--- a/tests/typing/test_health_check_decorator.py
+++ b/tests/typing/test_health_check_decorator.py
@@ -1,0 +1,43 @@
+"""Static typing samples for the `@health.check` decorator.
+
+Runs as a pytest module so the imports execute, and is also picked up
+by `uv run ty check` so the `assert_type` calls validate that the
+decorator returns the function unchanged with its original signature.
+A regression that widens the wrapped callable back to the
+`SyncHealthCheckFunc | AsyncHealthCheckFunc` union fails ty (a direct
+`await` on an async check would report `invalid-await`) even when all
+runtime tests pass.
+"""
+
+from __future__ import annotations
+
+from typing import assert_type
+
+from grelmicro.health import HealthChecks
+from grelmicro.health._types import HealthDetails
+
+health = HealthChecks()
+
+
+@health.check("database")
+async def check_database() -> HealthDetails | None:
+    """Async sample check."""
+    return None
+
+
+@health.check("disk")
+def check_disk() -> HealthDetails | None:
+    """Sync sample check."""
+    return None
+
+
+async def test_async_check_stays_directly_awaitable() -> None:
+    """An async check keeps its coroutine return type through the decorator."""
+    result = await check_database()
+    assert_type(result, HealthDetails | None)
+
+
+def test_sync_check_stays_a_plain_callable() -> None:
+    """A sync check keeps its plain return type through the decorator."""
+    result = check_disk()
+    assert_type(result, HealthDetails | None)


### PR DESCRIPTION
Fixes #499.

## Problem

`@health.check("name")` was typed `Callable[[HealthCheckFunc], HealthCheckFunc]`. Because `HealthCheckFunc` is the `Sync | Async` union, decorating an `async def` widened its return type to include the non-awaitable sync variant. Awaiting your own check directly (a natural pattern in unit tests) then reported a false `invalid-await`, forcing a `# type: ignore` at every call site.

Reproduced with `ty` before the fix:

```
error[invalid-await]: `dict[...] | None | Awaitable[HealthDetails | None]` is not awaitable
  await check_database()
```

## Fix

Make `check` a PEP 695 generic bound to `HealthCheckFunc` (matching the codebase's existing generic style), so the decorator returns the function unchanged with its exact type. No runtime change: it already returned `func`; this is purely a typing fix.

## Regression guard

Added `tests/typing/test_health_check_decorator.py` following the existing `tests/typing/` pattern. It runs under both pytest and `ty check`, so a future re-widening fails CI. It `assert_type`s that async checks stay directly awaitable and sync checks stay plain callables.

## Verification

- Full `uv run ty check`: passes (including all docs snippets).
- `tests/typing` + `tests/health`: 96 passed.
- ruff lint + format: clean.