### PR TITLE
📝 Lead the README with one sentence and claim SLSA Build L2

### DIFF
--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -10,7 +10,7 @@ The launch ships on the current `0.x` line. It is not gated on a 1.0 bump.
 - [ ] `docs/benchmarks.md` numbers re-run on a clean machine and dated. Currently dated 2026-06-14 (Apple Silicon, macOS, CPython 3.12).
 - [x] The [FastAPI demo](examples/fastapi-demo) starts from a fresh clone in three commands. Verified 2026-07-28: `cd examples/fastapi-demo`, `docker compose up --wait`, `open http://localhost:8000/docs`.
 - [x] Record the demo asset (see below) and embed it in the README. `docs/img/demo.gif`, 840K, embedded at the top of `README.md`.
-- [ ] Enable the badges (see below). Scorecard is live. The SLSA 2 badge waits for the first release that publishes a verified attestation.
+- [x] Enable the badges (see below). Scorecard and SLSA 2 are both live in `README.md`. 0.32.5 is the first release publishing a verified attestation.
 - [ ] README "Why grelmicro" leads with one sentence a stranger understands.
 - [x] CHANGELOG `Unreleased` section moved under the release version heading.
 
@@ -34,19 +34,14 @@ Draft copy lives in this file's history; refine per channel. Do not cross-post t
 `ossf/scorecard-action` on a weekly schedule and on push to `main` with
 `publish_results: true`, and stays off pull-request triggers so it never gates PR CI.
 
-**SLSA Build L2: earned per release, badge not yet added.** `release.yml` runs
-`actions/attest-build-provenance` on the built artifacts, then `gh attestation verify`
-on each one before the release completes. Provenance is signed on GitHub
-infrastructure separate from the build job, which is what Level 2 asks for on a hosted
-runner.
+**SLSA Build L2: live.** `release.yml` runs `actions/attest-build-provenance` on the
+built artifacts, then `gh attestation verify` on each one before the release completes.
+Provenance is signed on GitHub infrastructure separate from the build job, which is
+what Level 2 asks for on a hosted runner.
 
-Add this to `README.md` **only after** a release has published with a verified
-attestation. Releases up to and including 0.32.4 have none, so the badge would claim a
-level the published artifacts cannot back:
-
-```markdown
-[![SLSA 2](https://slsa.dev/images/gh-badge-level2.svg)](https://slsa.dev/spec/latest/levels)
-```
+The badge went into `README.md` only once a release actually backed it. **0.32.5 is the
+first**, verified after publishing. 0.32.4 and earlier have no attestation, so the
+badge would have claimed a level those artifacts could not back.
 
 Check any published version with:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   <a href="https://github.com/astral-sh/ruff"><img alt="Ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
   <a href="https://github.com/astral-sh/ty"><img alt="ty" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/grelinfo/grelmicro"><img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/grelinfo/grelmicro/badge"></a>
+  <a href="https://slsa.dev/spec/latest/levels"><img alt="SLSA Build Level 2" src="https://slsa.dev/images/gh-badge-level2.svg"></a>
 </p>
 
 <p align="center">
@@ -37,7 +38,9 @@ ______________________________________________________________________
 
 ## Why grelmicro
 
-grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, the transactional outbox, logging, health checks, and task scheduling. Async-first, type-safe, and fully tested.
+grelmicro is an async Python toolkit for microservices and distributed systems: shared locks, caching, rate limits, circuit breakers, and scheduled tasks.
+
+It ships them as small, composable modules with pluggable backends, alongside the transactional outbox, logging, health checks, and tracing. Async-first, type-safe, and fully tested.
 
 It is built for any Python application that coordinates work across processes, workers, or replicas. The same primitives serve microservices, a modular monolith, or a self-contained system, and fit naturally into containerized and Kubernetes deployments.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@
   <a href="https://github.com/astral-sh/ruff"><img alt="Ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
   <a href="https://github.com/astral-sh/ty"><img alt="ty" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/grelinfo/grelmicro"><img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/grelinfo/grelmicro/badge"></a>
