### PR TITLE
✅ Start one k3s container per session instead of one per xdist worker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -364,6 +364,7 @@ addopts = """
     --strict-config
     --strict-markers
     -n auto
+    --dist loadgroup
 """
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"

--- a/tests/coordination/_k3s.py
+++ b/tests/coordination/_k3s.py
@@ -1,8 +1,8 @@
 """Shared k3s container helpers for the Kubernetes backend tests.
 
-Both `test_kubernetes.py` and `test_lock_backends.py` start a k3s container.
-They previously carried their own copies of these helpers, which drifted apart
-and had to be fixed twice.
+Both `test_kubernetes.py` and `test_lock_backends.py` need a k3s API server.
+They share the one container built here, started once per session by the
+`k3s_kubeconfig` fixture in `conftest.py`.
 """
 
 import time as time_module
@@ -10,13 +10,32 @@ import time as time_module
 from docker.errors import APIError
 from testcontainers.core.container import DockerContainer
 
-READY_TIMEOUT = 45
+K3S_IMAGE = "rancher/k3s:v1.31.4-k3s1"
+"""Pinned k3s image. An unpinned tag would make the suite drift with upstream."""
+
+READY_TIMEOUT = 120
 """Seconds to wait for k3s readiness.
 
-Must stay below the `pytest.mark.timeout` of any test using a k3s fixture.
-Fixture setup runs under the first test's timeout, so an equal budget means
-pytest-timeout fires at the same moment and hides the report below.
+A control plane boots in a few seconds when the machine is idle and takes far
+longer when it is not, so this is generous on purpose. It is a once-per-session
+cost, and the tests that use it exempt fixture setup from their own timeout.
 """
+
+
+def create_k3s_container() -> DockerContainer:
+    """Build the k3s container, unstarted.
+
+    Single construction point for the whole suite. Traefik and the metrics
+    server are disabled because no test uses them and both slow the boot.
+    """
+    return (
+        DockerContainer(K3S_IMAGE)
+        .with_command(
+            "server --disable=traefik,metrics-server --tls-san=127.0.0.1"
+        )
+        .with_kwargs(privileged=True, tmpfs={"/run": "", "/var/run": ""})
+        .with_exposed_ports(6443)
+    )
 
 
 def container_report(container: DockerContainer) -> str:

--- a/tests/coordination/conftest.py
+++ b/tests/coordination/conftest.py
@@ -1,0 +1,32 @@
+"""Shared fixtures for the coordination tests.
+
+The k3s container lives here because two modules need the same API server.
+Every test that touches it carries `pytest.mark.xdist_group("k3s")`, so
+`--dist loadgroup` sends them all to one worker and this fixture builds one
+container per session. Without the group, each worker that happened to receive
+a Kubernetes test would boot a control plane of its own.
+"""
+
+from collections.abc import Generator
+
+import pytest
+
+from tests.coordination._k3s import (
+    create_k3s_container,
+    extract_kubeconfig,
+    wait_for_k3s,
+)
+
+
+@pytest.fixture(scope="session")
+def k3s_kubeconfig(tmp_path_factory: pytest.TempPathFactory) -> Generator[str]:
+    """Start k3s once and yield the path to a kubeconfig pointing at it."""
+    with create_k3s_container() as container:
+        wait_for_k3s(container)
+        kubeconfig = extract_kubeconfig(container).replace(
+            "https://127.0.0.1:6443",
+            f"https://127.0.0.1:{container.get_exposed_port(6443)}",
+        )
+        path = tmp_path_factory.mktemp("k3s") / "kubeconfig.yaml"
+        path.write_text(kubeconfig)
+        yield str(path)

--- a/tests/coordination/test_kubernetes.py
+++ b/tests/coordination/test_kubernetes.py
@@ -1,8 +1,7 @@
 """Tests for the Kubernetes leader election backend."""
 
-import tempfile
 from asyncio import sleep
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 from uuid import uuid4
@@ -12,7 +11,6 @@ from lightkube.core.exceptions import ApiError
 from lightkube.models.coordination_v1 import LeaseSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.coordination_v1 import Lease
-from testcontainers.core.container import DockerContainer
 
 from grelmicro.coordination._protocol import LeaderElectionBackend
 from grelmicro.coordination.kubernetes import (
@@ -24,10 +22,6 @@ from grelmicro.coordination.kubernetes import (
     _sanitize_lease_name,
 )
 from grelmicro.errors import OutOfContextError, SettingsValidationError
-from tests.coordination._k3s import (
-    extract_kubeconfig,
-    wait_for_k3s,
-)
 
 TOKEN = "test-token"
 OTHER = "other-token"
@@ -684,48 +678,20 @@ _DURATION = 1.0
 _EXPIRE_WAIT = _DURATION + 2.0
 
 
-@pytest.fixture(scope="module")
-def k3s_container() -> Generator[str]:
-    """Start a k3s container and yield a kubeconfig path pointing at it."""
-    with (
-        DockerContainer("rancher/k3s:v1.31.4-k3s1")
-        .with_command(
-            "server --disable=traefik,metrics-server --tls-san=127.0.0.1"
-        )
-        .with_kwargs(
-            privileged=True,
-            tmpfs={"/run": "", "/var/run": ""},
-        )
-        .with_exposed_ports(6443) as container
-    ):
-        wait_for_k3s(container)
-        kubeconfig_content = extract_kubeconfig(container)
-        port = container.get_exposed_port(6443)
-        kubeconfig_content = kubeconfig_content.replace(
-            "https://127.0.0.1:6443",
-            f"https://127.0.0.1:{port}",
-        )
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False
-        ) as f:
-            f.write(kubeconfig_content)
-            kubeconfig_path = f.name
-        yield kubeconfig_path
-
-
 @pytest.fixture
 async def backend(
-    k3s_container: str,
+    k3s_kubeconfig: str,
 ) -> AsyncGenerator[KubernetesLeaderElectionAdapter]:
