### PR TITLE
🐛 Take the state lifetime off the circuit breaker admission path

### DIFF
--- a/benchmarks/circuitbreaker_benchmark.py
+++ b/benchmarks/circuitbreaker_benchmark.py
@@ -47,6 +47,8 @@ async def _bench_closed_path(iterations: int) -> None:
             name="bench",
             config=ConsecutiveCountConfig(),
         )
+        # Record once so admission reads a live circuit, not a fresh one.
+        await strategy.record_outcome(success=True)
 
         await _measure_async(
             "try_acquire (CLOSED)",

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -17,7 +17,7 @@ Each script measures the in-memory backend so the numbers reflect grelmicro's ow
 
 ## Results
 
-The numbers below were measured on 2026-06-14 on an Apple Silicon machine (macOS, CPython 3.12) and are indicative only. Run the scripts yourself for figures that match your hardware and Python build.
+The numbers below were measured on an Apple Silicon machine (macOS, CPython 3.12) and are indicative only. Most rows date from 2026-06-14. The circuit breaker rows were re-measured on 2026-07-29, after per-key state lifetimes landed. Run the scripts yourself for figures that match your hardware and Python build.
 
 | Primitive | Operation | Time per op |
 |---|---|---|
@@ -25,7 +25,7 @@ The numbers below were measured on 2026-06-14 on an Apple Silicon machine (macOS
 | Rate limiter | `RateLimiter.sliding_window` acquire (allowed) | ~455 ns |
 | Rate limiter | `MemoryTokenBucket.try_acquire` (sync, hit) | ~260 ns |
 | Circuit breaker | `try_acquire` (CLOSED) | ~90 ns |
-| Circuit breaker | `record_outcome` (success) | ~345 ns |
+| Circuit breaker | `record_outcome` (success) | ~420 ns |
 | Cache | `get` (hit) | ~340 ns |
 | Cache | `get` (miss) | ~260 ns |
 | Cache | `set` | ~290 ns |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* 🐛 Take the state lifetime off the in-memory circuit breaker's admission path. Every call recomputed the lifetime and read the clock, which made `try_acquire` 2.4x slower from 0.32.2 on. Entries now carry an absolute deadline, and a closed circuit admits from one dictionary lookup. ([#582](https://github.com/grelinfo/grelmicro/issues/582))
+
 ## 0.32.5 - 2026-07-28
 
 ### Security

--- a/grelmicro/resilience/circuitbreaker/memory.py
+++ b/grelmicro/resilience/circuitbreaker/memory.py
@@ -13,6 +13,7 @@ from grelmicro.resilience._protocol import (
     CircuitBreakerStrategy,
 )
 from grelmicro.resilience.circuitbreaker import (
+    _STATE_TTL,
     CircuitBreakerState,
     _resolve_state_ttl,
 )
@@ -34,6 +35,9 @@ _FORCED_STATES = (
 )
 """States held by an operator, which no lifetime may release."""
 
+_NEVER = float("inf")
+"""Deadline of an entry no lifetime may reclaim."""
+
 
 @dataclass(slots=True)
 class _BreakerState:
@@ -45,8 +49,13 @@ class _BreakerState:
     consecutive_error_count: int = 0
     consecutive_success_count: int = 0
     half_open_admit: int = 0
-    updated_at: float = 0.0
-    """Monotonic time of the last write, used for lazy expiry."""
+    expires_at: float = 0.0
+    """Monotonic deadline past which the entry reads as absent.
+
+    Every write stamps it from the entry's own cool-down, so reading it
+    is one float comparison and a sweep never judges another breaker's
+    entry by its own configuration.
+    """
 
 
 class MemoryCircuitBreakerAdapter(CircuitBreakerBackend):
@@ -98,7 +107,7 @@ class MemoryCircuitBreakerAdapter(CircuitBreakerBackend):
             states=self._states,
             name=name,
             config=config,
-            ttl=_resolve_state_ttl(config.reset_timeout),
+            open_ttl=_resolve_state_ttl(config.reset_timeout),
         )
 
 
@@ -115,7 +124,7 @@ class _MemoryConsecutiveCountStrategy(CircuitBreakerStrategy):
         states: dict[str, _BreakerState],
         name: str,
         config: ConsecutiveCountConfig,
-        ttl: float,
+        open_ttl: float,
     ) -> None:
         """Bind the strategy to the breaker's per-name state and config."""
         self._states = states
@@ -124,50 +133,37 @@ class _MemoryConsecutiveCountStrategy(CircuitBreakerStrategy):
         self._success_threshold = config.success_threshold
         self._reset_timeout = config.reset_timeout
         self._half_open_capacity = config.half_open_capacity
-        self._ttl = ttl
+        self._open_ttl = open_ttl
 
