### PR TITLE
♻️ Use the standard library uuid.uuid7() on Python 3.14+

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 
 ### Internal
 
+* ♻️ Use the standard library `uuid.uuid7()` on Python 3.14+, so outbox ids stay monotonic within a millisecond. The vendored generator stays as the fallback for 3.12 and 3.13. ([#522](https://github.com/grelinfo/grelmicro/issues/522))
 * ✅ Treat warnings as errors in the test suite and close the FastAPI health test client cleanly. ([#526](https://github.com/grelinfo/grelmicro/pull/526))
 * ⬆️ Adopt `httpx2` in the test suite so Starlette's `TestClient` stops warning about httpx v1. ([#527](https://github.com/grelinfo/grelmicro/pull/527))
 

--- a/grelmicro/outbox/_uuid.py
+++ b/grelmicro/outbox/_uuid.py
@@ -1,21 +1,35 @@
-"""Time-ordered UUIDv7 generation (RFC 9562)."""
+"""Time-ordered UUIDv7 generation (RFC 9562).
+
+On Python 3.14+ this re-exports the standard library `uuid.uuid7`, which
+is monotonic within a process: a counter fills the sub-millisecond bits,
+so ids minted in the same millisecond still sort in creation order. On
+3.12 and 3.13 a vendored implementation fills those bits with random
+data, so ids from the same millisecond may sort out of order.
+"""
 
 from __future__ import annotations
 
-import os
-import time
-from uuid import UUID
+import sys
+
+if sys.version_info >= (3, 14):  # pragma: no cover
+    from uuid import uuid7
+else:
+    import os
+    import time
+    from uuid import UUID
+
+    def uuid7() -> UUID:
+        """Return a time-ordered UUIDv7.
+
+        The first 48 bits hold a Unix millisecond timestamp, so ids sort by
+        creation time. The remaining bits are random. Sorting or indexing by
+        the id therefore tracks insertion order and keeps B-tree writes local.
+        """
+        timestamp_ms = time.time_ns() // 1_000_000
+        value = bytearray(timestamp_ms.to_bytes(6, "big") + os.urandom(10))
+        value[6] = (value[6] & 0x0F) | 0x70
+        value[8] = (value[8] & 0x3F) | 0x80
+        return UUID(bytes=bytes(value))
 
 
-def uuid7() -> UUID:
-    """Return a time-ordered UUIDv7.
-
-    The first 48 bits hold a Unix millisecond timestamp, so ids sort by
-    creation time. The remaining bits are random. Sorting or indexing by
-    the id therefore tracks insertion order and keeps B-tree writes local.
-    """
-    timestamp_ms = time.time_ns() // 1_000_000
-    value = bytearray(timestamp_ms.to_bytes(6, "big") + os.urandom(10))
-    value[6] = (value[6] & 0x0F) | 0x70
-    value[8] = (value[8] & 0x3F) | 0x80
-    return UUID(bytes=bytes(value))
+__all__ = ["uuid7"]

--- a/tests/outbox/test_uuid.py
+++ b/tests/outbox/test_uuid.py
@@ -1,0 +1,32 @@
+"""Tests for the time-ordered UUIDv7 generator.
+
+These pin the RFC 9562 layout the outbox relies on: version 7, the RFC
+variant, and ids that sort by creation time across milliseconds. The same
+guarantees hold whether the id comes from the vendored generator (3.12,
+3.13) or the standard library `uuid.uuid7` (3.14+).
+"""
+
+from __future__ import annotations
+
+import time
+
+from grelmicro.outbox._uuid import uuid7
+
+UUID_VERSION_7 = 7
+RFC_VARIANT = 0b10
+
+
+def test_uuid7_layout() -> None:
+    """The id is a UUIDv7 with the RFC 9562 variant."""
+    value = uuid7()
+    assert value.version == UUID_VERSION_7
+    assert (value.int >> 62) & 0b11 == RFC_VARIANT
+
+
+def test_uuid7_sorts_by_creation_time() -> None:
+    """Ids minted in separate milliseconds sort in creation order."""
+    first = uuid7()
+    time.sleep(0.002)
+    second = uuid7()
+    assert first < second
+    assert str(first) < str(second)


### PR DESCRIPTION
Fixes #522.

## Change

The outbox mints time-ordered message ids with a small vendored UUIDv7 generator (`grelmicro/outbox/_uuid.py`). Python 3.14 added [`uuid.uuid7()`](https://docs.python.org/3.14/library/uuid.html#uuid.uuid7) (RFC 9562) to the standard library, and its implementation is **monotonic within a process**: a counter fills the sub-millisecond bits, so two ids minted in the same millisecond still sort in creation order.

On Python 3.14+ the module now re-exports the stdlib `uuid.uuid7`. On 3.12 and 3.13 it keeps the vendored generator as the fallback, whose sub-millisecond bits are random (so same-millisecond ids may sort out of order, unchanged from before).

```python
if sys.version_info >= (3, 14):  # pragma: no cover
    from uuid import uuid7
else:
    def uuid7() -> UUID: ...  # vendored fallback
```

Benefits: process-monotonic ordering tightens the `(available_at, id)` claim order under same-millisecond bursts on 3.14+, and there is less vendored code to carry. No API change: `uuid7()` keeps its signature and RFC 9562 layout. The vendored branch can be dropped entirely once the minimum supported Python reaches 3.14.

## Test

Added `tests/outbox/test_uuid.py` pinning the RFC 9562 layout (version 7, RFC variant) and cross-millisecond time-ordering. These guarantees hold on both the vendored and the stdlib path.

## Verification

- Full `uv run ty check`: passes (correctly handles the `sys.version_info` gate, no false import error on 3.12).
- `_uuid.py` coverage 100%, no partial branches (the 3.14 path carries `# pragma: no cover`).
- `tests/outbox`: 112 passed. Full pre-commit suite (unit, integration, mkdocs strict) green.