### PR TITLE
💥 Replace idempotency Operation.response with a typed result() method

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking
+
+* 💥 Replace the idempotency `Operation.response` attribute with an `Operation.result()` method typed as the stored type, so the replay branch returns it without a cast. It is valid only on a replay: calling it on a first execution raises the new `IdempotencyStateError`. ([#504](https://github.com/grelinfo/grelmicro/issues/504))
+
 ### Fixed
 
 * 🏷️ Preserve the decorated function's type through `@health.check`, so awaiting an async check directly type-checks without `# type: ignore`. ([#499](https://github.com/grelinfo/grelmicro/issues/499))

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -33,7 +33,7 @@ async def charge(
 ) -> dict:
     async with idem(key) as op:
         if op.replayed:
-            return op.response
+            return op.result()
         response = await do_charge(amount)
         op.store(response)
         return response
@@ -56,18 +56,18 @@ Responses serialize through the cache serializers. The default is `JsonSerialize
 
 ## The block form
 
-`idem(key)` opens an async context manager. The yielded operation carries `replayed`, `response`, and `store(...)`.
+`idem(key)` opens an async context manager. The yielded operation carries `replayed`, `result()`, and `store(...)`.
 
 ```python
 async with idem(key) as op:
     if op.replayed:
-        return op.response
+        return op.result()
     response = await do_work()
     op.store(response)
     return response
 ```
 
-On a first execution, `replayed` is `False`. Call `op.store(response)` to persist the response. On a replay, `replayed` is `True` and `op.response` carries the stored value.
+On a first execution, `replayed` is `False`. Call `op.store(response)` to persist the response. On a replay, `replayed` is `True` and `op.result()` returns the stored value, typed as the stored type so the replay branch returns it without a cast. Calling `op.result()` on a first execution raises `IdempotencyStateError`, so guard it with `if op.replayed:`.
 
 Exiting the block without calling `op.store(...)` on a first execution stores nothing. The operation opted out and a later call with the same key executes fresh.
 

--- a/docs/reference/idempotency.md
+++ b/docs/reference/idempotency.md
@@ -12,5 +12,6 @@
         - IdempotencyConfig
         - IdempotencyConflictError
         - IdempotencyError
+        - IdempotencyStateError
         - Operation
         - idempotent

--- a/grelmicro/idempotency/__init__.py
+++ b/grelmicro/idempotency/__init__.py
@@ -18,6 +18,7 @@ from grelmicro.idempotency.errors import (
     IdempotencyConflictError,
     IdempotencyError,
     IdempotencySettingsValidationError,
+    IdempotencyStateError,
 )
 
 __all__ = [
@@ -26,6 +27,7 @@ __all__ = [
     "IdempotencyConflictError",
     "IdempotencyError",
     "IdempotencySettingsValidationError",
+    "IdempotencyStateError",
     "Operation",
     "idempotent",
 ]

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -22,6 +22,7 @@ from grelmicro.idempotency.config import IdempotencyConfig
 from grelmicro.idempotency.errors import (
     IdempotencyConflictError,
     IdempotencySettingsValidationError,
+    IdempotencyStateError,
 )
 from grelmicro.metrics import _emit
 
@@ -43,7 +44,7 @@ _FINGERPRINT_SUFFIX = "\x1ffp"
 class Operation(Generic[T]):
     """Handle for a single idempotent operation, yielded by `Idempotency.__call__`.
 
-    On a replay, `replayed` is True and `response` carries the stored
+    On a replay, `replayed` is True and `result()` returns the stored
     value. On a first execution, `replayed` is False and the body runs
     the work and calls `store(response)` to persist it.
     """
@@ -60,10 +61,23 @@ class Operation(Generic[T]):
         """Whether the key was already stored and the response replayed."""
         return self._replayed
 
-    @property
-    def response(self) -> T | None:
-        """The stored response when `replayed` is True, else None."""
-        return self._response
+    def result(self) -> T:
+        """Return the stored response. Valid only on a replay.
+
+        On a replay (`replayed` is True) this returns the stored value,
+        so a replay branch can return it directly without a cast. On a
+        first execution (`replayed` is False) no response is stored yet,
+        so calling it raises `IdempotencyStateError`. Guard with
+        `if op.replayed:`.
+        """
+        if not self._replayed:
+            msg = (
+                "Operation.result() is only available on a replay "
+                "(replayed is True). On a first execution, run the work "
+                "and call store(response)."
+            )
+            raise IdempotencyStateError(msg)
+        return cast("T", self._response)
 
     def store(
         self,
@@ -463,7 +477,7 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
         """Open an idempotent block for `key`.
 
         Use as an async context manager. The yielded `Operation` carries
-        `replayed`, `response`, and `store(...)`.
+        `replayed`, `result()`, and `store(...)`.
         """
         return _Block(
             self,
@@ -510,7 +524,7 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
 
         async with self(key, fingerprint=fingerprint) as operation:
             if operation.replayed:
-                return cast("T", operation.response)
+                return operation.result()
             response = factory()
             if asyncio.iscoroutine(response):
                 response = await response

--- a/grelmicro/idempotency/errors.py
+++ b/grelmicro/idempotency/errors.py
@@ -13,6 +13,15 @@ class IdempotencySettingsValidationError(
     """Idempotency Settings Validation Error."""
 
 
+class IdempotencyStateError(IdempotencyError, RuntimeError):
+    """Raised when an `Operation` value is read in the wrong state.
+
+    `Operation.result()` returns the stored response and is valid only
+    on a replay. Calling it on a first execution, before a response is
+    stored, raises this error. Guard the call with `if op.replayed:`.
+    """
+
+
 class IdempotencyConflictError(IdempotencyError):
     """Raised when a key is replayed with a different payload fingerprint.
 

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -202,6 +202,7 @@
     "IdempotencySettingsValidationError": {
       "()": "(error)"
     },
+    "IdempotencyStateError": null,
     "Operation": {
       "()": "(*, replayed, response)"
     },

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -26,6 +26,7 @@ from grelmicro.idempotency import (
     IdempotencyConfig,
     IdempotencyConflictError,
     IdempotencySettingsValidationError,
+    IdempotencyStateError,
     idempotent,
 )
 
@@ -61,7 +62,10 @@ class TestFirstExecutionAndReplay:
 
         async with idem("key-1") as op:
             assert op.replayed is False
-            assert op.response is None
+            with pytest.raises(
+                IdempotencyStateError, match="only available on a replay"
+            ):
+                op.result()
             calls += 1
             op.store({"status": "ok"})
 
@@ -78,7 +82,7 @@ class TestFirstExecutionAndReplay:
 
         async with idem("key-1") as op:
             assert op.replayed is True
-            assert op.response == {"status": "ok"}
+            assert op.result() == {"status": "ok"}
 
         assert calls == 1
 
@@ -163,7 +167,7 @@ class TestFailure:
 
         async with idem("key-1") as op:
             assert op.replayed is True
-            assert op.response == {"n": 1}
+            assert op.result() == {"n": 1}
 
 
 # ---------------------------------------------------------------------------
@@ -185,8 +189,7 @@ class TestSingleFlight:
         async def run() -> dict:
             async with idem("key-1") as op:
                 if op.replayed:
-                    assert op.response is not None
-                    return op.response
+                    return op.result()
                 nonlocal calls
                 calls += 1
                 await barrier.wait()
@@ -220,8 +223,7 @@ class TestSingleFlight:
         async def run(idem: Idempotency) -> dict:
             async with idem("key-1") as op:
                 if op.replayed:
-                    assert op.response is not None
-                    return op.response
+                    return op.result()
                 nonlocal calls
                 calls += 1
                 await barrier.wait()
@@ -284,7 +286,7 @@ class TestFingerprint:
 
         async with idem("key-1", fingerprint="xyz") as op:
             assert op.replayed is True
-            assert op.response == {"status": "fresh"}
+            assert op.result() == {"status": "fresh"}
 
     async def test_fingerprint_match_replays(self, cache: TTLCache) -> None:
         """A replay with the same fingerprint returns the stored response."""
@@ -295,7 +297,7 @@ class TestFingerprint:
 
         async with idem("key-1", fingerprint="abc") as op:
             assert op.replayed is True
-            assert op.response == {"status": "ok"}
+            assert op.result() == {"status": "ok"}
 
     async def test_fingerprint_conflict_raises(self, cache: TTLCache) -> None:
         """A replay with a different fingerprint raises a conflict."""
@@ -590,7 +592,7 @@ class TestCoverageGaps:
 
         async with idem("key-1") as op:
             assert op.replayed is True
-            assert op.response == {"status": "ok"}
+            assert op.result() == {"status": "ok"}
 
     async def test_exception_inside_try_releases_locks(self) -> None:
         """An exception inside the try block releases both the in-process and distributed locks."""

--- a/tests/typing/test_idempotency_operation.py
+++ b/tests/typing/test_idempotency_operation.py
@@ -1,0 +1,28 @@
+"""Static typing samples for the idempotency `Operation` replay path.
+
+Runs as a pytest module so the imports execute, and is also picked up
+by `uv run ty check` so the `assert_type` call validates that
+`op.result()` reads as `T` (not `T | None`) on the replay path. A
+regression that widens it back to `T | None` fails ty (the replay
+branch would need a `cast`/`assert` again) even when all runtime tests
+pass.
+"""
+
+from __future__ import annotations
+
+from typing import assert_type
+
+from grelmicro.idempotency import Idempotency
+
+idem = Idempotency[dict]("charge", ttl=3600)
+
+
+async def charge(key: str, amount: int) -> dict:
+    """Replay branch returns `op.result()` directly, no cast."""
+    async with idem(key) as op:
+        if op.replayed:
+            assert_type(op.result(), dict)
+            return op.result()
+        response = {"amount": amount}
+        op.store(response)
+        return response


### PR DESCRIPTION
Fixes #504.

## Problem

Inside an idempotency block, `op.response` was typed `T | None`. On a replay it is guaranteed to carry the stored value, but the type checker cannot link `op.replayed is True` to `op.response is not None`, so every replay call site needed a `cast(...)` or `assert op.response is not None`.

Reproduced with `ty` before the fix (a typed `Idempotency[dict]` returning `op.response` from a `-> dict` handler):

```
error[invalid-return-type]: expected `dict`, found `dict | None`
```

## Fix

Replace the `Operation.response` attribute with an `Operation.result()` method typed `-> T`. On a replay it returns the stored value, so the replay branch returns it without a cast. It is valid only on a replay: calling it on a first execution raises the new `IdempotencyStateError` (subclasses both `IdempotencyError` and `RuntimeError`, matching the `OutOfContextError` / `WouldBlockError` pattern).

A method (not a property) matches the Python convention for a state-guarded stored value that errors when read in the wrong state, mirroring `asyncio.Future.result()` and `concurrent.futures.Future.result()`. The library's own `run()` drops its `cast("T", operation.response)`.

```python
async with idem(key) as op:
    if op.replayed:
        return op.result()   # -> T, no cast; raises IdempotencyStateError on a first run
    response = await do_work()
    op.store(response)
    return response
```

This is a clean cut (pre-1.0): `Operation.response` is removed, not deprecated.

## Regression guard

Added `tests/typing/test_idempotency_operation.py` (runs under pytest + `ty check`). It `assert_type`s that `op.result()` reads as `T` on the replay path, so a regression back to `T | None` fails CI. The existing tests drop their `assert op.response is not None` boilerplate, and the first-execution test asserts `op.result()` raises `IdempotencyStateError`.

## Verification

- Full `uv run ty check`: passes (including all docs snippets).
- `tests/idempotency` + `tests/typing`: 41 passed; full pre-commit suite (unit, integration, mkdocs strict) green.
- Public API snapshot regenerated for the new `IdempotencyStateError` export.