-    @staticmethod
-    def _expired(state: _BreakerState, now: float) -> bool:
-        """Whether an entry has gone quiet for longer than its lifetime.
-
-        The lifetime comes from the entry's own cool-down, so a strategy
-        sweeping the shared map cannot judge another breaker's entry by
-        its own configuration.
-
-        Manually forced states never expire. An operator holds them
-        until an explicit `reset`, so a quiet period must not release
-        the hold.
-        """
-        if state.state in _FORCED_STATES:
-            return False
-        return now - state.updated_at >= _resolve_state_ttl(state.cool_down)
-
-    def _get_or_create(self) -> _BreakerState:
+    def _live(self, now: float) -> _BreakerState:
         """Return the live entry for this breaker, creating it if needed.
 
-        Expiry is lazy: a stale entry reads as absent and is replaced,
-        so a returning key starts from a clean `CLOSED` instead of
-        inheriting counters nobody has touched for a day.
+        Expiry is lazy: an entry past its deadline reads as absent and
+        is replaced, so a returning key starts from a clean `CLOSED`
+        instead of inheriting counters nobody has touched for a day.
+
+        A manually forced state carries no deadline. An operator holds
+        it until an explicit `reset`, so a quiet period must not release
+        the hold.
         """
         state = self._states.get(self._name)
-        if state is None or self._expired(state, monotonic()):
-            state = _BreakerState(updated_at=monotonic())
+        if state is None or now >= state.expires_at:
+            state = _BreakerState(expires_at=now + _STATE_TTL)
             self._states[self._name] = state
-            self._cull()
+            self._cull(now)
         return state
 
-    def _cull(self) -> None:
+    def _cull(self, now: float) -> None:
         """Reclaim a bounded number of expired entries.
 
         Runs only when a new entry is added, and stops after
         `_CULL_LIMIT`, so no single call pays for the whole keyspace.
         """
-        now = monotonic()
         reclaimed = 0
         for name, state in list(self._states.items()):
             if reclaimed >= _CULL_LIMIT:
                 return
-            if name != self._name and self._expired(state, now):
+            if name != self._name and now >= state.expires_at:
                 del self._states[name]
                 reclaimed += 1
 
@@ -181,36 +177,52 @@ class _MemoryConsecutiveCountStrategy(CircuitBreakerStrategy):
         return _DEFAULT_SNAPSHOT
 
     async def try_acquire(self) -> bool:
-        """Atomic admission in the loop thread."""
-        state = self._get_or_create()
+        """Atomic admission in the loop thread.
 
-        if state.state in (
+        A missing entry reads as `CLOSED`, and a closed circuit admits
+        whatever its counters say, so the steady-state path answers from
+        one dictionary lookup without reading the clock.
+        """
+        state = self._states.get(self._name)
+        if state is None:
+            return True
+
+        circuit = state.state
+        if circuit in (
             CircuitBreakerState.CLOSED,
             CircuitBreakerState.FORCED_CLOSED,
         ):
             return True
-
-        if state.state == CircuitBreakerState.FORCED_OPEN:
+        if circuit == CircuitBreakerState.FORCED_OPEN:
             return False
 
-        if state.state == CircuitBreakerState.OPEN:
-            if monotonic() >= state.opened_at + state.cool_down:
-                state.state = CircuitBreakerState.HALF_OPEN
-                state.consecutive_error_count = 0
-                state.consecutive_success_count = 0
-                state.half_open_admit = 0
-                state.opened_at = 0.0
-                state.cool_down = 0.0
-                state.updated_at = monotonic()
-            else:
-                return False
+        return self._admit_recovering(state)
 
-        if (
-            state.state == CircuitBreakerState.HALF_OPEN
-            and state.half_open_admit < self._half_open_capacity
-        ):
+    def _admit_recovering(self, state: _BreakerState) -> bool:
+        """Admit against a circuit that is neither closed nor forced.
+
+        `try_acquire` has already answered every other state, so the
+        entry here is `OPEN` or `HALF_OPEN`, and both need the clock.
+        """
+        now = monotonic()
+        if now >= state.expires_at:
+            self._live(now)
+            return True
+
+        if state.state == CircuitBreakerState.OPEN:
+            if now < state.opened_at + state.cool_down:
+                return False
+            state.state = CircuitBreakerState.HALF_OPEN
+            state.consecutive_error_count = 0
+            state.consecutive_success_count = 0
+            state.half_open_admit = 0
+            state.opened_at = 0.0
+            state.cool_down = 0.0
+            state.expires_at = now + _STATE_TTL
+
+        if state.half_open_admit < self._half_open_capacity:
             state.half_open_admit += 1
-            state.updated_at = monotonic()
+            state.expires_at = now + _STATE_TTL
             return True
 
         return False
