### PR TITLE
💥 Bring Metrics to Trace parity with an AUTO no-op exporter and basic_auth

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Breaking
+
+* 💥 Default `Metrics()` to the `auto` exporter. It exports over OTLP HTTP when an endpoint is configured and otherwise auto-disables into a true no-op, so an unconfigured `Metrics()` no longer falls back to `localhost:4318`. Register it unconditionally: an auto-disabled `Metrics` installs no provider and never conflicts with a second app. ([#508](https://github.com/grelinfo/grelmicro/issues/508))
+
+### Features
+
+* ✨ Add `basic_auth=(username, password)` to `Metrics`, matching `Trace`. grelmicro builds the `Authorization: Basic` header and attaches it to the OTLP exporter directly, bypassing the fragile `OTEL_EXPORTER_OTLP_HEADERS` encoding. From the environment, set `GREL_METRICS_BASIC_AUTH_USERNAME` and `GREL_METRICS_BASIC_AUTH_PASSWORD`. ([#507](https://github.com/grelinfo/grelmicro/issues/507))
+
 ## 0.30.1 - 2026-07-18
 
 ### Fixed

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -19,16 +19,30 @@ Pick an exporter with the `exporter` field or the `GREL_METRICS_EXPORTER` enviro
 
 | Exporter     | Use it for                                        |
 | ------------ | ------------------------------------------------- |
-| `otlp-http`  | Sending metrics to an OpenTelemetry collector (default). |
+| `auto`       | Exporting over OTLP HTTP when an endpoint is set, otherwise a no-op (default). |
+| `otlp-http`  | Sending metrics to an OpenTelemetry collector.    |
 | `otlp-grpc`  | The same, over gRPC.                              |
 | `prometheus` | Serving a `/metrics` endpoint that Prometheus scrapes. |
 | `console`    | Printing metrics to the console in development.   |
 | `none`       | Installing the provider without exporting.        |
 
-!!! warning "The default exporter expects a collector"
-    `Metrics()` defaults to `otlp-http`, which sends metrics to an OpenTelemetry collector over OTLP HTTP. Without a reachable collector, metrics are dropped. A bounded `shutdown_timeout` (default `5.0` seconds) caps the flush on exit, so a slow or unreachable collector cannot hang shutdown.
+!!! tip "Off until an endpoint is configured"
+    `Metrics()` defaults to `MetricsExporterType.AUTO`. It exports over OTLP HTTP when an endpoint is configured (the `endpoint` argument, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, or `OTEL_EXPORTER_OTLP_ENDPOINT`) and otherwise auto-disables into a true no-op: it installs no meter provider and leaves the global provider untouched. So you register `Metrics()` unconditionally and it stays silent in dev, test, and CI instead of falling back to `localhost:4318`, and it never conflicts with a second app. A bounded `shutdown_timeout` (default `5.0` seconds) caps the flush on exit, so a slow or unreachable collector cannot hang shutdown.
 
-    For local development, set `exporter="console"` to print metrics, or `exporter="prometheus"` to expose them on a `/metrics` route.
+    For local development, set `exporter="console"` to print metrics, or `exporter="prometheus"` to expose them on a `/metrics` route. An explicit `none` is different from the auto-disable above: it still installs the provider so custom instruments record, they are just not exported. Leave the exporter on `auto` for the unconditional no-op.
+
+!!! note "Basic auth in one line"
+    Backends like OpenObserve want an `Authorization: Basic` header. Pass `basic_auth=(username, password)` and `Metrics` builds and attaches it to the exporter:
+
+    ```python
+    Metrics(
+        service_name="orders",
+        endpoint="https://obs.example.com/api/default/v1/metrics",
+        basic_auth=("me@example.com", password),
+    )
+    ```
+
+    From the environment, set `GREL_METRICS_BASIC_AUTH_USERNAME` and `GREL_METRICS_BASIC_AUTH_PASSWORD` instead. The header is attached on the exporter directly, so it bypasses the `OTEL_EXPORTER_OTLP_HEADERS` encoding where base64 padding (`=`) can be mangled or dropped.
 
 `Metrics()` reads `GREL_METRICS_*` environment variables (see `MetricsConfig` for the full field set) or accepts the same fields as keyword arguments. The OTLP and Prometheus exporters require their own packages and are imported only when selected.
 

--- a/grelmicro/metrics/_component.py
+++ b/grelmicro/metrics/_component.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import threading
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
 
@@ -106,6 +107,19 @@ class Metrics:
         headers: Annotated[
             dict[str, str] | None, Doc("Exporter headers.")
         ] = None,
+        basic_auth: Annotated[
+            tuple[str, str] | None,
+            Doc(
+                """
+                HTTP Basic auth credentials as a `(username, password)`
+                pair. grelmicro builds the `Authorization: Basic` header and
+                attaches it to the OTLP exporter directly, so it never goes
+                through the fragile `OTEL_EXPORTER_OTLP_HEADERS` encoding.
+                From the environment, set `GREL_METRICS_BASIC_AUTH_USERNAME`
+                and `GREL_METRICS_BASIC_AUTH_PASSWORD` instead.
+                """
+            ),
+        ] = None,
         export_interval: Annotated[
             float | None, Doc("Seconds between periodic exports.")
         ] = None,
@@ -134,6 +148,9 @@ class Metrics:
         ] = None,
     ) -> None:
         """Initialize the component (defer provider build until `__aenter__`)."""
+        if basic_auth is not None and len(basic_auth) != 2:  # noqa: PLR2004
+            msg = "basic_auth must be a (username, password) tuple."
+            raise TypeError(msg)
         self._name = name
         self._explicit_config = config
         self._kwargs = {
@@ -141,6 +158,8 @@ class Metrics:
             "exporter": exporter,
             "endpoint": endpoint,
             "headers": headers,
+            "basic_auth_username": basic_auth[0] if basic_auth else None,
+            "basic_auth_password": basic_auth[1] if basic_auth else None,
             "export_interval": export_interval,
             "export_timeout": export_timeout,
             "resource_attributes": resource_attributes,
@@ -148,6 +167,7 @@ class Metrics:
         }
         self._env_load = env_load
         self._resolved: MetricsConfig | None = None
+        self._entered: bool = False
         self._provider: Any = None
         self._prior_provider: Any = None
         self._prometheus_registry: Any = None
@@ -200,14 +220,56 @@ class Metrics:
         """Return the installed OTel `MeterProvider`.
 
         Raises:
-            RuntimeError: If accessed before the component has been entered.
+            RuntimeError: If accessed before the component has been entered,
+                or when the exporter auto-disables so no provider is installed.
         """
         if self._provider is None:
             msg = (
-                "Metrics.provider is only available inside `async with micro:`"
+                "Metrics.provider is only available inside `async with micro:` "
+                "and only when the exporter is active. An auto-disabled Metrics "
+                "(default exporter with no endpoint) installs no provider."
             )
             raise RuntimeError(msg)
         return self._provider
+
+    @property
+    def active(self) -> bool:
+        """Whether entering installs a `MeterProvider` for this app.
+
+        `False` when the exporter auto-disables: the default `auto` exporter
+        with no endpoint configured. An auto-disabled `Metrics` is a no-op, so
+        it can be registered unconditionally in dev, test, and CI.
+        """
+        return not self._auto_disabled()
+
+    def owns_global_state(self) -> bool:
+        """Whether entering patches the process-global meter provider.
+
+        Consulted by the app's single-active-app guard. An auto-disabled
+        `Metrics` installs nothing, so overlapping apps may each carry one.
+        """
+        return self.active
+
+    def _auto_disabled(self) -> bool:
+        """Return True when the exporter was left `auto` and resolves to `none`."""
+        config = self._resolve()
+        return (
+            config.exporter is MetricsExporterType.AUTO
+            and _resolve_exporter_type(config) is MetricsExporterType.NONE
+        )
+
+    def _resolve(self) -> MetricsConfig:
+        """Resolve the config once per open cycle (cleared on exit)."""
+        if self._resolved is None:
+            self._resolved = resolve_config(
+                MetricsConfig,
+                explicit=self._explicit_config,
+                kwargs=self._kwargs,
+                env_prefix="GREL_METRICS_",
+                env_load=self._env_load,
+                error_type=MetricsSettingsValidationError,
+            )
+        return self._resolved
 
     @property
     def prometheus_registry(self) -> Any:  # noqa: ANN401
@@ -228,12 +290,20 @@ class Metrics:
     ) -> Meter:
         """Return an OTel `Meter` for `name`, cached per scope name.
 
+        When the exporter auto-disables (default `auto` exporter, no endpoint),
+        no provider is installed and this returns a no-op `Meter` from the OTel
+        global, so custom instruments stay safe to use unconditionally.
+
         Raises:
             RuntimeError: If accessed before the component has been entered.
         """
-        if self._provider is None:
+        if not self._entered:
             msg = "Metrics.meter is only available inside `async with micro:`"
             raise RuntimeError(msg)
+        if self._provider is None:
+            from opentelemetry import metrics  # noqa: PLC0415
+
+            return metrics.get_meter(name)
         meter = self._meters.get(name)
         if meter is None:
             meter = self._provider.get_meter(name)
@@ -305,20 +375,21 @@ class Metrics:
         )
 
     async def __aenter__(self) -> Self:
