### PR TITLE
🐛 Retry the k3s readiness probe while the container is not running

### DIFF
--- a/tests/coordination/test_lock_backends.py
+++ b/tests/coordination/test_lock_backends.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncGenerator, Generator
 from uuid import uuid4
 
 import pytest
+from docker.errors import APIError
 from testcontainers.core.container import DockerContainer
 from testcontainers.postgres import PostgresContainer
 from testcontainers.redis import RedisContainer
@@ -24,18 +25,39 @@ from grelmicro.providers.sqlite import SQLiteProvider
 pytestmark = [pytest.mark.timeout(30)]
 
 
+def _container_report(container: DockerContainer) -> str:
+    """Return the container state and tail of its logs, for a failed wait."""
+    try:
+        wrapped = container.get_wrapped_container()
+        wrapped.reload()
+        logs = wrapped.logs(tail=20).decode("utf-8", errors="replace")
+    except APIError as error:
+        return f"container state unavailable ({error})"
+    return f"status={wrapped.status}, last logs:\n{logs}"
+
+
 def _wait_for_k3s(
     container: DockerContainer,
     timeout: float = 60,
 ) -> None:
-    """Wait for k3s to be ready."""
+    """Wait for k3s to be ready.
+
+    Docker reports a container as started before it necessarily accepts a
+    command. In that window the probe raises `APIError` instead of returning
+    a non-zero exit code, so both mean "not ready yet" and are polled again.
+    On timeout the container state and logs are reported, which separates a
+    genuine k3s failure from a slow start.
+    """
     start = time_module.time()
     while time_module.time() - start < timeout:
-        exit_code, _ = container.exec("kubectl get --raw /readyz")
+        try:
+            exit_code, _ = container.exec("kubectl get --raw /readyz")
+        except APIError:
+            exit_code = None
         if exit_code == 0:
             return
         time_module.sleep(1)
-    msg = "k3s did not become ready"
+    msg = f"k3s did not become ready within {timeout}s. {_container_report(container)}"
     raise TimeoutError(msg)
 
 
@@ -494,3 +516,59 @@ async def test_owned_another(backend: LockBackend) -> None:
     # Assert
     assert owned_before is False
     assert owned_after is False
+
+
+class _FakeContainer:
+    """Minimal stand-in for the parts of `DockerContainer` the k3s wait uses."""
+
+    def __init__(self, results: list[int | Exception]) -> None:
+        """Queue one result per probe, an exception instance or an exit code."""
+        self.results = results
+        self.calls = 0
+
+    def exec(self, command: str) -> tuple[int, bytes]:  # noqa: ARG002
+        """Return the next queued exit code, or raise the next queued error."""
+        result = self.results[min(self.calls, len(self.results) - 1)]
+        self.calls += 1
+        if isinstance(result, Exception):
+            raise result
+        return (result, b"")
+
+    def get_wrapped_container(self) -> object:
+        """Report no state, matching a container that has gone away."""
+        msg = "no such container"
+        raise APIError(msg)
+
+
+def test_wait_for_k3s_retries_while_container_not_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the k3s wait treats a not-running container as not ready yet."""
+    # Arrange
+    expected_probes = 2
+    monkeypatch.setattr(time_module, "sleep", lambda _: None)
+    container = _FakeContainer([APIError("is not running"), 0])
+
+    # Act
+    _wait_for_k3s(container, timeout=10)  # ty: ignore[invalid-argument-type]
+
+    # Assert
+    assert container.calls == expected_probes
+
+
+def test_wait_for_k3s_reports_container_state_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the timeout message carries the container state."""
+    # Arrange
+    monkeypatch.setattr(time_module, "sleep", lambda _: None)
+    container = _FakeContainer([APIError("is not running")])
+
+    # Act
+    with pytest.raises(
+        TimeoutError, match="container state unavailable"
+    ) as error:
+        _wait_for_k3s(container, timeout=0.01)  # ty: ignore[invalid-argument-type]
+
+    # Assert
+    assert "did not become ready" in str(error.value)


### PR DESCRIPTION
Closes #579.

## The bug

`_wait_for_k3s` polled readiness like this:

```python
while time_module.time() - start < timeout:
    exit_code, _ = container.exec("kubectl get --raw /readyz")
    if exit_code == 0:
        return
    time_module.sleep(1)
```

It retried on a non-zero **exit code**. But when the container is not in a running state, the probe does not return a non-zero code, it **raises** `docker.errors.APIError` (409, "container is not running"). Nothing caught it, so the very first probe against a container still initialising aborted the fixture outright.

That is why the failure landed in well under a second rather than after its 60 second budget. testcontainers returns from `__enter__` once Docker reports the container started, which does not guarantee it accepts a command yet, and under `pytest-xdist` with 12 workers starting k3s, Redis, and Postgres at once that window widens.

## The fix

Treat a raised `APIError` the same as a non-zero exit code, meaning "not ready yet", and keep polling until the real timeout.

On timeout, report the container status and the last 20 lines of its logs. Previously a genuine k3s crash and a startup race produced the same opaque 409, which is what made this take a while to pin down.

## Tests

Two regression tests, in the unit tier so they need no Docker:

- `test_wait_for_k3s_retries_while_container_not_running` fails on the old code and passes on the new. It asserts the probe is retried after an `APIError` rather than propagating on the first call.
- `test_wait_for_k3s_reports_container_state_on_timeout` asserts the timeout message carries the container state.

## Verification

- The 18 Kubernetes integration tests pass.
- Full local hook run green, including both type checkers.

`ty` caught a genuine typing hole in the first draft of the fake container, where `list[object]` did not narrow to `int` after the `Exception` check. Fixed to `list[int | Exception]`.

## Not fixed here

Two unrelated flakes surfaced while running this, both the same shape of fixed startup budget under 12-way parallel load: the k3s fixture in one run, and `test_real_uvicorn_access_log` ("Uvicorn did not start in time") in another. The second is a separate test with a separate budget and is out of scope for this fix.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b