@@ -222,7 +234,8 @@ class _MemoryConsecutiveCountStrategy(CircuitBreakerStrategy):
         duration: float = 0.0,  # noqa: ARG002
     ) -> CircuitBreakerSnapshot:
         """Record a call outcome and apply any state transition."""
-        state = self._get_or_create()
+        now = monotonic()
+        state = self._live(now)
 
         if state.state in (
             CircuitBreakerState.FORCED_OPEN,
@@ -231,7 +244,7 @@ class _MemoryConsecutiveCountStrategy(CircuitBreakerStrategy):
         ):
             return _snapshot_of(state)
 
-        state.updated_at = monotonic()
+        state.expires_at = now + _STATE_TTL
 
         if success:
             state.consecutive_success_count += 1
@@ -251,8 +264,9 @@ class _MemoryConsecutiveCountStrategy(CircuitBreakerStrategy):
                 state.half_open_admit -= 1
             if state.consecutive_error_count >= self._error_threshold:
                 state.state = CircuitBreakerState.OPEN
-                state.opened_at = monotonic()
+                state.opened_at = now
                 state.cool_down = self._reset_timeout
+                state.expires_at = now + self._open_ttl
                 state.consecutive_error_count = 0
                 state.consecutive_success_count = 0
                 state.half_open_admit = 0
@@ -274,18 +288,26 @@ class _MemoryConsecutiveCountStrategy(CircuitBreakerStrategy):
         if desired == CircuitBreakerState.CLOSED:
             self._close()
             return
-        state = self._get_or_create()
-        state.updated_at = monotonic()
+        now = monotonic()
+        state = self._live(now)
         if desired == CircuitBreakerState.OPEN:
             state.state = CircuitBreakerState.OPEN
-            state.opened_at = monotonic()
+            state.opened_at = now
             state.cool_down = (
                 cool_down if cool_down is not None else self._reset_timeout
+            )
+            state.expires_at = now + (
+                self._open_ttl
+                if cool_down is None
+                else _resolve_state_ttl(cool_down)
             )
         else:
             state.state = desired
             state.opened_at = 0.0
             state.cool_down = 0.0
+            state.expires_at = (
+                _NEVER if desired in _FORCED_STATES else now + _STATE_TTL
+            )
         state.consecutive_error_count = 0
         state.consecutive_success_count = 0
         state.half_open_admit = 0
@@ -293,7 +315,7 @@ class _MemoryConsecutiveCountStrategy(CircuitBreakerStrategy):
     async def get_snapshot(self) -> CircuitBreakerSnapshot:
         """Read the current snapshot without mutating state."""
         state = self._states.get(self._name)
-        if state is None or self._expired(state, monotonic()):
+        if state is None or monotonic() >= state.expires_at:
             return _DEFAULT_SNAPSHOT
         return _snapshot_of(state)
 

