### PR TITLE
🐛 Check out the dispatch ref for a release dry run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,15 @@ jobs:
   full-checks:
     # Run the full test tier (matrix, slow, integration, demo) before any
     # artifact is built or published.
+    #
+    # A dry run checks out the dispatch ref instead of the version, because
+    # the point of a dry run is to validate a version before its tag exists.
+    # `github.ref` is used rather than an empty string, which an expression
+    # would treat as false and fall through to the version.
     uses: ./.github/workflows/reusable-tests.yml
     with:
       full: true
-      ref: ${{ github.event.release.tag_name || github.event.inputs.version }}
+      ref: ${{ github.event.release.tag_name || (inputs.dry_run && github.ref || inputs.version) }}
     permissions:
       contents: read
     secrets:
@@ -41,7 +46,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ env.RELEASE_VERSION }}
+          ref: ${{ github.event.release.tag_name || (inputs.dry_run && github.ref || inputs.version) }}
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -62,7 +67,7 @@ jobs:
     needs: publish-pypi
     uses: ./.github/workflows/reusable-docs.yml
     with:
-      ref: ${{ github.event.release.tag_name || github.event.inputs.version }}
+      ref: ${{ github.event.release.tag_name || (inputs.dry_run && github.ref || inputs.version) }}
       deploy: ${{ github.event.inputs.dry_run != 'true' }}
     permissions:
       contents: read


### PR DESCRIPTION
Found by running a dry run for 0.32.4 ([run 30384079687](https://github.com/grelinfo/grelmicro/actions/runs/30384079687)). Every `full-checks` job failed at Checkout in under 40 seconds.

## The bug

All three jobs resolved their checkout ref from the version:

```yaml
ref: ${{ github.event.release.tag_name || github.event.inputs.version }}
```

On a `workflow_dispatch` that is the raw version string, so checkout ran:

```
git fetch --depth=1 origin +refs/heads/0.32.4*:... +refs/tags/0.32.4*:...
```

The `0.32.4` tag does not exist, because the whole point of the dry run is to validate the release **before** tagging. So `dry_run: true` could only ever succeed against a version that was already released, which makes it useless as a pre-tag check. That is exactly backwards from what the input is for.

Nothing was burned: no tag was created and `publish-pypi` never started.

## The fix

A dry run now checks out the dispatch ref:

```yaml
ref: ${{ github.event.release.tag_name || (inputs.dry_run && github.ref || inputs.version) }}
```

- `release` event: unchanged, the tag wins.
- dispatch with `dry_run: true`: `github.ref`, so it validates what you are about to tag.
- dispatch with `dry_run: false`: unchanged, the version ref, which must already exist.

`github.ref` rather than `''` is deliberate. GitHub expressions treat an empty string as false, so `inputs.dry_run && '' || inputs.version` falls straight through to the version and reintroduces the bug.

`RELEASE_VERSION` is untouched and still drives `uv version`, so a dry run builds and verifies the wheel at the requested version even though the tree comes from the dispatch ref. That keeps the version-stamping path covered.

Applied to all three consumers: `full-checks`, the `publish-pypi` checkout, and `publish-docs`.

`actionlint` and `zizmor` clean.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b