+  <a href="https://slsa.dev/spec/latest/levels"><img alt="SLSA Build Level 2" src="https://slsa.dev/images/gh-badge-level2.svg"></a>
 </p>
 
 <p align="center">
@@ -37,7 +38,9 @@ ______________________________________________________________________
 
 ## Why grelmicro
 
-grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, the transactional outbox, logging, health checks, and task scheduling. Async-first, type-safe, and fully tested.
+grelmicro is an async Python toolkit for microservices and distributed systems: shared locks, caching, rate limits, circuit breakers, and scheduled tasks.
+
+It ships them as small, composable modules with pluggable backends, alongside the transactional outbox, logging, health checks, and tracing. Async-first, type-safe, and fully tested.
 
 It is built for any Python application that coordinates work across processes, workers, or replicas. The same primitives serve microservices, a modular monolith, or a self-contained system, and fit naturally into containerized and Kubernetes deployments.
 

--- a/tests/coordination/_k3s.py
+++ b/tests/coordination/_k3s.py
@@ -1,0 +1,64 @@
+"""Shared k3s container helpers for the Kubernetes backend tests.
+
+Both `test_kubernetes.py` and `test_lock_backends.py` start a k3s container.
+They previously carried their own copies of these helpers, which drifted apart
+and had to be fixed twice.
+"""
+
+import time as time_module
+
+from docker.errors import APIError
+from testcontainers.core.container import DockerContainer
+
+READY_TIMEOUT = 45
+"""Seconds to wait for k3s readiness.
+
+Must stay below the `pytest.mark.timeout` of any test using a k3s fixture.
+Fixture setup runs under the first test's timeout, so an equal budget means
+pytest-timeout fires at the same moment and hides the report below.
+"""
+
+
+def container_report(container: DockerContainer) -> str:
+    """Return the container state and tail of its logs, for a failed wait."""
+    try:
+        wrapped = container.get_wrapped_container()
+        wrapped.reload()
+        logs = wrapped.logs(tail=20).decode("utf-8", errors="replace")
+    except APIError as error:
+        return f"container state unavailable ({error})"
+    return f"status={wrapped.status}, last logs:\n{logs}"
+
+
+def wait_for_k3s(
+    container: DockerContainer,
+    timeout: float = READY_TIMEOUT,
+) -> None:
+    """Wait for k3s to be ready.
+
+    Docker reports a container as started before it necessarily accepts a
+    command. In that window the probe raises `APIError` instead of returning
+    a non-zero exit code, so both mean "not ready yet" and are polled again.
+    On timeout the container state and logs are reported, which separates a
+    genuine k3s failure from a slow start.
+    """
+    start = time_module.time()
+    while time_module.time() - start < timeout:
+        try:
+            exit_code, _ = container.exec("kubectl get --raw /readyz")
+        except APIError:
+            exit_code = None
+        if exit_code == 0:
+            return
+        time_module.sleep(1)
+    msg = f"k3s did not become ready within {timeout}s. {container_report(container)}"
+    raise TimeoutError(msg)
+
+
+def extract_kubeconfig(container: DockerContainer) -> str:
+    """Extract the kubeconfig from the k3s container."""
+    exit_code, output = container.exec("cat /etc/rancher/k3s/k3s.yaml")
+    if exit_code != 0:
+        msg = f"Failed to extract kubeconfig. {container_report(container)}"
+        raise RuntimeError(msg)
+    return output.decode()

--- a/tests/coordination/test_kubernetes.py
+++ b/tests/coordination/test_kubernetes.py
@@ -1,7 +1,6 @@
 """Tests for the Kubernetes leader election backend."""
 
 import tempfile
-import time as time_module
 from asyncio import sleep
 from collections.abc import AsyncGenerator, Generator
 from datetime import UTC, datetime
@@ -25,6 +24,10 @@ from grelmicro.coordination.kubernetes import (
     _sanitize_lease_name,
 )
 from grelmicro.errors import OutOfContextError, SettingsValidationError
