### PR TITLE
🔥 Drop the inert mypy type-ignore comments

### DIFF
--- a/benchmarks/logging_benchmark.py
+++ b/benchmarks/logging_benchmark.py
@@ -90,7 +90,7 @@ def _run_benchmark(backend: str, serializer: str, iterations: int) -> float:
 
     null_sink = _NullWriter()
     old_stdout = sys.stdout
-    sys.stdout = null_sink  # type: ignore[assignment,misc]
+    sys.stdout = null_sink
 
     try:
         grelmicro_logging.configure()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,10 @@
 
 * ✨ Add `basic_auth=(username, password)` to `Metrics`, matching `Trace`. grelmicro builds the `Authorization: Basic` header and attaches it to the OTLP exporter directly, bypassing the fragile `OTEL_EXPORTER_OTLP_HEADERS` encoding. From the environment, set `GREL_METRICS_BASIC_AUTH_USERNAME` and `GREL_METRICS_BASIC_AUTH_PASSWORD`. ([#507](https://github.com/grelinfo/grelmicro/issues/507))
 
+### Internal
+
+* 🔥 Drop the inert mypy `# type: ignore` comments. grelmicro type-checks with ty, which never read them, and `ty check` stays clean without them. ([#539](https://github.com/grelinfo/grelmicro/pull/539))
+
 ## 0.30.1 - 2026-07-18
 
 ### Fixed

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -972,13 +972,13 @@ class Grelmicro:
             for target in _iter_provider_backends(item):
                 if not getattr(target, "_owns_provider", False):
                     continue
-                provider = target._provider  # type: ignore[attr-defined]  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+                provider = target._provider  # noqa: SLF001  # ty: ignore[unresolved-attribute]
                 key = (type(provider), provider.env_prefix)
                 shared = cache.get(key)
                 if shared is None:
                     cache[key] = provider
                 elif shared is not provider:  # pragma: no branch
-                    target._rebind_provider(shared)  # type: ignore[attr-defined]  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+                    target._rebind_provider(shared)  # noqa: SLF001  # ty: ignore[unresolved-attribute]
 
     def _warn_unlifecycled_providers(self) -> None:
         """Warn when a user-listed Provider is ordered after its Component.
@@ -1021,7 +1021,7 @@ class Grelmicro:
         """
         import warnings  # noqa: PLC0415
 
-        if self._items.index(provider) > index:  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        if self._items.index(provider) > index:  # ty: ignore[invalid-argument-type]
             msg = (
                 f"{type(provider).__name__} is listed after "
                 f"{type(target).__name__} in Grelmicro(uses=[...]). "

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -187,10 +187,10 @@ def resolve_config[C: BaseModel](
 
         settings_cls = _build_settings_cls(config_cls, env_prefix)
         # The dynamic subclass is built at runtime via `type(...)` below, so
-        # neither mypy nor ty can prove that `settings_cls` accepts the kwargs
-        # declared on `config_cls` or that it returns `C`. Pydantic's runtime
-        # validation enforces the contract.
-        return settings_cls(**provided)  # type: ignore[return-value, arg-type]  # ty: ignore[invalid-return-type, invalid-argument-type]
+        # ty cannot prove that `settings_cls` accepts the kwargs declared on
+        # `config_cls` or that it returns `C`. Pydantic's runtime validation
+        # enforces the contract.
+        return settings_cls(**provided)  # ty: ignore[invalid-return-type, invalid-argument-type]
     except ValidationError as error:
         if error_type is None:
             raise
@@ -215,17 +215,13 @@ def _build_settings_cls[C: BaseModel](
     """
     # `model_config` is a TypedDict (`SettingsConfigDict`/`ConfigDict`).
     # Spreading it into a plain dict to add `env_prefix` widens the value
-    # type to `dict[str, object]`, which downstream constructors accept
-    # at runtime but mypy/ty cannot narrow back to the TypedDict shape.
-    merged_config: dict[str, object] = {**(config_cls.model_config or {})}  # type: ignore[dict-item]
+    # type to `dict[str, object]`.
+    merged_config: dict[str, object] = {**(config_cls.model_config or {})}
     merged_config["env_prefix"] = env_prefix
-    # `SettingsConfigDict(**merged_config)` round-trips a `dict[str, object]`
-    # through a TypedDict constructor. Static checkers reject the widened
-    # value types even though Pydantic's runtime validator accepts them.
     return type(
         f"_{config_cls.__name__}Settings",
         (config_cls, BaseSettings),
-        {"model_config": SettingsConfigDict(**merged_config)},  # type: ignore[typeddict-item]
+        {"model_config": SettingsConfigDict(**merged_config)},
     )
 
 

--- a/grelmicro/_json.py
+++ b/grelmicro/_json.py
@@ -70,7 +70,7 @@ except ImportError:
 
     def json_loads(data: bytes | str) -> JSONDecodable:
         """Deserialize JSON bytes or string using stdlib json."""
-        return json.loads(data)  # type: ignore[return-value]
+        return json.loads(data)
 
     _HAS_ORJSON = False
 

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -222,7 +222,7 @@ class TTLCache(Generic[T]):
     def _serialize(self, value: T) -> bytes:
         """Serialize a value to bytes for storage."""
         if self._serializer is not None:
-            return self._serializer.dumps(value)  # type: ignore[arg-type]
+            return self._serializer.dumps(value)
         if isinstance(value, bytes):
             return value
         msg = (
@@ -234,8 +234,8 @@ class TTLCache(Generic[T]):
     def _deserialize(self, raw: bytes) -> T:
         """Deserialize bytes from storage."""
         if self._serializer is not None:
-            return self._serializer.loads(raw)  # type: ignore[return-value]
-        return raw  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+            return self._serializer.loads(raw)
+        return raw  # ty: ignore[invalid-return-type]
 
     async def get(
         self,

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -89,9 +89,9 @@ def _normalize(func: HealthCheckFunc) -> AsyncHealthCheckFunc:
     The sync/async decision is made once at registration, not per call.
     """
     if is_async_callable(func):
-        return func  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+        return func  # ty: ignore[invalid-return-type]
 
-    sync_func: Callable[[], HealthDetails | None] = func  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+    sync_func: Callable[[], HealthDetails | None] = func  # ty: ignore[invalid-assignment]
 
     async def _async_wrapper() -> HealthDetails | None:
         return await asyncio.to_thread(sync_func)

--- a/grelmicro/integrations/faststream.py
+++ b/grelmicro/integrations/faststream.py
@@ -150,7 +150,7 @@ def install(
                 await micro.__aexit__(*sys.exc_info())
             raise
 
-    app.start = _start_with_micro_rollback  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    app.start = _start_with_micro_rollback  # ty: ignore[invalid-assignment]
 
     if ambient:
         middleware = type(

--- a/grelmicro/metrics/_measure.py
+++ b/grelmicro/metrics/_measure.py
@@ -80,7 +80,7 @@ def measure(
 ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
-def measure[**P, R](  # type: ignore[return-value]
+def measure[**P, R](
     func: Annotated[
         Callable[P, R] | None,
         Doc(
@@ -141,7 +141,7 @@ def measure[**P, R](  # type: ignore[return-value]
             async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
                 start = m.enter()
                 try:
-                    result = await fn(*args, **kwargs)  # type: ignore[misc]
+                    result = await fn(*args, **kwargs)
                 except BaseException as exc:
                     m.error(exc)
                     raise
@@ -151,7 +151,7 @@ def measure[**P, R](  # type: ignore[return-value]
                 finally:
                     m.exit(start)
 
-            return async_wrapper  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+            return async_wrapper  # ty: ignore[invalid-return-type]
 
         @functools.wraps(fn)
         def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
@@ -167,7 +167,7 @@ def measure[**P, R](  # type: ignore[return-value]
             finally:
                 m.exit(start)
 
-        return sync_wrapper  # type: ignore[return-value]
+        return sync_wrapper
 
     if func is not None:
         return decorator(func)

--- a/grelmicro/metrics/_otel.py
+++ b/grelmicro/metrics/_otel.py
@@ -32,4 +32,4 @@ def get() -> OTel:
         from opentelemetry import metrics  # noqa: PLC0415
     except ImportError:
         return OTel(None)
-    return OTel(metrics)  # type: ignore[arg-type]
+    return OTel(metrics)

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -425,7 +425,7 @@ def _resolve_command_timeout(
     if not env_load:
         return None
     try:
-        settings = _PostgresTimeoutEnvSettings(_env_prefix=env_prefix)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+        settings = _PostgresTimeoutEnvSettings(_env_prefix=env_prefix)  # ty: ignore[unknown-argument]
     except ValidationError as error:
         raise PostgresProviderConfigError(error) from None
     return settings.command_timeout
@@ -467,7 +467,7 @@ def _resolve_url(
         # `_env_prefix` is a pydantic-settings runtime kwarg that overrides
         # `model_config["env_prefix"]` per call. The stubs do not expose it,
         # so static checkers reject it even though the runtime accepts it.
-        settings = _PostgresEnvSettings(_env_prefix=env_prefix)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+        settings = _PostgresEnvSettings(_env_prefix=env_prefix)  # ty: ignore[unknown-argument]
     except ValidationError as error:
         raise PostgresProviderConfigError(error) from None
 

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -521,7 +521,7 @@ def _resolve_url(
         # `_env_prefix` is a pydantic-settings runtime kwarg that overrides
         # `model_config["env_prefix"]` per call. The stubs do not expose it,
         # so static checkers reject it even though the runtime accepts it.
-        settings = _RedisEnvSettings(_env_prefix=env_prefix)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+        settings = _RedisEnvSettings(_env_prefix=env_prefix)  # ty: ignore[unknown-argument]
     except ValidationError as error:
         raise RedisProviderConfigError(error) from None
 

--- a/grelmicro/providers/sqlite.py
+++ b/grelmicro/providers/sqlite.py
@@ -60,7 +60,7 @@ def _resolve_path(
         # `_env_prefix` is a pydantic-settings runtime kwarg that overrides
         # `model_config["env_prefix"]` per call. The stubs do not expose it,
         # so static checkers reject it even though the runtime accepts it.
-        settings = _SQLiteEnvSettings(_env_prefix=env_prefix)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+        settings = _SQLiteEnvSettings(_env_prefix=env_prefix)  # ty: ignore[unknown-argument]
         if settings.path:
             return settings.path
     msg = f"SQLite path is not set. Pass path=... or set {env_prefix}PATH."

--- a/grelmicro/providers/valkey.py
+++ b/grelmicro/providers/valkey.py
@@ -189,7 +189,7 @@ class ValkeyProvider(RedisProvider):
         )
 
     @classmethod
-    def from_client(  # type: ignore[override]
+    def from_client(
         cls,
         client: Annotated[  # noqa: ANN401
             Any,

--- a/grelmicro/resilience/_match.py
+++ b/grelmicro/resilience/_match.py
@@ -128,7 +128,7 @@ class Match:
                 exc = outcome.exception
                 if not outcome.raised or exc is None:
                     return False
-                return _coerce_bool(predicate(exc), predicate)  # type: ignore[arg-type]
+                return _coerce_bool(predicate(exc), predicate)
 
             return cls(
                 _check_predicate,
@@ -256,7 +256,7 @@ class Match:
                 exc = outcome.exception
                 if not outcome.raised or exc is None:
                     return False
-                return _coerce_bool(predicate(exc.__cause__), predicate)  # type: ignore[arg-type]
+                return _coerce_bool(predicate(exc.__cause__), predicate)
 
             return cls(
                 _check_predicate,

--- a/grelmicro/resilience/bulkhead.py
+++ b/grelmicro/resilience/bulkhead.py
@@ -229,7 +229,7 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
                 # so the value is never `None` on this branch.
                 raise BulkheadFullError(
                     name=self._name,
-                    max_concurrent=state.config.max_concurrent,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+                    max_concurrent=state.config.max_concurrent,  # ty: ignore[invalid-argument-type]
                 ) from None
         if self._uses and not self._opened:
             await self._open_uses()

--- a/grelmicro/resilience/fallback.py
+++ b/grelmicro/resilience/fallback.py
@@ -224,7 +224,7 @@ def _resolve_config(
     env_prefix = default_env_prefix("FALLBACK", name)
     _load_default_from_env(kwargs, env_prefix)
     settings_cls = _build_settings_cls(FallbackConfig, env_prefix)
-    return settings_cls(**kwargs)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+    return settings_cls(**kwargs)  # ty: ignore[invalid-return-type]
 
 
 def _load_default_from_env(kwargs: dict[str, Any], env_prefix: str) -> None:
@@ -285,7 +285,7 @@ class FallbackResult[T]:
                 "fallback path to fill it when an exception is matched."
             )
             raise RuntimeError(msg)
-        return self._value  # type: ignore[no-any-return]
+        return self._value
 
 
 class _FallbackBlock[T]:
@@ -504,7 +504,7 @@ def fallback(
                         raise
                     return _resolve_value(config, exc)
 
-            return async_wrapper  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+            return async_wrapper  # ty: ignore[invalid-return-type]
 
         @functools.wraps(fn)
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
@@ -515,7 +515,7 @@ def fallback(
                     raise
                 return _resolve_value(config, exc)
 
-        return sync_wrapper  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+        return sync_wrapper  # ty: ignore[invalid-return-type]
 
     return wrap
 

--- a/grelmicro/resilience/retry.py
+++ b/grelmicro/resilience/retry.py
@@ -820,7 +820,7 @@ def _decorator(
     """Build a decorator from anonymous Retry kwargs."""
     config = RetryConfig(
         attempts=attempts,
-        when=when,  # type: ignore[arg-type]
+        when=when,
         backoff=backoff or ExponentialBackoff(),
     )
     matcher: Matcher = config.when
@@ -832,13 +832,13 @@ def _decorator(
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
                 return await _run_async(fn, args, kwargs, config, matcher)
 
-            return async_wrapper  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+            return async_wrapper  # ty: ignore[invalid-return-type]
 
         @functools.wraps(fn)
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
             return _run_sync(fn, args, kwargs, config, matcher)
 
-        return sync_wrapper  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+        return sync_wrapper  # ty: ignore[invalid-return-type]
 
     return wrap
 
@@ -933,7 +933,7 @@ class _RetryingFactory:
         """Yield successive attempts for the block form."""
         config = RetryConfig(
             attempts=attempts,
-            when=when,  # type: ignore[arg-type]
+            when=when,
             backoff=backoff or ExponentialBackoff(),
         )
         return _async_iter(config, config.when)

--- a/grelmicro/testing.py
+++ b/grelmicro/testing.py
@@ -45,7 +45,7 @@ class Call:
 
     method: Annotated[str, Doc("Name of the method that was called.")]
     args: Annotated[
-        tuple,  # type: ignore[type-arg]
+        tuple,
         Doc("Positional arguments the method was called with."),
     ] = field(default_factory=tuple)
     kwargs: Annotated[
@@ -74,7 +74,7 @@ class CallLog:
             Doc("Method name to match, or `None` to count every call."),
         ] = None,
         args: Annotated[
-            tuple | None,  # type: ignore[type-arg]
+            tuple | None,
             Doc("Positional arguments to match, or `None` to skip the check."),
         ] = None,
         **kwargs: Any,  # noqa: ANN401

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -315,9 +315,9 @@ class Trace:
                 "release or open an issue against grelmicro."
             )
             raise TraceError(msg)
-        self._prior_provider = trace._TRACER_PROVIDER  # type: ignore[attr-defined]  # noqa: SLF001
+        self._prior_provider = trace._TRACER_PROVIDER  # noqa: SLF001
         self._provider = _build_provider(config)
-        trace._TRACER_PROVIDER = self._provider  # type: ignore[attr-defined]  # noqa: SLF001
+        trace._TRACER_PROVIDER = self._provider  # noqa: SLF001
         return self
 
     async def __aexit__(
@@ -360,7 +360,7 @@ class Trace:
                         timeout,
                     )
         finally:
-            trace._TRACER_PROVIDER = self._prior_provider  # type: ignore[attr-defined]  # noqa: SLF001
+            trace._TRACER_PROVIDER = self._prior_provider  # noqa: SLF001
             self._provider = None
             self._prior_provider = None
             self._resolved = None

--- a/grelmicro/trace/_instrument.py
+++ b/grelmicro/trace/_instrument.py
@@ -53,7 +53,7 @@ _DEFAULT_SENSITIVE_NAMES = frozenset(
 
 def _record_exception(otel_span: object) -> None:
     """Record the current exception on an OTel span."""
-    if (  # type: ignore[truthy-function]
+    if (
         otel_span is not None
         and hasattr(otel_span, "is_recording")
         and otel_span.is_recording()  # ty: ignore[call-non-callable]
@@ -61,7 +61,7 @@ def _record_exception(otel_span: object) -> None:
         exc = sys.exc_info()[1]
         if exc is not None:  # pragma: no branch
             otel = _get_otel()
-            otel_span.set_status(otel.status_code.ERROR, str(exc))  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]
+            otel_span.set_status(otel.status_code.ERROR, str(exc))  # ty: ignore[unresolved-attribute]
             otel_span.record_exception(exc)  # ty: ignore[unresolved-attribute]
 
 
@@ -108,7 +108,7 @@ def instrument(
 ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
-def instrument[**P, R](  # type: ignore[return-value]
+def instrument[**P, R](
     func: Annotated[
         Callable[P, R] | None,
         Doc(
@@ -202,15 +202,15 @@ def instrument[**P, R](  # type: ignore[return-value]
                             attributes={k: str(v) for k, v in fields.items()},
                         ) as otel_span:
                             try:
-                                return await fn(*args, **kwargs)  # type: ignore[misc]
+                                return await fn(*args, **kwargs)
                             except BaseException:
                                 _record_exception(otel_span)
                                 raise
-                    return await fn(*args, **kwargs)  # type: ignore[misc]
+                    return await fn(*args, **kwargs)
                 finally:
                     _pop_context(token)
 
-            return async_wrapper  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+            return async_wrapper  # ty: ignore[invalid-return-type]
 
         @functools.wraps(fn)
         def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
@@ -231,7 +231,7 @@ def instrument[**P, R](  # type: ignore[return-value]
             finally:
                 _pop_context(token)
 
-        return sync_wrapper  # type: ignore[return-value]
+        return sync_wrapper
 
     if func is not None:
         return decorator(func)

--- a/grelmicro/trace/_otel.py
+++ b/grelmicro/trace/_otel.py
@@ -34,4 +34,4 @@ def get() -> OTel:
         from opentelemetry.trace import StatusCode  # noqa: PLC0415
     except ImportError:
         return OTel(None, None)
-    return OTel(trace, StatusCode)  # type: ignore[arg-type]
+    return OTel(trace, StatusCode)

--- a/grelmicro/trace/_span.py
+++ b/grelmicro/trace/_span.py
@@ -56,7 +56,7 @@ def span(name: str, **fields: object) -> Generator[None, None, None]:
             ):
                 exc = sys.exc_info()[1]
                 if exc is not None:  # pragma: no branch
-                    otel_span.set_status(otel.status_code.ERROR, str(exc))  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]
+                    otel_span.set_status(otel.status_code.ERROR, str(exc))  # ty: ignore[unresolved-attribute]
                     otel_span.record_exception(exc)
             raise
         finally:

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -230,7 +230,7 @@ class TestAsyncCachedCacheControl:
         await fetch(1)  # miss
         await fetch(2)  # miss
         await fetch(1)  # hit
-        info = fetch.cache_info()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        info = fetch.cache_info()  # ty: ignore[unresolved-attribute]
 
         # Assert
         assert info.hits == EXPECTED_HITS_1
@@ -247,7 +247,7 @@ class TestAsyncCachedCacheControl:
             return x
 
         # Assert
-        assert inspect.iscoroutinefunction(fetch.cache_clear)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        assert inspect.iscoroutinefunction(fetch.cache_clear)  # ty: ignore[unresolved-attribute]
 
     async def test_cache_clear_empties_the_cache(self) -> None:
         """Awaiting cache_clear() causes subsequent calls to recompute."""
@@ -265,7 +265,7 @@ class TestAsyncCachedCacheControl:
         assert call_count == EXPECTED_CALL_COUNT_1
 
         # Act
-        await fetch.cache_clear()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        await fetch.cache_clear()  # ty: ignore[unresolved-attribute]
         await fetch(1)
 
         # Assert: recomputed after clear
@@ -282,13 +282,13 @@ class TestAsyncCachedCacheControl:
 
         await fetch(1)
         await fetch(2)
-        assert fetch.cache_info().currsize == EXPECTED_CURRSIZE_2  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        assert fetch.cache_info().currsize == EXPECTED_CURRSIZE_2  # ty: ignore[unresolved-attribute]
 
         # Act
-        await fetch.cache_clear()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        await fetch.cache_clear()  # ty: ignore[unresolved-attribute]
 
         # Assert
-        assert fetch.cache_info().currsize == 0  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        assert fetch.cache_info().currsize == 0  # ty: ignore[unresolved-attribute]
 
 
 class TestAsyncCachedFunctionMetadata:
@@ -771,7 +771,7 @@ class TestSyncCachedCacheControl:
         # Act
         await asyncio.to_thread(lambda: compute(1))  # miss
         await asyncio.to_thread(lambda: compute(1))  # hit
-        info = compute.cache_info()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        info = compute.cache_info()  # ty: ignore[unresolved-attribute]
 
         # Assert
         assert info.hits == EXPECTED_HITS_1
@@ -793,7 +793,7 @@ class TestSyncCachedCacheControl:
         assert call_count == EXPECTED_CALL_COUNT_1
 
         # Act: cache_clear is always a coroutine
-        await compute.cache_clear()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        await compute.cache_clear()  # ty: ignore[unresolved-attribute]
         await asyncio.to_thread(lambda: compute(1))
 
         # Assert: recomputed after clear
@@ -1148,7 +1148,7 @@ class TestEarlyRefresh:
         """An unknown lock value raises at decoration time."""
         cache = _make_cache()
         with pytest.raises(ValueError, match="lock"):
-            cached(cache, lock="global")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+            cached(cache, lock="global")  # ty: ignore[invalid-argument-type]
 
     async def test_early_outside_window_does_not_refresh(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1834,10 +1834,10 @@ class TestPrivateCacheForm:
             return expected_value
 
         assert await get_value() == expected_value
-        info = get_value.cache_info()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        info = get_value.cache_info()  # ty: ignore[unresolved-attribute]
         assert info.hits == 0
         assert info.misses == EXPECTED_MISSES_1
-        await get_value.cache_clear()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        await get_value.cache_clear()  # ty: ignore[unresolved-attribute]
 
     async def test_maxsize_bounds_private_cache(self) -> None:
         """maxsize= bounds the private cache and evicts the oldest entry."""

--- a/tests/cache/test_cached_mutations.py
+++ b/tests/cache/test_cached_mutations.py
@@ -66,7 +66,7 @@ def _private_cache(wrapper: object) -> TTLCache:
     The wrapper's `cache_info` is the cache's bound method, so its
     `__self__` is the cache instance.
     """
-    cache = wrapper.cache_info.__self__  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    cache = wrapper.cache_info.__self__  # ty: ignore[unresolved-attribute]
     assert isinstance(cache, TTLCache)
     return cache
 

--- a/tests/cache/test_postgres.py
+++ b/tests/cache/test_postgres.py
@@ -310,7 +310,7 @@ class TestAsyncMethods:
         """`__aenter__` opens the provider when the adapter owns it."""
         stub = _StubProvider()
         backend = PostgresCacheAdapter.__new__(PostgresCacheAdapter)
-        backend._provider = stub  # type: ignore[assignment]
+        backend._provider = stub
         backend._owns_provider = True
         backend._auto_migrate = False
         backend._cleanup_interval = None

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -536,7 +536,7 @@ class TestCacheInfo:
 
         # Act / Assert
         with pytest.raises(AttributeError):
-            info.hits = 99  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+            info.hits = 99  # ty: ignore[invalid-assignment]
 
     async def test_currsize_reflects_lru_tracker(
         self, backend: MemoryCacheAdapter

--- a/tests/coordination/test_handle.py
+++ b/tests/coordination/test_handle.py
@@ -23,7 +23,7 @@ def test_handle_is_frozen() -> None:
     handle = LockHandle(name="cart", token="worker-1", fencing_token=1)
 
     with pytest.raises(dataclasses.FrozenInstanceError):
-        handle.fencing_token = 2  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        handle.fencing_token = 2  # ty: ignore[invalid-assignment]
 
 
 def test_handle_uses_slots() -> None:

--- a/tests/coordination/test_tasklock.py
+++ b/tests/coordination/test_tasklock.py
@@ -794,7 +794,7 @@ async def test_tasklock_reconfigure_rejects_different_config_type(
     )
 
     with pytest.raises(TypeError, match="TaskLockConfig"):
-        await task_lock.reconfigure(LockConfig(worker=WORKER_1))  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        await task_lock.reconfigure(LockConfig(worker=WORKER_1))  # ty: ignore[invalid-argument-type]
 
 
 # --- refresh ---

--- a/tests/health/test_checks.py
+++ b/tests/health/test_checks.py
@@ -565,7 +565,7 @@ async def test_reconfigure_rejects_different_config_type() -> None:
 
     registry = HealthChecks()
     with pytest.raises(TypeError, match="HealthChecksConfig"):
-        await registry.reconfigure(Other())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        await registry.reconfigure(Other())  # ty: ignore[invalid-argument-type]
 
 
 async def test_reconfigure_changes_cache_ttl_for_next_run() -> None:

--- a/tests/health/test_provider_checks.py
+++ b/tests/health/test_provider_checks.py
@@ -19,7 +19,7 @@ class FakeProvider(Provider):
         self, short_name: str = "fake", *, healthy: bool = True
     ) -> None:
         """Record the vendor name and the desired check outcome."""
-        self.short_name = short_name  # type: ignore[misc]  # ty: ignore[invalid-attribute-access]
+        self.short_name = short_name  # ty: ignore[invalid-attribute-access]
         self._healthy = healthy
         self.calls = 0
 

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -610,7 +610,7 @@ class TestCoverageGaps:
         # Three calls: before try, inside try before distributed lock, after lock.
         _RAISE_AFTER = 3  # noqa: N806
         call_count = 0
-        original_replay = idem._replay  # type: ignore[attr-defined]
+        original_replay = idem._replay
 
         async def patched_replay(key: str, fp: str | None) -> object:
             nonlocal call_count
@@ -620,7 +620,7 @@ class TestCoverageGaps:
                 raise RuntimeError(msg)
             return await original_replay(key, fp)
 
-        idem._replay = patched_replay  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+        idem._replay = patched_replay  # ty: ignore[invalid-assignment]
 
         async with micro:
             with pytest.raises(RuntimeError, match="cache error after lock"):

--- a/tests/logging/test_backends.py
+++ b/tests/logging/test_backends.py
@@ -570,7 +570,7 @@ class TestStructlogCallerInfo:
         processor = _add_caller_info(caller_enabled=True)
 
         # Act
-        result: dict[str, object] = processor(None, "info", event_dict)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+        result: dict[str, object] = processor(None, "info", event_dict)  # ty: ignore[invalid-assignment]
 
         # Assert
         assert result["logger"] == "mymodule"
@@ -587,7 +587,7 @@ class TestStructlogCallerInfo:
         processor = _add_caller_info(caller_enabled=False)
 
         # Act
-        result: dict[str, object] = processor(None, "info", event_dict)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+        result: dict[str, object] = processor(None, "info", event_dict)  # ty: ignore[invalid-assignment]
 
         # Assert
         assert result["logger"] == "mymodule"
@@ -600,7 +600,7 @@ class TestStructlogCallerInfo:
         processor = _add_caller_info(caller_enabled=True)
 
         # Act
-        result: dict[str, object] = processor(None, "info", event_dict)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+        result: dict[str, object] = processor(None, "info", event_dict)  # ty: ignore[invalid-assignment]
 
         # Assert
         assert result["logger"] == "unknown"

--- a/tests/logging/test_ratelimit.py
+++ b/tests/logging/test_ratelimit.py
@@ -64,7 +64,7 @@ def test_config_property_is_frozen() -> None:
     # Assert
     assert isinstance(flt.config, RateLimitFilterConfig)
     with pytest.raises(ValidationError):
-        flt.config.capacity = 99  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        flt.config.capacity = 99  # ty: ignore[invalid-assignment]
 
 
 @pytest.mark.parametrize(

--- a/tests/metrics/test_component.py
+++ b/tests/metrics/test_component.py
@@ -225,7 +225,7 @@ async def test_metrics_shutdown_timeout_logs_warning(
         def _slow(*_a: object, **_k: object) -> None:
             time.sleep(0.3)
 
-        provider.shutdown = _slow  # type: ignore[method-assign]
+        provider.shutdown = _slow
 
     assert any(
         "MeterProvider.shutdown timed out" in record.message
@@ -245,7 +245,7 @@ async def test_metrics_shutdown_exception_logged_not_propagated(
 
     micro = Grelmicro(uses=[Metrics(exporter=MetricsExporterType.NONE)])
     async with micro:
-        micro.metrics.provider.shutdown = _raise  # type: ignore[method-assign]
+        micro.metrics.provider.shutdown = _raise
 
     assert any(
         "MeterProvider.shutdown raised an exception" in record.message

--- a/tests/outbox/test_config.py
+++ b/tests/outbox/test_config.py
@@ -89,14 +89,14 @@ def test_invalid_value_raises() -> None:
 def test_extra_field_forbidden() -> None:
     """Unknown fields are rejected."""
     with pytest.raises(ValidationError):
-        OutboxConfig(unknown=1)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+        OutboxConfig(unknown=1)  # ty: ignore[unknown-argument]
 
 
 def test_config_is_frozen() -> None:
     """The config is immutable."""
     config = OutboxConfig()
     with pytest.raises(ValidationError):
-        config.max_attempts = KWARG_ATTEMPTS  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        config.max_attempts = KWARG_ATTEMPTS  # ty: ignore[invalid-assignment]
 
 
 def test_keep_delivered_accepts_bool_and_timedelta() -> None:

--- a/tests/resilience/backoffs/test_constant.py
+++ b/tests/resilience/backoffs/test_constant.py
@@ -31,4 +31,4 @@ def test_frozen_config() -> None:
     """`ConstantBackoff` is frozen."""
     config = ConstantBackoff()
     with pytest.raises(ValidationError):
-        config.delay = _NEW_DELAY  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        config.delay = _NEW_DELAY  # ty: ignore[invalid-assignment]

--- a/tests/resilience/backoffs/test_exponential.py
+++ b/tests/resilience/backoffs/test_exponential.py
@@ -127,4 +127,4 @@ def test_frozen_config() -> None:
     """`ExponentialBackoff` is frozen."""
     config = ExponentialBackoff()
     with pytest.raises(ValidationError):
-        config.base_delay = 0.5  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        config.base_delay = 0.5  # ty: ignore[invalid-assignment]

--- a/tests/resilience/backoffs/test_fibonacci.py
+++ b/tests/resilience/backoffs/test_fibonacci.py
@@ -48,4 +48,4 @@ def test_frozen_config() -> None:
     """`FibonacciBackoff` is frozen."""
     config = FibonacciBackoff()
     with pytest.raises(ValidationError):
-        config.base_delay = 2.0  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        config.base_delay = 2.0  # ty: ignore[invalid-assignment]

--- a/tests/resilience/backoffs/test_linear.py
+++ b/tests/resilience/backoffs/test_linear.py
@@ -45,4 +45,4 @@ def test_frozen_config() -> None:
     """`LinearBackoff` is frozen."""
     config = LinearBackoff()
     with pytest.raises(ValidationError):
-        config.base_delay = 5.0  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        config.base_delay = 5.0  # ty: ignore[invalid-assignment]

--- a/tests/resilience/backoffs/test_random.py
+++ b/tests/resilience/backoffs/test_random.py
@@ -46,4 +46,4 @@ def test_frozen_config() -> None:
     """`RandomBackoff` is frozen."""
     config = RandomBackoff()
     with pytest.raises(ValidationError):
-        config.min_delay = 1.0  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        config.min_delay = 1.0  # ty: ignore[invalid-assignment]

--- a/tests/resilience/shield/test_env.py
+++ b/tests/resilience/shield/test_env.py
@@ -131,7 +131,7 @@ def test_config_accepts_single_exception_class() -> None:
     """A bare exception class is wrapped in a one-tuple."""
     from grelmicro.resilience import ApiShieldConfig  # noqa: PLC0415
 
-    cfg = ApiShieldConfig(timeout_errors=TimeoutError)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    cfg = ApiShieldConfig(timeout_errors=TimeoutError)  # ty: ignore[invalid-argument-type]
     assert TimeoutError in cfg.timeout_errors
 
 
@@ -155,4 +155,4 @@ def test_config_normalizer_passes_through_unknown_shapes() -> None:
     # raw dict to exercise the passthrough branch.
     cls = _BaseShieldConfig._normalize_timeout_errors
     raw: Any = {"not": "valid"}
-    assert cls(raw) == raw  # type: ignore[arg-type]
+    assert cls(raw) == raw

--- a/tests/resilience/shield/test_profiles.py
+++ b/tests/resilience/shield/test_profiles.py
@@ -88,20 +88,20 @@ def test_config_kind_discriminator() -> None:
 def test_config_extra_forbidden() -> None:
     """Unknown fields are rejected."""
     with pytest.raises(ValidationError):
-        ApiShieldConfig(unknown_field="x")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+        ApiShieldConfig(unknown_field="x")  # ty: ignore[unknown-argument]
 
 
 def test_timeout_errors_rejects_base_exception_class() -> None:
     """`BaseException`-only types cannot be passed as `timeout_errors`."""
     with pytest.raises(TypeError, match="not an Exception subclass"):
-        ApiShieldConfig(timeout_errors=KeyboardInterrupt)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        ApiShieldConfig(timeout_errors=KeyboardInterrupt)  # ty: ignore[invalid-argument-type]
 
 
 def test_config_frozen() -> None:
     """Configs are frozen after construction."""
     config = ApiShieldConfig()
     with pytest.raises(ValidationError):
-        config.max_rate = 5  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        config.max_rate = 5  # ty: ignore[invalid-assignment]
 
 
 def test_model_dump_roundtrip() -> None:

--- a/tests/resilience/shield/test_shield.py
+++ b/tests/resilience/shield/test_shield.py
@@ -205,14 +205,14 @@ async def test_decorator_rejects_sync_functions() -> None:
     """Sync functions cannot be wrapped by Shield."""
     s = _shield()
     with pytest.raises(TypeError, match="async"):
-        s(lambda: None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        s(lambda: None)  # ty: ignore[invalid-argument-type]
 
 
 async def test_run_rejects_sync_functions() -> None:
     """`Shield.run` raises a clear error for sync callables."""
     s = _shield()
     with pytest.raises(TypeError, match="async"):
-        await s.run(lambda: None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        await s.run(lambda: None)  # ty: ignore[invalid-argument-type]
 
 
 async def test_state_shared_across_calls_through_one_instance() -> None:
@@ -241,7 +241,7 @@ async def test_from_config_constructs_instance() -> None:
 async def test_name_is_required_on_factory() -> None:
     """`Shield.api(name)` requires the name positionally."""
     with pytest.raises(TypeError):
-        Shield.api()  # type: ignore[call-arg]  # ty: ignore[missing-argument]
+        Shield.api()  # ty: ignore[missing-argument]
 
 
 async def test_pep_678_note_format() -> None:

--- a/tests/resilience/test_bulkhead.py
+++ b/tests/resilience/test_bulkhead.py
@@ -200,7 +200,7 @@ def test_decorator_rejects_sync_function() -> None:
 
     with pytest.raises(TypeError, match="only decorates async functions"):
 
-        @bulkhead  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        @bulkhead  # ty: ignore[invalid-argument-type]
         def handler() -> None: ...
 
 

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -1068,7 +1068,7 @@ async def test_reconfigure_rejects_different_config_type() -> None:
 
     cb = CircuitBreaker("rc")
     with pytest.raises(TypeError, match="ConsecutiveCountConfig"):
-        await cb.reconfigure(Other())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        await cb.reconfigure(Other())  # ty: ignore[invalid-argument-type]
 
 
 # --- shared-backend integration ---

--- a/tests/resilience/test_circuitbreaker_postgres.py
+++ b/tests/resilience/test_circuitbreaker_postgres.py
@@ -75,7 +75,7 @@ def test_bind_rejects_unknown_kind(monkeypatch: pytest.MonkeyPatch) -> None:
         kind = "failure_rate"
 
     with pytest.raises(NotImplementedError, match="failure_rate"):
-        backend.bind(name="x", config=Fake())  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
+        backend.bind(name="x", config=Fake())  # ty: ignore[invalid-argument-type]
 
 
 # --- Integration tests against a real Postgres container ---

--- a/tests/resilience/test_circuitbreaker_redis.py
+++ b/tests/resilience/test_circuitbreaker_redis.py
@@ -67,7 +67,7 @@ def test_bind_rejects_unknown_kind(monkeypatch: pytest.MonkeyPatch) -> None:
         kind = "failure_rate"
 
     with pytest.raises(NotImplementedError, match="failure_rate"):
-        backend.bind(name="x", config=Fake())  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
+        backend.bind(name="x", config=Fake())  # ty: ignore[invalid-argument-type]
 
 
 # --- Integration tests against a real Redis container ---

--- a/tests/resilience/test_circuitbreaker_sqlite.py
+++ b/tests/resilience/test_circuitbreaker_sqlite.py
@@ -113,7 +113,7 @@ def test_bind_rejects_unknown_kind(monkeypatch: pytest.MonkeyPatch) -> None:
         kind = "failure_rate"
 
     with pytest.raises(NotImplementedError, match="failure_rate"):
-        backend.bind(name="x", config=Fake())  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
+        backend.bind(name="x", config=Fake())  # ty: ignore[invalid-argument-type]
 
 
 # --- Behavior tests against a temp file (no server required) ---

--- a/tests/resilience/test_errors.py
+++ b/tests/resilience/test_errors.py
@@ -124,19 +124,19 @@ def test_resilience_module_exports() -> None:
 def test_resilience_lazy_loader_unknown_attribute_raises() -> None:
     """The top-level lazy loader raises `AttributeError` for unknown names."""
     with pytest.raises(AttributeError, match=r"grelmicro\.resilience"):
-        _ = resilience_mod.NotAThing  # type: ignore[attr-defined]
+        _ = resilience_mod.NotAThing
 
 
 def test_circuitbreaker_lazy_loader_unknown_attribute_raises() -> None:
     """The circuit-breaker subpackage loader rejects unknown names."""
     with pytest.raises(AttributeError, match="circuitbreaker"):
-        _ = cb_mod.NotAThing  # type: ignore[attr-defined]
+        _ = cb_mod.NotAThing
 
 
 def test_ratelimiter_lazy_loader_unknown_attribute_raises() -> None:
     """The rate-limiter subpackage loader rejects unknown names."""
     with pytest.raises(AttributeError, match="ratelimiter"):
-        _ = rl_mod.NotAThing  # type: ignore[attr-defined]
+        _ = rl_mod.NotAThing
 
 
 def test_resilience_lazy_table_matches_all_and_is_loadable() -> None:

--- a/tests/resilience/test_fallback.py
+++ b/tests/resilience/test_fallback.py
@@ -26,7 +26,7 @@ _NINETY_NINE = 99
 def test_config_requires_when() -> None:
     """`FallbackConfig` raises when `when` is missing."""
     with pytest.raises(ValidationError):
-        FallbackConfig(default=1)  # type: ignore[call-arg]  # ty: ignore[missing-argument]
+        FallbackConfig(default=1)  # ty: ignore[missing-argument]
 
 
 def test_config_requires_default_or_factory() -> None:
@@ -55,7 +55,7 @@ def test_config_frozen() -> None:
     """`FallbackConfig` is frozen."""
     cfg = FallbackConfig(when=Match.exception(ValueError), default=1)
     with pytest.raises(ValidationError):
-        cfg.default = 2  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        cfg.default = 2  # ty: ignore[invalid-assignment]
 
 
 # --- Class-form construction ----------------------------------------------
@@ -307,7 +307,7 @@ async def test_env_populates_when_and_default(
     """`GREL_FALLBACK_{NAME}_WHEN` and `_DEFAULT` populate unset fields."""
     monkeypatch.setenv("GREL_FALLBACK_RECS_WHEN", "builtins.ValueError")
     monkeypatch.setenv("GREL_FALLBACK_RECS_DEFAULT", "[]")
-    policy = Fallback("recs")  # type: ignore[call-arg]
+    policy = Fallback("recs")
     assert policy.config.default == []
     assert policy.config.when(Outcome.from_exception(ValueError()))
 
@@ -336,7 +336,7 @@ async def test_env_when_rejects_non_dotted_name(
     monkeypatch.setenv("GREL_FALLBACK_BAD_WHEN", "ValueError")
     monkeypatch.setenv("GREL_FALLBACK_BAD_DEFAULT", "0")
     with pytest.raises((ValidationError, ValueError)):
-        Fallback("bad")  # type: ignore[call-arg]
+        Fallback("bad")
 
 
 async def test_env_default_parses_null_as_none(
@@ -345,7 +345,7 @@ async def test_env_default_parses_null_as_none(
     """`GREL_FALLBACK_{NAME}_DEFAULT=null` becomes `None`."""
     monkeypatch.setenv("GREL_FALLBACK_NULLD_WHEN", "builtins.ValueError")
     monkeypatch.setenv("GREL_FALLBACK_NULLD_DEFAULT", "null")
-    policy = Fallback("nulld")  # type: ignore[call-arg]
+    policy = Fallback("nulld")
     assert policy.config.default is None
 
 
@@ -355,7 +355,7 @@ async def test_env_default_keeps_non_json_string(
     """A non-JSON env string is kept as a plain string."""
     monkeypatch.setenv("GREL_FALLBACK_RAW_WHEN", "builtins.ValueError")
     monkeypatch.setenv("GREL_FALLBACK_RAW_DEFAULT", "hello world")
-    policy = Fallback("raw")  # type: ignore[call-arg]
+    policy = Fallback("raw")
     assert policy.config.default == "hello world"
 
 
@@ -393,7 +393,7 @@ def test_config_string_default_is_not_json_parsed() -> None:
 def test_when_rejects_invalid_value() -> None:
     """Non-Match, non-class, non-tuple, non-callable raises."""
     with pytest.raises((ValidationError, TypeError)):
-        Fallback("api", when=42, default=0)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        Fallback("api", when=42, default=0)  # ty: ignore[invalid-argument-type]
 
 
 # --- Env: bad `when=` FQNs ------------------------------------------------
@@ -408,7 +408,7 @@ async def test_env_when_rejects_unknown_module(
     with pytest.raises(
         (ValidationError, ValueError), match="cannot import module"
     ):
-        Fallback("bad2")  # type: ignore[call-arg]
+        Fallback("bad2")
 
 
 async def test_env_when_rejects_unknown_attribute(
@@ -418,7 +418,7 @@ async def test_env_when_rejects_unknown_attribute(
     monkeypatch.setenv("GREL_FALLBACK_BAD3_WHEN", "builtins.NoSuchClass")
     monkeypatch.setenv("GREL_FALLBACK_BAD3_DEFAULT", "0")
     with pytest.raises((ValidationError, ValueError), match="has no attribute"):
-        Fallback("bad3")  # type: ignore[call-arg]
+        Fallback("bad3")
 
 
 async def test_env_when_rejects_non_exception_class(
@@ -428,7 +428,7 @@ async def test_env_when_rejects_non_exception_class(
     monkeypatch.setenv("GREL_FALLBACK_BAD4_WHEN", "builtins.int")
     monkeypatch.setenv("GREL_FALLBACK_BAD4_DEFAULT", "0")
     with pytest.raises((ValidationError, TypeError)):
-        Fallback("bad4")  # type: ignore[call-arg]
+        Fallback("bad4")
 
 
 # --- Env opt-out and factory-only paths -----------------------------------

--- a/tests/resilience/test_match.py
+++ b/tests/resilience/test_match.py
@@ -54,7 +54,7 @@ def test_exception_requires_arguments() -> None:
 def test_exception_rejects_non_exception_class() -> None:
     """Non-exception class raises ``TypeError``."""
     with pytest.raises(TypeError, match="exception classes"):
-        Match.exception(int)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        Match.exception(int)  # ty: ignore[invalid-argument-type]
 
 
 # --- Match.result ----------------------------------------------------------
@@ -253,7 +253,7 @@ def test_exception_cause_skips_when_returned() -> None:
 def test_exception_cause_rejects_non_exception_class() -> None:
     """Non-exception arg raises ``TypeError``."""
     with pytest.raises(TypeError, match="exception classes"):
-        Match.exception_cause(int)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        Match.exception_cause(int)  # ty: ignore[invalid-argument-type]
 
 
 def test_not_exception_message_scoped_to_raised() -> None:
@@ -311,7 +311,7 @@ def test_predicate_non_bool_warns(caplog: pytest.LogCaptureFixture) -> None:
     """A predicate returning a non-bool value logs a warning on first call."""
     import grelmicro.resilience._match as match_mod  # noqa: PLC0415
 
-    def truthy_int(_exc: Exception) -> int:  # type: ignore[return]
+    def truthy_int(_exc: Exception) -> int:
         return 1
 
     match_mod._warned_predicates.discard(id(truthy_int))
@@ -329,7 +329,7 @@ def test_predicate_non_bool_warns_only_once(
     """The non-bool warning fires at most once per predicate."""
     import grelmicro.resilience._match as match_mod  # noqa: PLC0415
 
-    def truthy_int(_exc: Exception) -> int:  # type: ignore[return]
+    def truthy_int(_exc: Exception) -> int:
         return 1
 
     match_mod._warned_predicates.discard(id(truthy_int))

--- a/tests/resilience/test_outcome.py
+++ b/tests/resilience/test_outcome.py
@@ -28,7 +28,7 @@ def test_outcome_is_frozen() -> None:
     """``Outcome`` instances are immutable."""
     outcome = Outcome.from_result(1)
     with pytest.raises(AttributeError):
-        outcome.raised = True  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        outcome.raised = True  # ty: ignore[invalid-assignment]
 
 
 def test_outcome_with_none_result() -> None:

--- a/tests/resilience/test_ratelimiter.py
+++ b/tests/resilience/test_ratelimiter.py
@@ -290,7 +290,7 @@ async def test_acquire_result_is_named_tuple(limiter: RateLimiter) -> None:
     assert isinstance(result, RateLimitResult)
     assert isinstance(result, tuple)
     with pytest.raises(AttributeError):
-        result.allowed = False  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        result.allowed = False  # ty: ignore[invalid-assignment]
 
 
 # --- acquire_or_raise ---

--- a/tests/resilience/test_ratelimiter_sqlite.py
+++ b/tests/resilience/test_ratelimiter_sqlite.py
@@ -42,8 +42,8 @@ def test_refill_clamps_clock_step_back() -> None:
     """
     # Arrange
     bucket = _SQLiteTokenBucket(
-        conn=None,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-        lock=None,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        conn=None,  # ty: ignore[invalid-argument-type]
+        lock=None,  # ty: ignore[invalid-argument-type]
         prefix="grel:ratelimiter:test:",
         table_name="rate_limit",
         config=TokenBucketConfig(capacity=10, refill_rate=1.0),
@@ -142,12 +142,12 @@ async def test_acquire_rolls_back_on_error(
             raise RuntimeError(msg)
         return original_execute(sql, *args, **kwargs)
 
-    conn.execute = fail_on_insert  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    conn.execute = fail_on_insert  # ty: ignore[invalid-assignment]
     try:
         with pytest.raises(RuntimeError, match="boom"):
             await strategy.acquire(key="rollback", cost=1)
     finally:
-        conn.execute = original_execute  # type: ignore[method-assign]
+        conn.execute = original_execute
 
     # The connection is usable again: the failed transaction rolled back.
     result = await strategy.acquire(key="rollback", cost=1)

--- a/tests/resilience/test_retry.py
+++ b/tests/resilience/test_retry.py
@@ -55,7 +55,7 @@ def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_config_requires_when() -> None:
     """`RetryConfig` raises when `when` is missing."""
     with pytest.raises(ValidationError):
-        RetryConfig()  # type: ignore[call-arg]  # ty: ignore[missing-argument]
+        RetryConfig()  # ty: ignore[missing-argument]
 
 
 def test_config_default_attempts_and_backoff() -> None:
@@ -76,7 +76,7 @@ def test_config_frozen() -> None:
     """`RetryConfig` is frozen."""
     config = RetryConfig(when=(ValueError,))
     with pytest.raises(ValidationError):
-        config.attempts = _FIVE  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        config.attempts = _FIVE  # ty: ignore[invalid-assignment]
 
 
 # --- Class-form construction ----------------------------------------------
@@ -548,7 +548,7 @@ async def test_env_populates_attempts_and_when(
     """`GREL_RETRY_{NAME}_ATTEMPTS` and `_WHEN` populate unset fields."""
     monkeypatch.setenv("GREL_RETRY_PAYMENTS_ATTEMPTS", "7")
     monkeypatch.setenv("GREL_RETRY_PAYMENTS_WHEN", "builtins.ValueError")
-    policy = Retry("payments")  # type: ignore[call-arg]
+    policy = Retry("payments")
     expected_attempts = 7
     assert policy.config.attempts == expected_attempts
     matcher = policy.config.when
@@ -563,7 +563,7 @@ async def test_env_backoff_via_json(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(
         "GREL_RETRY_FOO_BACKOFF", '{"kind":"constant","delay":2.5}'
     )
-    policy = Retry("foo")  # type: ignore[call-arg]
+    policy = Retry("foo")
     assert isinstance(policy.config.backoff, ConstantBackoff)
     expected_delay = 2.5
     assert policy.config.backoff.delay == expected_delay
@@ -742,7 +742,7 @@ def test_when_accepts_match_directly(fast_constant: ConstantBackoff) -> None:
 def test_when_rejects_invalid_value(fast_constant: ConstantBackoff) -> None:
     """Non-Match, non-class, non-tuple, non-callable raises."""
     with pytest.raises((ValidationError, TypeError)):
-        Retry("api", fast_constant, when=42)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        Retry("api", fast_constant, when=42)  # ty: ignore[invalid-argument-type]
 
 
 async def test_env_when_rejects_non_dotted_name(
@@ -751,7 +751,7 @@ async def test_env_when_rejects_non_dotted_name(
     """Bare-name env entry raises a clear error."""
     monkeypatch.setenv("GREL_RETRY_BAD_WHEN", "ValueError")
     with pytest.raises((ValidationError, ValueError)):
-        Retry("bad")  # type: ignore[call-arg]
+        Retry("bad")
 
 
 async def test_env_when_rejects_non_exception_class(
@@ -760,7 +760,7 @@ async def test_env_when_rejects_non_exception_class(
     """FQN that resolves to a non-Exception class raises."""
     monkeypatch.setenv("GREL_RETRY_BAD2_WHEN", "builtins.int")
     with pytest.raises((ValidationError, TypeError)):
-        Retry("bad2")  # type: ignore[call-arg]
+        Retry("bad2")
 
 
 # --- Block form coverage extras -------------------------------------------
@@ -803,7 +803,7 @@ async def test_env_when_rejects_unknown_module(
     with pytest.raises(
         (ValidationError, ValueError), match="cannot import module"
     ):
-        Retry("bad3")  # type: ignore[call-arg]
+        Retry("bad3")
 
 
 async def test_env_when_rejects_unknown_attribute(
@@ -812,7 +812,7 @@ async def test_env_when_rejects_unknown_attribute(
     """FQN that points to a missing attribute raises with a clear message."""
     monkeypatch.setenv("GREL_RETRY_BAD4_WHEN", "builtins.NoSuchClass")
     with pytest.raises((ValidationError, ValueError), match="has no attribute"):
-        Retry("bad4")  # type: ignore[call-arg]
+        Retry("bad4")
 
 
 async def test_async_budget_elapsed_note(mocker: MockerFixture) -> None:

--- a/tests/resilience/test_retry_mutants.py
+++ b/tests/resilience/test_retry_mutants.py
@@ -1072,4 +1072,4 @@ def test_env_when_rejects_non_exception_fqn(
     with pytest.raises(
         (ValueError, TypeError), match="not an Exception subclass"
     ):
-        Retry("notexc", env_load=True)  # type: ignore[call-arg]
+        Retry("notexc", env_load=True)

--- a/tests/resilience/test_timeout.py
+++ b/tests/resilience/test_timeout.py
@@ -18,7 +18,7 @@ _ONE = 1.0
 def test_config_requires_seconds() -> None:
     """`TimeoutConfig` raises when `seconds` is missing."""
     with pytest.raises(ValidationError):
-        TimeoutConfig()  # type: ignore[call-arg]  # ty: ignore[missing-argument]
+        TimeoutConfig()  # ty: ignore[missing-argument]
 
 
 def test_config_rejects_zero_seconds() -> None:
@@ -37,13 +37,13 @@ def test_config_frozen() -> None:
     """`TimeoutConfig` is frozen."""
     cfg = TimeoutConfig(seconds=1.0)
     with pytest.raises(ValidationError):
-        cfg.seconds = 2.0  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        cfg.seconds = 2.0  # ty: ignore[invalid-assignment]
 
 
 def test_config_forbids_extra() -> None:
     """`TimeoutConfig` rejects unknown fields."""
     with pytest.raises(ValidationError):
-        TimeoutConfig(seconds=1.0, policy="raise")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+        TimeoutConfig(seconds=1.0, policy="raise")  # ty: ignore[unknown-argument]
 
 
 # --- Class-form construction ----------------------------------------------
@@ -183,7 +183,7 @@ def test_decorator_rejects_sync_function() -> None:
     def sync_fn() -> None: ...
 
     with pytest.raises(TypeError):
-        policy(sync_fn)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        policy(sync_fn)  # ty: ignore[invalid-argument-type]
 
 
 # --- Live reconfiguration -------------------------------------------------
@@ -205,7 +205,7 @@ async def test_reconfigure_requires_same_type() -> None:
     """`reconfigure` rejects a different config type."""
     policy = Timeout("t", seconds=1.0)
     with pytest.raises(TypeError):
-        await policy.reconfigure("not a config")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        await policy.reconfigure("not a config")  # ty: ignore[invalid-argument-type]
 
 
 async def test_reconfigure_does_not_affect_in_flight_scope() -> None:

--- a/tests/task/test_cron_task.py
+++ b/tests/task/test_cron_task.py
@@ -178,7 +178,7 @@ async def test_cron_delay_uses_true_elapsed_across_dst(
         return True  # break the loop after the first scheduled sleep
 
     def frozen_now(tz: object) -> datetime:
-        return pre_dst.astimezone(tz)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        return pre_dst.astimezone(tz)  # ty: ignore[invalid-argument-type]
 
     mocker.patch(
         "grelmicro.task._cron.sleep_or_stop", side_effect=capture_sleep

--- a/tests/task/test_router.py
+++ b/tests/task/test_router.py
@@ -148,7 +148,7 @@ def test_router_interval_name_generation_error() -> None:
         FunctionTypeError,
         match="callable without __module__ or __qualname__ attribute",
     ):
-        router.every(seconds=10)(object())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        router.every(seconds=10)(object())  # ty: ignore[invalid-argument-type]
 
 
 def test_router_interval_with_lock() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -242,7 +242,7 @@ def test_frozen_is_preserved() -> None:
         env_load=True,
     )
     with pytest.raises(ValidationError):
-        cfg.timeout = ENV_TIMEOUT  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        cfg.timeout = ENV_TIMEOUT  # ty: ignore[invalid-assignment]
 
 
 def test_returns_correct_instance_type() -> None:

--- a/tests/test_health_router.py
+++ b/tests/test_health_router.py
@@ -363,7 +363,7 @@ def test_healthz_details_dep_none_rejected() -> None:
 def test_healthz_details_invalid_type_rejected() -> None:
     """An invalid ``show_details`` value is rejected at router build time."""
     with pytest.raises(TypeError, match="show_details"):
-        health_router(show_details="yes")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        health_router(show_details="yes")  # ty: ignore[invalid-argument-type]
 
 
 def test_healthz_exclude_checker(

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -209,7 +209,7 @@ async def test_trace_shutdown_timeout_logs_warning(
         provider = micro.trace.provider
         # Replace shutdown with a sleep that outlives the configured
         # timeout. The daemon-thread wrapper means this is safe.
-        provider.shutdown = lambda: time.sleep(0.3)  # type: ignore[method-assign]
+        provider.shutdown = lambda: time.sleep(0.3)
 
     assert any(
         "TracerProvider.shutdown timed out" in record.message
@@ -229,7 +229,7 @@ async def test_trace_shutdown_exception_logged_not_propagated(
 
     micro = Grelmicro(uses=[Trace(exporter=TraceExporterType.NONE)])
     async with micro:
-        micro.trace.provider.shutdown = _raise  # type: ignore[method-assign]
+        micro.trace.provider.shutdown = _raise
 
     assert any(
         "TracerProvider.shutdown raised an exception" in record.message

--- a/tests/tracing/test_context.py
+++ b/tests/tracing/test_context.py
@@ -338,7 +338,7 @@ class TestOTelResolver:
 
         real_import = builtins.__import__
 
-        def fake_import(name, *args, **kwargs):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN002, ANN003, ANN202
+        def fake_import(name, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
             if name.startswith("opentelemetry"):
                 raise ImportError(name)
             return real_import(name, *args, **kwargs)


### PR DESCRIPTION
grelmicro type-checks with `ty`, not mypy. mypy is not installed, configured, or run anywhere: not in `pyproject.toml`, `.pre-commit-config.yaml`, any workflow, or any config file.

The 140 `# type: ignore[...]` comments across 63 files were therefore inert. Nothing validated them, so nothing would ever report one going stale, which is exactly the failure mode `ty` caught eight of in #538.

Verified before removing:

* Stripping all 140 leaves `ty check` fully clean, so none were load-bearing.
* `ty` never flagged them as unused either, so it is not tracking them at all.
* mypy already reported 62 errors in 24 files **with** the comments in place, so the codebase never passed mypy. Removing them takes that to 98, under a checker the project does not run.

Also fixed the two comments in `grelmicro/_config.py` that referenced mypy, and dropped the justification above `SettingsConfigDict(**merged_config)` that claimed static checkers reject the widened value types. `ty` accepts it, and no suppression remains on that line.

`ruff format` rejoined three previously-wrapped lines that got shorter once the trailing comment went away.

Full pre-commit passes: ruff, codespell, ty-check, unit, integration, coverage, mkdocs-build.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b