### PR TITLE
🔖 Prepare the 0.31.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.31.0 - 2026-07-27
 
 ### Breaking
 


### PR DESCRIPTION
Stamps the changelog for 0.31.0.

## Contents

8 commits since 0.30.1, plus #537 (Metrics parity) which carries the headline breaking change.

### Breaking

1. `Metrics()` defaults to the `auto` exporter. An unconfigured `Metrics()` now exports nothing instead of falling back to `localhost:4318`.
2. Credential fields are `SecretStr`: `basic_auth_password` on `TraceConfig` and `MetricsConfig`, `password` on `PostgresConfig` and `RedisConfig`. Constructing from a plain string still works; reading the value back needs `.get_secret_value()`.

### Security

Credentials were leaking into `repr()`, `model_dump()` and `model_dump_json()` on four config objects. Fixed in #549.

### Notable fixes

* Resilience decorators preserve the wrapped signature, so applying a policy no longer silently disables type-checking at every call site (#545).
* `_loop` is declared on four backend protocols, so a third-party adapter that omits it fails type-checking instead of raising `AttributeError` on the first `from_thread` call (#540).
* Clear errors replace `AttributeError` on unopened backends and on brokerless FastStream apps (#540).

### Internal

mypy runs alongside ty, a `tests/typechecking` suite pins the public API types, and the mypy override ladder is down to 19 modules.

## Known and deferred

* #550: connection URLs still carry credentials in `repr` and `dump`. Deliberately deferred, the fix reshapes a public field and needs a design decision.
* #546: SQLite coordination adapters bypass `SQLiteProvider`.
* #551: ty can resolve inference cycles nondeterministically. Mitigated, not eliminated.

## Before publishing

The Release workflow runs the full tier (matrix, slow, integration, demo) that PR CI skips. Tags are immutable here, so the full tier gets a `workflow_dispatch` run on main **before** the tag is created.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b