-        """Build the `MeterProvider` and install it as the global provider."""
+        """Build the `MeterProvider` and install it as the global provider.
+
+        When the exporter auto-disables (default `auto` exporter, no endpoint),
+        this is a true no-op: no provider is built, the process-global meter
+        provider is left untouched, and no instruments are emitted.
+        """
+        config = self._resolve()
+        self._entered = True
+        if not self.active:
+            return self
         try:
             import opentelemetry.metrics._internal as otel_internal  # noqa: PLC0415
         except ImportError as exc:  # pragma: no cover
             raise DependencyNotFoundError(module="opentelemetry-api") from exc
 
-        self._resolved = resolve_config(
-            MetricsConfig,
-            explicit=self._explicit_config,
-            kwargs=self._kwargs,
-            env_prefix="GREL_METRICS_",
-            env_load=self._env_load,
-            error_type=MetricsSettingsValidationError,
-        )
         # `opentelemetry.metrics.set_meter_provider()` refuses to replace an
         # already-installed provider, so `Metrics` patches the private
         # `_METER_PROVIDER` global directly. A future OTel release can rename
@@ -333,9 +404,7 @@ class Metrics:
             )
             raise MetricsError(msg)
         self._prior_provider = otel_internal._METER_PROVIDER  # noqa: SLF001
