### PR TITLE
🔖 Prepare the 0.30.1 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.30.1 - 2026-07-18
+
+### Fixed
+
+* 🐛 Use `inspect.iscoroutinefunction` in `@cached`, so grelmicro runs clean on Python 3.14, where `asyncio.iscoroutinefunction` is deprecated. ([#532](https://github.com/grelinfo/grelmicro/pull/532))
+
 ## 0.30.0 - 2026-07-18
 
 ### Breaking

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -340,7 +340,7 @@ def cached(  # noqa: PLR0913, C901
     def decorator(
         func: Callable[P, R],
     ) -> Callable[P, R]:
-        is_async_func = asyncio.iscoroutinefunction(func)
+        is_async_func = inspect.iscoroutinefunction(func)
         if is_private_cache and not is_async_func:
             msg = (
                 "@cached(ttl=...) supports async functions only: the "

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -1,6 +1,7 @@
 """Test Cached Decorator."""
 
 import asyncio
+import inspect
 import threading
 import time
 from contextlib import suppress
@@ -246,7 +247,7 @@ class TestAsyncCachedCacheControl:
             return x
 
         # Assert
-        assert asyncio.iscoroutinefunction(fetch.cache_clear)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        assert inspect.iscoroutinefunction(fetch.cache_clear)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
     async def test_cache_clear_empties_the_cache(self) -> None:
         """Awaiting cache_clear() causes subsequent calls to recompute."""


### PR DESCRIPTION
Ship the Python 3.14 fix that blocked the 0.30.0 release.

## Why

0.30.0 bundled #526 (treat warnings as errors). On Python 3.14 that escalated a latent `DeprecationWarning` into a hard failure: `@cached` (and one test) called `asyncio.iscoroutinefunction`, deprecated in 3.14 and slated for removal in 3.16. The release full-checks tier (which runs 3.12/3.13/3.14) failed on 3.14, so `publish-pypi` was skipped and 0.30.0 never reached PyPI.

## Fix

- `grelmicro/cache/cached.py`: `asyncio.iscoroutinefunction` -> `inspect.iscoroutinefunction`, matching every other call site in the codebase.
- `tests/cache/test_cached.py`: same swap in one assertion.

## Verification

- Full unit tier on **Python 3.14** (`uv run --python 3.14`, warnings as errors, no `-x`): 3374 passed.
- Cache tests on 3.12: 440 passed. Full pre-commit suite green.

After merge, I will publish the GitHub Release tag `0.30.1`.