### PR TITLE
🔖 Prepare the 0.32.4 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.32.4 - 2026-07-28
 
 ### Docs
 


### PR DESCRIPTION
Moves the `Unreleased` heading to `0.32.4 - 2026-07-28`. The version itself comes from the tag at publish time (`uv version -- "$RELEASE_VERSION"`), so this is the only file that changes, matching #567.

## Contents

Four documentation entries, closing three adopter questions:

- `CircuitBreaker` lifecycle, #497
- what the `auto` trace exporter selects, #498
- the cron cross-replica model, plus the leadership-gating warning, #502

No code changes, so no runtime behaviour moves in this release.

## Pre-release verification

The Release workflow runs tiers that PR CI skips, so I ran them locally against this branch:

- `pytest -m "slow and not integration"`: 5 passed
- `pytest -m integration`: 235 passed, no Kubernetes flake

## Note for the release run

This will be the first release since #569 moved docs deployment to GitHub Pages OIDC. `publish-docs` now runs on a tag ref through the `github-pages` environment, which is the path that had no tag policy before. The policy is in place, but this release is the first time it actually executes, so the `publish-docs` job is worth watching. A failure there lands after PyPI publish has already succeeded and is recoverable by re-running the job.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b