--- a/tests/resilience/test_circuitbreaker_keyed.py
+++ b/tests/resilience/test_circuitbreaker_keyed.py
@@ -401,6 +401,26 @@ async def test_backend_reclaims_expired_circuits(
     assert len(backend._states) < KEYS
 
 
+async def test_returning_key_starts_from_a_clean_circuit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Errors nobody has touched for a lifetime do not count toward a trip."""
+    clock = 0.0
+    monkeypatch.setattr(
+        "grelmicro.resilience.circuitbreaker.monotonic", lambda: clock
+    )
+    monkeypatch.setattr(
+        "grelmicro.resilience.circuitbreaker.memory.monotonic", lambda: clock
+    )
+    cb = CircuitBreaker.consecutive_count("upstream", error_threshold=ERRORS)
+    await trip(cb.keyed("quiet"), ERRORS - 1)
+
+    clock += DAY + 1
+    await trip(cb.keyed("quiet"), 1)
+
+    assert cb.keyed("quiet").state == CircuitBreakerState.CLOSED
+
+
 async def test_backend_cull_is_bounded(
     backend: MemoryCircuitBreakerAdapter,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/resilience/test_circuitbreaker_memory_snapshot.py
+++ b/tests/resilience/test_circuitbreaker_memory_snapshot.py
@@ -24,6 +24,7 @@ CLOSED = CircuitBreakerState.CLOSED
 OPEN = CircuitBreakerState.OPEN
 HALF_OPEN = CircuitBreakerState.HALF_OPEN
 CLOCK_START = 1000.0
+DAY = 86400.0
 
 
 def strategy(
@@ -160,3 +161,44 @@ async def test_half_open_admission_capacity_and_release() -> None:
         await cb.record_outcome(success=False)
         assert await cb.try_acquire() is True
         assert await cb.try_acquire() is False
+
+
+async def test_admission_never_revives_a_stale_circuit() -> None:
+    """Skipping expiry on admission does not leak the stale counters."""
+    config = ConsecutiveCountConfig(error_threshold=5, reset_timeout=30.0)
+    async with VirtualClock(start=CLOCK_START) as clock:
+        cb = strategy(config)
+        await cb.record_outcome(success=False)
+        assert (await cb.get_snapshot()).consecutive_error_count == 1
+
+        await clock.advance(DAY)
+
+        assert await cb.try_acquire() is True
+        assert (await cb.get_snapshot()).consecutive_error_count == 0
+        snap = await cb.record_outcome(success=False)
+        assert snap.consecutive_error_count == 1
+
+
+async def test_closed_admission_reads_no_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Admission on a closed circuit answers from the stored entry alone."""
+    config = ConsecutiveCountConfig(error_threshold=5)
+    async with VirtualClock(start=CLOCK_START):
+        cb = strategy(config)
+        await cb.record_outcome(success=False)  # materializes the entry
+
+        reads = 0
+
+        def counting_monotonic() -> float:
+            nonlocal reads
+            reads += 1
+            return CLOCK_START
+
+        monkeypatch.setattr(
+            "grelmicro.resilience.circuitbreaker.memory.monotonic",
+            counting_monotonic,
+        )
+        assert await cb.try_acquire() is True
+
+        assert reads == 0


### PR DESCRIPTION
Closes #582.

## Problem

`try_acquire` started with `_get_or_create`, so every admission paid for lazy-expiry work: a `monotonic()` call (a ContextVar read plus `time.monotonic`), then `_expired`, which did a tuple membership test and recomputed `_resolve_state_ttl(state.cool_down)`. None of that can change an admission decision. A closed circuit admits whatever its counters say, and a forced state never expires.

## Change

`_BreakerState.updated_at` becomes `expires_at`, an absolute deadline stamped at write time, so an expiry check is one float comparison. Forced states store `inf` instead of being special-cased, which takes `_FORCED_STATES` off the read path entirely.

`try_acquire` answers `CLOSED`, `FORCED_CLOSED`, and `FORCED_OPEN` from a single dictionary lookup with no clock read, and a missing entry admits without creating one. `OPEN` and `HALF_OPEN` fall through to `_admit_recovering`, which reads the clock once and still applies expiry, so a half-open circuit abandoned at capacity is never stuck. `record_outcome` and `transition` now read the clock once instead of twice.

Entry lifetimes are unchanged: non-open entries stamp `_STATE_TTL`, open entries stamp from their own cool-down, exactly as `_expired` derived them before.

## Results

Measured on one machine, back to back, with `benchmarks/circuitbreaker_benchmark.py`.

| | 0.32.1 | main | this branch |
|---|---|---|---|
| `try_acquire` (CLOSED) | 96.7 ns | 261.1 ns | **~90 ns** |
| `record_outcome` (success) | 346.3 ns | 573.0 ns | **~420 ns** |
| pair (one protected call) | 490.7 ns | 917.0 ns | **~560 ns** |

`record_outcome` stays about 75 ns above 0.32.1. That residual is one `monotonic()` call, which is what refreshing a sliding per-key deadline costs. 0.32.1 had no per-key lifetime at all, so there is nothing to reclaim there. Closing the gap would mean making expiry lazier, which would give up the property #563 added.

## Correctness

A differential fuzz ran the old and new strategies through identical randomized scripts: 5000 seeds, randomized thresholds, `reset_timeout` from 1 s to 40000 s, half-open capacity 1 to 3, up to 3 breaker names, 20 to 60 operations per seed, and time jumps from 0 to 40 days.

* 0 observable mismatches. Every `try_acquire` result, `record_outcome` snapshot, `transition`, and `get_snapshot` is identical.
* 0 seeds where the new peak resident entry count exceeds the old. The memory bound is not weakened, and it improves slightly because `try_acquire` no longer materializes an entry for a key with no state.

The only divergence is which internal `_states` keys are resident, which is the intended part of the change.

Three tests added: admission on a closed circuit reads the clock zero times, a stale circuit is not revived by admission, and a returning key does not inherit counters toward a trip. The module keeps 100% statement and branch coverage.

## Benchmarks page

`docs/benchmarks.md` advertised the pre-regression figures. The circuit breaker rows are re-measured. `try_acquire` stays at ~90 ns and `record_outcome` moves from ~345 ns to ~420 ns. A 0.32.1 control run on the same machine reproduced the published numbers (96.7 ns and 346.3 ns), so the new figures are comparable to the untouched rows. The other primitives were re-run at 0.32.1 and at main and showed no drift, so their rows are unchanged.

The benchmark script itself had a flaw: its `try_acquire` phase ran against an empty state map, measuring the missing-entry path rather than steady state. It now records one outcome first.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b