### PR TITLE
🏗️ Route the SQLite coordination adapters through SQLiteProvider

### DIFF
--- a/docs/architecture/sqlite.md
+++ b/docs/architecture/sqlite.md
@@ -2,8 +2,12 @@
 
 This page documents the internal design of the SQLite [Coordination backend](../coordination.md#backends).
 
+## One Connection
+
+`SQLiteProvider` owns the connection and a lock that serializes it. Every adapter on the same provider borrows both, so an app running a lock, a schedule, and a cache against one file holds a single connection. Writes run inside a `BEGIN IMMEDIATE` transaction: the provider's lock serializes them within the process, and the transaction's write lock serializes them across processes sharing the file.
+
 ## WAL Mode
 
-The backend enables [Write-Ahead Logging (WAL)](https://www.sqlite.org/wal.html) on connection with `PRAGMA journal_mode=WAL`. Without WAL, SQLite uses a rollback journal where writers block readers and readers block writers. WAL allows concurrent reads and writes, which is important for async lock operations where multiple tasks may check or acquire locks simultaneously.
+The provider enables [Write-Ahead Logging (WAL)](https://www.sqlite.org/wal.html) on connection with `PRAGMA journal_mode=WAL`. Without WAL, SQLite uses a rollback journal where writers block readers and readers block writers. WAL allows concurrent reads and writes, which is important for async lock operations where multiple tasks may check or acquire locks simultaneously.
 
 WAL mode is persistent per database file. Once enabled, it remains active for all subsequent connections until explicitly changed.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,10 +5,16 @@
 ### Breaking
 
 * 💥 Credential-carrying URL fields are now `SecretUrl`: `url` on `PostgresConfig` and `RedisConfig`, and `endpoint` on `TraceConfig` and `MetricsConfig`. Each `headers` value on `TraceConfig` and `MetricsConfig` is now a `SecretStr`. Passing a plain string still works, but reading the value back needs `.get_secret_value()`. ([#550](https://github.com/grelinfo/grelmicro/issues/550))
+* 💥 `SQLiteLockAdapter` and `SQLiteScheduleAdapter` now take `provider=` instead of `path=`, like every other SQLite adapter. Replace `SQLiteLockAdapter("app.db")` with `SQLiteLockAdapter(provider=SQLiteProvider("app.db"))`, or pass the provider to `Coordination(sqlite)` and let it build both. A missing path now raises `SettingsValidationError` instead of `CoordinationSettingsValidationError`. ([#546](https://github.com/grelinfo/grelmicro/issues/546))
 
 ### Features
 
 * ✨ Add `grelmicro.types.SecretUrl`, a URL that never shows its credentials. It displays the URL with the userinfo password and credential-like query values replaced by `***`, so the scheme, host, and path stay readable in logs. Parametrize it with any pydantic URL type to keep that type's validation: `SecretUrl[RedisDsn]`, `SecretUrl[PostgresDsn]`, or a bare `SecretUrl` for any URL. ([#550](https://github.com/grelinfo/grelmicro/issues/550))
+
+### Fixed
+
+* 🐛 Share one SQLite connection across every component on the same file. `SQLiteLockAdapter` and `SQLiteScheduleAdapter` opened their own connection, so an app pairing a lock with a cache held two. They now borrow the provider's connection and shared lock, so `Grelmicro` can dedupe them onto one provider like every other adapter. ([#546](https://github.com/grelinfo/grelmicro/issues/546))
+* 🐛 Adopt the provider behind a `Coordination` schedule backend. Provider discovery walked the lock and election backends only, so a schedule-only `Coordination` left its provider unopened and duplicate providers undeduped. ([#546](https://github.com/grelinfo/grelmicro/issues/546))
 
 ### Security
 

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -927,9 +927,9 @@ class Grelmicro:
         micro = Grelmicro(uses=[Coordination(redis), Cache(redis)])  # adopted
         ```
 
-        A `Coordination` holds two backends (a lock backend and an election
-        backend), each able to borrow its own Provider, so both are walked and
-        each borrowed Provider is adopted.
+        A `Coordination` holds three backends (a lock backend, an election
+        backend, and a schedule backend), each able to borrow its own Provider,
+        so all are walked and each borrowed Provider is adopted.
 
         Providers the user already listed are left untouched, so their declared
         order still applies and the ordering check in
@@ -1037,14 +1037,16 @@ def _iter_provider_backends(item: object) -> list[object]:
     """Return the provider-holding backends to inspect for `item`.
 
     Most components expose one backend via `backend`. A `Coordination`
-    component holds a lock backend and an election backend, either of which
-    may own a Provider, so both are returned. A plain item with no backend
-    is inspected directly.
+    component holds a lock backend, an election backend, and a schedule
+    backend, any of which may own a Provider, so all present ones are
+    returned. A plain item with no backend is inspected directly.
     """
-    lock_backend = getattr(item, "_lock_backend", None)
-    election_backend = getattr(item, "_election_backend", None)
-    if lock_backend is not None or election_backend is not None:
-        return [b for b in (lock_backend, election_backend) if b is not None]
+    backends = [
+        getattr(item, name, None)
+        for name in ("_lock_backend", "_election_backend", "_schedule_backend")
+    ]
+    if any(backend is not None for backend in backends):
+        return [backend for backend in backends if backend is not None]
     return [getattr(item, "backend", item)]
 
 

--- a/grelmicro/coordination/sqlite.py
+++ b/grelmicro/coordination/sqlite.py
@@ -1,44 +1,29 @@
-"""SQLite Lock Adapter."""
+"""SQLite coordination adapters."""
+
+from __future__ import annotations
 
 import asyncio
 import re
 from math import ceil
-from pathlib import Path
-from types import TracebackType
-from typing import Annotated, Self
+from typing import TYPE_CHECKING, Annotated, Self
 
-import aiosqlite
-from pydantic_settings import BaseSettings
 from typing_extensions import Doc
 
 from grelmicro.coordination._protocol import LockBackend, ScheduleBackend
-from grelmicro.coordination.errors import CoordinationSettingsValidationError
-from grelmicro.errors import OutOfContextError
+from grelmicro.providers.sqlite import SQLiteProvider
 
-
-class _SQLiteSettings(BaseSettings):
-    """SQLite settings from the environment variables."""
-
-    SQLITE_PATH: str | None = None
-
-
-def _get_sqlite_path() -> str:
-    """Get the SQLite path from the environment variables.
-
-    Raises:
-        CoordinationSettingsValidationError: If SQLITE_PATH is not set.
-    """
-    settings = _SQLiteSettings()
-
-    if settings.SQLITE_PATH:
-        return settings.SQLITE_PATH
-
-    msg = "SQLITE_PATH must be set"
-    raise CoordinationSettingsValidationError(msg)
+if TYPE_CHECKING:
+    from types import TracebackType
 
 
 class SQLiteLockAdapter(LockBackend):
     """SQLite Lock Adapter.
+
+    Borrows the connection and a shared lock from a `SQLiteProvider` and
+    implements the `LockBackend` protocol for distributed locks on a single
+    host. Pass an explicit `provider=` to share a connection with other
+    components, or rely on the default `env_prefix=` to build one from
+    environment variables.
 
     Fencing tokens live in a `fence` column on the lock row. Acquire runs
     inside a `BEGIN IMMEDIATE` transaction, bumps the fence on every
@@ -46,6 +31,20 @@ class SQLiteLockAdapter(LockBackend):
     with `RETURNING fence`. Release clears the holder and expiry but keeps the
     row and its fence, so the fence is strictly monotonic per name across
     release and re-acquire cycles.
+
+    The provider's lock serializes the single connection within the process,
+    and the transaction's write lock serializes across processes sharing the
+    same file.
+
+    Example:
+    ```python
+    from grelmicro import Grelmicro
+    from grelmicro.coordination import Coordination
+    from grelmicro.providers.sqlite import SQLiteProvider
+
+    sqlite = SQLiteProvider("app.db")
+    micro = Grelmicro(uses=[sqlite, Coordination(lock=sqlite)])
+    ```
     """
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """
@@ -103,15 +102,27 @@ class SQLiteLockAdapter(LockBackend):
 
     def __init__(
         self,
-        path: Annotated[
-            str | Path | None,
-            Doc("""
-                The SQLite database path.
-
-                If not provided, the path will be taken from the environment variable SQLITE_PATH.
-                """),
-        ] = None,
         *,
+        provider: Annotated[
+            SQLiteProvider | None,
+            Doc(
+                """
+                A pre-built `SQLiteProvider`. When set, the adapter
+                borrows the provider's connection and does not manage
+                its lifecycle.
+                """,
+            ),
+        ] = None,
+        env_prefix: Annotated[
+            str,
+            Doc(
+                """
+                Environment variable prefix used by the implicit
+                `SQLiteProvider` when `provider` is not set. Resolves
+                the path from `SQLITE_PATH` by default.
+                """,
+            ),
+        ] = "SQLITE_",
         table_name: Annotated[
             str, Doc("The table name to store the locks.")
         ] = "locks",
@@ -121,7 +132,13 @@ class SQLiteLockAdapter(LockBackend):
             msg = f"Table name '{table_name}' is not a valid SQL identifier"
             raise ValueError(msg)
 
-        self._path = str(path) if path is not None else _get_sqlite_path()
+        if provider is None:
+            self._provider = SQLiteProvider(env_prefix=env_prefix)
+            self._owns_provider = True
+        else:
+            self._provider = provider
+            self._owns_provider = False
+        self._env_prefix = env_prefix
         self._table_name = table_name
         self._acquire_sql = self._SQL_ACQUIRE_OR_EXTEND.format(
             table_name=table_name
@@ -129,20 +146,29 @@ class SQLiteLockAdapter(LockBackend):
         self._release_sql = self._SQL_RELEASE.format(table_name=table_name)
         self._locked_sql = self._SQL_LOCKED.format(table_name=table_name)
         self._owned_sql = self._SQL_OWNED.format(table_name=table_name)
-        self._conn: aiosqlite.Connection | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
 
+    @property
+    def provider(self) -> SQLiteProvider:
+        """The bound `SQLiteProvider`."""
+        return self._provider
+
+    def _rebind_provider(self, provider: SQLiteProvider) -> None:
+        """Swap the underlying provider (used by `Grelmicro` for sharing)."""
+        self._provider = provider
+        self._owns_provider = False
+
     async def __aenter__(self) -> Self:
-        """Open the lock backend."""
+        """Open the adapter and its provider when owned."""
+        if self._owns_provider:
+            await self._provider.__aenter__()
         self._loop = asyncio.get_running_loop()
-        self._conn = await aiosqlite.connect(self._path)
-        await self._conn.execute("PRAGMA journal_mode=WAL;")
-        await self._conn.execute(
-            self._SQL_CREATE_TABLE_IF_NOT_EXISTS.format(
-                table_name=self._table_name
-            ),
-        )
-        await self._conn.commit()
+        async with self._provider.connection_lock:
+            await self._provider.client.execute(
+                self._SQL_CREATE_TABLE_IF_NOT_EXISTS.format(
+                    table_name=self._table_name
+                ),
+            )
         return self
 
     async def __aexit__(
@@ -151,16 +177,15 @@ class SQLiteLockAdapter(LockBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the lock backend."""
-        if self._conn:  # pragma: no branch
-            await self._conn.execute(
+        """Close the provider when owned. External providers are left alone."""
+        async with self._provider.connection_lock:
+            await self._provider.client.execute(
                 self._SQL_RELEASE_ALL_EXPIRED.format(
                     table_name=self._table_name
                 ),
             )
-            await self._conn.commit()
-            await self._conn.close()
-            self._conn = None
+        if self._owns_provider:
+            await self._provider.__aexit__(exc_type, exc_value, traceback)
 
     async def acquire(
         self, *, name: str, token: str, duration: float
@@ -170,48 +195,47 @@ class SQLiteLockAdapter(LockBackend):
         Runs the read-modify-write inside a `BEGIN IMMEDIATE` transaction so
         the fence high-water update is serialized against concurrent writers.
         """
-        if not self._conn:
-            raise OutOfContextError(self, "acquire")
-
-        await self._conn.execute("BEGIN IMMEDIATE;")
-        try:
-            async with self._conn.execute(
-                self._acquire_sql, (name, token, ceil(duration))
-            ) as cursor:
-                result = await cursor.fetchone()
-        except BaseException:
-            await self._conn.rollback()
-            raise
-        await self._conn.commit()
+        conn = self._provider.client
+        async with self._provider.connection_lock:
+            await conn.execute("BEGIN IMMEDIATE;")
+            try:
+                async with conn.execute(
+                    self._acquire_sql, (name, token, ceil(duration))
+                ) as cursor:
+                    result = await cursor.fetchone()
+                await conn.execute("COMMIT;")
+            except BaseException:
+                await conn.execute("ROLLBACK;")
+                raise
         return int(result[0]) if result is not None else None
 
     async def release(self, *, name: str, token: str) -> bool:
         """Release the lock."""
-        if not self._conn:
-            raise OutOfContextError(self, "release")
-
-        async with self._conn.execute(
-            self._release_sql, (name, token)
-        ) as cursor:
+        conn = self._provider.client
+        async with (
+            self._provider.connection_lock,
+            conn.execute(self._release_sql, (name, token)) as cursor,
+        ):
             result = await cursor.fetchone()
-        await self._conn.commit()
         return result is not None
 
     async def locked(self, *, name: str) -> bool:
         """Check if the lock is acquired."""
-        if not self._conn:
-            raise OutOfContextError(self, "locked")
-
-        async with self._conn.execute(self._locked_sql, (name,)) as cursor:
+        conn = self._provider.client
+        async with (
+            self._provider.connection_lock,
+            conn.execute(self._locked_sql, (name,)) as cursor,
+        ):
             result = await cursor.fetchone()
         return result is not None
 
     async def owned(self, *, name: str, token: str) -> bool:
         """Check if the lock is owned."""
-        if not self._conn:
-            raise OutOfContextError(self, "owned")
-
-        async with self._conn.execute(self._owned_sql, (name, token)) as cursor:
+        conn = self._provider.client
+        async with (
+            self._provider.connection_lock,
+            conn.execute(self._owned_sql, (name, token)) as cursor,
+        ):
             result = await cursor.fetchone()
         return result is not None
 
@@ -219,12 +243,26 @@ class SQLiteLockAdapter(LockBackend):
 class SQLiteScheduleAdapter(ScheduleBackend):
     """SQLite Schedule Adapter.
 
-    Implements the `ScheduleBackend` protocol for durable distributed cron on a
-    single host. The `last_fired` epoch is stored as a `REAL` column on a row
-    keyed by `name`, and the claim decision runs in a single UPSERT gated by a
-    `WHERE` clause. The cursor's `rowcount` tells whether this call performed
-    the write, so the compare-and-set is atomic across processes sharing the
-    file.
+    Borrows the connection and a shared lock from a `SQLiteProvider` and
+    implements the `ScheduleBackend` protocol for durable distributed cron on a
+    single host. Pass an explicit `provider=` to share a connection with other
+    components, or rely on the default `env_prefix=` to build one from
+    environment variables.
+
+    The `last_fired` epoch is stored as a `REAL` column on a row keyed by
+    `name`, and the claim decision runs in a single UPSERT gated by a `WHERE`
+    clause. The cursor's `rowcount` tells whether this call performed the
+    write, so the compare-and-set is atomic across processes sharing the file.
+
+    Example:
+    ```python
+    from grelmicro import Grelmicro
+    from grelmicro.coordination import Coordination
+    from grelmicro.providers.sqlite import SQLiteProvider
+
+    sqlite = SQLiteProvider("app.db")
+    micro = Grelmicro(uses=[sqlite, Coordination(schedule=sqlite)])
+    ```
     """
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """
@@ -248,15 +286,27 @@ class SQLiteScheduleAdapter(ScheduleBackend):
 
     def __init__(
         self,
-        path: Annotated[
-            str | Path | None,
-            Doc("""
-                The SQLite database path.
-
-                If not provided, the path will be taken from the environment variable SQLITE_PATH.
-                """),
-        ] = None,
         *,
+        provider: Annotated[
+            SQLiteProvider | None,
+            Doc(
+                """
+                A pre-built `SQLiteProvider`. When set, the adapter
+                borrows the provider's connection and does not manage
+                its lifecycle.
+                """,
+            ),
+        ] = None,
+        env_prefix: Annotated[
+            str,
+            Doc(
+                """
+                Environment variable prefix used by the implicit
+                `SQLiteProvider` when `provider` is not set. Resolves
+                the path from `SQLITE_PATH` by default.
+                """,
+            ),
+        ] = "SQLITE_",
         table_name: Annotated[
             str, Doc("The table name to store the schedules.")
         ] = "schedules",
@@ -266,26 +316,41 @@ class SQLiteScheduleAdapter(ScheduleBackend):
             msg = f"Table name '{table_name}' is not a valid SQL identifier"
             raise ValueError(msg)
 
-        self._path = str(path) if path is not None else _get_sqlite_path()
+        if provider is None:
+            self._provider = SQLiteProvider(env_prefix=env_prefix)
+            self._owns_provider = True
+        else:
+            self._provider = provider
+            self._owns_provider = False
+        self._env_prefix = env_prefix
         self._table_name = table_name
         self._claim_sql = self._SQL_CLAIM.format(table_name=table_name)
         self._last_fired_sql = self._SQL_LAST_FIRED.format(
             table_name=table_name
         )
-        self._conn: aiosqlite.Connection | None = None
-        self._lock = asyncio.Lock()
         self._loop: asyncio.AbstractEventLoop | None = None
 
+    @property
+    def provider(self) -> SQLiteProvider:
+        """The bound `SQLiteProvider`."""
+        return self._provider
+
+    def _rebind_provider(self, provider: SQLiteProvider) -> None:
+        """Swap the underlying provider (used by `Grelmicro` for sharing)."""
+        self._provider = provider
+        self._owns_provider = False
+
     async def __aenter__(self) -> Self:
-        """Open the schedule backend."""
+        """Open the adapter and its provider when owned."""
+        if self._owns_provider:
+            await self._provider.__aenter__()
         self._loop = asyncio.get_running_loop()
-        self._conn = await aiosqlite.connect(self._path, isolation_level=None)
-        await self._conn.execute("PRAGMA journal_mode=WAL;")
-        await self._conn.execute(
-            self._SQL_CREATE_TABLE_IF_NOT_EXISTS.format(
-                table_name=self._table_name
-            ),
-        )
+        async with self._provider.connection_lock:
+            await self._provider.client.execute(
+                self._SQL_CREATE_TABLE_IF_NOT_EXISTS.format(
+                    table_name=self._table_name
+                ),
+            )
         return self
 
     async def __aexit__(
@@ -294,40 +359,38 @@ class SQLiteScheduleAdapter(ScheduleBackend):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Close the schedule backend."""
-        if self._conn:  # pragma: no branch
-            await self._conn.close()
-            self._conn = None
+        """Close the provider when owned. External providers are left alone."""
+        if self._owns_provider:
+            await self._provider.__aexit__(exc_type, exc_value, traceback)
 
     async def claim(self, name: str, due: float) -> bool:
         """Atomically claim the fire at `due`.
 
         Runs the gated UPSERT inside a `BEGIN IMMEDIATE` transaction so the
-        compare-and-set is serialized against concurrent writers. The lock
-        serializes the single connection within the process, and the
+        compare-and-set is serialized against concurrent writers. The provider's
+        lock serializes the single connection within the process, and the
         transaction's write lock serializes across processes sharing the file.
         An insert or a successful update changes one row (won), the gated update
         changes none (lost).
         """
-        if not self._conn:
-            raise OutOfContextError(self, "claim")
-
-        async with self._lock:
-            await self._conn.execute("BEGIN IMMEDIATE;")
+        conn = self._provider.client
+        async with self._provider.connection_lock:
+            await conn.execute("BEGIN IMMEDIATE;")
             try:
-                cursor = await self._conn.execute(self._claim_sql, (name, due))
-                changes = cursor.rowcount
-                await self._conn.execute("COMMIT;")
+                async with conn.execute(self._claim_sql, (name, due)) as cursor:
+                    changes = cursor.rowcount
+                await conn.execute("COMMIT;")
             except BaseException:
-                await self._conn.execute("ROLLBACK;")
+                await conn.execute("ROLLBACK;")
                 raise
         return changes == 1
 
     async def last_fired(self, name: str) -> float | None:
         """Return the stored `last_fired` epoch, or `None`."""
-        if not self._conn:
-            raise OutOfContextError(self, "last_fired")
-
-        async with self._conn.execute(self._last_fired_sql, (name,)) as cursor:
+        conn = self._provider.client
+        async with (
+            self._provider.connection_lock,
+            conn.execute(self._last_fired_sql, (name,)) as cursor,
+        ):
             result = await cursor.fetchone()
         return float(result[0]) if result is not None else None

--- a/grelmicro/providers/sqlite.py
+++ b/grelmicro/providers/sqlite.py
@@ -211,26 +211,20 @@ class SQLiteProvider(Provider):
         return SQLiteRateLimiterAdapter(provider=self, **kwargs)
 
     def lock(self, **kwargs: Any) -> SQLiteLockAdapter:  # noqa: ANN401
-        """Build a `SQLiteLockAdapter` for this provider's path.
-
-        The lock adapter opens its own connection to the same file.
-        """
+        """Build a `SQLiteLockAdapter` bound to this provider."""
         from grelmicro.coordination.sqlite import (  # noqa: PLC0415
             SQLiteLockAdapter,
         )
 
-        return SQLiteLockAdapter(self._path, **kwargs)
+        return SQLiteLockAdapter(provider=self, **kwargs)
 
     def schedule(self, **kwargs: Any) -> SQLiteScheduleAdapter:  # noqa: ANN401
-        """Build a `SQLiteScheduleAdapter` for this provider's path.
-
-        The schedule adapter opens its own connection to the same file.
-        """
+        """Build a `SQLiteScheduleAdapter` bound to this provider."""
         from grelmicro.coordination.sqlite import (  # noqa: PLC0415
             SQLiteScheduleAdapter,
         )
 
-        return SQLiteScheduleAdapter(self._path, **kwargs)
+        return SQLiteScheduleAdapter(provider=self, **kwargs)
 
     def cache(self, **kwargs: Any) -> SQLiteCacheAdapter:  # noqa: ANN401
         """Build a `SQLiteCacheAdapter` bound to this provider."""

--- a/tests/coordination/test_lock_backends.py
+++ b/tests/coordination/test_lock_backends.py
@@ -19,6 +19,7 @@ from grelmicro.coordination.redis import RedisLockAdapter
 from grelmicro.coordination.sqlite import SQLiteLockAdapter
 from grelmicro.providers.postgres import PostgresProvider
 from grelmicro.providers.redis import RedisProvider
+from grelmicro.providers.sqlite import SQLiteProvider
 
 pytestmark = [pytest.mark.timeout(30)]
 
@@ -162,7 +163,8 @@ async def backend(
         async with MemoryLockAdapter() as backend:
             yield backend
     elif backend_name == "sqlite":
-        async with SQLiteLockAdapter(":memory:") as backend:
+        provider = SQLiteProvider(":memory:")
+        async with provider, SQLiteLockAdapter(provider=provider) as backend:
             yield backend
     elif backend_name == "kubernetes" and container:
         async with KubernetesLockAdapter(namespace="default") as backend:

--- a/tests/coordination/test_schedule_sqlite.py
+++ b/tests/coordination/test_schedule_sqlite.py
@@ -7,9 +7,8 @@ from pathlib import Path
 import pytest
 
 from grelmicro.coordination._protocol import ScheduleBackend
-from grelmicro.coordination.errors import CoordinationSettingsValidationError
 from grelmicro.coordination.sqlite import SQLiteScheduleAdapter
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import OutOfContextError, SettingsValidationError
 from grelmicro.providers.sqlite import SQLiteProvider
 
 pytestmark = [pytest.mark.timeout(5)]
@@ -22,7 +21,8 @@ OTHER = 200.0
 @pytest.fixture
 async def backend(tmp_path: Path) -> AsyncGenerator[SQLiteScheduleAdapter]:
     """Open a SQLite schedule adapter on a temp file."""
-    async with SQLiteScheduleAdapter(tmp_path / "schedule.db") as adapter:
+    provider = SQLiteProvider(tmp_path / "schedule.db")
+    async with provider, SQLiteScheduleAdapter(provider=provider) as adapter:
         yield adapter
 
 
@@ -44,12 +44,14 @@ def test_table_name_invalid(table_name: str) -> None:
     with pytest.raises(
         ValueError, match=r"Table name '.*' is not a valid SQL identifier"
     ):
-        SQLiteScheduleAdapter(path=":memory:", table_name=table_name)
+        SQLiteScheduleAdapter(
+            provider=SQLiteProvider(":memory:"), table_name=table_name
+        )
 
 
 async def test_out_of_context_errors() -> None:
     """Adapter methods raise when called outside the context manager."""
-    adapter = SQLiteScheduleAdapter(path=":memory:")
+    adapter = SQLiteScheduleAdapter(provider=SQLiteProvider(":memory:"))
 
     with pytest.raises(OutOfContextError):
         await adapter.claim("job", OLD)
@@ -57,44 +59,99 @@ async def test_out_of_context_errors() -> None:
         await adapter.last_fired("job")
 
 
-def test_sqlite_env_var_settings(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Without a path, the adapter reads `SQLITE_PATH`."""
+def test_no_provider_builds_implicit_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without `provider=`, the adapter builds one from `SQLITE_PATH`."""
+    # Arrange
     monkeypatch.setenv("SQLITE_PATH", "schedules.db")
 
+    # Act
     adapter = SQLiteScheduleAdapter()
 
-    assert adapter._path == "schedules.db"
+    # Assert
+    assert adapter.provider.path == "schedules.db"
+    assert adapter._owns_provider is True
+
+
+def test_explicit_provider_is_borrowed() -> None:
+    """An explicit `provider=` is borrowed, not owned."""
+    # Arrange
+    provider = SQLiteProvider("schedules.db")
+
+    # Act
+    adapter = SQLiteScheduleAdapter(provider=provider)
+
+    # Assert
+    assert adapter.provider is provider
+    assert adapter._owns_provider is False
+
+
+def test_rebind_provider_borrows() -> None:
+    """`_rebind_provider` swaps the provider and marks it borrowed."""
+    # Arrange
+    adapter = SQLiteScheduleAdapter(provider=SQLiteProvider("a.db"))
+    shared = SQLiteProvider("shared.db")
+
+    # Act
+    adapter._rebind_provider(shared)
+
+    # Assert
+    assert adapter.provider is shared
+    assert adapter._owns_provider is False
 
 
 def test_sqlite_env_var_settings_validation_error() -> None:
     """A missing path raises a settings validation error."""
-    with pytest.raises(
-        CoordinationSettingsValidationError,
-        match=(r"Could not validate settings:\n"),
-    ):
+    with pytest.raises(SettingsValidationError, match="SQLITE_PATH"):
         SQLiteScheduleAdapter()
 
 
 def test_custom_table_name() -> None:
     """Custom `table_name=` is stored on the adapter."""
-    adapter = SQLiteScheduleAdapter(path=":memory:", table_name="my_schedules")
+    adapter = SQLiteScheduleAdapter(
+        provider=SQLiteProvider(":memory:"), table_name="my_schedules"
+    )
 
     assert adapter._table_name == "my_schedules"
 
 
-def test_provider_factory_returns_sqlite_adapter() -> None:
-    """`SQLiteProvider.schedule()` returns a bound adapter on the same path."""
+def test_provider_factory_returns_bound_adapter() -> None:
+    """`SQLiteProvider.schedule()` returns an adapter bound to the provider."""
+    # Arrange
     provider = SQLiteProvider("schedules.db")
 
+    # Act
     adapter = provider.schedule()
 
+    # Assert
     assert isinstance(adapter, SQLiteScheduleAdapter)
-    assert adapter._path == "schedules.db"
+    assert adapter.provider is provider
 
 
 def test_satisfies_protocol() -> None:
     """The adapter satisfies the `ScheduleBackend` protocol."""
-    assert isinstance(SQLiteScheduleAdapter(path=":memory:"), ScheduleBackend)
+    assert isinstance(
+        SQLiteScheduleAdapter(provider=SQLiteProvider(":memory:")),
+        ScheduleBackend,
+    )
+
+
+async def test_owned_provider_opens_and_closes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An implicit (owned) provider is opened on enter and closed on exit."""
+    # Arrange
+    monkeypatch.setenv("SQLITE_PATH", str(tmp_path / "owned.db"))
+    adapter = SQLiteScheduleAdapter()  # builds and owns the provider
+
+    # Act
+    async with adapter:
+        assert await adapter.claim("job", OLD) is True
+
+    # Assert
+    with pytest.raises(OutOfContextError):
+        _ = adapter.provider.client
 
 
 # Behavior (real file).
@@ -168,17 +225,19 @@ async def test_names_are_independent(
 async def test_state_survives_reopen(tmp_path: Path) -> None:
     """Stored fires persist across a close and reopen of the same file."""
     path = tmp_path / "durable.db"
-    async with SQLiteScheduleAdapter(path) as backend:
+    provider = SQLiteProvider(path)
+    async with provider, SQLiteScheduleAdapter(provider=provider) as backend:
         await backend.claim("job", OLD)
-    async with SQLiteScheduleAdapter(path) as backend:
+    provider = SQLiteProvider(path)
+    async with provider, SQLiteScheduleAdapter(provider=provider) as backend:
         assert await backend.last_fired("job") == OLD
 
 
 async def test_claim_rolls_back_on_error(tmp_path: Path) -> None:
     """A failing claim rolls back the open transaction and re-raises."""
-    async with SQLiteScheduleAdapter(tmp_path / "schedule.db") as backend:
-        conn = backend._conn
-        assert conn is not None
+    provider = SQLiteProvider(tmp_path / "schedule.db")
+    async with provider, SQLiteScheduleAdapter(provider=provider) as backend:
+        conn = provider.client
         await conn.execute("DROP TABLE schedules;")
 
         with pytest.raises(Exception, match="no such table"):

--- a/tests/coordination/test_sqlite_lock.py
+++ b/tests/coordination/test_sqlite_lock.py
@@ -4,9 +4,10 @@ from pathlib import Path
 
 import pytest
 
-from grelmicro.coordination.errors import CoordinationSettingsValidationError
+from grelmicro.cache.sqlite import SQLiteCacheAdapter
 from grelmicro.coordination.sqlite import SQLiteLockAdapter
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import OutOfContextError, SettingsValidationError
+from grelmicro.providers.sqlite import SQLiteProvider
 
 pytestmark = [pytest.mark.timeout(1)]
 
@@ -27,13 +28,15 @@ def test_sync_backend_table_name_invalid(table_name: str) -> None:
     with pytest.raises(
         ValueError, match=r"Table name '.*' is not a valid SQL identifier"
     ):
-        SQLiteLockAdapter(path=":memory:", table_name=table_name)
+        SQLiteLockAdapter(
+            provider=SQLiteProvider(":memory:"), table_name=table_name
+        )
 
 
 async def test_sync_backend_out_of_context_errors() -> None:
     """Test Synchronization Backend Out Of Context Errors."""
     # Arrange
-    backend = SQLiteLockAdapter(path=":memory:")
+    backend = SQLiteLockAdapter(provider=SQLiteProvider(":memory:"))
     name = "lock"
     key = "token"
 
@@ -48,10 +51,10 @@ async def test_sync_backend_out_of_context_errors() -> None:
         await backend.owned(name=name, token=key)
 
 
-def test_sqlite_env_var_settings(
+def test_no_provider_builds_implicit_one(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test SQLite Settings from Environment Variables."""
+    """Without `provider=`, the adapter builds one from `SQLITE_PATH`."""
     # Arrange
     monkeypatch.setenv("SQLITE_PATH", "locks.db")
 
@@ -59,37 +62,114 @@ def test_sqlite_env_var_settings(
     backend = SQLiteLockAdapter()
 
     # Assert
-    assert backend._path == "locks.db"
+    assert backend.provider.path == "locks.db"
+    assert backend._owns_provider is True
+
+
+def test_explicit_provider_is_borrowed() -> None:
+    """An explicit `provider=` is borrowed, not owned."""
+    # Arrange
+    provider = SQLiteProvider("locks.db")
+
+    # Act
+    backend = SQLiteLockAdapter(provider=provider)
+
+    # Assert
+    assert backend.provider is provider
+    assert backend._owns_provider is False
+
+
+def test_rebind_provider_borrows() -> None:
+    """`_rebind_provider` swaps the provider and marks it borrowed."""
+    # Arrange
+    backend = SQLiteLockAdapter(provider=SQLiteProvider("a.db"))
+    shared = SQLiteProvider("shared.db")
+
+    # Act
+    backend._rebind_provider(shared)
+
+    # Assert
+    assert backend.provider is shared
+    assert backend._owns_provider is False
 
 
 def test_sqlite_env_var_settings_validation_error() -> None:
     """Test SQLite Settings Validation Error."""
     # Assert / Act
-    with pytest.raises(
-        CoordinationSettingsValidationError,
-        match=(r"Could not validate settings:\n"),
-    ):
+    with pytest.raises(SettingsValidationError, match="SQLITE_PATH"):
         SQLiteLockAdapter()
 
 
 def test_sync_backend_custom_table_name() -> None:
     """Test Synchronization Backend Custom Table Name."""
     # Act
-    backend = SQLiteLockAdapter(path=":memory:", table_name="my_locks")
+    backend = SQLiteLockAdapter(
+        provider=SQLiteProvider(":memory:"), table_name="my_locks"
+    )
 
     # Assert
     assert backend._table_name == "my_locks"
 
 
+async def test_owned_provider_opens_and_closes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An implicit (owned) provider is opened on enter and closed on exit."""
+    # Arrange
+    monkeypatch.setenv("SQLITE_PATH", str(tmp_path / "owned.db"))
+    backend = SQLiteLockAdapter()  # builds and owns the provider
+
+    # Act
+    async with backend:
+        fence = await backend.acquire(name="lock", token="token", duration=1)
+
+    # Assert
+    assert fence == 1
+    with pytest.raises(OutOfContextError):
+        _ = backend.provider.client
+
+
+async def test_borrowed_provider_stays_open(tmp_path: Path) -> None:
+    """A borrowed provider outlives the adapter that used it."""
+    # Arrange
+    provider = SQLiteProvider(tmp_path / "shared.db")
+
+    # Act
+    async with provider:
+        async with SQLiteLockAdapter(provider=provider) as backend:
+            await backend.acquire(name="lock", token="token", duration=1)
+
+        # Assert
+        assert provider.client is not None
+
+
+async def test_shares_one_connection_with_another_component(
+    tmp_path: Path,
+) -> None:
+    """A lock and a cache on one provider run on the same connection."""
+    # Arrange
+    provider = SQLiteProvider(tmp_path / "shared.db")
+
+    # Act
+    async with (
+        provider,
+        SQLiteLockAdapter(provider=provider) as lock,
+        SQLiteCacheAdapter(provider=provider) as cache,
+    ):
+        await lock.acquire(name="lock", token="token", duration=1)
+        await cache.set(key="k", value=b"v", ttl=10)
+
+        # Assert
+        assert lock.provider.client is cache.provider.client
+
+
 async def test_acquire_rolls_back_on_error(tmp_path: Path) -> None:
     """A failing acquire rolls back the open transaction and re-raises."""
     # Arrange
-    backend = SQLiteLockAdapter(tmp_path / "locks.db")
-    async with backend:
-        conn = backend._conn
-        assert conn is not None
+    provider = SQLiteProvider(tmp_path / "locks.db")
+    async with provider, SQLiteLockAdapter(provider=provider) as backend:
+        conn = provider.client
         await conn.execute("DROP TABLE locks;")
-        await conn.commit()
 
         # Act / Assert
         with pytest.raises(Exception, match="no such table"):
@@ -103,4 +183,3 @@ async def test_acquire_rolls_back_on_error(tmp_path: Path) -> None:
                 table_name="locks"
             )
         )
-        await conn.commit()

--- a/tests/coordination/test_sqlite_lock.py
+++ b/tests/coordination/test_sqlite_lock.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import aiosqlite
 import pytest
 
 from grelmicro.cache.sqlite import SQLiteCacheAdapter
@@ -161,6 +162,44 @@ async def test_shares_one_connection_with_another_component(
 
         # Assert
         assert lock.provider.client is cache.provider.client
+
+
+async def test_acquire_and_release_commit_for_other_processes(
+    tmp_path: Path,
+) -> None:
+    """Acquire and release are durable, not left open on the connection.
+
+    The provider's connection runs in autocommit, so both statements commit
+    when they finish. A second connection stands in for another process: it
+    can only see writes that actually committed, which an assertion on the
+    adapter's own connection could not distinguish.
+    """
+    # Arrange
+    path = tmp_path / "locks.db"
+    provider = SQLiteProvider(path)
+
+    async with provider, SQLiteLockAdapter(provider=provider) as backend:
+        # Act
+        await backend.acquire(name="lock", token="token", duration=60)
+
+        # Assert
+        async with (
+            aiosqlite.connect(path) as other,
+            other.execute("SELECT token FROM locks WHERE name = 'lock';") as c,
+        ):
+            assert await c.fetchone() == ("token",)
+
+        # Act
+        released = await backend.release(name="lock", token="token")
+
+        # Assert
+        assert released is True
+        async with (
+            aiosqlite.connect(path) as other,
+            other.execute("SELECT token FROM locks WHERE name = 'lock';") as c,
+        ):
+            assert await c.fetchone() == (None,)
+        assert provider.client.in_transaction is False
 
 
 async def test_acquire_rolls_back_on_error(tmp_path: Path) -> None:

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -65,9 +65,13 @@ async def test_sync_postgres_async_with(
         pass
 
 
-async def test_sync_sqlite_async_with(tmp_path) -> None:  # noqa: ANN001
+async def test_sync_sqlite_async_with(
+    tmp_path,  # noqa: ANN001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The SQLite sync adapter opens and closes cleanly."""
-    async with SQLiteLockAdapter(tmp_path / "lock.db"):
+    monkeypatch.setenv("SQLITE_PATH", str(tmp_path / "lock.db"))
+    async with SQLiteLockAdapter():
         pass
 
 

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -151,13 +151,44 @@ class _RecordingElectionAdapter:
         raise NotImplementedError
 
 
+class _RecordingScheduleAdapter:
+    """A `ScheduleBackend` that borrows a provider it does not own.
+
+    Only the lifecycle hooks run in these tests. The schedule methods are
+    stubs present to satisfy the `ScheduleBackend` protocol.
+    """
+
+    def __init__(self, provider: _RecordingProvider) -> None:
+        self._provider = provider
+        self._owns_provider = False
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def __aenter__(self) -> Self:
+        self._loop = asyncio.get_running_loop()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def claim(self, name: str, due: float) -> bool:
+        raise NotImplementedError
+
+    async def last_fired(self, name: str) -> float | None:
+        raise NotImplementedError
+
+
 class _RecordingProvider(Provider):
     """A Provider that records its enter/exit lifecycle for discovery tests.
 
-    `Coordination(provider)` asks for both a lock backend and an election
-    backend, so this Provider ships both. The two adapters borrow the same
-    Provider instance, so discovery walks both backends and still adopts the
-    Provider exactly once.
+    `Coordination(provider)` asks for a lock backend, an election backend,
+    and a schedule backend, so this Provider ships all three. The adapters
+    borrow the same Provider instance, so discovery walks every backend and
+    still adopts the Provider exactly once.
     """
 
     short_name: ClassVar[str] = "rec"
@@ -174,6 +205,9 @@ class _RecordingProvider(Provider):
         **kwargs: object,  # noqa: ARG002
     ) -> _RecordingElectionAdapter:
         return _RecordingElectionAdapter(self)
+
+    def schedule(self, **kwargs: object) -> _RecordingScheduleAdapter:  # noqa: ARG002
+        return _RecordingScheduleAdapter(self)
 
     async def __aenter__(self) -> Self:
         self.entered += 1
@@ -730,6 +764,17 @@ async def test_discovers_both_providers_of_a_coordination() -> None:
     assert lock_provider.exited == 1
     assert election_provider.entered == 1
     assert election_provider.exited == 1
+
+
+async def test_discovers_the_provider_of_a_schedule_backend() -> None:
+    """A `Coordination` holding only a schedule backend adopts its provider."""
+    provider = _RecordingProvider()
+    micro = Grelmicro(uses=[Coordination(schedule=provider)])
+    async with micro:
+        pass
+
+    assert provider.entered == 1
+    assert provider.exited == 1
 
 
 async def test_explicit_provider_takes_precedence_over_discovery() -> None:


### PR DESCRIPTION
Closes #546.

`SQLiteCacheAdapter`, `SQLiteRateLimiterAdapter`, and `SQLiteCircuitBreakerAdapter` all take `provider=` and borrow the provider's connection. `SQLiteLockAdapter` and `SQLiteScheduleAdapter` took a raw `path=` and opened their own, so an app pairing a lock with a cache on one file held two connections and neither adapter could be rebound.

Per the maintainer decision on the issue, this is option 3: a clean cut to `provider=`, matching the pre-1.0 no-deprecation-shims convention.

## Changes

- Both adapters now take `(*, provider=None, env_prefix="SQLITE_", table_name=...)`, expose a `provider` property, and implement `_rebind_provider`, identical in shape to `PostgresLockAdapter` and the other SQLite adapters.
- They borrow the provider's connection and its `connection_lock`. Writes moved from `conn.commit()`/`conn.rollback()` to explicit `COMMIT;`/`ROLLBACK;` because the provider's connection runs in autocommit (`isolation_level=None`), which is the pattern `SQLiteCacheAdapter` already uses. `BEGIN IMMEDIATE` is unchanged.
- `SQLiteScheduleAdapter`'s private `asyncio.Lock` is replaced by the provider's shared one, so the two adapters no longer serialize independently against the same file.
- `SQLiteProvider.lock()` / `.schedule()` pass `provider=self` instead of a path.
- Provider discovery now walks `Coordination`'s schedule backend. `_iter_provider_backends` only looked at the lock and election backends, so a schedule-only `Coordination` left its provider unopened and duplicate providers undeduped. This predates the SQLite change and affected Postgres too.

## Breaking

`SQLiteLockAdapter("app.db")` becomes `SQLiteLockAdapter(provider=SQLiteProvider("app.db"))`, or just pass the provider to `Coordination(sqlite)` and let it build both. A missing path now raises `SettingsValidationError` instead of `CoordinationSettingsValidationError`.

The documented form is unchanged:

```python
sqlite = SQLiteProvider("app.db")
micro = Grelmicro(uses=[sqlite, Coordination(lock=sqlite)])
```

## Verification

Full `pre-commit` green: ruff, ty, mypy, 3469 unit tests, the integration tier, coverage, and `mkdocs build --strict`. New tests cover owned vs borrowed providers, rebinding, and that a lock and a cache on one provider share a single connection.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b