### PR TITLE
📝 Document the bug report process and add the OpenSSF Best Practices badge

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Report incorrect or unexpected behaviour in grelmicro.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a report. The
+        [reporting guide](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#reporting-a-bug)
+        explains what happens next.
+
+        Do not report a security vulnerability here. Use the
+        [security policy](https://github.com/grelinfo/grelmicro/security/policy)
+        instead.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched the existing issues and found no match.
+          required: true
+        - label: I reproduced this on the latest released version.
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: grelmicro version
+      description: >-
+        `python -c "from importlib.metadata import version;
+        print(version('grelmicro'))"`
+      placeholder: 0.32.6
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Python version and operating system
+      description: '`python --version` and the platform you run on.'
+      placeholder: Python 3.13.1 on Ubuntu 24.04
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend
+      description: The provider behind the pattern that misbehaves.
+      options:
+        - Memory
+        - Redis
+        - Valkey
+        - Postgres
+        - SQLite
+        - None or not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: >-
+        The smallest snippet that shows the problem. Include every import
+        so it runs as pasted.
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What happened instead, with the full traceback or log output.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/grelinfo/grelmicro/security/advisories/new
+    about: Report a vulnerability privately. Never open a public issue for one.
+  - name: Documentation
+    url: https://grelmicro.grel.info
+    about: Read the docs first. Most usage questions are answered there.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Suggest a new capability or an improvement to an existing one.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem you hit first and the API you would like
+        second. See the
+        [reporting guide](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#requesting-a-feature)
+        for how requests are triaged.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: >-
+        What are you trying to do, and where does grelmicro get in the way?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: >-
+        The API you would like, written as the code you would want to
+        write.
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: >-
+        What you do today instead, and why it falls short.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,56 @@ ergonomics as [FastAPI](https://fastapi.tiangolo.com/) and
 [Pydantic](https://docs.pydantic.dev/). When in doubt, imitate those
 two projects.
 
+## Reporting a bug
+
+Open a bug report at
+<https://github.com/grelinfo/grelmicro/issues/new/choose>. Anyone with
+a GitHub account can file one. There is no mailing list and no other
+channel to learn.
+
+Search the
+[existing issues](https://github.com/grelinfo/grelmicro/issues?q=is%3Aissue)
+first, so a known problem keeps one thread instead of three.
+
+The bug report form asks for what a fix needs:
+
+- The grelmicro version. Print it with
+  `python -c "from importlib.metadata import version; print(version('grelmicro'))"`.
+- The Python version and the operating system.
+- The backend in use (Memory, Redis, Valkey, Postgres, or SQLite).
+- A minimal snippet that reproduces the problem, plus the full
+  traceback.
+- What you expected to happen instead.
+
+What happens after you file:
+
+- You get a reply within a few days.
+- A confirmed bug is labelled `bug` and given a `priority:high`,
+  `priority:medium`, or `priority:low` label.
+- A report that turns out to be a usage question or a documentation
+  gap is relabelled and answered in the same thread.
+- Fixes ship in the next patch release, and the issue closes when that
+  release publishes.
+
+Every report stays public and searchable in the
+[issue archive](https://github.com/grelinfo/grelmicro/issues?q=is%3Aissue),
+open and closed alike.
+
+Security issues are the one exception. Report a vulnerability
+privately through the
+[security policy](https://github.com/grelinfo/grelmicro/security/policy),
+never in a public issue.
+
+## Requesting a feature
+
+Open a feature request at the same address,
+<https://github.com/grelinfo/grelmicro/issues/new/choose>. Describe the
+problem you hit first and the API you would like second. Feature
+requests get the same reply window as bug reports. Accepted ones are
+labelled `enhancement` and prioritised alongside everything else. See
+[Issues and releases](#issues-and-releases) for how those labels drive
+a release.
+
 ## Quick start
 
 ```bash

--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -34,6 +34,13 @@ Draft copy lives in this file's history; refine per channel. Do not cross-post t
 `ossf/scorecard-action` on a weekly schedule and on push to `main` with
 `publish_results: true`, and stays off pull-request triggers so it never gates PR CI.
 
+**OpenSSF Best Practices: passing at 100%.** [Project 13655](https://www.bestpractices.dev/projects/13655).
+The last criterion to close was `report_process`, which needs a URL documenting how
+users submit bug reports. `CONTRIBUTING.md#reporting-a-bug` is that URL, backed by the
+GitHub issue forms under `.github/ISSUE_TEMPLATE/`. The self-certification is a
+questionnaire, so a criterion that stops being true only goes stale if the answers are
+never revisited. Re-check it when the reporting or release process changes.
+
 **SLSA Build L2: live.** `release.yml` runs `actions/attest-build-provenance` on the
 built artifacts, then `gh attestation verify` on each one before the release completes.
 Provenance is signed on GitHub infrastructure separate from the build job, which is

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   <a href="https://github.com/astral-sh/ruff"><img alt="Ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
   <a href="https://github.com/astral-sh/ty"><img alt="ty" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/grelinfo/grelmicro"><img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/grelinfo/grelmicro/badge"></a>
+  <a href="https://www.bestpractices.dev/projects/13655"><img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/13655/badge"></a>
   <a href="https://slsa.dev/spec/latest/levels"><img alt="SLSA Build Level 2" src="https://slsa.dev/images/gh-badge-level2.svg"></a>
 </p>
 
@@ -289,7 +290,7 @@ For multiple Redis instances, separate names, or test overrides, see the [docs](
 
 ## Contributing
 
-Report bugs and request features in [GitHub issues](https://github.com/grelinfo/grelmicro/issues). Search the open issues first, then include the grelmicro version and the steps to reproduce.
+Report bugs and request features in [GitHub issues](https://github.com/grelinfo/grelmicro/issues/new/choose). The [reporting guide](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#reporting-a-bug) lists what to include and what happens after you file.
 
 To contribute code or docs, read the [contributing guide](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md). It explains the pull request process and the requirements for acceptable contributions: the development setup, the code style, and the pre-merge checklist.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,9 +4,9 @@
 
 ### Docs
 
-* 📝 Document how to report a bug: where to file, what a report needs, and what happens after you file it. ([#588](https://github.com/grelinfo/grelmicro/pull/588))
-* 📝 Add GitHub issue forms for bug reports and feature requests, so a report arrives with the version, the backend, and a runnable reproduction. ([#588](https://github.com/grelinfo/grelmicro/pull/588))
-* 📝 Add the OpenSSF Best Practices badge, now passing at 100%. ([#588](https://github.com/grelinfo/grelmicro/pull/588))
+* 📝 Document how to report a bug: where to file, what a report needs, and what happens after you file it. ([#592](https://github.com/grelinfo/grelmicro/pull/592))
+* 📝 Add GitHub issue forms for bug reports and feature requests, so a report arrives with the version, the backend, and a runnable reproduction. ([#592](https://github.com/grelinfo/grelmicro/pull/592))
+* 📝 Add the OpenSSF Best Practices badge, now passing at 100%. ([#592](https://github.com/grelinfo/grelmicro/pull/592))
 
 ## 0.32.6 - 2026-07-29
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Docs
+
+* 📝 Document how to report a bug: where to file, what a report needs, and what happens after you file it. ([#588](https://github.com/grelinfo/grelmicro/pull/588))
+* 📝 Add GitHub issue forms for bug reports and feature requests, so a report arrives with the version, the backend, and a runnable reproduction. ([#588](https://github.com/grelinfo/grelmicro/pull/588))
+* 📝 Add the OpenSSF Best Practices badge, now passing at 100%. ([#588](https://github.com/grelinfo/grelmicro/pull/588))
+
 ## 0.32.6 - 2026-07-29
 
 ### Fixed

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@
   <a href="https://github.com/astral-sh/ruff"><img alt="Ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
   <a href="https://github.com/astral-sh/ty"><img alt="ty" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/grelinfo/grelmicro"><img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/grelinfo/grelmicro/badge"></a>
+  <a href="https://www.bestpractices.dev/projects/13655"><img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/13655/badge"></a>
   <a href="https://slsa.dev/spec/latest/levels"><img alt="SLSA Build Level 2" src="https://slsa.dev/images/gh-badge-level2.svg"></a>
 </p>
 
@@ -289,7 +290,7 @@ For multiple Redis instances, separate names, or test overrides, see the [docs](
 
 ## Contributing
 
-Report bugs and request features in [GitHub issues](https://github.com/grelinfo/grelmicro/issues). Search the open issues first, then include the grelmicro version and the steps to reproduce.
+Report bugs and request features in [GitHub issues](https://github.com/grelinfo/grelmicro/issues/new/choose). The [reporting guide](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#reporting-a-bug) lists what to include and what happens after you file.
 
 To contribute code or docs, read the [contributing guide](https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md). It explains the pull request process and the requirements for acceptable contributions: the development setup, the code style, and the pre-merge checklist.
 


### PR DESCRIPTION
Closes the last open OpenSSF Best Practices criterion, `report_process`: "The project MUST provide a process for users to submit bug reports (e.g., using an issue tracker or a mailing list). (URL required)".

The URL that answers it:

https://github.com/grelinfo/grelmicro/blob/main/CONTRIBUTING.md#reporting-a-bug

## What changed

- **`CONTRIBUTING.md`**: new `## Reporting a bug` and `## Requesting a feature` sections, placed before the dev setup so a user filing a report does not scroll past it. Covers where to file, what a report needs, what happens after (reply window, labelling, when the issue closes), and the public issue archive.
- **`.github/ISSUE_TEMPLATE/`**: issue forms for bug reports (version, Python and OS, backend, reproduction, expected, actual) and feature requests (problem, proposal, alternatives). Blank issues stay enabled. A contact link routes vulnerabilities to the private advisory form.
- **`README.md`**: the Best Practices badge next to Scorecard, and the contributing line now points at the issue chooser plus the reporting guide.
- **`LAUNCH_CHECKLIST.md`**: records the badge as passing with project ID 13655, and notes that self-certification goes stale silently, unlike the SLSA claim the release enforces on every run.

The project now passes at 100%: https://www.bestpractices.dev/projects/13655

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b