### PR TITLE
📝 Correct the cross-replica model for cron tasks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,8 @@
 ### Docs
 
 * 📝 Document the recommended `CircuitBreaker` lifecycle. Build one per name at module level. The circuit lives in the backend keyed by name, but `last_error`, the call totals, and the cached state are per instance, so a per-request breaker reports empty metrics and logs a transition that never happened. ([#497](https://github.com/grelinfo/grelmicro/issues/497))
+* 📝 Correct the cross-replica story for cron tasks. The task page said at-most-once always needs a `TaskLock` or `LeaderElection`, which is true for `every` and false for `cron`. Cron claims each fire against the schedule backend, so a wired `Coordination` component is all it needs. ([#502](https://github.com/grelinfo/grelmicro/issues/502))
+* 📝 Warn against gating a cron body on leadership. Winning the claim advances the durable state before the body runs, so an early return consumes the fire without doing the work. ([#502](https://github.com/grelinfo/grelmicro/issues/502))
 * 📝 Document what the `auto` trace exporter selects. It resolves to OTLP HTTP or to the no-op and never to gRPC, whatever the endpoint URL or the installed exporter packages. ([#498](https://github.com/grelinfo/grelmicro/issues/498))
 
 ## 0.32.3 - 2026-07-28

--- a/docs/coordination.md
+++ b/docs/coordination.md
@@ -305,9 +305,11 @@ async with task_lock:
 ```
 
 !!! tip
-    For scheduled tasks, prefer the
+    For interval tasks, prefer the
     [`every()` decorator with `lock=TaskLock(...)`](task.md#distributed-lock),
-    which re-stamps the lock with the task name automatically.
+    which re-stamps the lock with the task name automatically. Cron tasks need
+    no lock at all. They claim each fire against the
+    [schedule backend](task.md#distributed-cron) instead.
 
 !!! warning
     When the lock expires before the task completes (`lease_duration`

--- a/docs/task.md
+++ b/docs/task.md
@@ -28,7 +28,7 @@ async with micro:
 ```
 
 !!! warning "Per-process by default"
-    `Tasks` runs schedules **in the local process only**. Every process that boots a `Tasks` instance runs its own copy of every registered task. To run a task at most once across the fleet, gate it with [`TaskLock`](coordination.md#task-lock) or [`LeaderElection`](coordination.md#leader-election). Without one of those, a 3-replica deployment runs the same `@tasks.every(...)` three times per tick.
+    `Tasks` runs schedules **in the local process only**. Every process that boots a `Tasks` instance runs its own copy of every registered task. To run an interval task at most once across the fleet, gate it with [`TaskLock`](coordination.md#task-lock) or [`LeaderElection`](coordination.md#leader-election). Without one of those, a 3-replica deployment runs the same `@tasks.every(...)` three times per tick. Cron tasks work differently. They claim each fire against the schedule backend, so a wired [`Coordination`](coordination.md) component is all they need.
 
 !!! note
     This is not a replacement for full task queues such as Celery, taskiq, or APScheduler. It is small, simple, and safe for running tasks in a distributed system.
@@ -46,7 +46,8 @@ Choose the entry point by the job:
 | Simple recurring function | `@tasks.every(...)` |
 | Group tasks across modules | `TaskRouter` |
 | Add an object that already implements the task protocol | `tasks.add_task(...)` |
-| Run at most once across replicas | `@tasks.every(..., lock=TaskLock(...))` |
+| Run an interval task at most once across replicas | `@tasks.every(..., lock=TaskLock(...))` |
+| Run a cron task at most once across replicas | `@tasks.cron(...)` with a [`Coordination`](coordination.md) component |
 | Run only on the leader | `@tasks.every(..., leader=leader_election)` |
 
 Start it standalone using the application lifespan:
@@ -159,6 +160,11 @@ Use the `cron` decorator to run a task on a cron schedule:
 --8<-- "task/cron.py"
 ```
 
+!!! note "Cron has no `lock` parameter"
+    `every` needs a [`TaskLock`](coordination.md#task-lock) to run at most once across replicas. Cron does not. It claims each fire against the schedule backend instead, so at-most-once is automatic once a [`Coordination`](coordination.md) component is wired. See [Distributed cron](#distributed-cron).
+
+    Pass `sync=` to hold a [`Lock`](coordination.md#lock) around a shared resource during the run.
+
 The expression has five fields: `minute hour day-of-month month day-of-week`. The example above runs every day at 02:00 in the `Europe/Zurich` timezone. The `timezone` defaults to `"UTC"`.
 
 Each field accepts:
@@ -188,6 +194,19 @@ async def sync_data():
 ```
 
 The schedule backend stores the last fire on the provider (Redis, Postgres, and SQLite all ship today). Because that state is durable, a fire missed while every worker was down replays once when a worker comes back. Only the most recent missed fire runs, never a backlog of skipped ones. Without a backend, the task runs on every worker, every fire. Kubernetes is intentionally not provided: use a native [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).
+
+!!! warning "Do not gate a cron body on leadership"
+    Winning the claim advances the durable last-fire state **before** the body runs. A body that returns early still consumes the fire, so the work is skipped and the next attempt is a whole cron period away:
+
+    ```python
+    @task.cron("0 3 * * *")
+    async def nightly():
+        if not leader.is_leader():
+            return  # the fire is already claimed, so it is now lost
+        await do_work()
+    ```
+
+    Nothing needs gating here. The claim already picks exactly one worker per fire.
 
 Set `misfire_grace_seconds` to bound how late a missed fire may run:
 


### PR DESCRIPTION
Closes #502.

Docs only. No signature changes. The issue offered API parity as option 2, and three independent design passes rejected it.

## Why not API parity

`lock=` on `cron` is a category error. `TaskLock` correctness rests on `lease_duration >= seconds`, and cron has no `seconds`. `0 9 * * 1-5` has 15-hour night gaps, so the lease knobs the parameter carries have no referent. A lock is also ephemeral, so it cannot express the durable last-fire state that `misfire_grace_seconds` replay depends on. Accepting it as an alias would leave the lease fields as silently dead config.

`leader=` on `cron` looked defensible (leader-gating is placement, the claim is delivery) but has no correct implementation:

- **Before the claim** it breaks misfire replay deterministically. The startup catch-up tick runs at `_cron.py:427`, before the sleep loop, and `LeaderElection` has not won its first `acquire_or_renew` yet, so on a full-fleet restart every worker fails the gate and the replay is skipped fleet-wide. It is the normal path, not a race window, and the catch-up tick is a one-shot.
- **After the claim** the fire is already consumed, so a non-leader winner drops it outright.
- The gate cannot add safety anyway: `claim` is a single atomic CAS that is already exactly-one, so an advisory local `is_leader()` in front of it subtracts liveness and adds nothing.

Adding a keyword later is backward compatible, so nothing forces this before 1.0.

## What actually needed fixing

The docs were wrong, not merely thin.

- **`docs/task.md:31`** told readers that at-most-once across the fleet requires `TaskLock` or `LeaderElection`. False for cron, which gets it by default from the schedule backend via `Coordination`. Now scoped to interval tasks with the cron model stated beside it.
- **The "Choose the entry point" table** had one at-most-once row pointing at `@tasks.every(..., lock=...)` and no cron row, teaching `lock=` as *the* answer. Split into interval and cron rows.
- **`## Cron Task`** never mentioned locks at all. The words "lock" and "leader" appeared nowhere in the cron half of the page, so a reader searching for "lock" only hit interval sections. Added a callout at the point of use.
- **`docs/coordination.md:308`** said "For scheduled tasks, prefer the `every()` decorator with `lock=TaskLock(...)`", unqualified, on the page `TaskLock` links back from. Now scoped to interval tasks.

## New warning

Added the footgun the missing parameter pushes people toward. `_cron.py:506-507` runs `if await backend.claim(...): await self._run()`, so the durable state advances **before** the body. A hand-rolled `if not leader.is_leader(): return` inside a cron body consumes the fire without doing the work, and on `0 3 * * *` the next attempt is a day later.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b