### PR TITLE
👷 Deploy release docs through GitHub Pages OIDC

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,20 @@
+name: Docs
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        description: 'Git ref to build and publish. Defaults to the triggering ref.'
+        default: ''
+permissions: {}
+jobs:
+  publish-docs:
+    # Publishes the documentation site on demand, outside the release cycle.
+    # Use it to redeploy the current docs without cutting a release.
+    uses: ./.github/workflows/reusable-docs.yml
+    with:
+      ref: ${{ inputs.ref }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,25 +62,21 @@ jobs:
     needs: publish-pypi
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pages: write
       id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     env:
       UV_FROZEN: 1
       RELEASE_VERSION: ${{ github.event.release.tag_name || github.event.inputs.version }}
-      GH_ACTOR: ${{ github.actor }}
-      GH_ACTOR_ID: ${{ github.actor_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.RELEASE_VERSION }}
-          fetch-depth: 0
-          persist-credentials: true
-      - name: Configure Git User
-        run: |
-          git config user.name "$GH_ACTOR"
-          git config user.email "${GH_ACTOR_ID}+${GH_ACTOR}@users.noreply.github.com"
+          persist-credentials: false
       - name: Install uv and Activate Environment
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
@@ -90,6 +86,11 @@ jobs:
         run: uv sync --group docs
       - name: Build Docs
         run: mkdocs build --strict
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site
       - name: Deploy Docs on GitHub Pages
+        id: deployment
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        run: mkdocs gh-deploy --force
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,37 +60,11 @@ jobs:
           attestations: true
   publish-docs:
     needs: publish-pypi
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/reusable-docs.yml
+    with:
+      ref: ${{ github.event.release.tag_name || github.event.inputs.version }}
+      deploy: ${{ github.event.inputs.dry_run != 'true' }}
     permissions:
       contents: read
       pages: write
       id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    env:
-      UV_FROZEN: 1
-      RELEASE_VERSION: ${{ github.event.release.tag_name || github.event.inputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ env.RELEASE_VERSION }}
-          persist-credentials: false
-      - name: Install uv and Activate Environment
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: false
-          activate-environment: true
-      - name: Install Docs Dependencies
-        run: uv sync --group docs
-      - name: Build Docs
-        run: mkdocs build --strict
-      - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: site
-      - name: Deploy Docs on GitHub Pages
-        id: deployment
-        if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -1,0 +1,50 @@
+name: Reusable Docs
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to check out and build. Defaults to the triggering ref.'
+        type: string
+        default: ''
+      deploy:
+        description: 'Publish the built site to GitHub Pages.'
+        type: boolean
+        default: true
+permissions: {}
+env:
+    UV_FROZEN: 1
+jobs:
+  publish:
+    name: Publish Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+      - name: Install uv and Activate Environment
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: false
+          activate-environment: true
+      - name: Install Docs Dependencies
+        run: uv sync --group docs
+      - name: Build Docs
+        run: mkdocs build --strict
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site
+      - name: Deploy Docs on GitHub Pages
+        id: deployment
+        if: ${{ inputs.deploy }}
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Moves release docs from `mkdocs gh-deploy --force` to the official GitHub Pages OIDC path, and adds an on-demand docs deploy so the migration can be done without taking the site down.

## What it buys

Least privilege on the release path. Today the job runs `mkdocs build` (and every third-party plugin in the `docs` group) with `contents: write` and `persist-credentials: true`, leaving a push credential for this repo in the checkout. After this it holds `contents: read` and deploys with a short-lived OIDC token.

Being precise about scope: **zizmor does not flag the current setup**, at default or `--persona=pedantic`. This is hardening, not a live vulnerability. The measurable signal is zizmor's suppressed-finding count on `release.yml` dropping 6 to 5, the `artipacked` finding for the persisted credential.

## Why a new workflow, not just a swap

Switching the Pages source does not keep the existing site served. A fresh Actions deployment is required, and GitHub's docs do not cover the transition. Since docs previously deployed only on release, flipping the setting would have left https://grelinfo.github.io/grelmicro/ dark until the next release.

`docs.yml` (`workflow_dispatch`) fixes that: the site can be republished on demand, so the source flip is followed immediately by a deploy. It also closes a standing gap, since redeploying docs previously required cutting a release.

The shared logic lives in `reusable-docs.yml`, matching the existing `reusable-tests.yml` pattern, so `release.yml` and `docs.yml` cannot drift.

## Coordinated changes outside this PR

1. **Allow tag deployments on the `github-pages` environment.** This one would have broken the next release silently. The environment has `custom_branch_policies: true` with only `gh-pages` and `main`, both type `branch`. Releases run on a tag ref, so `deploy-pages` would be rejected by environment protection, and because `publish-docs` has `needs: publish-pypi` the failure lands after the package is already on PyPI.
2. **Flip Pages `build_type` from `legacy` to `workflow`,** then immediately dispatch `docs.yml` to republish.

Rollback is flipping `build_type` back to `legacy`. The `gh-pages` branch is left untouched and keeps serving as the fallback.

## Checks

`actionlint` and `zizmor` clean across every workflow. Both new action SHAs resolved from their `v5.0.0` tags via the API, satisfying `sha_pinning_required: true`.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b