### PR TITLE
🐛 Declare the backend _loop contract and fix the gaps it exposed

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,9 +10,17 @@
 
 * ✨ Add `basic_auth=(username, password)` to `Metrics`, matching `Trace`. grelmicro builds the `Authorization: Basic` header and attaches it to the OTLP exporter directly, bypassing the fragile `OTEL_EXPORTER_OTLP_HEADERS` encoding. From the environment, set `GREL_METRICS_BASIC_AUTH_USERNAME` and `GREL_METRICS_BASIC_AUTH_PASSWORD`. ([#507](https://github.com/grelinfo/grelmicro/issues/507))
 
+### Fixed
+
+* 🐛 Declare `_loop` on `LockBackend`, `ScheduleBackend`, `CacheBackend`, and `CircuitBreakerBackend`. The attribute was already required in prose, so a third-party adapter that omitted it type-checked and then raised `AttributeError` on the first `from_thread` call. ([#540](https://github.com/grelinfo/grelmicro/pull/540))
+* 🐛 Raise a clear error when `Lock.from_thread` or `TaskLock.from_thread` runs before the backend is opened, matching the cache and circuit-breaker behavior. ([#540](https://github.com/grelinfo/grelmicro/pull/540))
+* 🐛 Point the circuit-breaker worker-thread error at `async with micro:` instead of `grelmicro.lifespan()`, which is not a public API. ([#540](https://github.com/grelinfo/grelmicro/pull/540))
+* 🐛 Raise a clear error when installing the FastStream ambient middleware on an app with no broker, instead of an `AttributeError`. ([#540](https://github.com/grelinfo/grelmicro/pull/540))
+
 ### Internal
 
 * 🔥 Drop the inert mypy `# type: ignore` comments. grelmicro type-checks with ty, which never read them, and `ty check` stays clean without them. ([#539](https://github.com/grelinfo/grelmicro/pull/539))
+* ♻️ Return `OTel | None` from the private trace resolver so the handles narrow together, rather than a tuple of independently optional fields. ([#540](https://github.com/grelinfo/grelmicro/pull/540))
 
 ## 0.30.1 - 2026-07-18
 

--- a/examples/third-party-adapter/grelmicro_mongo.py
+++ b/examples/third-party-adapter/grelmicro_mongo.py
@@ -8,6 +8,7 @@ working backend.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any, Self
 
 from grelmicro.providers import Provider
@@ -23,9 +24,15 @@ class MongoLockAdapter:
         """Bind the adapter to the provider it borrows."""
         self._provider = provider
         self._owns_provider = False
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     async def __aenter__(self) -> Self:
-        """Open the adapter."""
+        """Open the adapter.
+
+        Capture the running loop so `Lock.from_thread` can dispatch
+        coroutines back into it from a worker thread.
+        """
+        self._loop = asyncio.get_running_loop()
         return self
 
     async def __aexit__(

--- a/grelmicro/_async.py
+++ b/grelmicro/_async.py
@@ -5,7 +5,24 @@ from __future__ import annotations
 import asyncio
 import functools
 import inspect
-from typing import Any
+from typing import Any, NoReturn
+
+
+def raise_backend_not_open(what: str) -> NoReturn:
+    """Raise for a sync adapter used before its backend captured a loop.
+
+    Call this only on the failure branch of ``if loop is None``. ``what``
+    names the caller, for example ``"Lock 'orders'"``.
+
+    Raises:
+        RuntimeError: Always.
+    """
+    msg = (
+        f"{what} cannot be used from a worker thread before its backend "
+        "is opened. Wrap startup with `async with micro:` or "
+        "`async with backend:`."
+    )
+    raise RuntimeError(msg)
 
 
 async def sleep_or_stop(seconds: float, stop: asyncio.Event | None) -> bool:

--- a/grelmicro/cache/_component.py
+++ b/grelmicro/cache/_component.py
@@ -132,4 +132,5 @@ class Cache:
         tb: TracebackType | None,
     ) -> bool | None:
         """Close the underlying backend."""
-        return await self._backend.__aexit__(exc_type, exc, tb)
+        await self._backend.__aexit__(exc_type, exc, tb)
+        return None

--- a/grelmicro/cache/_protocol.py
+++ b/grelmicro/cache/_protocol.py
@@ -6,6 +6,7 @@ implementation. Concrete backends (`RedisCacheAdapter`,
 `MemoryCacheAdapter`, `PostgresCacheAdapter`) provide the bodies.
 """
 
+import asyncio
 from collections.abc import Mapping, Sequence
 from types import TracebackType
 from typing import Annotated, Protocol, Self, runtime_checkable
@@ -25,6 +26,8 @@ class CacheBackend(Protocol):
     in a ``_loop`` attribute so the sync ``@cached`` wrapper can
     dispatch coroutines back into it.
     """
+
+    _loop: asyncio.AbstractEventLoop | None
 
     async def __aenter__(self) -> Self:
         """Open the backend connection."""

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -14,6 +14,7 @@ from typing import Annotated, Any, Literal, NamedTuple, ParamSpec, TypeVar
 
 from typing_extensions import Doc
 
+from grelmicro._async import raise_backend_not_open
 from grelmicro.cache._key import make_cache_key
 from grelmicro.cache._stampede import (
     AsyncStampedeGuard,
@@ -673,13 +674,9 @@ def _build_sync_wrapper(  # noqa: C901
     @functools.wraps(func)
     def sync_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, C901
         key = _make_key(func, args, kwargs, key_maker, typed=typed)
-        loop = cache._get_backend()._loop  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+        loop = cache._get_backend()._loop  # noqa: SLF001
         if loop is None:
-            msg = (
-                "The cache backend has no running event loop. "
-                "Open it first with 'async with backend:' or 'async with micro:'."
-            )
-            raise RuntimeError(msg)
+            raise_backend_not_open("The cache")
         result = _run(cache.get(key, _SENTINEL), loop)
         if result is not _SENTINEL:
             if early is not None:

--- a/grelmicro/coordination/_protocol.py
+++ b/grelmicro/coordination/_protocol.py
@@ -15,6 +15,7 @@ from pydantic import PositiveFloat
 from typing_extensions import Doc
 
 if TYPE_CHECKING:
+    import asyncio
     from collections.abc import Mapping
     from datetime import datetime
     from types import TracebackType
@@ -30,6 +31,8 @@ class LockBackend(Protocol):
     in a ``_loop`` attribute so lock adapters (``Lock.from_thread``,
     ``TaskLock.from_thread``) can dispatch coroutines back into it.
     """
+
+    _loop: asyncio.AbstractEventLoop | None
 
     async def __aenter__(self) -> Self:
         """Open the lock backend."""
@@ -170,6 +173,8 @@ class ScheduleBackend(Protocol):
     Implementations capture the running event loop on `__aenter__` in a
     `_loop` attribute when they bridge from threads, mirroring `LockBackend`.
     """
+
+    _loop: asyncio.AbstractEventLoop | None
 
     async def __aenter__(self) -> Self:
         """Open the schedule backend."""

--- a/grelmicro/coordination/lock.py
+++ b/grelmicro/coordination/lock.py
@@ -12,6 +12,7 @@ from pydantic import model_validator
 from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro
+from grelmicro._async import raise_backend_not_open
 from grelmicro._config import (
     Reconfigurable,
     default_env_prefix,
@@ -391,6 +392,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
 
         """
         await self.release()
+        return None
 
     @property
     def from_thread(self) -> "ThreadLockAdapter":
@@ -749,6 +751,14 @@ class ThreadLockAdapter:
         """Initialize the lock adapter."""
         self._lock = lock
 
+    @property
+    def _backend_loop(self) -> asyncio.AbstractEventLoop:
+        """Return the event loop the backend captured on ``__aenter__``."""
+        loop = self._lock.backend._loop  # noqa: SLF001
+        if loop is None:
+            raise_backend_not_open(f"Lock {self._lock.name!r}")
+        return loop
+
     def __enter__(self) -> LockHandle:
         """Acquire the lock with the context manager.
 
@@ -783,7 +793,7 @@ class ThreadLockAdapter:
         """
         return asyncio.run_coroutine_threadsafe(
             self._lock.do_thread_acquire(get_ident(), timeout=timeout),
-            self._lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+            self._backend_loop,
         ).result()
 
     def extend(self) -> LockHandle:
@@ -797,7 +807,7 @@ class ThreadLockAdapter:
         """
         return asyncio.run_coroutine_threadsafe(
             self._lock.do_thread_extend(get_ident()),
-            self._lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+            self._backend_loop,
         ).result()
 
     def acquire_nowait(self) -> LockHandle:
@@ -813,7 +823,7 @@ class ThreadLockAdapter:
         """
         return asyncio.run_coroutine_threadsafe(
             self._lock.do_thread_acquire_nowait(get_ident()),
-            self._lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+            self._backend_loop,
         ).result()
 
     def release(self) -> None:
@@ -825,14 +835,14 @@ class ThreadLockAdapter:
         """
         asyncio.run_coroutine_threadsafe(
             self._lock.do_thread_release(get_ident()),
-            self._lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+            self._backend_loop,
         ).result()
 
     def locked(self) -> bool:
         """Return True if the lock is currently held."""
         return asyncio.run_coroutine_threadsafe(
             self._lock.locked(),
-            self._lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+            self._backend_loop,
         ).result()
 
     def owned(self) -> bool:
@@ -844,5 +854,5 @@ class ThreadLockAdapter:
                     thread_id=get_ident(),
                 ),
             ),
-            self._lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+            self._backend_loop,
         ).result()

--- a/grelmicro/coordination/tasklock.py
+++ b/grelmicro/coordination/tasklock.py
@@ -16,6 +16,7 @@ from pydantic import model_validator
 from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro
+from grelmicro._async import raise_backend_not_open
 from grelmicro._config import (
     Reconfigurable,
     default_env_prefix,
@@ -363,6 +364,7 @@ class TaskLock(Reconfigurable[TaskLockConfig], LockPrimitive):
         config = self._config
         token = generate_task_token(config.worker, self._token_nonce)
         await self.do_exit(token, min_hold_duration=config.min_hold_duration)
+        return None
 
     @property
     def from_thread(self) -> "ThreadTaskLockAdapter":
@@ -552,6 +554,14 @@ class ThreadTaskLockAdapter:
         """Initialize the task lock adapter."""
         self._task_lock = task_lock
 
+    @property
+    def _backend_loop(self) -> asyncio.AbstractEventLoop:
+        """Return the event loop the backend captured on ``__aenter__``."""
+        loop = self._task_lock.backend._loop  # noqa: SLF001
+        if loop is None:
+            raise_backend_not_open(f"TaskLock {self._task_lock.name!r}")
+        return loop
+
     def __enter__(self) -> Self:
         """Acquire the task lock with the context manager.
 
@@ -562,7 +572,7 @@ class ThreadTaskLockAdapter:
         """
         asyncio.run_coroutine_threadsafe(
             self._task_lock.do_thread_enter(),
-            self._task_lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+            self._backend_loop,
         ).result()
         return self
 
@@ -579,12 +589,12 @@ class ThreadTaskLockAdapter:
         """
         asyncio.run_coroutine_threadsafe(
             self._task_lock.do_thread_exit(),
-            self._task_lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+            self._backend_loop,
         ).result()
 
     def locked(self) -> bool:
         """Return True if the lock is currently held."""
         return asyncio.run_coroutine_threadsafe(
             self._task_lock.locked(),
-            self._task_lock.backend._loop,  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+            self._backend_loop,
         ).result()

--- a/grelmicro/integrations/faststream.py
+++ b/grelmicro/integrations/faststream.py
@@ -153,12 +153,20 @@ def install(
     app.start = _start_with_micro_rollback  # ty: ignore[invalid-assignment]
 
     if ambient:
+        broker = app.broker
+        if broker is None:
+            msg = (
+                "Cannot register the ambient middleware: the FastStream app "
+                "has no broker. Pass a broker to `FastStream(...)`, or call "
+                "`install(app, micro, ambient=False)`."
+            )
+            raise ValueError(msg)
         middleware = type(
             "GrelmicroBrokerMiddleware",
             (_GrelmicroBrokerMiddleware,),
             {"micro": micro},
         )
-        app.broker.add_middleware(middleware)  # ty: ignore[unresolved-attribute]
+        broker.add_middleware(middleware)
     else:
         micro._on_ambient_disabled()  # noqa: SLF001
     _instrument_broker(app, micro)

--- a/grelmicro/resilience/_components.py
+++ b/grelmicro/resilience/_components.py
@@ -98,7 +98,8 @@ class RateLimiterRegistry:
         tb: TracebackType | None,
     ) -> bool | None:
         """Close the underlying backend."""
-        return await self._backend.__aexit__(exc_type, exc, tb)
+        await self._backend.__aexit__(exc_type, exc, tb)
+        return None
 
 
 class CircuitBreakerRegistry:
@@ -184,4 +185,5 @@ class CircuitBreakerRegistry:
         tb: TracebackType | None,
     ) -> bool | None:
         """Close the underlying backend."""
-        return await self._backend.__aexit__(exc_type, exc, tb)
+        await self._backend.__aexit__(exc_type, exc, tb)
+        return None

--- a/grelmicro/resilience/_protocol.py
+++ b/grelmicro/resilience/_protocol.py
@@ -22,6 +22,7 @@ from typing import (
 from typing_extensions import Doc
 
 if TYPE_CHECKING:
+    import asyncio
     from types import TracebackType
 
     from grelmicro.resilience.circuitbreaker import (
@@ -315,6 +316,8 @@ class CircuitBreakerBackend(Protocol):
     in a ``_loop`` attribute so the sync ``from_thread`` adapter can
     dispatch coroutines back into it.
     """
+
+    _loop: asyncio.AbstractEventLoop | None
 
     is_shared: ClassVar[bool]
     """Whether the backend stores state outside the local process.

--- a/grelmicro/resilience/circuitbreaker/__init__.py
+++ b/grelmicro/resilience/circuitbreaker/__init__.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Self
 from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro
+from grelmicro._async import raise_backend_not_open
 from grelmicro._config import Reconfigurable, default_env_prefix
 from grelmicro.metrics import _emit
 from grelmicro.resilience.errors import CircuitBreakerError
@@ -483,9 +484,9 @@ class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):
         ``cb.from_thread``.
         """
         backend = self.backend
-        loop: asyncio.AbstractEventLoop | None = backend._loop  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+        loop: asyncio.AbstractEventLoop | None = backend._loop  # noqa: SLF001
         if loop is None:  # pragma: no cover
-            backend._loop = asyncio.get_running_loop()  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+            backend._loop = asyncio.get_running_loop()  # noqa: SLF001
         state = self._state
         strategy = state.strategy or self._resolve_strategy(state)
         if not await strategy.try_acquire():
@@ -729,14 +730,9 @@ class _ThreadAdapter:
         """Enter the breaker context from a worker thread."""
         cb = self._cb
         backend = cb.backend
-        loop = backend._loop  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+        loop = backend._loop  # noqa: SLF001
         if loop is None:
-            msg = (
-                f"CircuitBreaker {cb.name!r} cannot be used from a worker "
-                "thread before its backend is opened. Wrap startup with "
-                "`async with grelmicro.lifespan():` or `async with backend:`."
-            )
-            raise RuntimeError(msg)
+            raise_backend_not_open(f"CircuitBreaker {cb.name!r}")
         config = cb._state.config  # noqa: SLF001
         if not asyncio.run_coroutine_threadsafe(
             _async_admit(cb), loop
@@ -762,7 +758,11 @@ class _ThreadAdapter:
         """Exit the breaker context from a worker thread."""
         cb = self._cb
         config = self._tls.stack.pop()
-        loop = cb.backend._loop  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+        loop = cb.backend._loop  # noqa: SLF001
+        if loop is None:  # pragma: no cover
+            # `__enter__` already resolved the loop, so this only guards
+            # against a backend closed mid-context.
+            raise_backend_not_open(f"CircuitBreaker {cb.name!r}")
         asyncio.run_coroutine_threadsafe(
             _async_handle_exit(cb, config, exc_type, exc_value), loop
         ).result()

--- a/grelmicro/resilience/timeout.py
+++ b/grelmicro/resilience/timeout.py
@@ -163,13 +163,14 @@ class Timeout(Reconfigurable[TimeoutConfig]):
         if not stack:
             del self._scopes[task]
         try:
-            return await scope.__aexit__(exc_type, exc, tb)
+            await scope.__aexit__(exc_type, exc, tb)
         finally:
             if scope.expired():
                 _emit.incr(
                     "grelmicro.timeout.exceeded",
                     **{"timeout.name": self._name},
                 )
+        return None
 
     def __call__(
         self, fn: Callable[..., Awaitable[Any]], /

--- a/grelmicro/trace/_context.py
+++ b/grelmicro/trace/_context.py
@@ -47,7 +47,7 @@ def add_context(**fields: object) -> None:
     _context_stack.set((*stack[:-1], new_frame))
 
     otel = _get_otel()
-    if otel.trace is not None:  # pragma: no branch
+    if otel is not None:  # pragma: no branch
         span = otel.trace.get_current_span()
         if span.is_recording():
             for k, v in fields.items():

--- a/grelmicro/trace/_instrument.py
+++ b/grelmicro/trace/_instrument.py
@@ -59,8 +59,8 @@ def _record_exception(otel_span: object) -> None:
         and otel_span.is_recording()  # ty: ignore[call-non-callable]
     ):
         exc = sys.exc_info()[1]
-        if exc is not None:  # pragma: no branch
-            otel = _get_otel()
+        otel = _get_otel()
+        if exc is not None and otel is not None:  # pragma: no branch
             otel_span.set_status(otel.status_code.ERROR, str(exc))  # ty: ignore[unresolved-attribute]
             otel_span.record_exception(exc)  # ty: ignore[unresolved-attribute]
 
@@ -184,9 +184,7 @@ def instrument[**P, R](
         )
         otel = _get_otel()
         tracer = (
-            otel.trace.get_tracer(fn.__module__)
-            if otel.trace is not None
-            else None
+            otel.trace.get_tracer(fn.__module__) if otel is not None else None
         )
 
         if inspect.iscoroutinefunction(fn):

--- a/grelmicro/trace/_otel.py
+++ b/grelmicro/trace/_otel.py
@@ -20,18 +20,25 @@ if TYPE_CHECKING:
 
 
 class OTel(NamedTuple):
-    """Resolved opentelemetry handles, or `None` when not installed."""
+    """Resolved opentelemetry handles.
 
-    trace: _OTelTrace | None
-    status_code: type[StatusCode] | None
+    Both handles come from the same import, so an instance always
+    carries both. Absence is `None` in place of the whole tuple.
+    """
+
+    trace: _OTelTrace
+    status_code: type[StatusCode]
 
 
 @cache
-def get() -> OTel:
-    """Return resolved opentelemetry handles. Cached after first call."""
+def get() -> OTel | None:
+    """Return resolved opentelemetry handles, or `None` when not installed.
+
+    Cached after first call.
+    """
     try:
         from opentelemetry import trace  # noqa: PLC0415
         from opentelemetry.trace import StatusCode  # noqa: PLC0415
     except ImportError:
-        return OTel(None, None)
+        return None
     return OTel(trace, StatusCode)

--- a/grelmicro/trace/_span.py
+++ b/grelmicro/trace/_span.py
@@ -42,7 +42,7 @@ def span(name: str, **fields: object) -> Generator[None, None, None]:
         otel.trace.get_tracer(__name__).start_as_current_span(
             name, attributes={k: str(v) for k, v in fields.items()}
         )
-        if otel.trace is not None
+        if otel is not None
         else nullcontext()
     )
     with otel_cm as otel_span:
@@ -50,13 +50,14 @@ def span(name: str, **fields: object) -> Generator[None, None, None]:
             yield
         except BaseException:
             if (
-                otel_span is not None
+                otel is not None
+                and otel_span is not None
                 and hasattr(otel_span, "is_recording")
                 and otel_span.is_recording()
             ):
                 exc = sys.exc_info()[1]
                 if exc is not None:  # pragma: no branch
-                    otel_span.set_status(otel.status_code.ERROR, str(exc))  # ty: ignore[unresolved-attribute]
+                    otel_span.set_status(otel.status_code.ERROR, str(exc))
                     otel_span.record_exception(exc)
             raise
         finally:

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -1446,3 +1446,14 @@ async def test_owned_check_error_carries_name(
     with pytest.raises(LockOwnedCheckError) as exc:
         await lock.owned()
     assert f"name={LOCK_NAME}" in str(exc.value)
+
+
+async def test_lock_from_thread_unopened_backend_raises() -> None:
+    """Worker-thread use before the backend is opened raises a clear error."""
+    lock = Lock("unopened", backend=MemoryLockAdapter())
+
+    def acquire() -> None:
+        lock.from_thread.acquire()
+
+    with pytest.raises(RuntimeError, match="async with micro:"):
+        await asyncio.to_thread(acquire)

--- a/tests/coordination/test_tasklock.py
+++ b/tests/coordination/test_tasklock.py
@@ -870,3 +870,14 @@ async def test_tasklock_backend_out_of_context() -> None:
         OutOfContextError, match="TaskLock\\('out-of-context'\\)"
     ):
         _ = task_lock.backend
+
+
+async def test_task_lock_from_thread_unopened_backend_raises() -> None:
+    """Worker-thread use before the backend is opened raises a clear error."""
+    task_lock = TaskLock("unopened", backend=MemoryLockAdapter())
+
+    def enter() -> None:
+        task_lock.from_thread.__enter__()
+
+    with pytest.raises(RuntimeError, match="async with micro:"):
+        await asyncio.to_thread(enter)

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -178,8 +178,8 @@ async def test_circuit_from_thread_unopened_backend_raises() -> None:
     def enter() -> None:
         cb.from_thread.__enter__()
 
-    # Act + Assert: the helpful message guides the user to open lifespan.
-    with pytest.raises(RuntimeError, match="lifespan"):
+    # Act + Assert: the helpful message guides the user to open the app.
+    with pytest.raises(RuntimeError, match="async with micro:"):
         await asyncio.to_thread(enter)
 
 

--- a/tests/test_faststream.py
+++ b/tests/test_faststream.py
@@ -257,3 +257,10 @@ def test_check_ambient_binding_false_without_middleware() -> None:
     micro = Grelmicro(uses=[RateLimiterRegistry(MemoryRateLimiterAdapter())])
     app = FastStream(RedisBroker())
     assert micro.check_ambient_binding(app) is False
+
+
+def test_install_without_broker_raises() -> None:
+    """Ambient install on a brokerless app raises a clear error."""
+    app = FastStream()
+    with pytest.raises(ValueError, match="has no broker"):
+        Grelmicro().install(app)

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -83,8 +83,10 @@ class _RecordingLockAdapter:
     def __init__(self, provider: _RecordingProvider) -> None:
         self._provider = provider
         self._owns_provider = False
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     async def __aenter__(self) -> Self:
+        self._loop = asyncio.get_running_loop()
         return self
 
     async def __aexit__(

--- a/tests/tracing/test_context.py
+++ b/tests/tracing/test_context.py
@@ -125,7 +125,7 @@ class TestAddContext:
         mock_trace.get_current_span.return_value = mock_span
         mocker.patch(
             "grelmicro.trace._context._get_otel",
-            return_value=OTel(mock_trace, None),
+            return_value=OTel(mock_trace, MagicMock()),
         )
 
         token = _push_context({"a": 1})
@@ -148,7 +148,7 @@ class TestAddContext:
         mock_trace.get_current_span.return_value = mock_span
         mocker.patch(
             "grelmicro.trace._context._get_otel",
-            return_value=OTel(mock_trace, None),
+            return_value=OTel(mock_trace, MagicMock()),
         )
 
         token = _push_context({"a": 1})
@@ -300,7 +300,7 @@ class TestInstrumentNoOtel:
         """Test sync @instrument works when tracer is None."""
         mocker.patch(
             "grelmicro.trace._instrument._get_otel",
-            return_value=OTel(None, None),
+            return_value=None,
         )
 
         @instrument
@@ -316,7 +316,7 @@ class TestInstrumentNoOtel:
         """Test async @instrument works when tracer is None."""
         mocker.patch(
             "grelmicro.trace._instrument._get_otel",
-            return_value=OTel(None, None),
+            return_value=None,
         )
 
         @instrument
@@ -333,7 +333,7 @@ class TestOTelResolver:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """`get()` returns `OTel(None, None)` when opentelemetry import fails."""
+        """`get()` returns `None` when opentelemetry import fails."""
         from grelmicro.trace import _otel  # noqa: PLC0415
 
         real_import = builtins.__import__
@@ -350,4 +350,4 @@ class TestOTelResolver:
         finally:
             _otel.get.cache_clear()
 
-        assert result == OTel(None, None)
+        assert result is None


### PR DESCRIPTION
Triaged the 98 mypy errors down to ~8 root causes and fixed the four that are genuine. mypy drops **98 to 77**, `ty check` stays clean, and two latent runtime bugs are closed.

## The main find

`LockBackend`'s docstring already stated the contract:

> Implementations capture the running event loop on `__aenter__` in a `_loop` attribute so lock adapters (`Lock.from_thread`, `TaskLock.from_thread`) can dispatch coroutines back into it.

The protocol never declared it. So a third-party backend could implement every documented method, type-check, pass `isinstance`, and then raise `AttributeError` on the first `.from_thread()` call.

Declaring `_loop` on `LockBackend`, `ScheduleBackend`, `CacheBackend`, and `CircuitBreakerBackend` immediately caught **our own shipped example**, `examples/third-party-adapter/grelmicro_mongo.py`, which omitted it. That example is what users copy to build a backend, so it was teaching people to write a broken adapter. Fixed there and in the matching test double.

`issubclass()` is never used against these protocols in-tree, so the data member breaks nothing.

## Also fixed

* **`Lock.from_thread` / `TaskLock.from_thread` had no guard** for an unopened backend, while `cached.py` and the circuit breaker both did. They now raise the same clear error through a shared `raise_backend_not_open` helper.
* **The circuit-breaker error pointed at `grelmicro.lifespan()`**, which is not a public API. It now points at `async with micro:`. The test asserting `match="lifespan"` was locking in that bad guidance.
* **FastStream ambient install** called `app.broker.add_middleware` unguarded, though `_instrument_broker` right below it already handled `broker is None`. A brokerless app raised `AttributeError`; it now raises a clear `ValueError`.
* **`__aexit__` correctness**: four sites did `return await backend.__aexit__(...)` where the protocol returns `None`, implying a suppression signal that cannot exist. Two others fell off the end. Verified `asyncio.Timeout.__aexit__` really returns `None`, so no behavior changed.
* **Trace OTel handles** were a `NamedTuple` of independently `Optional` fields, though they are always both set or both `None`. `get()` now returns `OTel | None` so they narrow together, removing several `# ty: ignore` comments.

## Kept deliberately

The remaining 77 are legitimate checker boundaries, mostly dynamic Pydantic (`_config.py`), optional-import rebinding, and third-party stub variance. They should become *validated* suppressions if mypy joins CI, not unvalidated ones.

## Performance note

An earlier draft built the error string on every call via `what=f"Lock {name!r}"`. That is a hot path, so the message is now built only on the failure branch behind a `NoReturn` helper.

## Verification

Full pre-commit passes: ruff, codespell, ty-check, unit, integration, coverage (100% enforced), mkdocs-build. 3394 unit tests pass, plus three new tests covering the guard branches.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b