### PR TITLE
🔖 Prepare the 0.32.6 release

### DIFF
--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -7,7 +7,7 @@ Maintainer planning doc (not published to the docs site). Tracks the launch task
 The launch ships on the current `0.x` line. It is not gated on a 1.0 bump.
 
 - [ ] Tag and publish the launch release on PyPI. Confirm `pip install grelmicro` resolves it.
-- [ ] `docs/benchmarks.md` numbers re-run on a clean machine and dated. Currently dated 2026-06-14 (Apple Silicon, macOS, CPython 3.12).
+- [ ] `docs/benchmarks.md` numbers re-run on a clean machine and dated. Most rows date from 2026-06-14 and the circuit breaker rows from 2026-07-29 (Apple Silicon, macOS, CPython 3.12). Both runs shared the machine with other work, so neither meets the clean-machine bar.
 - [x] The [FastAPI demo](examples/fastapi-demo) starts from a fresh clone in three commands. Verified 2026-07-28: `cd examples/fastapi-demo`, `docker compose up --wait`, `open http://localhost:8000/docs`.
 - [x] Record the demo asset (see below) and embed it in the README. `docs/img/demo.gif`, 840K, embedded at the top of `README.md`.
 - [x] Enable the badges (see below). Scorecard and SLSA 2 are both live in `README.md`. 0.32.5 is the first release publishing a verified attestation.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.32.6 - 2026-07-29
 
 ### Fixed
 
 * 🐛 Take the state lifetime off the in-memory circuit breaker's admission path. Every call recomputed the lifetime and read the clock, which made `try_acquire` 2.4x slower from 0.32.2 on. Entries now carry an absolute deadline, and a closed circuit admits from one dictionary lookup. ([#582](https://github.com/grelinfo/grelmicro/issues/582))
+
+### Docs
+
+* 📝 Lead the README with one sentence that says what grelmicro is, and add the SLSA Build Level 2 badge. ([#581](https://github.com/grelinfo/grelmicro/pull/581))
 
 ## 0.32.5 - 2026-07-28
 


### PR DESCRIPTION
Changelog only, matching how 0.32.5 was prepared.

* `## Unreleased` becomes `## 0.32.6 - 2026-07-29`.
* Adds the missing `### Docs` entry for #581 (README lead sentence and the SLSA Build Level 2 badge). The three test-only commits since 0.32.5 (#580, #583, #586) get no entry, consistent with past practice.
* Corrects the `docs/benchmarks.md` line in `LAUNCH_CHECKLIST.md`. It still claimed the numbers were all dated 2026-06-14. It now records the mixed dating and notes that neither run meets the clean-machine bar, so the item stays unchecked.

## Pre-release verification

The full release tier was run locally, since PR CI skips the slow and integration tiers.

| Tier | Result |
|---|---|
| Unit 3.12 | 3517 passed |
| Unit 3.13 | 3517 passed |
| Unit 3.14 | 3517 passed |
| Slow | 5 passed |
| Integration | 235 passed |

Only one library file changed since 0.32.5: `grelmicro/resilience/circuitbreaker/memory.py`. It was re-checked with a differential fuzz using the released 0.32.5 file as the baseline, 5000 randomized seeds, 0 observable behaviour mismatches and no case where memory retention got worse.

The SLSA Build Level 2 claim added in #581 was verified against GitHub's documentation. Artifact attestations alone provide SLSA v1.0 Build Level 2, and Build Level 3 would require the attestation to be generated from a reusable workflow. `release.yml` calls `attest-build-provenance` inline, so Level 2 is accurate and Level 3 is correctly not claimed.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b