### PR TITLE
🐛 Bound the cache cleanup sweep and log its failures

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* 🐛 Bound the cache cleanup sweep. It deleted every expired row in one statement, so a large backlog held one long delete against the table. Each pass now takes at most 1000 rows and the interval is jittered, so replicas do not sweep in lockstep. ([#496](https://github.com/grelinfo/grelmicro/issues/496))
+* 🐛 Log cache cleanup failures instead of swallowing them. A failing sweep was silently suppressed, so a cache that stopped reclaiming disk gave no signal. ([#496](https://github.com/grelinfo/grelmicro/issues/496))
+
 ## 0.32.2 - 2026-07-28
 
 ### Features

--- a/grelmicro/cache/postgres.py
+++ b/grelmicro/cache/postgres.py
@@ -5,12 +5,23 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import re
+from logging import getLogger
 from typing import TYPE_CHECKING, Annotated, Self
 
 from typing_extensions import Doc
 
 from grelmicro.cache._protocol import CacheBackend
+from grelmicro.coordination._base import jittered_interval
 from grelmicro.providers.postgres import PostgresProvider
+
+logger = getLogger("grelmicro")
+
+_JANITOR_LIMIT = 1000
+"""Rows a single sweep may delete, bounding how long it holds the write."""
+
+_JANITOR_JITTER = 0.2
+"""Interval jitter, so replicas do not sweep in lockstep."""
+
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -105,7 +116,11 @@ class PostgresCacheAdapter(CacheBackend):
     _SQL_CLEAR_ALL = "DELETE FROM {table_name};"
 
     _SQL_JANITOR = (
-        "DELETE FROM {table_name} WHERE expires_at < NOW() - INTERVAL '1 hour';"
+        "DELETE FROM {table_name} WHERE key IN ("
+        "  SELECT key FROM {table_name}"
+        "    WHERE expires_at < NOW() - INTERVAL '1 hour'"
+        "    LIMIT $1"
+        ");"
     )
 
     def __init__(
@@ -357,12 +372,22 @@ class PostgresCacheAdapter(CacheBackend):
             await self._provider.client.execute(self._clear_all_sql)
 
     async def _janitor_loop(self) -> None:
-        """Periodically delete rows expired for more than one hour."""
+        """Periodically delete rows expired for more than one hour.
+
+        Each pass deletes at most `_JANITOR_LIMIT` rows, so a large
+        backlog is worked off over several passes instead of holding
+        one long delete. The interval is jittered so replicas sharing
+        one database do not sweep at the same instant.
+        """
         interval = self._cleanup_interval or 0
         while True:
-            await asyncio.sleep(interval)
-            with contextlib.suppress(Exception):
-                await self._provider.client.execute(self._janitor_sql)
+            await asyncio.sleep(jittered_interval(interval, _JANITOR_JITTER))
+            try:
+                await self._provider.client.execute(
+                    self._janitor_sql, _JANITOR_LIMIT
+                )
+            except Exception:
+                logger.warning("Cache cleanup sweep failed", exc_info=True)
 
 
 def _escape_like(value: str) -> str:

--- a/grelmicro/cache/sqlite.py
+++ b/grelmicro/cache/sqlite.py
@@ -5,13 +5,24 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import re
+from logging import getLogger
 from time import time
 from typing import TYPE_CHECKING, Annotated, Self
 
 from typing_extensions import Doc
 
 from grelmicro.cache._protocol import CacheBackend
+from grelmicro.coordination._base import jittered_interval
 from grelmicro.providers.sqlite import SQLiteProvider
+
+logger = getLogger("grelmicro")
+
+_JANITOR_LIMIT = 1000
+"""Rows a single sweep may delete, bounding how long it holds the write."""
+
+_JANITOR_JITTER = 0.2
+"""Interval jitter, so replicas do not sweep in lockstep."""
+
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -104,7 +115,11 @@ class SQLiteCacheAdapter(CacheBackend):
 
     _SQL_CLEAR_ALL = "DELETE FROM {table_name};"
 
-    _SQL_JANITOR = "DELETE FROM {table_name} WHERE expires_at < ?;"
+    _SQL_JANITOR = (
+        "DELETE FROM {table_name} WHERE rowid IN ("
+        "  SELECT rowid FROM {table_name} WHERE expires_at < ? LIMIT ?"
+        ");"
+    )
 
     def __init__(
         self,
@@ -400,14 +415,24 @@ class SQLiteCacheAdapter(CacheBackend):
                 await conn.execute(self._clear_all_sql)
 
     async def _janitor_loop(self) -> None:
-        """Periodically delete rows expired for more than one hour."""
+        """Periodically delete rows expired for more than one hour.
+
+        Each pass deletes at most `_JANITOR_LIMIT` rows, so a large
+        backlog is worked off over several passes instead of holding
+        the write lock for one long delete. The interval is jittered so
+        processes sharing one file do not sweep at the same instant.
+        """
         interval = self._cleanup_interval or 0
         conn = self._provider.client
         while True:
-            await asyncio.sleep(interval)
-            with contextlib.suppress(Exception):
+            await asyncio.sleep(jittered_interval(interval, _JANITOR_JITTER))
+            try:
                 async with self._provider.connection_lock:
-                    await conn.execute(self._janitor_sql, (time() - 3600,))
+                    await conn.execute(
+                        self._janitor_sql, (time() - 3600, _JANITOR_LIMIT)
+                    )
+            except Exception:
+                logger.warning("Cache cleanup sweep failed", exc_info=True)
 
 
 def _escape_like(value: str) -> str:

--- a/tests/cache/test_postgres.py
+++ b/tests/cache/test_postgres.py
@@ -1,12 +1,14 @@
 """Tests for the Postgres Cache Adapter."""
 
 import asyncio
+import logging
 from types import TracebackType
 from typing import Self
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from grelmicro.cache import postgres as cache_postgres
 from grelmicro.cache.postgres import PostgresCacheAdapter, _escape_like
 from grelmicro.providers.postgres import (
     PostgresProvider,
@@ -362,6 +364,25 @@ class TestAsyncMethods:
         call = pool.execute.await_args
         assert call is not None
         assert "DELETE FROM grelmicro_cache" in call.args[0]
+        assert "LIMIT $1" in call.args[0]
+        assert call.args[1] == cache_postgres._JANITOR_LIMIT
+
+    async def test_janitor_survives_a_failing_sweep(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A sweep error is logged and the loop keeps running."""
+        backend, pool = _build_with_mock_pool(
+            cleanup_interval=0.01, auto_migrate=False
+        )
+        pool.execute = AsyncMock(side_effect=RuntimeError("boom"))
+
+        async with backend:
+            with caplog.at_level(logging.WARNING, logger="grelmicro"):
+                await asyncio.sleep(0.05)
+            assert backend._janitor_task is not None
+            assert not backend._janitor_task.done()
+
+        assert "Cache cleanup sweep failed" in caplog.text
 
     async def test_janitor_suppresses_errors(self) -> None:
         """Janitor swallows errors so transient failures don't crash the task."""

--- a/tests/cache/test_sqlite.py
+++ b/tests/cache/test_sqlite.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+from time import time
 from typing import TYPE_CHECKING
 
 import pytest
@@ -15,6 +17,12 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 pytestmark = [pytest.mark.timeout(5)]
+
+JANITOR_SWEEP = 3
+"""Rows a bounded sweep is allowed to delete in tests."""
+
+JANITOR_OVERFLOW = 8
+"""Expired rows queued up, more than one sweep can take."""
 
 
 # --- Construction and wiring ---
@@ -199,3 +207,44 @@ async def test_clear_without_prefix_drops_everything(
 
         assert await cache.get(key="a") is None
         assert await cache.get(key="b") is None
+
+
+async def test_janitor_sweep_is_bounded(tmp_path: Path) -> None:
+    """One sweep deletes at most the row limit, leaving the rest for later."""
+    path = tmp_path / "bounded.db"
+    async with (
+        SQLiteProvider(str(path)) as provider,
+        SQLiteCacheAdapter(provider=provider, cleanup_interval=None) as cache,
+    ):
+        for index in range(JANITOR_OVERFLOW):
+            await cache.set(key=f"stale-{index}", value=b"v", ttl=-7200)
+
+        await provider.client.execute(
+            cache._janitor_sql, (time() - 3600, JANITOR_SWEEP)
+        )
+
+        async with provider.client.execute(
+            "SELECT COUNT(*) FROM grelmicro_cache;"
+        ) as cursor:
+            row = await cursor.fetchone()
+
+        assert row is not None
+        assert row[0] == JANITOR_OVERFLOW - JANITOR_SWEEP
+
+
+async def test_janitor_survives_a_failing_sweep(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A sweep error is logged and the loop keeps running."""
+    path = tmp_path / "broken.db"
+    async with (
+        SQLiteProvider(str(path)) as provider,
+        SQLiteCacheAdapter(provider=provider, cleanup_interval=0.01) as cache,
+    ):
+        cache._janitor_sql = "DELETE FROM nope WHERE expires_at < ? LIMIT ?;"
+        with caplog.at_level(logging.WARNING, logger="grelmicro"):
+            await asyncio.sleep(0.3)
+
+        assert cache._janitor_task is not None
+        assert not cache._janitor_task.done()
+        assert "Cache cleanup sweep failed" in caplog.text


### PR DESCRIPTION
Found while reviewing the circuit-breaker sweep in #563: I argued for "periodic and bounded" there while the shipped cache precedent was periodic and **unbounded**.

## Unbounded delete

`grelmicro/cache/postgres.py` deleted every expired row in one statement:

```sql
DELETE FROM {table_name} WHERE expires_at < NOW() - INTERVAL '1 hour';
```

On a large backlog that is one long delete holding the table. SQLite had the same shape. Both now take at most 1000 rows per pass through a primary-key subselect (SQLite uses `rowid`, since `DELETE ... LIMIT` needs a compile flag that stock builds do not set), so a backlog is worked off over several passes.

## Silent failures

Both janitors wrapped the sweep in `contextlib.suppress(Exception)`, so a cache that stopped reclaiming disk gave no signal at all. They now log a warning and keep running, matching the circuit-breaker janitor.

## Jitter

The interval is jittered with the existing `jittered_interval` helper, so replicas sharing one database do not sweep in lockstep.

## Tests

Bounded-sweep and failure-logging tests for both adapters. 3752 tests, 100% coverage.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b