### PR TITLE
🔖 Prepare the 0.32.1 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.32.1 - 2026-07-28
+
+Re-cut of 0.32.0, which never reached PyPI. A flaky test failed the release run, so publishing was skipped. The 0.32.0 tag is immutable, so the same contents ship here. See [0.32.0](#0320---2026-07-28) for the changes.
 
 ### Internal
 


### PR DESCRIPTION
Re-cut of 0.32.0, which never reached PyPI.

The 0.32.0 Release run failed on a flaky lock test on Python 3.14, so `publish-pypi` and `publish-docs` were both skipped. Release tags are immutable, so 0.32.0 is burned and the same contents ship as 0.32.1.

The flake itself is fixed in #561, which is already on main.

Changelog only.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b