### PR TITLE
👷 Pin the ty-check pre-commit hook to single-threaded, matching CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,10 @@ repos:
   - id: ty-check
     name: ty-check
     description: "Run 'ty check' for static type checking"
-    entry: uv run ty check
+    # Single-threaded so cycle resolution is deterministic, matching CI. ty
+    # resolves inference cycles in whichever order threads reach them, which
+    # can flip a diagnostic on unchanged code (astral-sh/ty#1670).
+    entry: env TY_MAX_PARALLELISM=1 uv run ty check
     language: system
     require_serial: true
     pass_filenames: false

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,8 @@
 * ✅ Add `tests/test_adapter_contracts.py`, which asserts every first-party adapter initializes `_loop` and captures the running loop on `__aenter__`. A `Protocol` attribute annotation declares the requirement but never creates it, so both type checkers pass an adapter that omits it. ([#541](https://github.com/grelinfo/grelmicro/issues/541))
 * 👷 Clear 16 modules from the mypy override ladder, leaving 3. The `uses=` resolver, the optional-import rebinding, and the `functools.wraps` returns now type-check under both checkers. ([#541](https://github.com/grelinfo/grelmicro/issues/541))
 * 🔥 Drop a stale `# type: ignore` in `grelmicro/metrics/_component.py`. grelmicro suppresses with `# ty: ignore` only. ([#541](https://github.com/grelinfo/grelmicro/issues/541))
+* ⬆️ Bump `ruff` to 0.16. Markdown formatting is now stable, so the formatter skips `*.md` and leaves the README and docs examples written as they read best. The new `CPY001` rule stays off: the MIT licence lives in `LICENSE`, not in a per-file header. ([#557](https://github.com/grelinfo/grelmicro/pull/557))
+* 👷 Pin the `ty-check` pre-commit hook to `TY_MAX_PARALLELISM=1`, matching CI. ty resolves inference cycles in whichever order threads reach them, so a local run could flag a diagnostic that CI did not. ([#551](https://github.com/grelinfo/grelmicro/issues/551))
 
 ## 0.31.0 - 2026-07-27
 


### PR DESCRIPTION
Closes #551.

`ty` resolves inference cycles in whichever order threads reach them, so the same unchanged code can pass or fail depending on scheduling ([astral-sh/ty#1670](https://github.com/astral-sh/ty/issues/1670)). CI already pins `TY_MAX_PARALLELISM: "1"` in the Lint job, but the `ty-check` pre-commit hook did not, so a local run could flag a diagnostic that CI never saw.

## Changes

* `.pre-commit-config.yaml`: the `ty-check` entry becomes `env TY_MAX_PARALLELISM=1 uv run ty check`, with the same comment `ci.yml` carries.
* `docs/changelog.md`: two `Internal` entries. One for this pin (#551), one for the ruff 0.16 bump that shipped in #557 without a changelog line.

No library code changes.

## Verification

* `pre-commit run --all-files`: 17/17 passed, `ty-check` included under the new entry
* `pytest -m "slow and not integration"`: 5 passed
* `pytest -m integration`: 220 passed

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b