### PR TITLE
🔖 Prepare the 0.32.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.32.0 - 2026-07-28
 
 ### Breaking
 


### PR DESCRIPTION
Flips `## Unreleased` to `## 0.32.0 - 2026-07-28`. No other change.

Minor bump rather than a patch: the slate carries two breaking changes, so the version shape itself tells anyone scanning tags to read the changelog before upgrading.

## Release contents

2 breaking, 1 feature, 3 fixed, 2 security, 6 internal. Closes out #541, #546, #550, #551, and #557.

## Verification on this tree

Full release tier, run locally:

* `pytest -m "not integration and not slow"`: 3470 passed
* `pytest -m "slow and not integration"`: 5 passed
* `pytest -m integration`: 220 passed
* `pre-commit run --all-files`: all passed, coverage at 100%

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b