### PR TITLE
📝 Document how to republish the docs without a release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -409,6 +409,13 @@ uv run coverage report --fail-under=100
   an explicit **"Choosing a ..." guide**: a numbered decision
   list plus a side-by-side comparison table.
 
+Every release publishes the site to GitHub Pages. To republish
+without cutting a release, run the `Docs` workflow:
+
+```bash
+gh workflow run docs.yml --ref main
+```
+
 ## Third-party material
 
 If you adapt code from another project, even a snippet:


### PR DESCRIPTION
Follow-up to #569. Adds a line to the **Documentation** section of `CONTRIBUTING.md` pointing at the new `Docs` workflow, so the on-demand deploy is discoverable rather than folklore.

```bash
gh workflow run docs.yml --ref main
```

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b