### PR TITLE
✅ Widen the circuit-breaker cool-down margins in the backend tests

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
 
 ### Internal
 
+* ✅ Widen the circuit-breaker cool-down margins in the SQLite, Postgres, and Redis backend tests. The rejection assert now uses a 60s cool-down so a stalled runner cannot let the window elapse between two adjacent calls, and the elapse asserts wait 5x the cool-down instead of racing a 0.05s gap. ([#548](https://github.com/grelinfo/grelmicro/pull/548))
 * 👷 Enable the Pydantic mypy plugin and shrink the mypy override ladder from 29 modules to 19. Ten modules now type-check under both checkers. ([#547](https://github.com/grelinfo/grelmicro/pull/547))
 * ♻️ Declare `arbitrary_types_allowed` in the `_BaseShieldConfig` class kwargs instead of a second `model_config` assignment. Pydantic merged both, so the settings are unchanged. ([#547](https://github.com/grelinfo/grelmicro/pull/547))
 * 🔥 Drop the inert mypy `# type: ignore` comments. grelmicro type-checks with ty, which never read them, and `ty check` stays clean without them. ([#539](https://github.com/grelinfo/grelmicro/pull/539))

--- a/tests/resilience/test_circuitbreaker_postgres.py
+++ b/tests/resilience/test_circuitbreaker_postgres.py
@@ -160,11 +160,16 @@ async def test_open_rejects_until_reset_timeout_elapses(
 ) -> None:
     """OPEN rejects calls until `reset_timeout`, then enters HALF_OPEN."""
     strategy = _bind(backend, reset_timeout=0.5)
-    await strategy.transition(desired=CircuitBreakerState.OPEN)
 
+    # A long cool-down makes the rejection assert independent of scheduling:
+    # a stalled runner cannot let the window elapse between the two calls.
+    await strategy.transition(desired=CircuitBreakerState.OPEN, cool_down=60)
     assert await strategy.try_acquire() is False
 
-    await asyncio.sleep(0.6)
+    # Re-open with a short cool-down and wait several times past it, so the
+    # elapse assert has margin instead of racing a 0.1s gap.
+    await strategy.transition(desired=CircuitBreakerState.OPEN, cool_down=0.1)
+    await asyncio.sleep(0.5)
 
     assert await strategy.try_acquire() is True
     snapshot = await strategy.get_snapshot()
@@ -180,7 +185,7 @@ async def test_half_open_admission_cap_enforced_globally(
     cap = 2
     strategy = _bind(backend, half_open_capacity=cap, reset_timeout=0.1)
     await strategy.transition(desired=CircuitBreakerState.OPEN)
-    await asyncio.sleep(0.15)
+    await asyncio.sleep(0.5)  # 5x the 0.1s cool-down, not a 0.05s race
 
     results = await asyncio.gather(*(strategy.try_acquire() for _ in range(10)))
 

--- a/tests/resilience/test_circuitbreaker_redis.py
+++ b/tests/resilience/test_circuitbreaker_redis.py
@@ -150,11 +150,16 @@ async def test_open_rejects_until_reset_timeout_elapses(
 ) -> None:
     """OPEN rejects calls until `reset_timeout`, then enters HALF_OPEN."""
     strategy = _bind(backend, reset_timeout=0.5)
-    await strategy.transition(desired=CircuitBreakerState.OPEN)
 
+    # A long cool-down makes the rejection assert independent of scheduling:
+    # a stalled runner cannot let the window elapse between the two calls.
+    await strategy.transition(desired=CircuitBreakerState.OPEN, cool_down=60)
     assert await strategy.try_acquire() is False
 
-    await asyncio.sleep(0.6)
+    # Re-open with a short cool-down and wait several times past it, so the
+    # elapse assert has margin instead of racing a 0.1s gap.
+    await strategy.transition(desired=CircuitBreakerState.OPEN, cool_down=0.1)
+    await asyncio.sleep(0.5)
 
     assert await strategy.try_acquire() is True
     snapshot = await strategy.get_snapshot()
@@ -170,7 +175,7 @@ async def test_half_open_admission_cap_enforced_globally(
     cap = 2
     strategy = _bind(backend, half_open_capacity=cap, reset_timeout=0.1)
     await strategy.transition(desired=CircuitBreakerState.OPEN)
-    await asyncio.sleep(0.15)
+    await asyncio.sleep(0.5)  # 5x the 0.1s cool-down, not a 0.05s race
 
     results = await asyncio.gather(*(strategy.try_acquire() for _ in range(10)))
 

--- a/tests/resilience/test_circuitbreaker_sqlite.py
+++ b/tests/resilience/test_circuitbreaker_sqlite.py
@@ -181,11 +181,16 @@ async def test_open_rejects_until_reset_timeout_elapses(
 ) -> None:
     """OPEN rejects calls until `reset_timeout`, then enters HALF_OPEN."""
     strategy = _bind(backend, reset_timeout=0.5)
-    await strategy.transition(desired=CircuitBreakerState.OPEN)
 
+    # A long cool-down makes the rejection assert independent of scheduling:
+    # a stalled runner cannot let the window elapse between the two calls.
+    await strategy.transition(desired=CircuitBreakerState.OPEN, cool_down=60)
     assert await strategy.try_acquire() is False
 
-    await asyncio.sleep(0.6)
+    # Re-open with a short cool-down and wait several times past it, so the
+    # elapse assert has margin instead of racing a 0.1s gap.
+    await strategy.transition(desired=CircuitBreakerState.OPEN, cool_down=0.1)
+    await asyncio.sleep(0.5)
 
     assert await strategy.try_acquire() is True
     snapshot = await strategy.get_snapshot()
@@ -199,7 +204,7 @@ async def test_half_open_admission_cap_enforced_globally(
     cap = 2
     strategy = _bind(backend, half_open_capacity=cap, reset_timeout=0.1)
     await strategy.transition(desired=CircuitBreakerState.OPEN)
-    await asyncio.sleep(0.15)
+    await asyncio.sleep(0.5)  # 5x the 0.1s cool-down, not a 0.05s race
 
     results = await asyncio.gather(*(strategy.try_acquire() for _ in range(10)))
 
@@ -336,7 +341,7 @@ async def test_half_open_success_below_threshold_stays_half_open(
         backend, success_threshold=2, half_open_capacity=2, reset_timeout=0.1
     )
     await strategy.transition(desired=CircuitBreakerState.OPEN)
-    await asyncio.sleep(0.15)
+    await asyncio.sleep(0.5)  # 5x the 0.1s cool-down, not a 0.05s race
     assert await strategy.try_acquire() is True  # consumes one admit slot
 
     snapshot = await strategy.record_outcome(success=True)
@@ -353,7 +358,7 @@ async def test_half_open_failure_releases_admit_slot(
         backend, error_threshold=2, half_open_capacity=2, reset_timeout=0.1
     )
     await strategy.transition(desired=CircuitBreakerState.OPEN)
-    await asyncio.sleep(0.15)
+    await asyncio.sleep(0.5)  # 5x the 0.1s cool-down, not a 0.05s race
     assert await strategy.try_acquire() is True  # consumes one admit slot
 
     snapshot = await strategy.record_outcome(success=False)


### PR DESCRIPTION
Fixes the flake that turned `main` red on `4a14d91` right after #547 merged.

## What happened

`test_circuitbreaker_sqlite.py::test_open_rejects_until_reset_timeout_elapses` failed with `assert True is False` on the **first** assert, the one checking the breaker still rejects immediately after opening.

I confirmed this was not a regression from #547 before touching anything: nothing in that PR goes near circuit breakers, the test passed 8/8 locally, and re-running the job made `main` green again.

## Root cause

The test was a genuine race, not a mystery:

```python
strategy = _bind(backend, reset_timeout=0.5)
await strategy.transition(desired=CircuitBreakerState.OPEN)
assert await strategy.try_acquire() is False   # needs < 0.5s to have passed
await asyncio.sleep(0.6)
assert await strategy.try_acquire() is True    # needs > 0.5s to have passed
```

`try_acquire` moves OPEN to HALF_OPEN once `time() >= opened_at + cool_down`. The first assert therefore only holds if **less than 500 ms elapses between two adjacent awaits**. Under `pytest-xdist` on a contended runner, a 500 ms stall is entirely achievable, and then the breaker has legitimately cooled down and admits the call.

The whole test hinged on a 0.1s margin (0.5 versus 0.6). Three other tests were worse, pairing `reset_timeout=0.1` with `sleep(0.15)`: a **0.05s** margin.

The same pattern was copy-pasted across all three backend test files, so SQLite, Postgres, and Redis were all exposed. SQLite drew the short straw because it is the one that runs in the light PR tier.

## Fix

Applies the liveness-versus-expiry margin principle from #469.

**Rejection assert:** use `transition(..., cool_down=60)`. Scheduling can no longer influence it, since no plausible stall approaches 60s. `cool_down` is already on the `CircuitBreakerStrategy` protocol and implemented by all four backends, so this needs no production change.

**Elapse assert:** re-open with `cool_down=0.1` and wait `0.5`, giving 5x margin instead of 1.2x. The three `sleep(0.15)` sites get the same treatment.

Test wall-clock is essentially unchanged: the 0.6s sleep becomes 0.5s.

## Verification

Full pre-commit passes: ruff, codespell, ty-check, mypy-check, unit, integration, coverage (100%), mkdocs-build. The SQLite circuit-breaker file ran 5 consecutive clean passes locally.

Note this is a **test-only** change. No production code is touched, so the underlying behavior is unchanged and was never wrong.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b