+from tests.coordination._k3s import (
+    extract_kubeconfig,
+    wait_for_k3s,
+)
 
 TOKEN = "test-token"
 OTHER = "other-token"
@@ -681,36 +684,6 @@ _DURATION = 1.0
 _EXPIRE_WAIT = _DURATION + 2.0
 
 
-def _wait_for_k3s(
-    container: DockerContainer,
-    timeout: float = 60,
-) -> None:
-    """Wait for k3s to become ready."""
-    start = time_module.time()
-    while time_module.time() - start < timeout:
-        try:
-            exit_code, _ = container.exec("kubectl get --raw /readyz")
-        except Exception:  # noqa: BLE001
-            # Right after start, the Docker daemon can reject the exec with
-            # 409 "container is not running" before the container is fully
-            # up. Treat any exec error as not-ready and keep polling.
-            exit_code = 1
-        if exit_code == 0:
-            return
-        time_module.sleep(1)
-    msg = "k3s did not become ready"
-    raise TimeoutError(msg)
-
-
-def _extract_kubeconfig(container: DockerContainer) -> str:
-    """Extract the kubeconfig from the k3s container."""
-    exit_code, output = container.exec("cat /etc/rancher/k3s/k3s.yaml")
-    if exit_code != 0:
-        msg = "Failed to extract kubeconfig"
-        raise RuntimeError(msg)
-    return output.decode()
-
-
 @pytest.fixture(scope="module")
 def k3s_container() -> Generator[str]:
     """Start a k3s container and yield a kubeconfig path pointing at it."""
@@ -725,8 +698,8 @@ def k3s_container() -> Generator[str]:
         )
         .with_exposed_ports(6443) as container
     ):
-        _wait_for_k3s(container)
-        kubeconfig_content = _extract_kubeconfig(container)
+        wait_for_k3s(container)
+        kubeconfig_content = extract_kubeconfig(container)
         port = container.get_exposed_port(6443)
         kubeconfig_content = kubeconfig_content.replace(
             "https://127.0.0.1:6443",

--- a/tests/coordination/test_lock_backends.py
+++ b/tests/coordination/test_lock_backends.py
@@ -21,53 +21,12 @@ from grelmicro.coordination.sqlite import SQLiteLockAdapter
 from grelmicro.providers.postgres import PostgresProvider
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.providers.sqlite import SQLiteProvider
+from tests.coordination._k3s import (
+    extract_kubeconfig,
+    wait_for_k3s,
+)
 
 pytestmark = [pytest.mark.timeout(30)]
-
-
-def _container_report(container: DockerContainer) -> str:
-    """Return the container state and tail of its logs, for a failed wait."""
-    try:
-        wrapped = container.get_wrapped_container()
-        wrapped.reload()
-        logs = wrapped.logs(tail=20).decode("utf-8", errors="replace")
-    except APIError as error:
-        return f"container state unavailable ({error})"
-    return f"status={wrapped.status}, last logs:\n{logs}"
-
-
-def _wait_for_k3s(
-    container: DockerContainer,
-    timeout: float = 60,
-) -> None:
-    """Wait for k3s to be ready.
-
-    Docker reports a container as started before it necessarily accepts a
-    command. In that window the probe raises `APIError` instead of returning
-    a non-zero exit code, so both mean "not ready yet" and are polled again.
-    On timeout the container state and logs are reported, which separates a
-    genuine k3s failure from a slow start.
-    """
-    start = time_module.time()
-    while time_module.time() - start < timeout:
-        try:
-            exit_code, _ = container.exec("kubectl get --raw /readyz")
-        except APIError:
-            exit_code = None
-        if exit_code == 0:
-            return
-        time_module.sleep(1)
-    msg = f"k3s did not become ready within {timeout}s. {_container_report(container)}"
-    raise TimeoutError(msg)
-
-
-def _extract_kubeconfig(container: DockerContainer) -> str:
-    """Extract kubeconfig from k3s container."""
-    exit_code, output = container.exec("cat /etc/rancher/k3s/k3s.yaml")
-    if exit_code != 0:
-        msg = "Failed to extract kubeconfig"
-        raise RuntimeError(msg)
-    return output.decode()
 
 
 @pytest.fixture(scope="module")
@@ -124,8 +83,8 @@ def container(
             )
             .with_exposed_ports(6443) as container
         ):
