### PR TITLE
📝 List each Provider once in the SQLite and bulkhead examples

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,7 @@
 * 🔥 Drop a stale `# type: ignore` in `grelmicro/metrics/_component.py`. grelmicro suppresses with `# ty: ignore` only. ([#541](https://github.com/grelinfo/grelmicro/issues/541))
 * ⬆️ Bump `ruff` to 0.16. Markdown formatting is now stable, so the formatter skips `*.md` and leaves the README and docs examples written as they read best. The new `CPY001` rule stays off: the MIT licence lives in `LICENSE`, not in a per-file header. ([#557](https://github.com/grelinfo/grelmicro/pull/557))
 * 👷 Pin the `ty-check` pre-commit hook to `TY_MAX_PARALLELISM=1`, matching CI. ty resolves inference cycles in whichever order threads reach them, so a local run could flag a diagnostic that CI did not. ([#551](https://github.com/grelinfo/grelmicro/issues/551))
+* 📝 List each Provider once in the SQLite and bulkhead examples. A Component that borrows a Provider already adopts its lifecycle, so the bare Provider beside it was redundant. The Redis and Postgres examples were already written this way. ([#559](https://github.com/grelinfo/grelmicro/pull/559))
 
 ## 0.31.0 - 2026-07-27
 

--- a/docs/snippets/coordination/sqlite.py
+++ b/docs/snippets/coordination/sqlite.py
@@ -3,4 +3,4 @@ from grelmicro.coordination import Coordination
 from grelmicro.providers.sqlite import SQLiteProvider
 
 sqlite = SQLiteProvider("locks.db")
-micro = Grelmicro(uses=[sqlite, Coordination(lock=sqlite)])
+micro = Grelmicro(uses=[Coordination(lock=sqlite)])

--- a/docs/snippets/resilience/bulkhead_uses.py
+++ b/docs/snippets/resilience/bulkhead_uses.py
@@ -9,7 +9,7 @@ checkout_redis = RedisProvider("redis://localhost:6379/1")
 checkout = Bulkhead(
     "checkout",
     max_concurrent=50,
-    uses=[checkout_redis, Coordination(checkout_redis)],
+    uses=[Coordination(checkout_redis)],
 )
 
 cart_lock = Lock("cart")

--- a/docs/snippets/resilience/circuitbreaker_sqlite.py
+++ b/docs/snippets/resilience/circuitbreaker_sqlite.py
@@ -3,6 +3,6 @@ from grelmicro.providers.sqlite import SQLiteProvider
 from grelmicro.resilience import CircuitBreaker, CircuitBreakerRegistry
 
 sqlite = SQLiteProvider("app.db")
-micro = Grelmicro(uses=[sqlite, CircuitBreakerRegistry(sqlite)])
+micro = Grelmicro(uses=[CircuitBreakerRegistry(sqlite)])
 
 payments = CircuitBreaker("payments")

--- a/docs/snippets/resilience/ratelimiter_sqlite.py
+++ b/docs/snippets/resilience/ratelimiter_sqlite.py
@@ -3,4 +3,4 @@ from grelmicro.providers.sqlite import SQLiteProvider
 from grelmicro.resilience import RateLimiterRegistry
 
 sqlite = SQLiteProvider("rate_limit.db")
-micro = Grelmicro(uses=[sqlite, RateLimiterRegistry(sqlite)])
+micro = Grelmicro(uses=[RateLimiterRegistry(sqlite)])


### PR DESCRIPTION
Docs polish found while auditing everything that changed since 0.31.0.

Four examples listed the same Provider twice, once bare and once inside the Component that borrows it:

```python
micro = Grelmicro(uses=[sqlite, CircuitBreakerRegistry(sqlite)])
```

A Component that borrows a Provider already adopts its lifecycle, so the bare entry does nothing. The Redis and Postgres examples were already written the short way, and so is the SQLite example on the Providers page, which made the four outliers read as if SQLite needed something extra.

## Changes

* `docs/snippets/coordination/sqlite.py`
* `docs/snippets/resilience/circuitbreaker_sqlite.py`
* `docs/snippets/resilience/ratelimiter_sqlite.py`
* `docs/snippets/resilience/bulkhead_uses.py`
* `docs/changelog.md`: one `Internal` entry

No library code changes.

## Verification

Each shortened form was run against a real app before the edit, so the examples still open and close cleanly:

* `Grelmicro(uses=[Coordination(sqlite)])`, `Grelmicro(uses=[Coordination(lock=sqlite)])`
* `Grelmicro(uses=[CircuitBreakerRegistry(sqlite)])`, `Grelmicro(uses=[RateLimiterRegistry(sqlite)])`
* `Bulkhead("checkout", max_concurrent=50, uses=[Coordination(checkout_redis)])`

`pre-commit run --all-files`: 17/17 passed. The snippet suite executes every file above, so the examples are checked as code.

## Audit result

The rest of the docs are current with the release. `SecretUrl` is covered in `providers.md`, `reference/types.md`, `tracing.md`, and `metrics.md`. The SQLite `provider=` change is reflected in `architecture/sqlite.md` and no example still passes `path=` to an adapter. No page claimed Postgres lacked `from_thread`. The changed prose carries no em-dashes or semicolons.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b