### PR TITLE
🔖 Prepare the 0.32.5 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.32.5 - 2026-07-28
+
+### Security
+
+* 🔒 Attest build provenance for every release. Each published artifact now carries a provenance attestation signed on GitHub infrastructure separate from the build job, and the release verifies it before publishing, so a missing or invalid attestation fails the release. ([#575](https://github.com/grelinfo/grelmicro/pull/575))
+
+### Docs
+
+* 📝 Move the documentation site to [grelmicro.grel.info](https://grelmicro.grel.info). The old GitHub Pages address redirects, so existing links keep working. ([#577](https://github.com/grelinfo/grelmicro/pull/577))
+* 📝 Add a root `CHANGELOG.md` pointing to the published changelog, so tools that look for one at the repository root find it. ([#576](https://github.com/grelinfo/grelmicro/pull/576))
+
 ## 0.32.4 - 2026-07-28
 
 ### Docs


### PR DESCRIPTION
Adds the `0.32.5` changelog section. The version itself comes from the tag at publish time, so this is the only file that changes.

## Contents

Three changes since 0.32.4, none touching library code:

- **Build provenance** (#575). Every published artifact now carries a provenance attestation signed on GitHub infrastructure separate from the build job, verified before publishing. This release is the first to produce one.
- **Docs moved to grelmicro.grel.info** (#577). The old GitHub Pages address returns a 301, so existing links keep working. This release is also the first to carry the corrected `Documentation` URL in the PyPI metadata.
- **Root `CHANGELOG.md`** (#576), a pointer to the published changelog for tools that look at the repository root.

## Pre-release verification

- Full local pre-commit run green, including the integration tier. An earlier run showed 2 errors in the Kubernetes container fixture, which did not reproduce. Known Docker contention flake, not a code issue.
- Docs site verified live on the new domain: root and deep pages 200, TLS certificate approved, old URL 301s.

## Risk to note

The attestation and verification steps have never executed. They are skipped on a dry run, so no dry run can exercise them. They run **before** the PyPI publish step, so a failure there means nothing is published, which is fail-safe. The cost of a failure is a burned `0.32.5` tag and a retry on `0.32.6`.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b