### PR TITLE
✅ Give the lock contention test a lease that outlives scheduling jitter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+* ✅ Stop `test_lock_acquire_nowait_would_block` racing its own lease. The test asserts that a second worker is blocked, but held the lock on a 10 ms lease, so a loaded runner could let the lease lapse before the second worker tried. It then acquired cleanly and `WouldBlock` never fired, which failed the 0.32.0 release on Python 3.14. Contention tests now use a lease that outlives scheduling jitter, matching the from-thread twin.
+
 ## 0.32.0 - 2026-07-28
 
 ### Breaking

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -69,13 +69,15 @@ async def lock(locks: list[Lock]) -> Lock:
     return locks[WORKER_1]
 
 
-# A lease long enough that it never expires during a from-thread test, even
-# under heavy parallel load. Each `from_thread` call is a thread<->loop
-# round-trip, and the shared session loop can be starved by parallel neighbors,
-# so the default 10 ms lease would lapse mid-sequence and flake. The 5 s module
-# timeout still catches a genuine hang. Tests that assert lease *expiry* keep
-# the short-lease `lock`/`locks` fixtures.
-THREAD_LEASE_DURATION = 30.0
+# A lease long enough that it never expires mid-test, even under heavy
+# parallel load. Two shapes need it. A `from_thread` call is a thread<->loop
+# round-trip, and the shared session loop can be starved by parallel
+# neighbors. A contention test needs the first worker to still hold the lock
+# when the second one tries. Either way the default 10 ms lease would lapse
+# mid-sequence and flake. The 5 s module timeout still catches a genuine hang.
+# Tests that assert lease *expiry* keep the short-lease `lock`/`locks`
+# fixtures.
+LONG_LEASE_DURATION = 30.0
 
 
 @pytest.fixture
@@ -86,7 +88,7 @@ async def thread_locks(backend: LockBackend) -> list[Lock]:
             backend=backend,
             name=LOCK_NAME,
             worker=f"worker_{i}",
-            lease_duration=THREAD_LEASE_DURATION,
+            lease_duration=LONG_LEASE_DURATION,
             retry_interval=0.001,
         )
         for i in range(WORKER_COUNT)
@@ -97,6 +99,28 @@ async def thread_locks(backend: LockBackend) -> list[Lock]:
 async def thread_lock(thread_locks: list[Lock]) -> Lock:
     """Single generous-lease lock for from-thread tests."""
     return thread_locks[WORKER_1]
+
+
+@pytest.fixture
+async def contended_locks(backend: LockBackend) -> list[Lock]:
+    """Locks whose lease outlives scheduling jitter, for contention tests.
+
+    A test asserting that a second worker is *blocked* needs the first
+    worker to still hold the lock when the second one tries. The
+    short-lease `locks` fixture races that: when the lease lapses first,
+    the second worker acquires and the expected `WouldBlock` never
+    happens.
+    """
+    return [
+        Lock(
+            backend=backend,
+            name=LOCK_NAME,
+            worker=f"worker_{i}",
+            lease_duration=LONG_LEASE_DURATION,
+            retry_interval=0.001,
+        )
+        for i in range(WORKER_COUNT)
+    ]
 
 
 @pytest.fixture
@@ -248,7 +272,7 @@ async def test_lock_from_thread_context_manager_wait(
         backend=backend,
         name=LOCK_NAME,
         worker=f"worker_{WORKER_2}",
-        lease_duration=THREAD_LEASE_DURATION,
+        lease_duration=LONG_LEASE_DURATION,
         retry_interval=0.001,
     )
     locked_before = None
@@ -405,8 +429,11 @@ async def test_lock_from_thread_acquire_nowait(thread_lock: Lock) -> None:
     assert locked_after is True
 
 
-async def test_lock_acquire_nowait_would_block(locks: list[Lock]) -> None:
+async def test_lock_acquire_nowait_would_block(
+    contended_locks: list[Lock],
+) -> None:
     """Test Lock wait acquire would block."""
+    locks = contended_locks
     # Arrange
     await locks[WORKER_1].acquire()
 


### PR DESCRIPTION
## Problem

The 0.32.0 Release workflow failed. `full-checks / Test Python 3.14` failed on `tests/coordination/test_lock.py::test_lock_acquire_nowait_would_block` with `DID NOT RAISE WouldBlockError` (1 failed, 3323 passed), which cancelled the 3.12 and 3.13 jobs and skipped both `publish-pypi` and `publish-docs`. Nothing reached PyPI.

## Cause

The test asserts that a **second** worker is blocked, so it needs the first worker to still hold the lock. It used the `locks` fixture, whose lease is 10 ms. On a loaded runner more than 10 ms can elapse between the two calls, the lease lapses, and the second worker acquires cleanly, so `WouldBlock` never fires.

Reproduced deterministically by inserting a 20 ms delay between the two calls:

```
REPRODUCED: worker_2 acquired, no WouldBlock raised
```

Its from-thread twin, `test_lock_from_thread_acquire_nowait_would_block`, already used the generous lease. The async twin was missed because the long-lease fixture is named `thread_locks`, which reads as being about threads rather than about the lease.

## Fix

Add a `contended_locks` fixture with a lease that outlives scheduling jitter, and point the test at it. Rename `THREAD_LEASE_DURATION` to `LONG_LEASE_DURATION` and widen the comment, so the next contention test finds it.

The other short-lease tests are left alone on purpose: `test_lock_context_manager_wait` and `test_lock_acquire_wait` depend on the lease expiring, which is exactly what they assert.

## Verification

- The previously failing test passes on 5 consecutive runs.
- Full suite: 3717 passed.
- Full pre-commit green, including `mkdocs build --strict`.

Unblocks re-cutting the release as 0.32.1.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b