### PR TITLE
📝 Document the CircuitBreaker lifecycle and what the auto trace exporter selects

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Docs
+
+* 📝 Document the recommended `CircuitBreaker` lifecycle. Build one per name at module level. The circuit lives in the backend keyed by name, but `last_error`, the call totals, and the cached state are per instance, so a per-request breaker reports empty metrics and logs a transition that never happened. ([#497](https://github.com/grelinfo/grelmicro/issues/497))
+* 📝 Document what the `auto` trace exporter selects. It resolves to OTLP HTTP or to the no-op and never to gRPC, whatever the endpoint URL or the installed exporter packages. ([#498](https://github.com/grelinfo/grelmicro/issues/498))
+
 ## 0.32.3 - 2026-07-28
 
 ### Fixed

--- a/docs/resilience/circuit-breaker.md
+++ b/docs/resilience/circuit-breaker.md
@@ -19,6 +19,29 @@ Wrap the protected call with `async with cb:` or decorate an async function with
 !!! warning "Thread safety"
     The Circuit Breaker is not thread-safe. The async API (`async with cb:` or `@cb` on `async def`) is the default. From a synchronous handler running in a worker thread (for example a sync route in your web framework), use `with cb.from_thread:` or apply `@cb` to a sync function. The adapter dispatches state changes onto the parent event loop captured by the backend, so calls stay serialized. See [Sync from thread](../architecture/sync-from-thread.md).
 
+## Lifecycle
+
+Declare a breaker once at module level and reuse it across requests:
+
+```python
+breaker = CircuitBreaker.consecutive_count("upstream")
+
+
+async def handler() -> None:
+    async with breaker:
+        await call_upstream()
+```
+
+The circuit is owned by the backend and keyed by breaker name, so two instances sharing a name share one circuit. The state, the consecutive counters, and the `half_open_capacity` probe budget all live there. Building a breaker inside a per-request dependency still blocks calls correctly.
+
+What a per-request instance loses is the per-instance reporting built on top of that circuit:
+
+- `last_error` and `last_error_time`, on both `metrics()` and the raised `CircuitBreakerError`, are recorded locally and start empty on a fresh instance.
+- `active_calls`, `total_error_count`, and `total_success_count` count only that instance, so they stay near zero.
+- A fresh instance starts cached as `CLOSED`. Reading an already-open circuit then looks like a transition, which emits a `grelmicro.circuit_breaker.transitions` metric and a transition log line for a change that never happened.
+
+Each construction also validates the config, creates a logger, and allocates a `ContextVar`. Build the breaker once.
+
 ## State machine
 
 The breaker watches call outcomes and moves between three normal states. After `reset_timeout`, it lets a few probe calls test whether the dependency is back.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -141,6 +141,8 @@ configure()
 
     `Trace()` reads `GREL_TRACE_*` environment variables (see `TraceConfig` for the full field set) or accepts the same fields as keyword arguments. The OTLP HTTP and gRPC exporters require their own packages (`opentelemetry-exporter-otlp-proto-http` or `opentelemetry-exporter-otlp-proto-grpc`) and are imported only when selected.
 
+    `AUTO` resolves to OTLP HTTP or to the no-op, never to gRPC. It does not read the endpoint URL scheme and does not check which exporter packages are installed, so the rule stays the same however you deploy. Set `exporter=TraceExporterType.OTLP_GRPC` to send over gRPC. Because `AUTO` already means HTTP whenever an endpoint is present, pinning `OTLP_HTTP` yourself for that case changes nothing.
+
 ??? note "Works with all logging backends"
     The tracing context is injected into all three logging backends (stdlib, loguru, structlog). Use whichever logger you prefer:
 
@@ -198,7 +200,7 @@ What is covered:
 | Redis | Cache and lock commands | per-client when grelmicro owns the client, cluster included |
 | asyncpg | Queries | covers a grelmicro `PostgresProvider` and any app-owned asyncpg or SQLAlchemy-on-asyncpg engine |
 | Any other installed instrumentor | Per that library | e.g. `sqlalchemy`, `httpx`, `psycopg` : install the package and it is wired |
-| Valkey | Commands | grelmicro ships a first-party instrumentor (valkey-py has no OpenTelemetry package); spans match the Redis ones |
+| Valkey | Commands | grelmicro ships a first-party instrumentor (valkey-py has no OpenTelemetry package). Spans match the Redis ones |
 | SQLite | None | aiosqlite has no OpenTelemetry package. Use `@instrument`. |
 
 !!! note "asyncpg and SQLAlchemy together"


### PR DESCRIPTION
Closes #497. Closes #498.

Two adopter questions, both answered from the code rather than from the assumptions in the issues.

## CircuitBreaker lifecycle (#497)

New **Lifecycle** section in `docs/resilience/circuit-breaker.md`. The recommendation is the module-level singleton the issue guessed at, but the reasoning in the issue was wrong in both directions and the docs now say what actually happens.

- **Re-registration is not a leak.** `_reconfigurables` is a `WeakSet` (`grelmicro/_config.py:310`), so a per-request breaker is collected normally.
- **Half-open capacity is not broken.** The circuit lives in the backend adapter keyed by breaker name (`memory.py:68`, `memory.py:152`), and the strategy holds a reference to that shared map. Two instances sharing a name share one circuit, including the `half_open_capacity` probe budget. A per-request breaker still blocks calls correctly.

What a per-request instance actually costs is the reporting layered on top:

- `last_error` and `last_error_time` are local and start empty, on `metrics()` and on the raised `CircuitBreakerError`. `_apply_snapshot` refreshes the state and consecutive counters from the backend but not these.
- `active_calls`, `total_error_count`, and `total_success_count` count only that instance.
- A fresh instance caches `CLOSED`, so reading an already-open circuit registers as a transition and emits a `grelmicro.circuit_breaker.transitions` metric plus a log line for a change that never happened.

## Auto trace exporter (#498)

`_resolve_exporter_type` (`grelmicro/trace/_component.py:451`) settles it: `AUTO` resolves to `OTLP_HTTP` when an endpoint is resolvable and to `NONE` otherwise. It never selects gRPC, does not read the endpoint URL scheme, and does not probe which exporter packages are installed.

`docs/tracing.md:119` already covered the HTTP-when-endpoint half. The added paragraph states the parts the issue asked about, so the defensive `OTLP_HTTP if endpoint else AUTO` guard in the issue can be dropped: it is exactly what `AUTO` already does.

## Also

Replaced a stray semicolon in the `docs/tracing.md` instrumentor table, matching the house style.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b