### PR TITLE
🏷️ Preserve the wrapped signature through the resilience decorators

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+* 🏷️ Preserve the wrapped function's signature through the resilience decorators. Applying `Retry`, `Shield`, `Bulkhead`, `Timeout`, `CircuitBreaker`, or `Fallback` no longer erases the parameter and return types, so calls to a decorated function stay type-checked. ([#545](https://github.com/grelinfo/grelmicro/pull/545))
 * 🐛 Declare `_loop` on `LockBackend`, `ScheduleBackend`, `CacheBackend`, and `CircuitBreakerBackend`. The attribute was already required in prose, so a third-party adapter that omitted it type-checked and then raised `AttributeError` on the first `from_thread` call. ([#540](https://github.com/grelinfo/grelmicro/pull/540))
 * 🐛 Raise a clear error when `Lock.from_thread` or `TaskLock.from_thread` runs before the backend is opened, matching the cache and circuit-breaker behavior. ([#540](https://github.com/grelinfo/grelmicro/pull/540))
 * 🐛 Point the circuit-breaker worker-thread error at `async with micro:` instead of `grelmicro.lifespan()`, which is not a public API. ([#540](https://github.com/grelinfo/grelmicro/pull/540))

--- a/grelmicro/resilience/bulkhead.py
+++ b/grelmicro/resilience/bulkhead.py
@@ -229,7 +229,7 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
                 # so the value is never `None` on this branch.
                 raise BulkheadFullError(
                     name=self._name,
-                    max_concurrent=state.config.max_concurrent,  # ty: ignore[invalid-argument-type]
+                    max_concurrent=state.config.max_concurrent,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
                 ) from None
         if self._uses and not self._opened:
             await self._open_uses()
@@ -293,9 +293,9 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
                 await exit_stack.enter_async_context(item)
             self._opened = True
 
-    def __call__(
-        self, fn: Callable[..., Awaitable[Any]], /
-    ) -> Callable[..., Awaitable[Any]]:
+    def __call__[**P, R](
+        self, fn: Callable[P, Awaitable[R]], /
+    ) -> Callable[P, Awaitable[R]]:
         """Decorate ``fn`` so each call runs under this bulkhead."""
         if not iscoroutinefunction(fn):
             msg = (
@@ -305,7 +305,7 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
             raise TypeError(msg)
 
         @functools.wraps(fn)
-        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             async with self:
                 return await fn(*args, **kwargs)
 

--- a/grelmicro/resilience/circuitbreaker/__init__.py
+++ b/grelmicro/resilience/circuitbreaker/__init__.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from inspect import iscoroutinefunction
 from logging import getLogger
-from typing import TYPE_CHECKING, Annotated, Any, Self
+from typing import TYPE_CHECKING, Annotated, Any, Self, overload
 
 from typing_extensions import Doc
 
@@ -32,7 +32,7 @@ _STATE_CODE = {
 """Numeric codes for the `grelmicro.circuit_breaker.state` gauge."""
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
     from types import TracebackType
 
     from pydantic import Discriminator, PositiveFloat, PositiveInt
@@ -387,12 +387,23 @@ class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):
         self._logger = getLogger(f"grelmicro.circuitbreaker.{name}")
         self._logger.setLevel(config.log_level)
 
+    @overload
+    def __call__[**P, R](
+        self, func: Callable[P, Awaitable[R]]
+    ) -> Callable[P, Awaitable[R]]: ...
+
+    @overload
+    def __call__[**P, R](self, func: Callable[P, R]) -> Callable[P, R]: ...
+
+    @overload
+    def __call__(self, func: None = None) -> Self: ...
+
     def __call__(
         self, func: Callable[..., Any] | None = None
-    ) -> Callable[..., Any]:
+    ) -> Callable[..., Any] | Self:
         """Return a decorator that protects a function with the circuit breaker."""
         if func is None:
-            return self.__call__
+            return self
 
         if iscoroutinefunction(func):
 

--- a/grelmicro/resilience/fallback.py
+++ b/grelmicro/resilience/fallback.py
@@ -429,12 +429,12 @@ class Fallback(Reconfigurable[FallbackConfig]):
         return cls(name, config=config)
 
     @overload
-    def __call__(
-        self, fn: Callable[..., Awaitable[Any]], /
-    ) -> Callable[..., Awaitable[Any]]: ...
+    def __call__[**P, R](
+        self, fn: Callable[P, Awaitable[R]], /
+    ) -> Callable[P, Awaitable[R]]: ...
 
     @overload
-    def __call__(self, fn: Callable[..., Any], /) -> Callable[..., Any]: ...
+    def __call__[**P, R](self, fn: Callable[P, R], /) -> Callable[P, R]: ...
 
     def __call__(self, fn: Callable[..., Any], /) -> Callable[..., Any]:
         """Decorate ``fn`` so each call runs through this fallback policy."""

--- a/grelmicro/resilience/retry.py
+++ b/grelmicro/resilience/retry.py
@@ -774,12 +774,12 @@ class Retry(Reconfigurable[RetryConfig]):
         return _sync_iter(state.config, state.matcher)
 
     @overload
-    def __call__(
-        self, fn: Callable[..., Awaitable[Any]], /
-    ) -> Callable[..., Awaitable[Any]]: ...
+    def __call__[**P, R](
+        self, fn: Callable[P, Awaitable[R]], /
+    ) -> Callable[P, Awaitable[R]]: ...
 
     @overload
-    def __call__(self, fn: Callable[..., Any], /) -> Callable[..., Any]: ...
+    def __call__[**P, R](self, fn: Callable[P, R], /) -> Callable[P, R]: ...
 
     def __call__(self, fn: Callable[..., Any], /) -> Callable[..., Any]:
         """Decorate ``fn`` so each call runs through this retry policy."""

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -488,13 +488,13 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
             raise TypeError(msg)
         return await self._execute(fn, args, kwargs)
 
-    def __call__(
+    def __call__[**P, R](
         self,
         fn: Annotated[
-            Callable[..., Awaitable[Any]],
+            Callable[P, Awaitable[R]],
             Doc("Async function to decorate."),
         ],
-    ) -> Callable[..., Awaitable[Any]]:
+    ) -> Callable[P, Awaitable[R]]:
         """Decorate `fn` so each call runs through this Shield."""
         if not inspect.iscoroutinefunction(fn):
             msg = (
@@ -504,7 +504,7 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
             raise TypeError(msg)
 
         @functools.wraps(fn)
-        async def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             return await self._execute(fn, args, kwargs)
 
         return wrapper

--- a/grelmicro/resilience/timeout.py
+++ b/grelmicro/resilience/timeout.py
@@ -172,9 +172,9 @@ class Timeout(Reconfigurable[TimeoutConfig]):
                 )
         return None
 
-    def __call__(
-        self, fn: Callable[..., Awaitable[Any]], /
-    ) -> Callable[..., Awaitable[Any]]:
+    def __call__[**P, R](
+        self, fn: Callable[P, Awaitable[R]], /
+    ) -> Callable[P, Awaitable[R]]:
         """Decorate ``fn`` so each call runs under this timeout."""
         if not iscoroutinefunction(fn):
             msg = (
@@ -184,7 +184,7 @@ class Timeout(Reconfigurable[TimeoutConfig]):
             raise TypeError(msg)
 
         @functools.wraps(fn)
-        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             async with self:
                 return await fn(*args, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -407,7 +407,6 @@ module = [
     "grelmicro.providers.sqlite",
     "grelmicro.providers.valkey",
     "grelmicro.resilience._components",
-    "grelmicro.resilience.bulkhead",
     "grelmicro.resilience.fallback",
     "grelmicro.resilience.retry",
     "grelmicro.trace._component",

--- a/tests/resilience/test_clock_driven.py
+++ b/tests/resilience/test_clock_driven.py
@@ -47,7 +47,7 @@ async def test_retry_backoff_driven_by_virtual_clock(
             raise _BOOM
         return "ok"
 
-    task = asyncio.create_task(flaky())  # ty: ignore[invalid-argument-type]
+    task = asyncio.create_task(flaky())
 
     # Let the first attempt run, fail, and suspend on the backoff sleep.
     await asyncio.sleep(0)
@@ -80,7 +80,7 @@ async def test_retry_max_seconds_stops_on_time_budget(
         calls += 1
         raise _BOOM
 
-    task = asyncio.create_task(always_fails())  # ty: ignore[invalid-argument-type]
+    task = asyncio.create_task(always_fails())
 
     # Attempt 1 runs at t=0.
     await asyncio.sleep(0)

--- a/tests/typechecking/resilience.py
+++ b/tests/typechecking/resilience.py
@@ -1,12 +1,16 @@
 """Type assertions for the resilience primitives."""
 
-from typing import Any, assert_type
+from typing import assert_type
 
 from grelmicro.resilience import (
+    Bulkhead,
     CircuitBreaker,
+    Fallback,
     RateLimiter,
     Retry,
     Shield,
+    Timeout,
+    retry,
 )
 
 
@@ -29,18 +33,26 @@ assert_type(
 assert_type(RateLimiter.sliding_window("rl", limit=10, window=1.0), RateLimiter)
 
 
-# --- Known gap: decorating erases the wrapped signature ---
-#
-# `Retry.__call__` and friends are typed `Callable[..., Awaitable[Any]]`, so a
-# decorated function loses both its parameter types and its return type. These
-# assertions pin the current behavior: when the decorators gain `ParamSpec`
-# generics, they fail and must be tightened to the real types. See #543.
+# --- Decorating preserves the wrapped signature ---
 
 retried = Retry.exponential("api", when=ValueError)(fetch)
 shielded = Shield.api("api")(fetch)
+bounded = Bulkhead("pool", max_concurrent=4)(fetch)
+deadlined = Timeout("slow", seconds=1.0)(fetch)
+broken = CircuitBreaker.consecutive_count("api")(fetch)
+fell_back = Fallback("api", when=ValueError, default={})(fetch)
+
+
+# The module-level functional form preserves signatures too.
+functional = retry(when=ValueError)(fetch)
 
 
 async def call_decorated() -> None:
-    """Awaiting a decorated coroutine currently yields `Any`."""
-    assert_type(await retried("ORD-1"), Any)
-    assert_type(await shielded("ORD-1"), Any)
+    """Awaiting a decorated coroutine yields the original return type."""
+    assert_type(await retried("ORD-1"), dict[str, int])
+    assert_type(await shielded("ORD-1", retries=5), dict[str, int])
+    assert_type(await bounded("ORD-1"), dict[str, int])
+    assert_type(await deadlined("ORD-1"), dict[str, int])
+    assert_type(await broken("ORD-1"), dict[str, int])
+    assert_type(await fell_back("ORD-1"), dict[str, int])
+    assert_type(await functional("ORD-1"), dict[str, int])


### PR DESCRIPTION
Fixes #543. **Stacked on #544** (`feat/typecheck-consumer-surface`), which adds the suite that found this. Merge #544 first and this retargets to `main`.

## Problem

`Retry.__call__` and friends were typed `Callable[..., Awaitable[Any]]`, so applying a resilience policy erased the wrapped function's parameter *and* return types:

```python
retried = Retry.exponential("api", when=ValueError)(fetch)
await retried("ORD-1")         # was Any, now dict[str, int]
await retried(123, bogus=True)  # was accepted, now two errors
```

grelmicro ships `py.typed`, so this silently disabled type-checking at every call site of any decorated function.

## Fix

`ParamSpec` generics on `__call__`, keeping the existing sync and async overloads:

* `Retry` and `Fallback` (overloaded sync + async)
* `Bulkhead`, `Timeout`, `Shield` (async-only)
* `CircuitBreaker` (supports both `@cb` and `@cb()`)

For `CircuitBreaker`, the bare-parens form returned `self.__call__`. It now returns `self`, which is behaviorally identical (both are callables that decorate) but types cleanly as `Self`, so generics survive the second call.

The module-level `@retry(...)` / `@fallback(...)` factories already used `Callable[[F], F]` and were **not** broken. Their remaining internal mypy errors are the known `functools.wraps` + TypeVar limitation, not a user-facing gap. Pinned in the suite regardless.

## Payoff beyond the fix

* `tests/typechecking/resilience.py` assertions tightened from `Any` to the real types, exactly as #544 predicted they would need to be.
* Two `# ty: ignore[invalid-argument-type]` comments in `tests/resilience/test_clock_driven.py` became unnecessary and are gone.
* **`grelmicro.resilience.bulkhead` leaves the mypy override ladder**, 30 modules to 29. That module is now permanently protected against new errors.

Clearing bulkhead surfaced one more diagnostic: a documented-but-unprovable invariant ("a semaphore exists only when `max_concurrent` is set") that already carried a `# ty: ignore`. It now carries a paired `# type: ignore[arg-type]`. That is *not* a return to the dead comments #539 deleted: mypy runs in CI now and `warn_unused_ignores` is on, so the suppression is validated and fails if it ever becomes unnecessary.

## Verification

Full pre-commit passes: ruff, codespell, ty-check, mypy-check, unit, integration, coverage (100%), mkdocs-build. 3395 unit tests pass.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b