### PR TITLE
🔒 Mask the OTLP Basic auth password and document the _loop contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run Ty
+        # Single-threaded so cycle resolution is deterministic. ty resolves
+        # inference cycles in whichever order threads reach them, which can
+        # flip a diagnostic on unchanged code (astral-sh/ty#1670).
+        env:
+          TY_MAX_PARALLELISM: "1"
         run: uv run ty check
 
       - name: Run Mypy

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -48,6 +48,23 @@ micro = Grelmicro(uses=[Coordination(mongo)])
 A worked skeleton lives in
 [`examples/third-party-adapter/`](https://github.com/grelinfo/grelmicro/tree/main/examples/third-party-adapter).
 
+### Capture the event loop
+
+Lock, schedule, cache, and circuit-breaker backends must capture the running
+loop on `__aenter__` and keep it in a `_loop` attribute:
+
+```python
+async def __aenter__(self) -> Self:
+    self._loop = asyncio.get_running_loop()
+    return self
+```
+
+The sync adapters (`Lock.from_thread`, `TaskLock.from_thread`, the sync
+`@cached` wrapper, `CircuitBreaker.from_thread`) dispatch coroutines back into
+that loop from a worker thread. The protocols declare `_loop`, so a type
+checker reports an adapter that omits it. Set it to `None` in `__init__` and
+assign the real loop in `__aenter__`.
+
 ## How resolution works
 
 Listing entry points never imports the target module. The module loads only

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@
 ### Breaking
 
 * 💥 Default `Metrics()` to the `auto` exporter. It exports over OTLP HTTP when an endpoint is configured and otherwise auto-disables into a true no-op, so an unconfigured `Metrics()` no longer falls back to `localhost:4318`. Register it unconditionally: an auto-disabled `Metrics` installs no provider and never conflicts with a second app. ([#508](https://github.com/grelinfo/grelmicro/issues/508))
-* 💥 `TraceConfig.basic_auth_password` and `MetricsConfig.basic_auth_password` are now `SecretStr`. Passing a plain string still works, but reading the value back needs `.get_secret_value()`. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
+* 💥 Credential fields are now `SecretStr`: `basic_auth_password` on `TraceConfig` and `MetricsConfig`, and `password` on `PostgresConfig` and `RedisConfig`. Passing a plain string still works, but reading the value back needs `.get_secret_value()`. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
 
 ### Features
 
@@ -21,7 +21,7 @@
 
 ### Security
 
-* 🔒 Stop leaking the OTLP Basic auth password. `basic_auth_password` was a plain `str`, so it appeared in `repr()`, `model_dump()`, and `model_dump_json()` of `TraceConfig` and `MetricsConfig`, and therefore in any log line or validation error carrying the config. It is now a `SecretStr`, which masks all three. The `Authorization` header sent on the wire is unchanged. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
+* 🔒 Stop leaking credentials through config objects. `basic_auth_password` on `TraceConfig` and `MetricsConfig`, and `password` on `PostgresConfig` and `RedisConfig`, were plain `str`, so they appeared in `repr()`, `model_dump()`, and `model_dump_json()`, and therefore in any log line or validation error carrying the config. All four are now `SecretStr`, which masks every path. The `Authorization` header and the connection URLs are unchanged. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
 
 ### Internal
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,11 +21,11 @@
 
 ### Security
 
-* 🔒 Stop leaking credentials through config objects. `basic_auth_password` on `TraceConfig` and `MetricsConfig`, and `password` on `PostgresConfig` and `RedisConfig`, were plain `str`, so they appeared in `repr()`, `model_dump()`, and `model_dump_json()`, and therefore in any log line or validation error carrying the config. All four are now `SecretStr`, which masks every path. The `Authorization` header and the connection URLs are unchanged. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
+* 🔒 Mask credentials in config objects. `basic_auth_password` on `TraceConfig` and `MetricsConfig`, and `password` on `PostgresConfig` and `RedisConfig`, were plain `str` and so appeared in `repr()`, `model_dump()`, and `model_dump_json()`. All four are now `SecretStr`. Nothing changes on the wire. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
 
 ### Internal
 
-* 🐛 Set `strict` directly on `LogTimeZoneType` instead of applying `@timezone_name_settings`. The decorator's return type references `TimeZoneName`, which is itself decorated, so resolving the subclass entered a type inference cycle that `ty` resolved differently between parallel runs. `ty check` was failing roughly 9 times in 10 on the `grelmicro/log` subset. Runtime behavior is identical: the decorator only assigns `cls.strict`. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
+* 🐛 Set `strict` directly on `LogTimeZoneType` instead of using `@timezone_name_settings`. The decorator's return type references the class it decorates, so `ty` resolved the subclass differently between parallel runs and failed about 9 runs in 10. Runtime behavior is unchanged. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
 * 📝 Document the `_loop` capture contract in the third-party adapter guide. The protocols require it, but the guide did not mention it, so a new adapter could follow the docs and still fail on the first `from_thread` call. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
 * ✅ Widen the circuit-breaker cool-down margins in the SQLite, Postgres, and Redis backend tests. The rejection assert now uses a 60s cool-down so a stalled runner cannot let the window elapse between two adjacent calls, and the elapse asserts wait 5x the cool-down instead of racing a 0.05s gap. ([#548](https://github.com/grelinfo/grelmicro/pull/548))
 * 👷 Enable the Pydantic mypy plugin and shrink the mypy override ladder from 29 modules to 19. Ten modules now type-check under both checkers. ([#547](https://github.com/grelinfo/grelmicro/pull/547))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,7 @@
 
 ### Internal
 
+* 🐛 Set `strict` directly on `LogTimeZoneType` instead of applying `@timezone_name_settings`. The decorator's return type references `TimeZoneName`, which is itself decorated, so resolving the subclass entered a type inference cycle that `ty` resolved differently between parallel runs. `ty check` was failing roughly 9 times in 10 on the `grelmicro/log` subset. Runtime behavior is identical: the decorator only assigns `cls.strict`. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
 * 📝 Document the `_loop` capture contract in the third-party adapter guide. The protocols require it, but the guide did not mention it, so a new adapter could follow the docs and still fail on the first `from_thread` call. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
 * ✅ Widen the circuit-breaker cool-down margins in the SQLite, Postgres, and Redis backend tests. The rejection assert now uses a 60s cool-down so a stalled runner cannot let the window elapse between two adjacent calls, and the elapse asserts wait 5x the cool-down instead of racing a 0.05s gap. ([#548](https://github.com/grelinfo/grelmicro/pull/548))
 * 👷 Enable the Pydantic mypy plugin and shrink the mypy override ladder from 29 modules to 19. Ten modules now type-check under both checkers. ([#547](https://github.com/grelinfo/grelmicro/pull/547))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Breaking
 
 * 💥 Default `Metrics()` to the `auto` exporter. It exports over OTLP HTTP when an endpoint is configured and otherwise auto-disables into a true no-op, so an unconfigured `Metrics()` no longer falls back to `localhost:4318`. Register it unconditionally: an auto-disabled `Metrics` installs no provider and never conflicts with a second app. ([#508](https://github.com/grelinfo/grelmicro/issues/508))
+* 💥 `TraceConfig.basic_auth_password` and `MetricsConfig.basic_auth_password` are now `SecretStr`. Passing a plain string still works, but reading the value back needs `.get_secret_value()`. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
 
 ### Features
 
@@ -18,8 +19,13 @@
 * 🐛 Point the circuit-breaker worker-thread error at `async with micro:` instead of `grelmicro.lifespan()`, which is not a public API. ([#540](https://github.com/grelinfo/grelmicro/pull/540))
 * 🐛 Raise a clear error when installing the FastStream ambient middleware on an app with no broker, instead of an `AttributeError`. ([#540](https://github.com/grelinfo/grelmicro/pull/540))
 
+### Security
+
+* 🔒 Stop leaking the OTLP Basic auth password. `basic_auth_password` was a plain `str`, so it appeared in `repr()`, `model_dump()`, and `model_dump_json()` of `TraceConfig` and `MetricsConfig`, and therefore in any log line or validation error carrying the config. It is now a `SecretStr`, which masks all three. The `Authorization` header sent on the wire is unchanged. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
+
 ### Internal
 
+* 📝 Document the `_loop` capture contract in the third-party adapter guide. The protocols require it, but the guide did not mention it, so a new adapter could follow the docs and still fail on the first `from_thread` call. ([#549](https://github.com/grelinfo/grelmicro/pull/549))
 * ✅ Widen the circuit-breaker cool-down margins in the SQLite, Postgres, and Redis backend tests. The rejection assert now uses a 60s cool-down so a stalled runner cannot let the window elapse between two adjacent calls, and the elapse asserts wait 5x the cool-down instead of racing a 0.05s gap. ([#548](https://github.com/grelinfo/grelmicro/pull/548))
 * 👷 Enable the Pydantic mypy plugin and shrink the mypy override ladder from 29 modules to 19. Ten modules now type-check under both checkers. ([#547](https://github.com/grelinfo/grelmicro/pull/547))
 * ♻️ Declare `arbitrary_types_allowed` in the `_BaseShieldConfig` class kwargs instead of a second `model_config` assignment. Pydantic merged both, so the settings are unchanged. ([#547](https://github.com/grelinfo/grelmicro/pull/547))

--- a/grelmicro/config/_external.py
+++ b/grelmicro/config/_external.py
@@ -47,7 +47,8 @@ def _coerce_source(value: ConfigBackend | str | PathLike[str]) -> ConfigBackend:
     HTTP adapter, a git URL to the git adapter, anything else to
     `FileConfigAdapter`. The network adapters resolve through the
     `grelmicro.config.adapters` entry points, so they raise
-    `AdapterNotRegisteredError` until their extra is installed.
+    `AdapterNotRegisteredError` until a package registering one is
+    installed. grelmicro itself ships only the file adapter.
 
     Raises:
         AdapterNotRegisteredError: The source needs an adapter that is

--- a/grelmicro/log/__init__.py
+++ b/grelmicro/log/__init__.py
@@ -41,7 +41,7 @@ def configure(
         Doc("Log format. Default: `AUTO`."),
     ] = None,
     timezone: Annotated[
-        LogTimeZoneType | None,  # ty: ignore[invalid-type-form]
+        LogTimeZoneType | None,
         Doc("IANA timezone for timestamps. Default: `UTC`."),
     ] = None,
     json_serializer: Annotated[

--- a/grelmicro/log/_component.py
+++ b/grelmicro/log/_component.py
@@ -92,7 +92,7 @@ class Log:
             LogFormatType | str | None, Doc("Log format.")
         ] = None,
         timezone: Annotated[
-            LogTimeZoneType | None,  # ty: ignore[invalid-type-form]
+            LogTimeZoneType | None,
             Doc("IANA timezone for timestamps."),
         ] = None,
         json_serializer: Annotated[

--- a/grelmicro/log/config.py
+++ b/grelmicro/log/config.py
@@ -4,10 +4,7 @@ from enum import StrEnum
 from typing import Annotated, Any, Self
 
 from pydantic import BaseModel, Field
-from pydantic_extra_types.timezone_name import (
-    TimeZoneName,
-    timezone_name_settings,
-)
+from pydantic_extra_types.timezone_name import TimeZoneName
 from typing_extensions import Doc
 
 try:
@@ -61,9 +58,10 @@ class LogSerializerType(_CaseInsensitiveEnum):
     ORJSON = "orjson"
 
 
-@timezone_name_settings(strict=False)
 class LogTimeZoneType(TimeZoneName):
     """Timezone name."""
+
+    strict = False
 
 
 class LogConfig(BaseModel, frozen=True, extra="forbid"):
@@ -83,7 +81,7 @@ class LogConfig(BaseModel, frozen=True, extra="forbid"):
         Field(union_mode="left_to_right"),
     ] = LogFormatType.AUTO
     timezone: Annotated[
-        LogTimeZoneType,  # ty: ignore[invalid-type-form]
+        LogTimeZoneType,
         Doc("IANA timezone for timestamps."),
     ] = LogTimeZoneType("UTC")
     json_serializer: Annotated[

--- a/grelmicro/metrics/config.py
+++ b/grelmicro/metrics/config.py
@@ -4,7 +4,13 @@ from base64 import b64encode
 from enum import StrEnum
 from typing import Annotated, Self
 
-from pydantic import BaseModel, Field, PositiveFloat, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    PositiveFloat,
+    SecretStr,
+    model_validator,
+)
 from typing_extensions import Doc
 
 
@@ -76,7 +82,7 @@ class MetricsConfig(BaseModel, frozen=True, extra="forbid"):
         ),
     ] = None
     basic_auth_password: Annotated[
-        str | None,
+        SecretStr | None,
         Doc(
             "HTTP Basic auth password for the OTLP exporter. Set together "
             "with `basic_auth_username`."
@@ -140,6 +146,11 @@ class MetricsConfig(BaseModel, frozen=True, extra="forbid"):
         """
         if self.basic_auth_username is None:
             return None
-        raw = f"{self.basic_auth_username}:{self.basic_auth_password}"
+        password = (
+            self.basic_auth_password.get_secret_value()
+            if self.basic_auth_password
+            else ""
+        )
+        raw = f"{self.basic_auth_username}:{password}"
         token = b64encode(raw.encode()).decode("ascii")
         return f"Basic {token}"

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -6,7 +6,7 @@ import re
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
 
 from asyncpg import Pool, create_pool
-from pydantic import BaseModel, PostgresDsn, ValidationError
+from pydantic import BaseModel, PostgresDsn, SecretStr, ValidationError
 from pydantic_core import MultiHostUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Doc
@@ -45,7 +45,7 @@ class PostgresConfig(BaseModel):
     port: int = 5432
     database: str | None = None
     user: str | None = None
-    password: str | None = None
+    password: SecretStr | None = None
     command_timeout: float | None = None
 
 
@@ -65,7 +65,7 @@ class _PostgresEnvSettings(BaseSettings):
     db: str | None = None
     database: str | None = None
     user: str | None = None
-    password: str | None = None
+    password: SecretStr | None = None
 
 
 class _PostgresTimeoutEnvSettings(BaseSettings):
@@ -205,7 +205,9 @@ class PostgresProvider(Provider):
             port=config.port,
             database=config.database,
             user=config.user,
-            password=config.password,
+            password=(
+                config.password.get_secret_value() if config.password else None
+            ),
             command_timeout=config.command_timeout,
             env_prefix=env_prefix,
             env_load=False,
@@ -482,7 +484,11 @@ def _resolve_url(
             port=settings.port,
             database=settings.db or settings.database,
             user=settings.user,
-            password=settings.password,
+            password=(
+                settings.password.get_secret_value()
+                if settings.password
+                else None
+            ),
         )
     msg = f"either {env_prefix}URL or {env_prefix}HOST must be set"
     raise PostgresProviderConfigError(msg)

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
 
-from pydantic import BaseModel, RedisDsn, ValidationError
+from pydantic import BaseModel, RedisDsn, SecretStr, ValidationError
 from pydantic_core import Url
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from redis.asyncio.client import Redis
@@ -46,7 +46,7 @@ class RedisConfig(BaseModel):
     host: str | None = None
     port: int = 6379
     db: int = 0
-    password: str | None = None
+    password: SecretStr | None = None
 
 
 class _RedisEnvSettings(BaseSettings):
@@ -58,7 +58,7 @@ class _RedisEnvSettings(BaseSettings):
     host: str | None = None
     port: int = 6379
     db: int = 0
-    password: str | None = None
+    password: SecretStr | None = None
 
 
 class RedisProvider(Provider):
@@ -215,7 +215,9 @@ class RedisProvider(Provider):
             host=config.host,
             port=config.port,
             db=config.db,
-            password=config.password,
+            password=(
+                config.password.get_secret_value() if config.password else None
+            ),
             env_prefix=env_prefix,
             env_load=False,
         )
@@ -535,7 +537,11 @@ def _resolve_url(
             host=settings.host,
             port=settings.port,
             db=settings.db,
-            password=settings.password,
+            password=(
+                settings.password.get_secret_value()
+                if settings.password
+                else None
+            ),
         )
     msg = f"either {env_prefix}URL or {env_prefix}HOST must be set"
     raise RedisProviderConfigError(msg)

--- a/grelmicro/providers/valkey.py
+++ b/grelmicro/providers/valkey.py
@@ -183,7 +183,9 @@ class ValkeyProvider(RedisProvider):
             host=config.host,
             port=config.port,
             db=config.db,
-            password=config.password,
+            password=(
+                config.password.get_secret_value() if config.password else None
+            ),
             env_prefix=env_prefix,
             env_load=False,
         )

--- a/grelmicro/trace/config.py
+++ b/grelmicro/trace/config.py
@@ -4,7 +4,13 @@ from base64 import b64encode
 from enum import StrEnum
 from typing import Annotated, Self
 
-from pydantic import BaseModel, Field, PositiveFloat, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    PositiveFloat,
+    SecretStr,
+    model_validator,
+)
 from typing_extensions import Doc
 
 
@@ -91,7 +97,7 @@ class TraceConfig(BaseModel, frozen=True, extra="forbid"):
         ),
     ] = None
     basic_auth_password: Annotated[
-        str | None,
+        SecretStr | None,
         Doc(
             "HTTP Basic auth password for the OTLP exporter. Set together "
             "with `basic_auth_username`."
@@ -153,6 +159,11 @@ class TraceConfig(BaseModel, frozen=True, extra="forbid"):
         """
         if self.basic_auth_username is None:
             return None
-        raw = f"{self.basic_auth_username}:{self.basic_auth_password}"
+        password = (
+            self.basic_auth_password.get_secret_value()
+            if self.basic_auth_password
+            else ""
+        )
+        raw = f"{self.basic_auth_username}:{password}"
         token = b64encode(raw.encode()).decode("ascii")
         return f"Basic {token}"

--- a/tests/metrics/test_component.py
+++ b/tests/metrics/test_component.py
@@ -475,4 +475,6 @@ async def test_metrics_basic_auth_from_env(
     )
     async with micro:
         assert micro.metrics.config.basic_auth_username == "me@example.com"
-        assert micro.metrics.config.basic_auth_password == "s3cret"
+        password = micro.metrics.config.basic_auth_password
+        assert password is not None
+        assert password.get_secret_value() == "s3cret"

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -444,4 +444,6 @@ async def test_trace_basic_auth_from_env(
     )
     async with micro:
         assert micro.trace.config.basic_auth_username == "me@example.com"
-        assert micro.trace.config.basic_auth_password == "s3cret"
+        password = micro.trace.config.basic_auth_password
+        assert password is not None
+        assert password.get_secret_value() == "s3cret"


### PR DESCRIPTION
Pre-release review findings. **This is why the release was worth reviewing rather than tagging.**

## 1. Security: credentials leaked through config objects

Four credential fields were plain `str`, so they appeared in **all three** serialization paths: `basic_auth_password` on `TraceConfig` and `MetricsConfig`, and `password` on `PostgresConfig` and `RedisConfig`.

```
MetricsConfig:  repr=True  dump=True  json=True
TraceConfig:    repr=True  dump=True  json=True
PostgresConfig: repr=True  dump=True  json=True
RedisConfig:    repr=True  dump=True  json=True
```

That means any log line, debug print, or Pydantic validation error carrying the config exposes the collector password.

Now a `SecretStr`, which masks all three:

```
all four:       repr=False dump=False json=False
```

Verified nothing changed on the wire: the header is still `Basic YWxpY2U6aHVudGVyMg==`, decoding to `alice:hunter2`, and env loading via `GREL_METRICS_BASIC_AUTH_PASSWORD` works end to end through `resolve_config`. For the providers the decisive proof is the integration suite: **220 tests pass against real Postgres and Redis**, so authentication still works.

This release was about to **double the exposure** by adding `basic_auth` to `Metrics`, so fixing it now avoids shipping the same flaw twice and avoids a second breaking change later.

**Breaking where the API already shipped:** `Trace`, `Postgres` and `Redis`. Reading the value back now needs `.get_secret_value()`; passing a plain string still works. `Metrics` is new in this release, so nothing to migrate there. Recorded under both **Breaking** and **Security**.

The provider leak was found by following through after the first fix, on the reasoning that masking one credential and leaving three others would be worse than not starting. `PostgresProvider` already had a redacted `url` property and custom `__repr__`, so the common logging path was covered, but the config object itself was not.

## 2. Docs: the adapter guide omitted the loop-capture contract

`docs/architecture/plugins.md` has a "Publish a third-party adapter" section that never mentioned `_loop`. #540 declared it on four protocols and fixed the shipped Mongo example, but the prose guide was missed, so an author could follow the docs exactly and still `AttributeError` on the first `from_thread` call. Added a short section with the `__aenter__` snippet.

## 3. Docs: the config source coercer promised an extra that does not exist

The `_coerce_source` docstring said network config adapters raise `AdapterNotRegisteredError` "until **their extra** is installed", implying grelmicro ships one. It does not: `grelmicro/config/` has only `file.py`. Reworded to match the runtime error, which was already honest.

## Dimensions checked and clean

* **Packaging**: `packages = ["grelmicro"]`, so tests and `tests/typechecking` do not ship.
* **Public API**: the snapshot diff is purely additive, no removals.
* **Docs accuracy**: `metrics.md` already documents the new `AUTO` default and `basic_auth` correctly.
* **THIRD_PARTY_NOTICES**: covers source adaptations (Upstash Lua, font glyphs), not dependency licenses, so the 22 version bumps do not touch it.
* **Changelog**: every user-visible change is recorded.

## Note

`ty` caught a real slip here that mypy did not: I first wrote `config.basic_auth_password.get_secret_value()` in the tests, but the field is `SecretStr | None`. mypy is scoped to `grelmicro` and `tests/typechecking`, so only `ty` saw it. Both tests now narrow explicitly.

Full pre-commit passes: ruff, codespell, ty-check, mypy-check, unit, integration, coverage (100%), mkdocs-build. 3395 unit tests pass.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b
