### PR TITLE
📝 Document the missing required check failure mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -515,6 +515,35 @@ schedule and every release run the full tier (the Python matrix plus
 the slow, integration, and demo tiers), so a release is always tested
 against everything before it publishes.
 
+### When a required check is missing
+
+Sometimes a pull request stays blocked while `gh pr checks` shows only
+passing rows. `CI Green` never appeared at all, and a check that never
+reports looks nothing like one that failed.
+
+GitHub runs `pull_request` workflows against a temporary merge commit.
+When it cannot create that commit, no run is created at all. A merge
+conflict is the documented cause.
+
+Update the branch. `main` requires branches to be up to date anyway,
+and the new head commit triggers a fresh run:
+
+```bash
+gh pr update-branch <number>
+```
+
+On a Dependabot pull request, comment `@dependabot recreate` instead.
+
+If neither fits, dispatch the workflow by hand:
+
+```bash
+gh workflow run ci.yml --ref <branch>
+```
+
+Dispatch after your last push, because a later push needs a new
+dispatch. A dispatched run also executes the full test tier instead of
+the light one, so expect it to take much longer.
+
 ## Before opening a PR
 
 - All pre-commit gates pass locally


### PR DESCRIPTION
Closes #542.

Adds a short troubleshooting subsection to `CONTRIBUTING.md` under **Pull requests** for the case where `CI Green` never appears and the PR stays blocked while `gh pr checks` shows only passing rows.

The remedy leads with `gh pr update-branch`, which is better than a manual dispatch on every axis:

- `main` is `strict: true`, so an up-to-date branch is required before merging regardless.
- The new head commit triggers a real `pull_request` run on the **light** tier, against the correct merge state.
- `ci.yml:149` sets `full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}`, so a manual dispatch runs the **full** tier (matrix, slow, integration, demo) against the branch head rather than the merge result. It stays documented as the last resort, with that cost stated.

`@dependabot recreate` is called out for bot PRs.

## Why no workflow change

Verified against current upstream workflow files: fastapi, pydantic, httpx, starlette, and uvicorn all use `push` on the default branch plus `pull_request`, with no push trigger on PR branches, no `pull_request_target` for test jobs, and no retry automation. grelmicro's `CI Green` rollup already matches FastAPI's `test-alls-green` down to the same pinned `re-actors/alls-green` SHA.

The one structural fix is a merge queue (`merge_group`), which attrs uses. It is unavailable here: merge queues need an org-owned public repo, and `grelinfo` is a `User` account.

The failure mode is already fail-safe. A missing required check blocks the merge, so untested code cannot reach `main`. The only cost was the diagnosis, which this removes.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b