### PR TITLE
👷 Enable the Pydantic mypy plugin and shrink the override ladder

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,8 @@
 
 ### Internal
 
+* 👷 Enable the Pydantic mypy plugin and shrink the mypy override ladder from 29 modules to 19. Ten modules now type-check under both checkers. ([#547](https://github.com/grelinfo/grelmicro/pull/547))
+* ♻️ Declare `arbitrary_types_allowed` in the `_BaseShieldConfig` class kwargs instead of a second `model_config` assignment. Pydantic merged both, so the settings are unchanged. ([#547](https://github.com/grelinfo/grelmicro/pull/547))
 * 🔥 Drop the inert mypy `# type: ignore` comments. grelmicro type-checks with ty, which never read them, and `ty check` stays clean without them. ([#539](https://github.com/grelinfo/grelmicro/pull/539))
 * ✅ Add `tests/typechecking/`, a suite of `assert_type` claims on the public API, checked by both ty and mypy. grelmicro ships `py.typed`, so these annotations are part of the contract. ([#544](https://github.com/grelinfo/grelmicro/pull/544))
 * 👷 Run mypy in CI alongside ty. The 30 modules that do not pass yet are listed in `[[tool.mypy.overrides]]` and tracked in [#541](https://github.com/grelinfo/grelmicro/issues/541). ([#544](https://github.com/grelinfo/grelmicro/pull/544))

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from logging import getLogger
 from time import monotonic
 from types import TracebackType
-from typing import Annotated, ClassVar, Self
+from typing import Annotated, Any, ClassVar, Self
 from uuid import UUID
 
 from pydantic import model_validator
@@ -599,10 +599,9 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
         await self.wait_for_leader()
         work: asyncio.Future[T] = asyncio.ensure_future(func(*args))
         loss = asyncio.ensure_future(self.wait_lose_leader())
+        racing: set[asyncio.Future[Any]] = {work, loss}
         try:
-            await asyncio.wait(
-                {work, loss}, return_when=asyncio.FIRST_COMPLETED
-            )
+            await asyncio.wait(racing, return_when=asyncio.FIRST_COMPLETED)
             if work.done():
                 return work.result()
             return None

--- a/grelmicro/idempotency/_decorator.py
+++ b/grelmicro/idempotency/_decorator.py
@@ -77,6 +77,6 @@ def idempotent(
                 fingerprint=call_fingerprint,
             )
 
-        return wrapper  # ty: ignore[invalid-return-type]
+        return wrapper  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
 
     return decorator

--- a/grelmicro/log/_shared.py
+++ b/grelmicro/log/_shared.py
@@ -21,7 +21,7 @@ from grelmicro.log.errors import LogSettingsValidationError
 try:
     from opentelemetry import trace
 except ImportError:  # pragma: no cover
-    trace: Any = None
+    trace: Any = None  # type: ignore[no-redef]
 
 from grelmicro._json import has_orjson, json_default, json_dumps_str
 

--- a/grelmicro/log/config.py
+++ b/grelmicro/log/config.py
@@ -13,7 +13,7 @@ from typing_extensions import Doc
 try:
     import opentelemetry
 except ImportError:  # pragma: no cover
-    opentelemetry: Any = None
+    opentelemetry: Any = None  # type: ignore[no-redef]
 
 
 class _CaseInsensitiveEnum(StrEnum):

--- a/grelmicro/metrics/_component.py
+++ b/grelmicro/metrics/_component.py
@@ -610,7 +610,7 @@ def _build_exporter(
         return OTLPMetricExporter(**_exporter_kwargs(config))
 
     try:  # pragma: no cover
-        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (  # noqa: PLC0415
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (  # noqa: PLC0415  # type: ignore[assignment]
             OTLPMetricExporter,
         )
     except ImportError as exc:  # pragma: no cover

--- a/grelmicro/metrics/_measure.py
+++ b/grelmicro/metrics/_measure.py
@@ -151,7 +151,7 @@ def measure[**P, R](
                 finally:
                     m.exit(start)
 
-            return async_wrapper  # ty: ignore[invalid-return-type]
+            return async_wrapper  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
 
         @functools.wraps(fn)
         def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:

--- a/grelmicro/providers/valkey.py
+++ b/grelmicro/providers/valkey.py
@@ -162,7 +162,7 @@ class ValkeyProvider(RedisProvider):
         instrumentor = getattr(self, "_valkey_instrumentor", None)
         if instrumentor is not None:
             instrumentor.uninstrument()
-            self._valkey_instrumentor = None
+            self._valkey_instrumentor = None  # type: ignore[assignment]
 
     @classmethod
     def from_config(

--- a/grelmicro/resilience/shield/_profile.py
+++ b/grelmicro/resilience/shield/_profile.py
@@ -57,7 +57,9 @@ def _resolve_fqn(fqn: str) -> type[BaseException]:
     return cls
 
 
-class _BaseShieldConfig(BaseModel, frozen=True, extra="forbid"):
+class _BaseShieldConfig(
+    BaseModel, frozen=True, extra="forbid", arbitrary_types_allowed=True
+):
     """Base Shield configuration shared by every profile.
 
     Subclasses freeze the profile-specific algorithm parameters as
@@ -135,8 +137,6 @@ class _BaseShieldConfig(BaseModel, frozen=True, extra="forbid"):
             "exception. May be sync or async."
         ),
     ] = None
-
-    model_config = {"arbitrary_types_allowed": True}
 
     @field_validator("timeout_errors", mode="before")
     @classmethod

--- a/grelmicro/trace/_valkey.py
+++ b/grelmicro/trace/_valkey.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.instrumentor import (  # type: ignore[attr-defined]
+    BaseInstrumentor,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Collection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,11 +370,18 @@ filterwarnings = [
 testpaths = "tests"
 
 [tool.mypy]
+plugins = ["pydantic.mypy"]
 files = ["grelmicro", "tests/typechecking"]
 python_version = "3.12"
 ignore_missing_imports = true
 warn_unused_ignores = true
 warn_redundant_casts = true
+
+# grelmicro type-checks with `ty`. mypy runs as a second opinion because the
+# package ships `py.typed`, so downstream mypy users see these annotations.
+# The modules below do not pass yet: they are dynamic-Pydantic, optional-import
+# rebinding, or third-party stub variance. Tracked in #541. Clear one, delete
+# its entry. Never add an entry to silence a new error.
 
 # grelmicro type-checks with `ty`. mypy runs as a second opinion because the
 # package ships `py.typed`, so downstream mypy users see these annotations.
@@ -388,30 +395,20 @@ module = [
     "grelmicro.cache._component",
     "grelmicro.cache.ttl",
     "grelmicro.coordination._component",
-    "grelmicro.coordination.leaderelection",
-    "grelmicro.coordination.lock",
-    "grelmicro.coordination.tasklock",
     "grelmicro.health._checks",
-    "grelmicro.idempotency._decorator",
     "grelmicro.integrations.faststream",
-    "grelmicro.log._shared",
     "grelmicro.log._structlog",
-    "grelmicro.log.config",
     "grelmicro.log.uvicorn",
     "grelmicro.metrics._component",
-    "grelmicro.metrics._measure",
     "grelmicro.outbox._codec",
     "grelmicro.outbox._component",
     "grelmicro.providers.postgres",
     "grelmicro.providers.redis",
-    "grelmicro.providers.sqlite",
-    "grelmicro.providers.valkey",
     "grelmicro.resilience._components",
     "grelmicro.resilience.fallback",
     "grelmicro.resilience.retry",
     "grelmicro.trace._component",
     "grelmicro.trace._instrument",
-    "grelmicro.trace._valkey",
 ]
 ignore_errors = true
 


### PR DESCRIPTION
Continues #541. The mypy ladder goes from **29 modules to 19**, and two real code issues are fixed along the way.

## Pydantic mypy plugin

grelmicro is Pydantic-heavy but was not loading `pydantic.mypy`, so mypy misread models as plain dataclasses. It produced nonsense like:

```
grelmicro/coordination/lock.py:66: error: Non-frozen dataclass cannot inherit from a frozen dataclass
```

which would be a runtime `TypeError` if it were true. Enabling the plugin (as FastAPI does) removed those false positives and cleared `coordination/lock.py`, `coordination/tasklock.py`, and `providers/sqlite.py` outright.

## Two real findings

**`_BaseShieldConfig` specified config twice.** It set `frozen=True, extra="forbid"` as class kwargs *and* assigned `model_config = {"arbitrary_types_allowed": True}` in the body. I verified at runtime before changing anything: Pydantic v2 merges them, so all three settings survive and both `frozen` and `extra=forbid` are enforced. **No behavior bug**, but the ambiguity is real and the plugin was right to flag it. Now a single class-kwargs declaration.

**`LeaderElection.lead` built an untypeable set.** `asyncio.wait({work, loss})` joined `Future[T]` and `Future[None]` to `Future[object]`, which does not satisfy `asyncio.wait`'s type variable. Now an explicit `set[asyncio.Future[Any]]`.

## Validated suppressions for the rest

Seven modules had a single error each, all genuine checker boundaries: optional-import rebinding (`no-redef`), the dual OTLP http/grpc import, a missing `BaseInstrumentor` in the OTel stubs, and the `functools.wraps` plus `ParamSpec` limitation. Each got a line-level `# type: ignore[code]`.

These are **validated**, unlike the 140 deleted in #539: mypy runs in CI and `warn_unused_ignores` is on. That was proved during this work. `ruff --fix` rewrapped an import and moved a suppression onto the wrong line, and mypy immediately reported `Unused "type: ignore" comment`. A line-level ignore is also far narrower than exempting a whole module.

## Result

| | before | after |
|---|---|---|
| ladder entries | 29 | **19** |
| modules mypy-protected | 139 | **149** |

Remaining 19 are the genuinely hard ones, led by `_config.py` (13 errors, dynamic Pydantic subclassing).

## Verification

Full pre-commit passes: ruff, codespell, ty-check, mypy-check, unit, integration, coverage (100%), mkdocs-build. 3395 unit tests pass, which matters here because the plugin and the `_profile.py` change both touch real Pydantic behavior.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b