-    """Open a backend connected to the k3s container."""
+    """Open a backend connected to the shared k3s container."""
     async with KubernetesLeaderElectionAdapter(
-        namespace="default", kubeconfig=k3s_container
+        namespace="default", kubeconfig=k3s_kubeconfig
     ) as backend:
         yield backend
 
 
 @pytest.mark.integration
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(60, func_only=True)
+@pytest.mark.xdist_group("k3s")
 async def test_acquire(backend: KubernetesLeaderElectionAdapter) -> None:
     """A fresh election is acquired and creates a live Lease."""
     name = "acquire-" + uuid4().hex
@@ -744,7 +710,8 @@ async def test_acquire(backend: KubernetesLeaderElectionAdapter) -> None:
 
 
 @pytest.mark.integration
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(60, func_only=True)
+@pytest.mark.xdist_group("k3s")
 async def test_renew_keeps_transitions(
     backend: KubernetesLeaderElectionAdapter,
 ) -> None:
@@ -766,7 +733,8 @@ async def test_renew_keeps_transitions(
 
 
 @pytest.mark.integration
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(60, func_only=True)
+@pytest.mark.xdist_group("k3s")
 async def test_live_lease_not_taken(
     backend: KubernetesLeaderElectionAdapter,
 ) -> None:
@@ -788,7 +756,8 @@ async def test_live_lease_not_taken(
 
 
 @pytest.mark.integration
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(60, func_only=True)
+@pytest.mark.xdist_group("k3s")
 async def test_takeover_after_expiry(
     backend: KubernetesLeaderElectionAdapter,
 ) -> None:
@@ -808,7 +777,8 @@ async def test_takeover_after_expiry(
 
 
 @pytest.mark.integration
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(60, func_only=True)
+@pytest.mark.xdist_group("k3s")
 async def test_release(backend: KubernetesLeaderElectionAdapter) -> None:
     """Release returns True for the holder, False for non-holders."""
     name = "release-" + uuid4().hex
@@ -823,7 +793,8 @@ async def test_release(backend: KubernetesLeaderElectionAdapter) -> None:
 
 
 @pytest.mark.integration
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(60, func_only=True)
+@pytest.mark.xdist_group("k3s")
 async def test_get_live_and_expired(
     backend: KubernetesLeaderElectionAdapter,
 ) -> None:
@@ -842,7 +813,8 @@ async def test_get_live_and_expired(
 
 
 @pytest.mark.integration
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(60, func_only=True)
+@pytest.mark.xdist_group("k3s")
 async def test_metadata_roundtrip(
     backend: KubernetesLeaderElectionAdapter,
 ) -> None:

--- a/tests/coordination/test_lock_backends.py
+++ b/tests/coordination/test_lock_backends.py
@@ -1,6 +1,5 @@
 """Test Lock Backends."""
 
-import tempfile
 import time as time_module
 from asyncio import sleep
 from collections.abc import AsyncGenerator, Generator
@@ -21,12 +20,15 @@ from grelmicro.coordination.sqlite import SQLiteLockAdapter
 from grelmicro.providers.postgres import PostgresProvider
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.providers.sqlite import SQLiteProvider
-from tests.coordination._k3s import (
-    extract_kubeconfig,
-    wait_for_k3s,
-)
+from tests.coordination._k3s import wait_for_k3s
 
-pytestmark = [pytest.mark.timeout(30)]
+pytestmark = [pytest.mark.timeout(30, func_only=True)]
+"""Thirty seconds of test body.
+
+`func_only` keeps container startup out of the budget. A test body is the
+only thing this timeout should catch, and a container that will not boot
+reports itself through its own wait.
+"""
 
 
 @pytest.fixture(scope="module")
@@ -43,7 +45,13 @@ def monkeypatch() -> Generator[pytest.MonkeyPatch, None, None]:
         "sqlite",
         pytest.param("redis", marks=[pytest.mark.integration]),
         pytest.param("postgres", marks=[pytest.mark.integration]),
-        pytest.param("kubernetes", marks=[pytest.mark.integration]),
+        pytest.param(
+            "kubernetes",
+            marks=[
+                pytest.mark.integration,
+                pytest.mark.xdist_group("k3s"),
+            ],
+        ),
     ],
     scope="module",
 )
@@ -58,6 +66,7 @@ def backend_name(request: pytest.FixtureRequest) -> str:
 def container(
     backend_name: str,
     monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> Generator[DockerContainer | None, None, None]:
     """Test Container for each Backend."""
     if backend_name == "redis":
@@ -72,32 +81,11 @@ def container(
         with PostgresContainer() as container:
             yield container
     elif backend_name == "kubernetes":
-        with (
-            DockerContainer("rancher/k3s:v1.31.4-k3s1")
-            .with_command(
-                "server --disable=traefik,metrics-server --tls-san=127.0.0.1"
-            )
-            .with_kwargs(
-                privileged=True,
-                tmpfs={"/run": "", "/var/run": ""},
-            )
-            .with_exposed_ports(6443) as container
-        ):
-            wait_for_k3s(container)
-            kubeconfig_content = extract_kubeconfig(container)
-            port = container.get_exposed_port(6443)
-            kubeconfig_content = kubeconfig_content.replace(
-                "https://127.0.0.1:6443",
-                f"https://127.0.0.1:{port}",
-            )
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".yaml", delete=False
-            ) as f:
-                f.write(kubeconfig_content)
-                kubeconfig_path = f.name
-            monkeypatch.setenv("KUBECONFIG", kubeconfig_path)
-            monkeypatch.setenv("KUBE_NAMESPACE", "default")
-            yield container
+        monkeypatch.setenv(
+            "KUBECONFIG", request.getfixturevalue("k3s_kubeconfig")
+        )
+        monkeypatch.setenv("KUBE_NAMESPACE", "default")
+        yield None
     elif backend_name in ("memory", "sqlite"):
         yield None
 
@@ -147,7 +135,9 @@ async def backend(
         provider = SQLiteProvider(":memory:")
         async with provider, SQLiteLockAdapter(provider=provider) as backend:
             yield backend
-    elif backend_name == "kubernetes" and container:
+    elif backend_name == "kubernetes":
+        # `container` points the adapter at the shared k3s server through
+        # the environment, so it is a dependency even though it yields None.
         async with KubernetesLockAdapter(namespace="default") as backend:
             yield backend
 


### PR DESCRIPTION
The Kubernetes integration tests have been flaky for a long time. Two previous fixes (#580, #583) tuned timeouts and it kept happening, because the timeout was never the problem.

## Root cause

A session or module scoped fixture under `--dist load` runs **once per xdist worker** ([pytest-xdist docs](https://pytest-xdist.readthedocs.io/en/stable/how-to.html)). With `-n auto` on a 12 core machine, every worker that received a Kubernetes test booted its own k3s server. Each one is a privileged control plane with a documented baseline of 2 CPUs and 2 GB RAM ([k3s requirements](https://docs.k3s.io/installation/requirements)).

Measured directly, same tests, same machine, back to back:

| | k3s containers started |
|---|---|
| `main` | **15** |
| this branch | **1** |

Both runs pass. That is exactly the failure shape: 15 control planes boot fine on an idle machine and starve each other under load, so no timeout value is ever right.

## The dead invariant

`_k3s.py` set `READY_TIMEOUT = 45` and documented a rule: it "must stay below the `pytest.mark.timeout` of any test using a k3s fixture". But `test_lock_backends.py` has carried `pytest.mark.timeout(30)` since #338, and `READY_TIMEOUT` arrived in #581, so the rule was violated the moment it was written. pytest-timeout fired at 30s before the helper's own wait could reach `container_report()`, which is why failures came back as blind timeouts with no diagnostics.

That is the case against the invariant itself: two constants in two files, related by arithmetic, with nothing enforcing it. It had already drifted, and every new k3s using module re-created the trap.

## Change

**One container.** A session scoped `k3s_kubeconfig` fixture in a new `tests/coordination/conftest.py`, with the container construction moved into `_k3s.py`. This deletes the ~25 line duplicate that both test modules carried, which `_k3s.py`'s own docstring notes had already "drifted apart and had to be fixed twice".

**Grouping, which is what makes session scope mean once.** `--dist loadgroup` in `pyproject.toml` plus `pytest.mark.xdist_group("k3s")` on every Kubernetes test. Tests without the mark distribute exactly as before ([distribution docs](https://pytest-xdist.readthedocs.io/en/stable/distribution.html)).

**`func_only=True` on the timeout markers**, which removes the cross file invariant for good. Fixture setup is no longer billed to a test's timeout, so container startup and test duration stop competing for one budget. Verified on the installed pytest-timeout: it exempts fixture setup and still kills a slow test body, so the deadlock catching purpose is intact. `READY_TIMEOUT` goes to 120 to match testcontainers' own default, safe now that it is a once per session cost.

The `/readyz` probe and `container_report()` are unchanged. The probe was never the problem, and with `func_only` its diagnostics are finally reachable on a genuine k3s failure.

## Validation

Three consecutive runs with random ordering at load average 11.35, higher than the 4 to 5 that produced the original failure: `61 passed` each time, exactly 1 container each. Full pre-commit green.

Cost: the integration tier goes from about 18s to about 23s, since the k3s tests now serialize on one worker. Five seconds to stop booting 14 extra control planes.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b