-        self._provider, self._prometheus_registry = _build_provider(
-            self._resolved
-        )
+        self._provider, self._prometheus_registry = _build_provider(config)
         otel_internal._METER_PROVIDER = self._provider  # noqa: SLF001
         _hub.activate(self)
         return self
@@ -353,6 +422,13 @@ class Metrics:
         call runs in a daemon thread bounded by `shutdown_timeout`. On timeout
         a warning is logged and the global provider is restored regardless.
         """
+        if self._provider is None:
+            # Auto-disabled on enter: nothing was installed, nothing to undo.
+            self._entered = False
+            self._resolved = None
+            self._prior_provider = None
+            return None
+
         import opentelemetry.metrics._internal as otel_internal  # noqa: PLC0415
 
         try:
@@ -372,6 +448,8 @@ class Metrics:
         finally:
             _hub.deactivate(self)
             otel_internal._METER_PROVIDER = self._prior_provider  # noqa: SLF001
+            self._entered = False
+            self._resolved = None
             self._provider = None
             self._prior_provider = None
             self._prometheus_registry = None
@@ -434,22 +512,44 @@ def _build_provider(config: MetricsConfig) -> tuple[Any, Any]:
         resource_attributes=config.resource_attributes,
     )
 
-    if config.exporter == MetricsExporterType.NONE:
+    exporter_type = _resolve_exporter_type(config)
+
+    if exporter_type == MetricsExporterType.NONE:
         return _make_provider(MeterProvider, resource, readers=[]), None
 
-    if config.exporter == MetricsExporterType.PROMETHEUS:
+    if exporter_type == MetricsExporterType.PROMETHEUS:
         reader, registry = _build_prometheus_reader()
         return _make_provider(MeterProvider, resource, readers=[reader]), (
             registry
         )
 
-    exporter = _build_exporter(config)
+    exporter = _build_exporter(config, exporter_type)
     reader = PeriodicExportingMetricReader(
         exporter,
         export_interval_millis=config.export_interval * 1000.0,
         export_timeout_millis=config.export_timeout * 1000.0,
     )
     return _make_provider(MeterProvider, resource, readers=[reader]), None
+
+
+def _resolve_exporter_type(config: MetricsConfig) -> MetricsExporterType:
+    """Resolve the `auto` exporter against the configured endpoint.
+
+    `auto` becomes `otlp-http` when an endpoint is resolvable (the
+    `endpoint` field, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, or
+    `OTEL_EXPORTER_OTLP_ENDPOINT`) and `none` otherwise. Any explicit
+    exporter is returned unchanged.
+    """
+    if config.exporter != MetricsExporterType.AUTO:
+        return config.exporter
+    endpoint_configured = (
+        config.endpoint is not None
+        or bool(os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"))
+        or bool(os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"))
+    )
+    if endpoint_configured:
+        return MetricsExporterType.OTLP_HTTP
+    return MetricsExporterType.NONE
 
 
 def _make_provider(
@@ -486,16 +586,19 @@ def _build_prometheus_reader() -> tuple[Any, Any]:
     return reader, registry
 
 
-def _build_exporter(config: MetricsConfig) -> Any:  # noqa: ANN401
-    """Build a metric exporter for the configured exporter type."""
-    if config.exporter == MetricsExporterType.CONSOLE:
+def _build_exporter(
+    config: MetricsConfig,
+    exporter_type: MetricsExporterType,
+) -> Any:  # noqa: ANN401
+    """Build a metric exporter for the resolved exporter type."""
+    if exporter_type == MetricsExporterType.CONSOLE:
         from opentelemetry.sdk.metrics.export import (  # noqa: PLC0415
             ConsoleMetricExporter,
         )
 
         return ConsoleMetricExporter()
 
-    if config.exporter == MetricsExporterType.OTLP_HTTP:  # pragma: no cover
+    if exporter_type == MetricsExporterType.OTLP_HTTP:  # pragma: no cover
         try:
             from opentelemetry.exporter.otlp.proto.http.metric_exporter import (  # noqa: PLC0415
                 OTLPMetricExporter,
@@ -504,12 +607,7 @@ def _build_exporter(config: MetricsConfig) -> Any:  # noqa: ANN401
             raise DependencyNotFoundError(
                 module="opentelemetry-exporter-otlp-proto-http"
             ) from exc
-        kwargs: dict[str, Any] = {}
-        if config.endpoint is not None:
-            kwargs["endpoint"] = config.endpoint
-        if config.headers:
-            kwargs["headers"] = config.headers
-        return OTLPMetricExporter(**kwargs)
+        return OTLPMetricExporter(**_exporter_kwargs(config))
 
     try:  # pragma: no cover
         from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (  # noqa: PLC0415
@@ -519,11 +617,25 @@ def _build_exporter(config: MetricsConfig) -> Any:  # noqa: ANN401
         raise DependencyNotFoundError(
             module="opentelemetry-exporter-otlp-proto-grpc"
         ) from exc
-    kwargs = {}  # pragma: no cover
-    if config.endpoint is not None:  # pragma: no cover
-        kwargs["endpoint"] = config.endpoint
-    if config.headers:  # pragma: no cover
-        kwargs["headers"] = config.headers
     return OTLPMetricExporter(  # pragma: no cover
-        **kwargs,  # ty: ignore[invalid-argument-type]
+        **_exporter_kwargs(config),
     )
+
+
+def _exporter_kwargs(config: MetricsConfig) -> dict[str, Any]:
+    """Build the shared `endpoint`/`headers` kwargs for the OTLP exporters.
+
+    Merges any configured Basic-auth credentials into the headers as an
+    `Authorization: Basic` value, so the credentials ride on the exporter
+    rather than the env-parsed `OTEL_EXPORTER_OTLP_HEADERS`.
+    """
+    kwargs: dict[str, Any] = {}
+    if config.endpoint is not None:
+        kwargs["endpoint"] = config.endpoint
+    headers = dict(config.headers)
+    authorization = config.authorization_header
+    if authorization is not None:
+        headers["Authorization"] = authorization
+    if headers:
+        kwargs["headers"] = headers
+    return kwargs

--- a/grelmicro/metrics/config.py
+++ b/grelmicro/metrics/config.py
@@ -1,9 +1,10 @@
 """Metrics Configuration."""
 
+from base64 import b64encode
 from enum import StrEnum
 from typing import Annotated, Self
 
-from pydantic import BaseModel, Field, PositiveFloat
+from pydantic import BaseModel, Field, PositiveFloat, model_validator
 from typing_extensions import Doc
 
 
@@ -22,6 +23,7 @@ class _CaseInsensitiveEnum(StrEnum):
 class MetricsExporterType(_CaseInsensitiveEnum):
     """Metric exporter selection."""
 
+    AUTO = "auto"
     OTLP_HTTP = "otlp-http"
     OTLP_GRPC = "otlp-grpc"
     PROMETHEUS = "prometheus"
@@ -41,8 +43,15 @@ class MetricsConfig(BaseModel, frozen=True, extra="forbid"):
     ] = None
     exporter: Annotated[
         MetricsExporterType,
-        Doc("Metric exporter."),
-    ] = MetricsExporterType.OTLP_HTTP
+        Doc(
+            "Metric exporter. The default `auto` resolves to `otlp-http` when "
+            "an endpoint is configured (the `endpoint` field, "
+            "`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, or "
+            "`OTEL_EXPORTER_OTLP_ENDPOINT`) and to `none` otherwise, so an "
+            "unconfigured `Metrics()` exports nothing instead of falling back "
+            "to `localhost:4318`."
+        ),
+    ] = MetricsExporterType.AUTO
     endpoint: Annotated[
         str | None,
         Doc(
@@ -57,6 +66,22 @@ class MetricsConfig(BaseModel, frozen=True, extra="forbid"):
             "when empty."
         ),
     ] = Field(default_factory=dict)
+    basic_auth_username: Annotated[
+        str | None,
+        Doc(
+            "HTTP Basic auth username for the OTLP exporter. Set together "
+            "with `basic_auth_password` to send an `Authorization: Basic` "
+            "header, built and attached on the exporter directly so it "
+            "bypasses the fragile `OTEL_EXPORTER_OTLP_HEADERS` encoding."
+        ),
+    ] = None
+    basic_auth_password: Annotated[
+        str | None,
+        Doc(
+            "HTTP Basic auth password for the OTLP exporter. Set together "
+            "with `basic_auth_username`."
+        ),
+    ] = None
     export_interval: Annotated[
         PositiveFloat,
         Doc(
@@ -84,3 +109,37 @@ class MetricsConfig(BaseModel, frozen=True, extra="forbid"):
             "shutdown past this deadline."
         ),
     ] = 5.0
+
+    @model_validator(mode="after")
+    def _check_basic_auth(self) -> Self:
+        """Require username and password together and guard header collisions."""
+        has_username = self.basic_auth_username is not None
+        has_password = self.basic_auth_password is not None
+        if has_username != has_password:
+            msg = (
+                "basic_auth_username and basic_auth_password must be set "
+                "together."
+            )
+            raise ValueError(msg)
+        if has_username and any(
+            key.lower() == "authorization" for key in self.headers
+        ):
+            msg = (
+                "basic_auth conflicts with an Authorization header already "
+                "set in headers. Use one or the other."
+            )
+            raise ValueError(msg)
+        return self
+
+    @property
+    def authorization_header(self) -> str | None:
+        """`Authorization: Basic` value from the credentials, or `None`.
+
+        Encodes `username:password` as base64 per RFC 7617. Returns `None`
+        when no Basic credentials are configured.
+        """
+        if self.basic_auth_username is None:
+            return None
+        raw = f"{self.basic_auth_username}:{self.basic_auth_password}"
+        token = b64encode(raw.encode()).decode("ascii")
+        return f"Basic {token}"

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -270,11 +270,11 @@
   },
   "grelmicro.metrics": {
     "Metrics": {
-      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., export_interval=..., export_timeout=..., resource_attributes=..., shutdown_timeout=..., env_load=...)",
+      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., basic_auth=..., export_interval=..., export_timeout=..., resource_attributes=..., shutdown_timeout=..., env_load=...)",
       ".from_config": "(config, *, name=...)"
     },
     "MetricsConfig": {
-      "()": "(*, service_name=..., exporter=..., endpoint=..., headers=..., export_interval=..., export_timeout=..., resource_attributes=..., shutdown_timeout=...)"
+      "()": "(*, service_name=..., exporter=..., endpoint=..., headers=..., basic_auth_username=..., basic_auth_password=..., export_interval=..., export_timeout=..., resource_attributes=..., shutdown_timeout=...)"
     },
     "MetricsError": null,
     "MetricsExporterType": {

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -72,6 +72,7 @@ async def metrics_reader() -> AsyncIterator[MetricsHarness]:
     component = Metrics()
     component._provider = provider
     component._resolved = component._explicit_config
+    component._entered = True
     _hub.activate(component)
     try:
         yield MetricsHarness(component, reader)

--- a/tests/metrics/test_component.py
+++ b/tests/metrics/test_component.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from base64 import b64encode
+
 import pytest
 from opentelemetry import metrics as otel_metrics
 from opentelemetry.sdk.metrics import MeterProvider
 
 from grelmicro import Component, ComponentAlreadyRegisteredError, Grelmicro
-from grelmicro.errors import SettingsValidationError
+from grelmicro.errors import MultipleActiveAppsError, SettingsValidationError
 from grelmicro.health import HealthChecks
 from grelmicro.metrics import (
     Metrics,
@@ -15,6 +17,10 @@ from grelmicro.metrics import (
     MetricsExporterType,
 )
 from grelmicro.metrics import _hub as hub
+from grelmicro.metrics._component import (
+    _exporter_kwargs,
+    _resolve_exporter_type,
+)
 from grelmicro.metrics.errors import (
     MetricsError,
     MetricsSettingsValidationError,
@@ -288,3 +294,185 @@ async def test_metrics_invalid_env_config_raises_settings_error(
 def test_metrics_settings_error_is_settings_validation_error() -> None:
     """`MetricsSettingsValidationError` is a `SettingsValidationError`."""
     assert issubclass(MetricsSettingsValidationError, SettingsValidationError)
+
+
+def test_auto_exporter_resolves_to_none_without_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`auto` collapses to `none` when no endpoint is configured."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+    assert _resolve_exporter_type(MetricsConfig()) == MetricsExporterType.NONE
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"],
+)
+def test_auto_exporter_resolves_to_otlp_http_with_endpoint_env(
+    monkeypatch: pytest.MonkeyPatch, env_var: str
+) -> None:
+    """`auto` resolves to `otlp-http` when an endpoint env var is set."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+    monkeypatch.setenv(env_var, "https://obs.example.com")
+    assert (
+        _resolve_exporter_type(MetricsConfig()) == MetricsExporterType.OTLP_HTTP
+    )
+
+
+def test_explicit_exporter_unchanged_without_endpoint() -> None:
+    """An explicit exporter is never downgraded by auto-resolution."""
+    config = MetricsConfig(exporter=MetricsExporterType.CONSOLE)
+    assert _resolve_exporter_type(config) == MetricsExporterType.CONSOLE
+
+
+async def test_auto_exporter_enters_inert_without_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A default `Metrics()` is a no-op: no provider installed, global untouched."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+    prior = otel_metrics.get_meter_provider()
+    micro = Grelmicro(uses=[Metrics(service_name="orders")])
+    async with micro:
+        assert micro.metrics.config.exporter == MetricsExporterType.AUTO
+        assert micro.metrics.active is False
+        assert otel_metrics.get_meter_provider() is prior
+        assert hub.active() is None
+    assert otel_metrics.get_meter_provider() is prior
+
+
+async def test_auto_disabled_provider_access_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`Metrics.provider` reports the auto-disabled state clearly."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+    micro = Grelmicro(uses=[Metrics()])
+    async with micro:
+        with pytest.raises(RuntimeError, match="auto-disabled"):
+            _ = micro.metrics.provider
+
+
+async def test_auto_disabled_instruments_are_noops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-disabled instruments are safe no-ops via the OTel global."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+    micro = Grelmicro(uses=[Metrics()])
+    async with micro:
+        # No provider, but custom instruments neither raise nor record.
+        micro.metrics.counter("orders.placed").add(1)
+        micro.metrics.histogram("request.duration", unit="s").record(0.5)
+
+
+async def test_auto_disabled_metrics_allow_overlapping_apps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-disabled `Metrics` owns no global state, so two apps overlap freely."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+    async with Grelmicro(uses=[Metrics()]), Grelmicro(uses=[Metrics()]):
+        pass  # no MultipleActiveAppsError
+
+
+async def test_active_metrics_still_blocks_second_app() -> None:
+    """An active `Metrics` (explicit exporter) still blocks an overlapping app."""
+    async with Grelmicro(uses=[Metrics(exporter=MetricsExporterType.CONSOLE)]):
+        with pytest.raises(MultipleActiveAppsError):
+            async with Grelmicro(
+                uses=[Metrics(exporter=MetricsExporterType.CONSOLE)]
+            ):
+                pass
+
+
+async def test_explicit_none_still_installs_provider() -> None:
+    """Explicit `exporter=none` keeps installing a provider (stays active)."""
+    micro = Grelmicro(uses=[Metrics(exporter=MetricsExporterType.NONE)])
+    async with micro:
+        assert micro.metrics.active is True
+        assert isinstance(micro.metrics.provider, MeterProvider)
+
+
+def test_basic_auth_header_is_base64_encoded() -> None:
+    """`authorization_header` encodes `username:password` per RFC 7617."""
+    config = MetricsConfig(
+        basic_auth_username="me@example.com", basic_auth_password="s3cret"
+    )
+    expected = b64encode(b"me@example.com:s3cret").decode("ascii")
+    assert config.authorization_header == f"Basic {expected}"
+
+
+def test_basic_auth_header_none_when_unset() -> None:
+    """`authorization_header` is `None` without credentials."""
+    assert MetricsConfig().authorization_header is None
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["basic_auth_username", "basic_auth_password"],
+)
+def test_basic_auth_requires_both_fields(field: str) -> None:
+    """Username and password must be set together."""
+    with pytest.raises(ValueError, match="must be set together"):
+        MetricsConfig.model_validate({field: "value"})
+
+
+def test_basic_auth_conflicts_with_authorization_header() -> None:
+    """`basic_auth` plus an explicit Authorization header is rejected."""
+    with pytest.raises(ValueError, match="Authorization header"):
+        MetricsConfig(
+            basic_auth_username="me",
+            basic_auth_password="secret",
+            headers={"authorization": "Bearer abc"},
+        )
+
+
+def test_exporter_kwargs_injects_authorization() -> None:
+    """`_exporter_kwargs` attaches the Basic header alongside other headers."""
+    config = MetricsConfig(
+        endpoint="https://obs.example.com/v1/metrics",
+        headers={"X-Org": "default"},
+        basic_auth_username="me",
+        basic_auth_password="secret",
+    )
+    kwargs = _exporter_kwargs(config)
+    assert kwargs["endpoint"] == "https://obs.example.com/v1/metrics"
+    assert kwargs["headers"]["X-Org"] == "default"
+    assert kwargs["headers"]["Authorization"].startswith("Basic ")
+
+
+def test_exporter_kwargs_empty_without_endpoint_or_headers() -> None:
+    """`_exporter_kwargs` is empty when nothing is configured."""
+    assert _exporter_kwargs(MetricsConfig()) == {}
+
+
+def test_metrics_basic_auth_kwarg_splits_into_fields() -> None:
+    """`Metrics(basic_auth=(u, p))` maps onto the two config fields."""
+    metrics = Metrics(
+        exporter=MetricsExporterType.NONE, basic_auth=("me", "secret")
+    )
+    assert metrics._kwargs["basic_auth_username"] == "me"
+    assert metrics._kwargs["basic_auth_password"] == "secret"
+
+
+def test_metrics_basic_auth_rejects_non_pair() -> None:
+    """`Metrics(basic_auth=...)` requires a 2-tuple."""
+    with pytest.raises(TypeError, match="username, password"):
+        Metrics(basic_auth=("only",))  # ty: ignore[invalid-argument-type]
+
+
+async def test_metrics_basic_auth_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Credentials resolve from `GREL_METRICS_BASIC_AUTH_*`."""
+    monkeypatch.setenv("GREL_METRICS_BASIC_AUTH_USERNAME", "me@example.com")
+    monkeypatch.setenv("GREL_METRICS_BASIC_AUTH_PASSWORD", "s3cret")
+    micro = Grelmicro(
+        uses=[Metrics(exporter=MetricsExporterType.NONE, env_load=True)]
+    )
+    async with micro:
+        assert micro.metrics.config.basic_auth_username == "me@example.com"
+        assert micro.metrics.config.basic_auth_password == "s3cret"

--- a/tests/metrics/test_config.py
+++ b/tests/metrics/test_config.py
@@ -11,7 +11,7 @@ from grelmicro.metrics import Metrics, MetricsConfig, MetricsExporterType
 def test_config_defaults() -> None:
     """Defaults match the documented values."""
     config = MetricsConfig()
-    assert config.exporter == MetricsExporterType.OTLP_HTTP
+    assert config.exporter == MetricsExporterType.AUTO
     assert config.export_interval == 60.0  # noqa: PLR2004
     assert config.export_timeout == 30.0  # noqa: PLR2004
     assert config.shutdown_timeout == 5.0  # noqa: PLR2004

--- a/tests/outbox/conftest.py
+++ b/tests/outbox/conftest.py
@@ -24,6 +24,7 @@ async def metrics_reader() -> AsyncIterator[MetricsHarness]:
     component = Metrics()
     component._provider = provider
     component._resolved = component._explicit_config
+    component._entered = True
     _hub.activate(component)
     try:
         yield MetricsHarness(component, reader)


### PR DESCRIPTION
Closes #508. Closes #507.

Brings `Metrics` to full parity with `Trace` on two fronts, mirroring the existing `Trace` implementation and test suite exactly.

## #508 — AUTO no-op exporter

- Add `MetricsExporterType.AUTO` and make it the **new default** (was `otlp-http`). `auto` resolves to `otlp-http` when an endpoint is set (`endpoint`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, or `OTEL_EXPORTER_OTLP_ENDPOINT`), otherwise `none`.
- Add `active`, `owns_global_state()`, `_auto_disabled()`, and lazy `_resolve()` so the single-active-app guard can consult state before enter.
- When auto-disabled: no meter provider installed, global untouched, hub not activated (emit hot path stays a one-check no-op).
- Auto-disabled instrument accessors (`counter`/`histogram`/`meter`/…) return real no-op instruments from the OTel global proxy instead of raising, so unconditional registration is genuinely transparent in dev/test/CI. `.provider` still raises with an "auto-disabled" message, matching `Trace`.
- Explicit `exporter="none"` still installs a provider and stays active — only `AUTO`→`none` is the true no-op.

Apps can now register `Metrics()` unconditionally and drop the production-only guard.

## #507 — basic_auth

- Add `basic_auth=(username, password)` to `Metrics`, plus `basic_auth_username`/`basic_auth_password` config fields, the `_check_basic_auth` validator, and `authorization_header` on `MetricsConfig`.
- Refactor the duplicated HTTP/gRPC exporter kwargs into a shared `_exporter_kwargs()` that merges the `Authorization: Basic` header onto the exporter directly, bypassing `OTEL_EXPORTER_OTLP_HEADERS`. Env: `GREL_METRICS_BASIC_AUTH_*`.

## Notes

- Basic-auth logic is kept parallel between `trace/config.py` and `metrics/config.py` rather than extracted, matching the codebase convention of keeping the two subsystems as independents (`_CaseInsensitiveEnum`, `_run_with_timeout` are already parallel). Extracting a base would also churn the frozen public-API snapshot.
- New tests mirror the full `Trace` suite (auto-resolution, inert enter, overlapping apps, still-blocks, no-op instruments, basic_auth encoding/validation/env).
- Public-API snapshot regenerated; `docs/metrics.md` and changelog updated. Full pre-commit passes at 100% coverage.