### PR TITLE
🐛 Give container startup waits headroom under their test timeout

### DIFF
--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -11,7 +11,7 @@ The launch ships on the current `0.x` line. It is not gated on a 1.0 bump.
 - [x] The [FastAPI demo](examples/fastapi-demo) starts from a fresh clone in three commands. Verified 2026-07-28: `cd examples/fastapi-demo`, `docker compose up --wait`, `open http://localhost:8000/docs`.
 - [x] Record the demo asset (see below) and embed it in the README. `docs/img/demo.gif`, 840K, embedded at the top of `README.md`.
 - [x] Enable the badges (see below). Scorecard and SLSA 2 are both live in `README.md`. 0.32.5 is the first release publishing a verified attestation.
-- [ ] README "Why grelmicro" leads with one sentence a stranger understands.
+- [x] README "Why grelmicro" leads with one sentence a stranger understands.
 - [x] CHANGELOG `Unreleased` section moved under the release version heading.
 
 ## Launch channels (#172)

--- a/tests/coordination/test_redis_sentinel_lock.py
+++ b/tests/coordination/test_redis_sentinel_lock.py
@@ -16,7 +16,10 @@ from uuid import uuid4
 
 import pytest
 
-pytestmark = [pytest.mark.timeout(60), pytest.mark.integration]
+# The fixture waits up to 30s for the master and 30s for the sentinel. The
+# marker must stay above their sum, otherwise pytest-timeout fires at the same
+# moment as the last wait and hides which container failed to come up.
+pytestmark = [pytest.mark.timeout(120), pytest.mark.integration]
 
 testcontainers = pytest.importorskip("testcontainers.core.container")
 

--- a/tests/logging/test_uvicorn.py
+++ b/tests/logging/test_uvicorn.py
@@ -547,7 +547,14 @@ async def app(scope, receive, send):
         await send({"type": "http.response.body", "body": b"ok"})
 """
 
-_STARTUP_TIMEOUT = 10
+_STARTUP_TIMEOUT = 30
+"""Seconds to wait for the uvicorn process to accept a request.
+
+Generous because the suite runs 12 xdist workers, so a real interpreter start
+competes with the container-backed tiers. Must stay below the
+`pytest.mark.timeout` of the tests below, so a slow start is reported as
+"did not start in time" rather than an opaque pytest-timeout.
+"""
 _POLL_INTERVAL = 0.1
 
 
@@ -555,7 +562,7 @@ class TestUvicornProcess:
     """Integration tests that start a real uvicorn process."""
 
     @pytest.mark.integration
-    @pytest.mark.timeout(15)
+    @pytest.mark.timeout(45)
     def test_real_uvicorn_access_log(self) -> None:
         """Test structured JSON output from a real uvicorn process."""
         # Arrange: write temp app and log config


### PR DESCRIPTION
Follow-up to #580 and #581. Audits every startup budget in the suite against its governing `pytest.mark.timeout`, and ticks a checklist box completed in #581.

## The pattern

A startup wait whose budget equals or exceeds the test timeout can never report its own diagnostic. pytest-timeout fires first, so the failure says "Timeout (>60.0s)" instead of naming which container failed to come up. That is what made the k3s flake in #581 take so long to diagnose.

Audit of all four startup sites:

| Site | Budget | Marker | Verdict |
|---|---|---|---|
| `tests/coordination/_k3s.py` | 45s | 60 | already fixed in #581 |
| `tests/coordination/test_redis_sentinel_lock.py` | 30 + 30 = **60s** | **60** | **exactly equal, same bug** |
| `tests/logging/test_uvicorn.py` | 10s | 15 | structurally fine, budget too tight |
| `tests/chaos/test_sentinel_chaos.py` | 60s | 120 | safe |

## Changes

**`test_redis_sentinel_lock.py`**: the fixture waits up to 30s for the Redis master and 30s for the sentinel, summing to exactly the 60s marker. Raised to 120, matching `test_sentinel_chaos.py` which already had that headroom, with a comment stating the constraint.

**`test_uvicorn.py`**: `_STARTUP_TIMEOUT` 10s to 30s, and the marker 15 to 45. This one was structurally correct, it did report its own `"Uvicorn did not start in time"` assertion, but 10 seconds is not enough for a real interpreter start competing with 12 xdist workers and the container-backed tiers. It failed once during yesterday's runs. The budget now carries a docstring explaining both why it is generous and why it must stay under the marker.

**`LAUNCH_CHECKLIST.md`**: ticks the README opener item, which #581 completed but left unchecked.

## Verification

Both touched suites pass. Full local hook run green.

## Not included

`docs/benchmarks.md` was deliberately not refreshed. Re-running the benchmarks surfaced a genuine performance regression, filed as #582: circuit breaker admission is 2.4x slower than 0.32.1, bisected to 0.32.2. Publishing today's numbers would bake that regression in as the new baseline.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b