### PR TITLE
🔖 Prepare the 0.30.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.30.0 - 2026-07-18
 
 ### Breaking
 


### PR DESCRIPTION
Finalize the changelog for **0.30.0**.

This release bundles the recent typing/DX fixes and a maintenance change. It is a minor bump because it carries a breaking change (`Operation.response` removed).

### Breaking
- `Operation.response` → `Operation.result()` method, plus the new `IdempotencyStateError`. ([#504](https://github.com/grelinfo/grelmicro/issues/504))

### Fixed
- `@health.check` preserves the decorated function's awaitable type. ([#499](https://github.com/grelinfo/grelmicro/issues/499))

### Internal
- Delegate `uuid7()` to the standard library on Python 3.14+. ([#522](https://github.com/grelinfo/grelmicro/issues/522))
- Test-suite hardening. ([#526](https://github.com/grelinfo/grelmicro/pull/526), [#527](https://github.com/grelinfo/grelmicro/pull/527))

After merge, I will publish the GitHub Release with tag `0.30.0` to trigger the full-checks tier and the PyPI publish.