### PR TITLE
🔖 Prepare the 0.32.2 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## Unreleased
+## 0.32.2 - 2026-07-28
 
 ### Features
 
-* ✨ Circuit breakers now reclaim their own stored state. A circuit that closes on recovery, or that you `reset()`, deletes its entry instead of writing an empty one, since every backend already reads a missing entry as `CLOSED`. What remains expires after a day without a call, always longer than the cool-down, so an open circuit cannot forget itself while waiting to probe. `isolate()` is exempt and holds until you reset it. Redis expires the key itself. Postgres and SQLite sweep hourly in the background, bounded per pass and skipping circuits in use, tunable with `cleanup_interval=`. This is what keeps a dynamic key set from growing the store forever. ([#496](https://github.com/grelinfo/grelmicro/issues/496))
-* ✨ Add `CircuitBreaker.keyed(key)` to give each tenant, endpoint, or model its own circuit. Each key gets independent counters, state, and cool-down, so one failing key opens alone while the rest keep calling. The returned circuit supports the same block, decorator, `from_thread`, `isolate`, `reset`, `state`, and `metrics` surface. A breaker keeps `maxsize` circuits resident (1024 by default) and never evicts one that is busy or recently used. ([#496](https://github.com/grelinfo/grelmicro/issues/496))
+* ✨ Add `CircuitBreaker.keyed(key)` to give each tenant, endpoint, or model its own circuit, with independent counters, state, and cool-down. ([#496](https://github.com/grelinfo/grelmicro/issues/496))
+* ✨ Circuit breakers now reclaim their stored state instead of keeping it forever, so a dynamic key set no longer grows the backend without bound. Redis expires the key, Postgres and SQLite sweep hourly via `cleanup_interval=`. ([#496](https://github.com/grelinfo/grelmicro/issues/496))
+
+### Upgrading
+
+Circuit-breaker rows written before this release carry no activity timestamp, so an already-open circuit on Postgres or SQLite reads as expired the first time the new code touches it and starts again from `CLOSED`. This happens once, on the first call after the upgrade. Circuits held open by `isolate()` are unaffected.
 
 ## 0.32.1 - 2026-07-28
 


### PR DESCRIPTION
Ships `CircuitBreaker.keyed()` and circuit-breaker state reclamation from #563.

Includes an Upgrading note: circuit-breaker rows written before this release carry no activity timestamp, so an already-open circuit on Postgres or SQLite reads as expired once on first contact after the upgrade. Circuits held by `isolate()` are unaffected.

Changelog only.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b