### PR TITLE
📝 Fix the 0.32.0 anchor in the 0.32.1 changelog note

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.32.1 - 2026-07-28
 
-Re-cut of 0.32.0, which never reached PyPI. A flaky test failed the release run, so publishing was skipped. The 0.32.0 tag is immutable, so the same contents ship here. See [0.32.0](#0320---2026-07-28) for the changes.
+Re-cut of 0.32.0, which never reached PyPI. A flaky test failed the release run, so publishing was skipped. The 0.32.0 tag is immutable, so the same contents ship here. See [0.32.0](#0320-2026-07-28) for the changes.
 
 ### Internal
 


### PR DESCRIPTION
The 0.32.1 note links to the 0.32.0 section as `#0320---2026-07-28`. The generated anchor is `#0320-2026-07-28`, so the link goes nowhere.

`mkdocs build --strict` reports this at INFO level rather than failing, which is why it got through: `Doc file 'changelog.md' contains a link '#0320---2026-07-28', but there is no such anchor on this page.`

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b