### PR TITLE
📝 Add a root CHANGELOG.md pointing to the published changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+The changelog is published with the documentation:
+
+**<https://grelinfo.github.io/grelmicro/changelog/>**
+
+Its source is [`docs/changelog.md`](docs/changelog.md). It lives under `docs/` so it
+renders as part of the documentation site alongside the rest of the guides.
+
+Every release also carries its own notes on the
+[GitHub Releases page](https://github.com/grelinfo/grelmicro/releases).


### PR DESCRIPTION
Adds a root `CHANGELOG.md` that points to the published changelog.

The OpenSSF Best Practices `release_notes` check auto-answered "No release notes file found" because its heuristic looks for a `CHANGELOG*` file at the repository root. This project keeps its changelog at `docs/changelog.md` so it renders as part of the documentation site, so the heuristic missed it. Other tooling looks in the same place.

It is a pointer, not a copy. Duplicating a 121K changelog would drift the moment either side is edited.

Verified the notes genuinely exist: `docs/changelog.md` is 121K and live at https://grelinfo.github.io/grelmicro/changelog/ , and the five most recent GitHub Releases all carry notes (532 to 5437 characters each).

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b