### PR TITLE
🔧 Serve the docs from grelmicro.grel.info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The changelog is published with the documentation:
 
-**<https://grelinfo.github.io/grelmicro/changelog/>**
+**<https://grelmicro.grel.info/changelog/>**
 
 Its source is [`docs/changelog.md`](docs/changelog.md). It lives under `docs/` so it
 renders as part of the documentation site alongside the rest of the guides.

--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -123,9 +123,9 @@ Backends for each pattern: Redis, PostgreSQL, SQLite, Kubernetes Lease, and in-m
 Why not separate libraries? If you only need one pattern, a focused library is often the right pick. The comparison page names the right one per domain. When you need two or more in the same service, grelmicro removes four or five separate config dialects and replaces them with one lifecycle (`async with micro:`) and one shared backend client.
 
 - Repo: https://github.com/grelinfo/grelmicro
-- Docs: https://grelinfo.github.io/grelmicro/
+- Docs: https://grelmicro.grel.info/
 - Demo: https://github.com/grelinfo/grelmicro/tree/main/examples/fastapi-demo
-- Comparison: https://grelinfo.github.io/grelmicro/comparison/
+- Comparison: https://grelmicro.grel.info/comparison/
 
 `pip install grelmicro`
 
@@ -158,7 +158,7 @@ The [FastAPI demo](https://github.com/grelinfo/grelmicro/tree/main/examples/fast
 What it is not: not a task queue (reach for Celery, Dramatiq, or taskiq), not a web framework (it plugs into FastAPI, not next to it).
 
 - Repo: https://github.com/grelinfo/grelmicro
-- Docs: https://grelinfo.github.io/grelmicro/
+- Docs: https://grelmicro.grel.info/
 - Demo: https://github.com/grelinfo/grelmicro/tree/main/examples/fastapi-demo
 
 `pip install grelmicro`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://grelinfo.github.io/grelmicro">
+  <a href="https://grelmicro.grel.info">
     <img alt="grelmicro" class="grel-wordmark" src="docs/img/logo/wordmark.svg" width="360">
   </a>
 </p>
@@ -29,7 +29,7 @@
 
 ______________________________________________________________________
 
-**Documentation**: [https://grelinfo.github.io/grelmicro/](https://grelinfo.github.io/grelmicro)
+**Documentation**: [https://grelmicro.grel.info/](https://grelmicro.grel.info)
 
 **Source Code**: [https://github.com/grelinfo/grelmicro](https://github.com/grelinfo/grelmicro)
 
@@ -49,23 +49,23 @@ It is built for any Python application that coordinates work across processes, w
 
 grelmicro is **not** a task queue (reach for Celery, Dramatiq, or taskiq) and **not** a web framework (it plugs into FastAPI, Starlette, or Litestar). It fills the gap between the web framework you picked and the infrastructure you run.
 
-Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? See the [comparison page](https://grelinfo.github.io/grelmicro/comparison/) for a per-domain breakdown.
+Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? See the [comparison page](https://grelmicro.grel.info/comparison/) for a per-domain breakdown.
 
 ## Modules
 
 | Module | Summary |
 |---|---|
-| [**Cache**](https://grelinfo.github.io/grelmicro/cache/) | `@cached` decorator with local and distributed stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
-| [**Idempotency**](https://grelinfo.github.io/grelmicro/idempotency/) | Idempotency keys that make a retried operation safe. Store the response once, replay it on repeat, single-flight across replicas. |
-| [**Coordination**](https://grelinfo.github.io/grelmicro/coordination/) | Distributed `Lock`, `TaskLock`, and `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
-| [**Outbox**](https://grelinfo.github.io/grelmicro/outbox/) | Transactional outbox. `publish` a message inside your database transaction and a background relay delivers it at least once with retries and dead-lettering. PostgreSQL, in-memory. |
-| [**Task Scheduler**](https://grelinfo.github.io/grelmicro/task/) | Interval and cron tasks with durable, distributed at-most-once execution. A modern, lightweight alternative to APScheduler and Celery beat. |
-| [**Resilience**](https://grelinfo.github.io/grelmicro/resilience/) | [Circuit Breaker](https://grelinfo.github.io/grelmicro/resilience/circuit-breaker/) and [Rate Limiter](https://grelinfo.github.io/grelmicro/resilience/rate-limiter/) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |
-| [**Logging**](https://grelinfo.github.io/grelmicro/logging/) | 12-factor logging with JSON, LOGFMT, TEXT, or PRETTY output, structured error rendering, and OpenTelemetry trace context. |
-| [**Tracing**](https://grelinfo.github.io/grelmicro/tracing/) | Unified instrumentation. `@instrument` creates OpenTelemetry spans and enriches log records with structured context. |
-| [**Metrics**](https://grelinfo.github.io/grelmicro/metrics/) | OpenTelemetry metrics with a `@measure` decorator, a Prometheus `/metrics` router, and built-in instrumentation across components. |
-| [**Health**](https://grelinfo.github.io/grelmicro/health/) | Health check registry with concurrent runners and FastAPI liveness / readiness integration. |
-| [**Configuration**](https://grelinfo.github.io/grelmicro/config/) | `ExternalConfig` reconfigures live components from a mounted ConfigMap, Secret, or `.env` / JSON / YAML / TOML file. |
+| [**Cache**](https://grelmicro.grel.info/cache/) | `@cached` decorator with local and distributed stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
+| [**Idempotency**](https://grelmicro.grel.info/idempotency/) | Idempotency keys that make a retried operation safe. Store the response once, replay it on repeat, single-flight across replicas. |
+| [**Coordination**](https://grelmicro.grel.info/coordination/) | Distributed `Lock`, `TaskLock`, and `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
+| [**Outbox**](https://grelmicro.grel.info/outbox/) | Transactional outbox. `publish` a message inside your database transaction and a background relay delivers it at least once with retries and dead-lettering. PostgreSQL, in-memory. |
+| [**Task Scheduler**](https://grelmicro.grel.info/task/) | Interval and cron tasks with durable, distributed at-most-once execution. A modern, lightweight alternative to APScheduler and Celery beat. |
+| [**Resilience**](https://grelmicro.grel.info/resilience/) | [Circuit Breaker](https://grelmicro.grel.info/resilience/circuit-breaker/) and [Rate Limiter](https://grelmicro.grel.info/resilience/rate-limiter/) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |
+| [**Logging**](https://grelmicro.grel.info/logging/) | 12-factor logging with JSON, LOGFMT, TEXT, or PRETTY output, structured error rendering, and OpenTelemetry trace context. |
+| [**Tracing**](https://grelmicro.grel.info/tracing/) | Unified instrumentation. `@instrument` creates OpenTelemetry spans and enriches log records with structured context. |
+| [**Metrics**](https://grelmicro.grel.info/metrics/) | OpenTelemetry metrics with a `@measure` decorator, a Prometheus `/metrics` router, and built-in instrumentation across components. |
+| [**Health**](https://grelmicro.grel.info/health/) | Health check registry with concurrent runners and FastAPI liveness / readiness integration. |
+| [**Configuration**](https://grelmicro.grel.info/config/) | `ExternalConfig` reconfigures live components from a mounted ConfigMap, Secret, or `.env` / JSON / YAML / TOML file. |
 
 ## Installation
 
@@ -73,7 +73,7 @@ Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? S
 pip install grelmicro
 ```
 
-See the [Installation guide](https://grelinfo.github.io/grelmicro/installation/) for `uv` and `poetry` commands, plus optional extras for Redis, PostgreSQL, SQLite, Kubernetes, OpenTelemetry, and structlog.
+See the [Installation guide](https://grelmicro.grel.info/installation/) for `uv` and `poetry` commands, plus optional extras for Redis, PostgreSQL, SQLite, Kubernetes, OpenTelemetry, and structlog.
 
 ## Example
 
@@ -282,7 +282,7 @@ The key shape:
 - **Patterns are declared at module load.** `Lock("cart")`, `TTLCache(ttl=60)`, `CircuitBreaker("svc")` carry no backend reference. They resolve through the active app inside `async with`, and `GrelmicroMiddleware` extends that scope to request handlers. The same `Lock` works in production with Redis and in tests with `MemoryLockAdapter`, no rewiring.
 - **Pay only for what you import.** `import grelmicro` does not pull in `redis`, `psycopg`, or any other vendor SDK. First-party Providers live under `grelmicro.providers.{vendor}` and load only when you import them.
 
-For multiple Redis instances, separate names, or test overrides, see the [docs](https://grelinfo.github.io/grelmicro/).
+For multiple Redis instances, separate names, or test overrides, see the [docs](https://grelmicro.grel.info/).
 
 ## Contributing
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+grelmicro.grel.info

--- a/docs/img/logo/README.md
+++ b/docs/img/logo/README.md
@@ -60,7 +60,7 @@ URL is shared on social platforms.
 <link rel="icon" type="image/png" sizes="16x16" href="img/logo/favicon-16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="img/logo/apple-touch-icon.png">
 <meta property="og:image"
-      content="https://grelinfo.github.io/grelmicro/img/logo/social-preview.png">
+      content="https://grelmicro.grel.info/img/logo/social-preview.png">
 ```
 
 ## Brand

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://grelinfo.github.io/grelmicro">
+  <a href="https://grelmicro.grel.info">
     <img alt="grelmicro" class="grel-wordmark" src="img/logo/wordmark.svg" width="360">
   </a>
 </p>
@@ -29,7 +29,7 @@
 
 ______________________________________________________________________
 
-**Documentation**: [https://grelinfo.github.io/grelmicro/](https://grelinfo.github.io/grelmicro)
+**Documentation**: [https://grelmicro.grel.info/](https://grelmicro.grel.info)
 
 **Source Code**: [https://github.com/grelinfo/grelmicro](https://github.com/grelinfo/grelmicro)
 
@@ -49,23 +49,23 @@ It is built for any Python application that coordinates work across processes, w
 
 grelmicro is **not** a task queue (reach for Celery, Dramatiq, or taskiq) and **not** a web framework (it plugs into FastAPI, Starlette, or Litestar). It fills the gap between the web framework you picked and the infrastructure you run.
 
-Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? See the [comparison page](https://grelinfo.github.io/grelmicro/comparison/) for a per-domain breakdown.
+Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? See the [comparison page](https://grelmicro.grel.info/comparison/) for a per-domain breakdown.
 
 ## Modules
 
 | Module | Summary |
 |---|---|
-| [**Cache**](https://grelinfo.github.io/grelmicro/cache/) | `@cached` decorator with local and distributed stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
-| [**Idempotency**](https://grelinfo.github.io/grelmicro/idempotency/) | Idempotency keys that make a retried operation safe. Store the response once, replay it on repeat, single-flight across replicas. |
-| [**Coordination**](https://grelinfo.github.io/grelmicro/coordination/) | Distributed `Lock`, `TaskLock`, and `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
-| [**Outbox**](https://grelinfo.github.io/grelmicro/outbox/) | Transactional outbox. `publish` a message inside your database transaction and a background relay delivers it at least once with retries and dead-lettering. PostgreSQL, in-memory. |
-| [**Task Scheduler**](https://grelinfo.github.io/grelmicro/task/) | Interval and cron tasks with durable, distributed at-most-once execution. A modern, lightweight alternative to APScheduler and Celery beat. |
-| [**Resilience**](https://grelinfo.github.io/grelmicro/resilience/) | [Circuit Breaker](https://grelinfo.github.io/grelmicro/resilience/circuit-breaker/) and [Rate Limiter](https://grelinfo.github.io/grelmicro/resilience/rate-limiter/) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |
-| [**Logging**](https://grelinfo.github.io/grelmicro/logging/) | 12-factor logging with JSON, LOGFMT, TEXT, or PRETTY output, structured error rendering, and OpenTelemetry trace context. |
-| [**Tracing**](https://grelinfo.github.io/grelmicro/tracing/) | Unified instrumentation. `@instrument` creates OpenTelemetry spans and enriches log records with structured context. |
-| [**Metrics**](https://grelinfo.github.io/grelmicro/metrics/) | OpenTelemetry metrics with a `@measure` decorator, a Prometheus `/metrics` router, and built-in instrumentation across components. |
-| [**Health**](https://grelinfo.github.io/grelmicro/health/) | Health check registry with concurrent runners and FastAPI liveness / readiness integration. |
-| [**Configuration**](https://grelinfo.github.io/grelmicro/config/) | `ExternalConfig` reconfigures live components from a mounted ConfigMap, Secret, or `.env` / JSON / YAML / TOML file. |
+| [**Cache**](https://grelmicro.grel.info/cache/) | `@cached` decorator with local and distributed stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
+| [**Idempotency**](https://grelmicro.grel.info/idempotency/) | Idempotency keys that make a retried operation safe. Store the response once, replay it on repeat, single-flight across replicas. |
+| [**Coordination**](https://grelmicro.grel.info/coordination/) | Distributed `Lock`, `TaskLock`, and `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
+| [**Outbox**](https://grelmicro.grel.info/outbox/) | Transactional outbox. `publish` a message inside your database transaction and a background relay delivers it at least once with retries and dead-lettering. PostgreSQL, in-memory. |
+| [**Task Scheduler**](https://grelmicro.grel.info/task/) | Interval and cron tasks with durable, distributed at-most-once execution. A modern, lightweight alternative to APScheduler and Celery beat. |
+| [**Resilience**](https://grelmicro.grel.info/resilience/) | [Circuit Breaker](https://grelmicro.grel.info/resilience/circuit-breaker/) and [Rate Limiter](https://grelmicro.grel.info/resilience/rate-limiter/) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |
+| [**Logging**](https://grelmicro.grel.info/logging/) | 12-factor logging with JSON, LOGFMT, TEXT, or PRETTY output, structured error rendering, and OpenTelemetry trace context. |
+| [**Tracing**](https://grelmicro.grel.info/tracing/) | Unified instrumentation. `@instrument` creates OpenTelemetry spans and enriches log records with structured context. |
+| [**Metrics**](https://grelmicro.grel.info/metrics/) | OpenTelemetry metrics with a `@measure` decorator, a Prometheus `/metrics` router, and built-in instrumentation across components. |
+| [**Health**](https://grelmicro.grel.info/health/) | Health check registry with concurrent runners and FastAPI liveness / readiness integration. |
+| [**Configuration**](https://grelmicro.grel.info/config/) | `ExternalConfig` reconfigures live components from a mounted ConfigMap, Secret, or `.env` / JSON / YAML / TOML file. |
 
 ## Installation
 
@@ -73,7 +73,7 @@ Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? S
 pip install grelmicro
 ```
 
-See the [Installation guide](https://grelinfo.github.io/grelmicro/installation/) for `uv` and `poetry` commands, plus optional extras for Redis, PostgreSQL, SQLite, Kubernetes, OpenTelemetry, and structlog.
+See the [Installation guide](https://grelmicro.grel.info/installation/) for `uv` and `poetry` commands, plus optional extras for Redis, PostgreSQL, SQLite, Kubernetes, OpenTelemetry, and structlog.
 
 ## Example
 
@@ -282,7 +282,7 @@ The key shape:
 - **Patterns are declared at module load.** `Lock("cart")`, `TTLCache(ttl=60)`, `CircuitBreaker("svc")` carry no backend reference. They resolve through the active app inside `async with`, and `GrelmicroMiddleware` extends that scope to request handlers. The same `Lock` works in production with Redis and in tests with `MemoryLockAdapter`, no rewiring.
 - **Pay only for what you import.** `import grelmicro` does not pull in `redis`, `psycopg`, or any other vendor SDK. First-party Providers live under `grelmicro.providers.{vendor}` and load only when you import them.
 
-For multiple Redis instances, separate names, or test overrides, see the [docs](https://grelinfo.github.io/grelmicro/).
+For multiple Redis instances, separate names, or test overrides, see the [docs](https://grelmicro.grel.info/).
 
 ## Contributing
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,37 +6,37 @@ Each primitive is a protocol, so you can swap Redis for PostgreSQL, SQLite, Kube
 
 ## Getting started
 
-- [Introduction](https://grelinfo.github.io/grelmicro/): what grelmicro is and the problem it solves.
-- [Installation](https://grelinfo.github.io/grelmicro/installation/): install with pip, uv, or poetry, plus optional extras for Redis, PostgreSQL, SQLite, Kubernetes, OpenTelemetry, and structlog.
-- [First steps](https://grelinfo.github.io/grelmicro/first-steps/): wire an app and use your first primitive.
-- [Wiring](https://grelinfo.github.io/grelmicro/wiring/): providers, components, and the application lifespan.
+- [Introduction](https://grelmicro.grel.info/): what grelmicro is and the problem it solves.
+- [Installation](https://grelmicro.grel.info/installation/): install with pip, uv, or poetry, plus optional extras for Redis, PostgreSQL, SQLite, Kubernetes, OpenTelemetry, and structlog.
+- [First steps](https://grelmicro.grel.info/first-steps/): wire an app and use your first primitive.
+- [Wiring](https://grelmicro.grel.info/wiring/): providers, components, and the application lifespan.
 
 ## User guide
 
-- [Cache](https://grelinfo.github.io/grelmicro/cache/): the `@cached` decorator with local and distributed stampede protection.
-- [Idempotency](https://grelinfo.github.io/grelmicro/idempotency/): idempotency keys that make a retried operation safe.
-- [Coordination](https://grelinfo.github.io/grelmicro/coordination/): distributed `Lock`, `TaskLock`, and `LeaderElection`.
-- [Outbox](https://grelinfo.github.io/grelmicro/outbox/): a transactional outbox that delivers messages at least once after your database transaction commits.
-- [Task Scheduler](https://grelinfo.github.io/grelmicro/task/): interval and cron tasks with durable, distributed at-most-once execution.
-- [Resilience](https://grelinfo.github.io/grelmicro/resilience/): circuit breaker and rate limiter with pluggable algorithms.
-- [Health](https://grelinfo.github.io/grelmicro/health/): a health check registry with FastAPI liveness and readiness integration.
-- [Logging](https://grelinfo.github.io/grelmicro/logging/): 12-factor logging with JSON, LOGFMT, TEXT, or PRETTY output.
-- [Tracing](https://grelinfo.github.io/grelmicro/tracing/): OpenTelemetry spans and structured log context through `@instrument`.
-- [Metrics](https://grelinfo.github.io/grelmicro/metrics/): OpenTelemetry metrics with a `@measure` decorator and a Prometheus router.
-- [Configuration](https://grelinfo.github.io/grelmicro/config/): reconfigure live components from a ConfigMap, Secret, or file.
-- [Testing](https://grelinfo.github.io/grelmicro/testing/): test grelmicro apps with the in-memory backends.
+- [Cache](https://grelmicro.grel.info/cache/): the `@cached` decorator with local and distributed stampede protection.
+- [Idempotency](https://grelmicro.grel.info/idempotency/): idempotency keys that make a retried operation safe.
+- [Coordination](https://grelmicro.grel.info/coordination/): distributed `Lock`, `TaskLock`, and `LeaderElection`.
+- [Outbox](https://grelmicro.grel.info/outbox/): a transactional outbox that delivers messages at least once after your database transaction commits.
+- [Task Scheduler](https://grelmicro.grel.info/task/): interval and cron tasks with durable, distributed at-most-once execution.
+- [Resilience](https://grelmicro.grel.info/resilience/): circuit breaker and rate limiter with pluggable algorithms.
+- [Health](https://grelmicro.grel.info/health/): a health check registry with FastAPI liveness and readiness integration.
+- [Logging](https://grelmicro.grel.info/logging/): 12-factor logging with JSON, LOGFMT, TEXT, or PRETTY output.
+- [Tracing](https://grelmicro.grel.info/tracing/): OpenTelemetry spans and structured log context through `@instrument`.
+- [Metrics](https://grelmicro.grel.info/metrics/): OpenTelemetry metrics with a `@measure` decorator and a Prometheus router.
+- [Configuration](https://grelmicro.grel.info/config/): reconfigure live components from a ConfigMap, Secret, or file.
+- [Testing](https://grelmicro.grel.info/testing/): test grelmicro apps with the in-memory backends.
 
 ## API reference
 
-- [API reference](https://grelinfo.github.io/grelmicro/reference/cache/): reference for every public module, generated from the source docstrings.
+- [API reference](https://grelmicro.grel.info/reference/cache/): reference for every public module, generated from the source docstrings.
 
 ## Architecture
 
-- [Architecture](https://grelinfo.github.io/grelmicro/architecture/): design decisions, backends, asyncio model, and internals.
+- [Architecture](https://grelmicro.grel.info/architecture/): design decisions, backends, asyncio model, and internals.
 
 ## Optional
 
-- [Comparison](https://grelinfo.github.io/grelmicro/comparison/): grelmicro next to aiocache, slowapi, pybreaker, tenacity, and aioredlock.
-- [Benchmarks](https://grelinfo.github.io/grelmicro/benchmarks/): performance measurements for the primitives.
-- [Changelog](https://grelinfo.github.io/grelmicro/changelog/): release notes for every version.
+- [Comparison](https://grelmicro.grel.info/comparison/): grelmicro next to aiocache, slowapi, pybreaker, tenacity, and aioredlock.
+- [Benchmarks](https://grelmicro.grel.info/benchmarks/): performance measurements for the primitives.
+- [Changelog](https://grelmicro.grel.info/changelog/): release notes for every version.
 - [Contributing](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md): how to report bugs, request features, and contribute code.

--- a/examples/third-party-adapter/README.md
+++ b/examples/third-party-adapter/README.md
@@ -1,7 +1,7 @@
 # Third-party adapter skeleton
 
 A minimal example of publishing a grelmicro backend from an external package,
-here a fake `grelmicro-mongo`. See the [Plugins](https://grelinfo.github.io/grelmicro/architecture/plugins/)
+here a fake `grelmicro-mongo`. See the [Plugins](https://grelmicro.grel.info/architecture/plugins/)
 docs for the full contract.
 
 ## What makes it discoverable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: grelmicro
 site_description: grelmicro is a lightweight toolkit for building Python applications that need to coordinate work across processes, workers, or services.
-site_url: https://grelinfo.github.io/grelmicro
+site_url: https://grelmicro.grel.info
 theme:
   name: material
   logo: img/logo/favicon-48.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://grelinfo.github.io/grelmicro"
+Documentation = "https://grelmicro.grel.info"
 Repository = "https://github.com/grelinfo/grelmicro.git"
 Issues = "https://github.com/grelinfo/grelmicro/issues"
 
@@ -238,12 +238,12 @@ path = "README.md"
 # Rewrite relative `docs/<section>/index.md` links to docs site URLs.
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
 pattern = '\]\(docs/(.+?)/index\.md\)'
-replacement = '](https://grelinfo.github.io/grelmicro/\1/)'
+replacement = '](https://grelmicro.grel.info/\1/)'
 
 # Rewrite relative `docs/<path>.md` links to docs site URLs.
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
 pattern = '\]\(docs/(.+?)\.md\)'
-replacement = '](https://grelinfo.github.io/grelmicro/\1/)'
+replacement = '](https://grelmicro.grel.info/\1/)'
 
 # Rewrite relative `docs/img/...` asset references to GitHub raw.
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]


### PR DESCRIPTION
Moves the documentation site to `grelmicro.grel.info`, a subdomain of a domain already owned. Nothing purchased.

## Why now

Pre-launch is the only cheap moment. Once the announcement is out, inbound links point at `grelinfo.github.io` permanently, and GitHub's custom-domain docs do not actually promise a redirect from the default domain for project sites.

## Changes

- **`docs/CNAME`** containing `grelmicro.grel.info`. This is the part that matters after #569: the site is deployed from a build artifact now, not the `gh-pages` branch, so the CNAME has to be inside the artifact or each deploy would drop the domain. Verified with a local `mkdocs build` that `site/CNAME` is produced with the right content.
- **`mkdocs.yml`** `site_url`
- **`pyproject.toml`** `Documentation` URL, so PyPI points at the new host from the next release
- **67 references** across `README.md`, `docs/index.md`, `docs/llms.txt`, `CHANGELOG.md`, `LAUNCH_CHECKLIST.md`, `docs/img/logo/README.md`, and `examples/third-party-adapter/README.md`

The path segment is dropped throughout: `grelinfo.github.io/grelmicro/x` becomes `grelmicro.grel.info/x`, because the custom domain serves at the root.

## DNS

Already live and verified before this was written:

```
$ dig +short grelmicro.grel.info CNAME
grelinfo.github.io.
```

Resolving to the four GitHub Pages addresses. After merge, the Pages custom domain still has to be set on the repository, then a `docs.yml` dispatch republishes and the site serves from the new host.

`mkdocs build --strict` passes, so no internal link or nav broke in the rewrite.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b