-            _wait_for_k3s(container)
-            kubeconfig_content = _extract_kubeconfig(container)
+            wait_for_k3s(container)
+            kubeconfig_content = extract_kubeconfig(container)
             port = container.get_exposed_port(6443)
             kubeconfig_content = kubeconfig_content.replace(
                 "https://127.0.0.1:6443",
@@ -550,7 +509,7 @@ def test_wait_for_k3s_retries_while_container_not_running(
     container = _FakeContainer([APIError("is not running"), 0])
 
     # Act
-    _wait_for_k3s(container, timeout=10)  # ty: ignore[invalid-argument-type]
+    wait_for_k3s(container, timeout=10)  # ty: ignore[invalid-argument-type]
 
     # Assert
     assert container.calls == expected_probes
@@ -568,7 +527,7 @@ def test_wait_for_k3s_reports_container_state_on_timeout(
     with pytest.raises(
         TimeoutError, match="container state unavailable"
     ) as error:
-        _wait_for_k3s(container, timeout=0.01)  # ty: ignore[invalid-argument-type]
+        wait_for_k3s(container, timeout=0.01)  # ty: ignore[invalid-argument-type]
 
     # Assert
     assert "did not become ready" in str(error.value)


### PR DESCRIPTION
Closes the last two pre-launch checklist items that did not need a clean machine, and folds in a second k3s flake found while running the gate.

## README opener

`LAUNCH_CHECKLIST` asked for an opener a stranger understands in one sentence. The old one packed eight modules and two pieces of jargon into the first breath:

> grelmicro ships microservice patterns as small, composable modules with pluggable backends: locks, rate limits, circuit breakers, cache, the transactional outbox, logging, health checks, and task scheduling.

Now:

> grelmicro is an async Python toolkit for microservices and distributed systems: shared locks, caching, rate limits, circuit breakers, and scheduled tasks.

The paragraph is split rather than replaced, so nothing is lost. The modules that moved out of the opener appear one line down, and tracing was added there since it was missing before.

## SLSA Build L2 badge

Added to `README.md` beside the OpenSSF Scorecard badge, now that a release actually backs it. **0.32.5 is the first**, verified after publishing:

```
$ gh attestation verify grelmicro-0.32.5-py3-none-any.whl --repo grelinfo/grelmicro
(exit 0)
```

0.32.4 returns HTTP 404 for the same command, which is why the badge waited.

## Second k3s flake, folded in

Running the gate surfaced a k3s failure in `test_kubernetes.py`, which turned out to be a **different bug in a different file** from the one #580 fixed. That file carried its own copy of `_wait_for_k3s`, already guarded against the exec race but with its own defect:

The tests are marked `@pytest.mark.timeout(60)` and the readiness budget was also **60 seconds**. Fixture setup runs under the first test's timeout, so pytest-timeout fired at exactly the moment the wait expired. The wait could never report its own diagnostic, which is why the failure was opaque.

Fixes:

- Both copies are now one shared helper, `tests/coordination/_k3s.py`. They had already drifted apart and needed fixing twice, which is the whole argument for deduplicating them.
- The readiness budget is 45 seconds, documented as needing to stay **below** the governing `pytest.mark.timeout` so the report can actually surface.
- `extract_kubeconfig` was duplicated too and is now shared, and reports container state on failure rather than a bare message.

## Verification

- 61 integration tests across both k3s suites pass
- Both regression tests from #580 still pass against the shared helper
- Full `pre-commit run --all-files` green, including both type checkers

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b