### PR TITLE
✨ Add IdempotencyMiddleware to replay an HTTP response on a repeated key

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Features
+
+* ✨ Add `IdempotencyMiddleware`. A request carrying an `Idempotency-Key` header runs once, and a retry replays the stored response without reaching the handler. Pure ASGI, so it works on FastAPI, Starlette, and Litestar alike. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
+* ✨ Bound the single-flight wait with `wait_timeout=` on an `Idempotency` block. A duplicate that waits longer than that raises `IdempotencyWaitTimeoutError`, which subclasses `TimeoutError`, instead of holding the caller indefinitely. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
+
+### Fixed
+
+* 🐛 Release the single-flight lock correctly when an `Idempotency` block is cancelled while acquiring it. The lock was bound to the block before it was held, so the cleanup path tried to release a lock the block did not own and raised `LockNotOwnedError` over the original error. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
+* 🐛 Release the in-process idempotency lock even when the distributed release is cancelled mid-flight. A cancellation there left the key locked for the life of the process. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
+
 ### Docs
 
 * 📝 Document how to report a bug: where to file, what a report needs, and what happens after you file it. ([#592](https://github.com/grelinfo/grelmicro/pull/592))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@
 * ✨ Add `IdempotencyMiddleware`. A request carrying an `Idempotency-Key` header runs once, and a retry replays the stored response without reaching the handler. Pure ASGI, so it works on FastAPI, Starlette, and Litestar alike. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 * ✨ Bound the single-flight wait with `wait_timeout=` on an `Idempotency` block. A duplicate that waits longer than that raises `IdempotencyWaitTimeoutError`, which subclasses `TimeoutError`, instead of holding the caller indefinitely. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 
+* ✨ Add `document_idempotency(app)`, which describes the installed `IdempotencyMiddleware` in the OpenAPI schema. A middleware is invisible to the generated schema, so a client built from it never learns the header exists. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
+
 ### Fixed
 
 * 🐛 Release the single-flight lock correctly when an `Idempotency` block is cancelled while acquiring it. The lock was bound to the block before it was held, so the cleanup path tried to release a lock the block did not own and raised `LockNotOwnedError` over the original error. ([#503](https://github.com/grelinfo/grelmicro/issues/503))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@
 ### Features
 
 * ✨ Add `IdempotencyMiddleware`. A request carrying an `Idempotency-Key` header runs once, and a retry replays the stored response without reaching the handler. Pure ASGI, so it works on FastAPI, Starlette, and Litestar alike. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
-* ✨ Bound the single-flight wait with `wait_timeout=` on an `Idempotency` block. A duplicate that waits longer than that raises `IdempotencyWaitTimeoutError`, which subclasses `TimeoutError`, instead of holding the caller indefinitely. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
+* ✨ Bound the single-flight wait with `wait_timeout=` on an `Idempotency` block and on `run()`. A duplicate that waits longer than that raises `IdempotencyWaitTimeoutError`, which subclasses `TimeoutError`, instead of holding the caller indefinitely. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 
 * ✨ Add `document_idempotency(app)`, which describes the installed `IdempotencyMiddleware` in the OpenAPI schema. A middleware is invisible to the generated schema, so a client built from it never learns the header exists. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -179,7 +179,7 @@ Fingerprinting buffers the request body before the handler runs, so it is off by
 
 ### OpenAPI
 
-The middleware runs below the routing layer, so nothing it does reaches the generated schema. A client built from that schema never learns the header exists. `document_idempotency` fixes that:
+The middleware runs outside the routing layer, so nothing it does reaches the generated schema. A client built from that schema never learns the header exists. `document_idempotency` fixes that:
 
 ```python
 from grelmicro.integrations.fastapi import (
@@ -192,7 +192,7 @@ micro.install(app)
 document_idempotency(app)
 ```
 
-Every operation the middleware covers gains the `Idempotency-Key` header parameter and the responses the middleware itself returns. Call order does not matter, and routes added afterwards are covered too.
+Every operation the middleware covers gains the `Idempotency-Key` header parameter and the responses the middleware itself returns. Call it any time after `add_middleware`, and routes added afterwards are covered too.
 
 An operation that already declares the header keeps its own declaration. The `422` that FastAPI generates for request validation keeps its schema and gains the idempotency case in its description, so neither is lost.
 
@@ -288,7 +288,7 @@ With a lock backend, two replicas that receive the same key at the same time run
 
 ### Bounding the wait
 
-The wait is unbounded by default. Pass `wait_timeout=` to bound it. Past it the block raises `IdempotencyWaitTimeoutError`, which subclasses `TimeoutError`.
+The wait is unbounded by default. Pass `wait_timeout=` to bound it, on the block or on `run()`. Past it the wait raises `IdempotencyWaitTimeoutError`, which subclasses `TimeoutError`.
 
 ```python
 from grelmicro.idempotency import IdempotencyWaitTimeoutError

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -6,6 +6,7 @@ This pairs with retries. Wrap a call in `Retry`, mark the operation idempotent, 
 
 - **[Idempotency](#the-block-form)**: an explicit block that runs the work once and replays it on repeat.
 - **[@idempotent](#decorator)**: a decorator that derives the key from the call arguments.
+- **[IdempotencyMiddleware](#http-middleware)**: replays a whole HTTP response when a request repeats its `Idempotency-Key` header.
 
 ## Quick start
 
@@ -40,6 +41,159 @@ async def charge(
 ```
 
 The first request with a given key runs `do_charge` and stores the response. Any later request with the same key replays that response without charging again.
+
+## HTTP middleware
+
+The quick start reads the key and opens a block in every handler that needs one. `IdempotencyMiddleware` does it once, for the whole app.
+
+```python title="middleware.py"
+--8<-- "idempotency/middleware.py"
+```
+
+Handlers stay as they are. There is no key parameter to thread through and no block to open.
+
+Add the middleware before `micro.install(app)`. The framework runs the last middleware added first, so installing last puts the grelmicro request scope outside the middleware, which is what lets it resolve the `Cache` backend.
+
+### What a client sees
+
+The first request runs the handler and gets the ordinary response:
+
+```http
+POST /charge?amount=100 HTTP/1.1
+Idempotency-Key: 5f9d2c1e
+
+HTTP/1.1 200 OK
+content-type: application/json
+
+{"amount":100}
+```
+
+The retry never reaches the handler:
+
+```http
+POST /charge?amount=100 HTTP/1.1
+Idempotency-Key: 5f9d2c1e
+
+HTTP/1.1 200 OK
+content-type: application/json
+idempotent-replayed: true
+
+{"amount":100}
+```
+
+Same status, same body, and the same headers the handler set. The `idempotent-replayed` header is the one addition, so a client can tell a replay from a fresh run.
+
+A request without the header passes straight through. Adding the middleware changes nothing until a client opts in.
+
+### Errors replay too
+
+Every response the app returns is stored, `4xx` and `5xx` included. A handler that writes to the database and then fails on the way out leaves a stored failure, so the retry gets that instead of running the write again.
+
+A handler that raises an unhandled exception is different. The framework turns it into a `500` outside the middleware, so nothing is stored and a retry runs fresh. A raised `HTTPException` is not an unhandled exception. The framework turns it into a response inside the middleware, so it is stored and replayed like any other.
+
+### What is never stored
+
+Four kinds of response, and each one lets a retry run the handler again:
+
+| Response | Reason |
+|---|---|
+| Carries `Set-Cookie` | Replaying it hands one caller another caller's session. |
+| Carries `Content-Encoding` | The stored bytes would reach a client that never negotiated that encoding. Add the middleware before any compression middleware. |
+| Declares trailers | Trailers cannot be replayed faithfully. |
+| Body over `max_body_size` (1 MiB) | A large response passes through instead of being held in memory. |
+
+All four are logged at warning level. Watch for those warnings: a response that was not stored means the next retry runs the handler again.
+
+Everything else is stored whatever its content type, so a `201 Created` with an empty body and a `Location` header replays like any other response.
+
+The response streams to the client as the handler produces it. The copy is buffered alongside and written to the cache after the last chunk is sent.
+
+### Custom rules with `skip`
+
+`skip` receives the finished response and returns `True` to leave it unstored. It mirrors [`skip` on `@cached`](cache.md#decorator-parameters).
+
+```python
+app.add_middleware(
+    IdempotencyMiddleware,
+    idempotency=Idempotency("http"),
+    skip=lambda response: response["status"] == 202,
+)
+```
+
+Use it for a response that is technically replayable but should not be. The four rules above run first, so `skip` never has to re-check them.
+
+### Keys are scoped per route
+
+The stored key combines the method, the path, the query string, and the header value. The same client key on `POST /charge` and `POST /refund` stores two entries, so one route never replays another one's response.
+
+!!! warning "Set `key_maker` in a multi-tenant app"
+    Without it, any client that learns another client's key replays their response, body included. Fold the caller identity into the key.
+
+    ```python
+    def tenant_key(scope, key):
+        tenant = dict(scope["headers"])[b"x-tenant"].decode()
+        return f"{tenant}|{scope['path']}|{key}"
+
+
+    app.add_middleware(
+        IdempotencyMiddleware,
+        idempotency=Idempotency("http"),
+        key_maker=tenant_key,
+    )
+    ```
+
+    Read the identity from wherever your authentication puts it. `scope["user"]` works only when an authentication middleware runs outside this one.
+
+`key_maker` receives the ASGI scope and the client's key, and returns the whole stored key. It mirrors [`key_maker` on `@cached`](cache.md#custom-keys).
+
+### Duplicates in flight
+
+A duplicate that arrives while the first execution is still running waits for it, then replays its response.
+
+The wait folds duplicates across replicas when a `Coordination` lock backend is configured, and in-process otherwise. See [Single-flight duplicates](#single-flight-duplicates).
+
+The wait is bounded by `wait_timeout`, ten seconds by default:
+
+```http
+HTTP/1.1 409 Conflict
+retry-after: 1
+
+{"detail": "A request with this Idempotency-Key is still in flight. Retry shortly."}
+```
+
+Past the timeout the duplicate receives that instead of holding the connection open.
+
+### Conflicting payloads
+
+Pass `fingerprint_body=True` to hash the request body and store the hash with the response. A key reused with a different body then gets `422 Unprocessable Content` instead of a wrong replay, matching the [Idempotency-Key header draft](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/).
+
+```python
+app.add_middleware(
+    IdempotencyMiddleware,
+    idempotency=Idempotency("http"),
+    fingerprint_body=True,
+)
+```
+
+Fingerprinting buffers the request body before the handler runs, so it is off by default. A request body over `max_body_size` is answered with `413`.
+
+### Background tasks
+
+A background task runs after the response is sent, so the response is stored and replayable while the task is still working. A replay can land before the original request's background work finishes. Put anything a retry must not repeat in the handler, not in a background task.
+
+### Middleware parameters
+
+| Parameter | Default | Behaviour |
+|---|---|---|
+| `idempotency` | required | The `Idempotency` that stores responses. Its `ttl` sets the replay window. |
+| `header` | `"Idempotency-Key"` | Request header carrying the key. |
+| `methods` | `("POST",)` | Methods that take a key. Every other method passes through. |
+| `key_maker` | `None` | Build the stored key from the scope and the client key. Set it in any multi-tenant app. |
+| `skip` | `None` | Predicate over the finished response. Return `True` to not store it. |
+| `require_key` | `False` | Answer `400` when a matched method arrives without the header. |
+| `fingerprint_body` | `False` | Hash the request body and answer `422` on a reused key with a different body. |
+| `max_body_size` | `1048576` | Largest body held in memory, in bytes. Caps the stored response, and the fingerprinted request. |
+| `wait_timeout` | `10.0` | Seconds a duplicate waits for an execution in flight before `409`. |
 
 ## Storage
 
@@ -109,6 +263,22 @@ micro = Grelmicro(uses=[Cache(redis), Coordination(redis)])
 ```
 
 With a lock backend, two replicas that receive the same key at the same time run the work once and both return the same response.
+
+### Bounding the wait
+
+The wait is unbounded by default. Pass `wait_timeout=` to bound it. Past it the block raises `IdempotencyWaitTimeoutError`, which subclasses `TimeoutError`.
+
+```python
+from grelmicro.idempotency import IdempotencyWaitTimeoutError
+
+try:
+    async with idem(key, wait_timeout=5) as op:
+        ...
+except IdempotencyWaitTimeoutError:
+    ...  # an execution for this key is still in flight
+```
+
+[IdempotencyMiddleware](#http-middleware) bounds it at ten seconds and answers `409`.
 
 ## Payload fingerprint
 

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -177,6 +177,28 @@ app.add_middleware(
 
 Fingerprinting buffers the request body before the handler runs, so it is off by default. A request body over `max_body_size` is answered with `413`.
 
+### OpenAPI
+
+The middleware runs below the routing layer, so nothing it does reaches the generated schema. A client built from that schema never learns the header exists. `document_idempotency` fixes that:
+
+```python
+from grelmicro.integrations.fastapi import (
+    IdempotencyMiddleware,
+    document_idempotency,
+)
+
+app.add_middleware(IdempotencyMiddleware, idempotency=Idempotency("http"))
+micro.install(app)
+document_idempotency(app)
+```
+
+Every operation the middleware covers gains the `Idempotency-Key` header parameter and the responses the middleware itself returns. Call order does not matter, and routes added afterwards are covered too.
+
+An operation that already declares the header keeps its own declaration. The `422` that FastAPI generates for request validation keeps its schema and gains the idempotency case in its description, so neither is lost.
+
+!!! note "Mounted sub-applications"
+    A mounted sub-application builds its own schema. Call `document_idempotency` on it as well.
+
 ### Background tasks
 
 A background task runs after the response is sent, so the response is stored and replayable while the task is still working. A replay can land before the original request's background work finishes. Put anything a retry must not repeat in the handler, not in a background task.

--- a/docs/reference/fastapi.md
+++ b/docs/reference/fastapi.md
@@ -1,12 +1,14 @@
 # FastAPI
 
 - **Start here**: [Request handlers and the ambient scope](../architecture/backends.md#request-handlers-and-the-ambient-scope)
-- **Common recipes**: `app.add_middleware(GrelmicroMiddleware, micro=micro)` binds the active app inside request handlers, so patterns resolve their backends ambiently without explicit `backend=` wiring. `health_router()` adds the `/livez`, `/readyz`, and `/healthz` endpoints.
+- **Common recipes**: `app.add_middleware(GrelmicroMiddleware, micro=micro)` binds the active app inside request handlers, so patterns resolve their backends ambiently without explicit `backend=` wiring. `health_router()` adds the `/livez`, `/readyz`, and `/healthz` endpoints. `app.add_middleware(IdempotencyMiddleware, idempotency=Idempotency("http"))` replays a stored response when a request repeats its `Idempotency-Key`.
 
 ::: grelmicro.integrations.fastapi
     options:
       members:
         - GrelmicroMiddleware
+        - IdempotencyMiddleware
+        - StoredResponse
         - health_router
         - CheckResultResponse
         - HealthzResponse

--- a/docs/reference/fastapi.md
+++ b/docs/reference/fastapi.md
@@ -9,6 +9,7 @@
         - GrelmicroMiddleware
         - IdempotencyMiddleware
         - StoredResponse
+        - document_idempotency
         - health_router
         - CheckResultResponse
         - HealthzResponse

--- a/docs/snippets/idempotency/middleware.py
+++ b/docs/snippets/idempotency/middleware.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI
+
+from grelmicro import Grelmicro
+from grelmicro.cache import Cache
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.idempotency import Idempotency
+from grelmicro.integrations.fastapi import IdempotencyMiddleware
+
+micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+app = FastAPI()
+
+app.add_middleware(
+    IdempotencyMiddleware, idempotency=Idempotency("http", ttl=3600)
+)
+# Install last, so the grelmicro request scope wraps the middleware.
+micro.install(app)
+
+
+@app.post("/charge")
+async def charge(amount: int) -> dict[str, int]:
+    # A retry carrying the same Idempotency-Key replays this response.
+    return {"amount": amount}

--- a/grelmicro/idempotency/__init__.py
+++ b/grelmicro/idempotency/__init__.py
@@ -19,6 +19,7 @@ from grelmicro.idempotency.errors import (
     IdempotencyError,
     IdempotencySettingsValidationError,
     IdempotencyStateError,
+    IdempotencyWaitTimeoutError,
 )
 
 __all__ = [
@@ -28,6 +29,7 @@ __all__ = [
     "IdempotencyError",
     "IdempotencySettingsValidationError",
     "IdempotencyStateError",
+    "IdempotencyWaitTimeoutError",
     "Operation",
     "idempotent",
 ]

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -23,6 +23,7 @@ from grelmicro.idempotency.errors import (
     IdempotencyConflictError,
     IdempotencySettingsValidationError,
     IdempotencyStateError,
+    IdempotencyWaitTimeoutError,
 )
 from grelmicro.metrics import _emit
 
@@ -113,11 +114,13 @@ class _Block(Generic[T]):
         idempotency: Idempotency[T],
         key: str,
         fingerprint: str | None,
+        wait_timeout: float | None = None,
     ) -> None:
         """Initialize the block."""
         self._idempotency = idempotency
         self._key = key
         self._fingerprint = fingerprint
+        self._wait_timeout = wait_timeout
         self._operation: Operation[T] | None = None
         self._local_lock: Any = None
         self._distributed_lock: Lock | None = None
@@ -130,7 +133,11 @@ class _Block(Generic[T]):
                 Pass `cache=`, register a `Cache` Component, or run the
                 call inside `async with micro:` or after
                 `micro.install(app)`.
+            IdempotencyWaitTimeoutError: `wait_timeout` elapsed while an
+                execution already in flight held the single-flight lock.
         """
+        import asyncio  # noqa: PLC0415
+
         from grelmicro._app import (  # noqa: PLC0415
             ComponentNotRegisteredError,
             NoActiveAppError,
@@ -165,48 +172,66 @@ class _Block(Generic[T]):
             return self._operation
 
         guard = self._idempotency._guard  # noqa: SLF001
-        self._local_lock = await guard.get_lock(self._key)
-        await self._local_lock.acquire()
         try:
-            replay = await self._idempotency._replay(  # noqa: SLF001
-                self._key, self._fingerprint
-            )
-            if replay is not _SENTINEL:
-                self._local_lock.release()
-                self._local_lock = None
-                _emit.incr(
-                    "grelmicro.idempotency.operations",
-                    **{
-                        "idempotency.name": self._idempotency._name,  # noqa: SLF001
-                        "result": "replay",
-                    },
-                )
-                self._operation = Operation(replayed=True, response=replay)
-                return self._operation
+            async with asyncio.timeout(self._wait_timeout) as scope:
+                self._local_lock = await guard.get_lock(self._key)
+                await self._local_lock.acquire()
+                try:
+                    replay = await self._idempotency._replay(  # noqa: SLF001
+                        self._key, self._fingerprint
+                    )
+                    if replay is not _SENTINEL:
+                        self._local_lock.release()
+                        self._local_lock = None
+                        _emit.incr(
+                            "grelmicro.idempotency.operations",
+                            **{
+                                "idempotency.name": self._idempotency._name,  # noqa: SLF001
+                                "result": "replay",
+                            },
+                        )
+                        self._operation = Operation(
+                            replayed=True, response=replay
+                        )
+                        return self._operation
 
-            if _has_lock_backend():
-                self._distributed_lock = Lock(
-                    _stampede_lock_name(
-                        self._idempotency._scoped(self._key)  # noqa: SLF001
-                    )
-                )
-                await self._distributed_lock.acquire()
-                replay = await self._idempotency._replay(  # noqa: SLF001
-                    self._key, self._fingerprint
-                )
-                if replay is not _SENTINEL:
+                    if _has_lock_backend():
+                        # Bound to the block only once held, so a failed or
+                        # cancelled acquire never sends `_release` at a lock
+                        # this block does not own.
+                        lock = Lock(
+                            _stampede_lock_name(
+                                self._idempotency._scoped(self._key)  # noqa: SLF001
+                            )
+                        )
+                        await lock.acquire()
+                        self._distributed_lock = lock
+                        replay = await self._idempotency._replay(  # noqa: SLF001
+                            self._key, self._fingerprint
+                        )
+                        if replay is not _SENTINEL:
+                            await self._release()
+                            _emit.incr(
+                                "grelmicro.idempotency.operations",
+                                **{
+                                    "idempotency.name": self._idempotency._name,  # noqa: SLF001
+                                    "result": "replay",
+                                },
+                            )
+                            self._operation = Operation(
+                                replayed=True, response=replay
+                            )
+                            return self._operation
+                except BaseException:
                     await self._release()
-                    _emit.incr(
-                        "grelmicro.idempotency.operations",
-                        **{
-                            "idempotency.name": self._idempotency._name,  # noqa: SLF001
-                            "result": "replay",
-                        },
-                    )
-                    self._operation = Operation(replayed=True, response=replay)
-                    return self._operation
-        except BaseException:
-            await self._release()
+                    raise
+        except TimeoutError:
+            if scope.expired():
+                raise IdempotencyWaitTimeoutError(
+                    name=self._idempotency._name,  # noqa: SLF001
+                    key=self._key,
+                    timeout=cast("float", self._wait_timeout),
+                ) from None
             raise
 
         _emit.incr(
@@ -243,13 +268,20 @@ class _Block(Generic[T]):
             await self._release()
 
     async def _release(self) -> None:
-        """Release the distributed and in-process locks, in that order."""
-        if self._distributed_lock is not None:
-            await self._distributed_lock.release()
-            self._distributed_lock = None
-        if self._local_lock is not None:
-            self._local_lock.release()
-            self._local_lock = None
+        """Release the distributed and in-process locks, in that order.
+
+        The in-process release runs even when the distributed release is
+        cancelled mid-flight, so a key never stays locked for the life of
+        the process.
+        """
+        try:
+            if self._distributed_lock is not None:
+                await self._distributed_lock.release()
+                self._distributed_lock = None
+        finally:
+            if self._local_lock is not None:
+                self._local_lock.release()
+                self._local_lock = None
 
 
 class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
@@ -473,6 +505,19 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
                 """,
             ),
         ] = None,
+        wait_timeout: Annotated[
+            float | None,
+            Doc(
+                """
+                Seconds to wait for a duplicate that is still in flight.
+
+                A duplicate arriving mid-flight waits for the first
+                execution to finish, then replays its response. When the
+                wait exceeds this many seconds, `TimeoutError` is raised
+                instead. When None (the default), the wait is unbounded.
+                """,
+            ),
+        ] = None,
     ) -> _Block[T]:
         """Open an idempotent block for `key`.
 
@@ -483,6 +528,7 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
             self,
             key,
             fingerprint if fingerprint is not None else self._fingerprint,
+            wait_timeout,
         )
 
     async def run(

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -557,6 +557,17 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
                 """,
             ),
         ] = None,
+        wait_timeout: Annotated[
+            float | None,
+            Doc(
+                """
+                Seconds to wait for a duplicate that is still in flight.
+
+                Past it, `IdempotencyWaitTimeoutError` is raised instead.
+                When None (the default), the wait is unbounded.
+                """,
+            ),
+        ] = None,
     ) -> T:
         """Run an operation once for `key`, then replay its response.
 
@@ -568,7 +579,9 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
         """
         import asyncio  # noqa: PLC0415
 
-        async with self(key, fingerprint=fingerprint) as operation:
+        async with self(
+            key, fingerprint=fingerprint, wait_timeout=wait_timeout
+        ) as operation:
             if operation.replayed:
                 return operation.result()
             response = factory()

--- a/grelmicro/idempotency/errors.py
+++ b/grelmicro/idempotency/errors.py
@@ -22,6 +22,25 @@ class IdempotencyStateError(IdempotencyError, RuntimeError):
     """
 
 
+class IdempotencyWaitTimeoutError(IdempotencyError, TimeoutError):
+    """Raised when a duplicate waits past `wait_timeout` for the first execution.
+
+    Subclasses `TimeoutError`, so an `except TimeoutError` around the
+    block catches it. Catch this instead to tell a single-flight wait
+    apart from a backend that timed out inside the block.
+    """
+
+    def __init__(self, *, name: str, key: str, timeout: float) -> None:
+        """Initialize the error."""
+        self.name = name
+        self.key = key
+        self.timeout = timeout
+        super().__init__(
+            f"Idempotency({name!r}) waited {timeout}s for an execution "
+            f"already in flight: key={key!r}"
+        )
+
+
 class IdempotencyConflictError(IdempotencyError):
     """Raised when a key is replayed with a different payload fingerprint.
 

--- a/grelmicro/integrations/fastapi.py
+++ b/grelmicro/integrations/fastapi.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
         Sequence,
     )
 
-    from fastapi import APIRouter
+    from fastapi import APIRouter, FastAPI
     from fastapi.params import Depends
     from starlette.applications import Starlette
 
@@ -47,6 +47,7 @@ __all__ = [
     "HealthzResponse",
     "IdempotencyMiddleware",
     "StoredResponse",
+    "document_idempotency",
     "health_router",
     "install",
 ]
@@ -531,6 +532,196 @@ class IdempotencyMiddleware:
             parts.append(query.decode("latin-1"))
         parts.append(key)
         return _KEY_SEPARATOR.join(parts)
+
+
+_OPERATION_METHODS = frozenset(
+    {
+        "get",
+        "put",
+        "post",
+        "delete",
+        "options",
+        "head",
+        "patch",
+        "trace",
+    }
+)
+"""Path item keys that are operations, as opposed to `parameters` or `servers`."""
+
+
+def document_idempotency(
+    app: Annotated[
+        "FastAPI",
+        Doc("The app carrying an `IdempotencyMiddleware` to document."),
+    ],
+) -> None:
+    """Describe the installed `IdempotencyMiddleware` in the OpenAPI schema.
+
+    A middleware runs below the routing layer, so nothing it does reaches
+    the generated schema and a client built from that schema never learns
+    the header exists. This reads the installed middleware and annotates
+    every operation it covers with the header parameter and the responses
+    the middleware itself can return.
+
+    ```python
+    from grelmicro.integrations.fastapi import (
+        IdempotencyMiddleware,
+        document_idempotency,
+    )
+
+    app.add_middleware(IdempotencyMiddleware, idempotency=Idempotency("http"))
+    micro.install(app)
+    document_idempotency(app)
+    ```
+
+    Call order does not matter. The schema is annotated the next time it
+    is built, so routes added afterwards are covered too.
+
+    An operation that already declares the header keeps its own
+    declaration. A `422` that FastAPI generated for request validation
+    keeps its schema, and the idempotency case is added to its
+    description.
+
+    A mounted sub-application builds its own schema, which this does not
+    reach. Call it on the sub-application as well.
+
+    Raises:
+        DependencyNotFoundError: If `fastapi` is not installed.
+        TypeError: If `app` is not a `FastAPI` app, or carries no
+            `IdempotencyMiddleware`.
+    """
+    try:
+        from fastapi import FastAPI as _FastAPI  # noqa: PLC0415
+    except ImportError:
+        from grelmicro.errors import (  # noqa: PLC0415
+            DependencyNotFoundError,
+        )
+
+        raise DependencyNotFoundError(module="fastapi") from None
+
+    if not isinstance(app, _FastAPI):
+        msg = (
+            f"document_idempotency() needs a FastAPI app, got "
+            f"{type(app).__name__}. Only FastAPI builds an OpenAPI schema."
+        )
+        raise TypeError(msg)
+
+    options = _idempotency_options(app)
+    original = app.openapi
+
+    def openapi() -> dict[str, Any]:
+        schema = original()
+        _annotate_schema(schema, options)
+        return schema
+
+    app.openapi = openapi  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    # Drop a schema built before this call, which would otherwise be
+    # served from the cache without the annotations.
+    app.openapi_schema = None
+
+
+def _idempotency_options(app: "FastAPI") -> dict[str, Any]:
+    """Return the installed middleware's arguments, defaults filled in."""
+    import inspect  # noqa: PLC0415
+
+    for middleware in app.user_middleware:
+        if middleware.cls is IdempotencyMiddleware:
+            # Every parameter after `app` is keyword-only, so `add_middleware`
+            # can only have passed them by keyword.
+            bound = inspect.signature(IdempotencyMiddleware).bind_partial(
+                **middleware.kwargs
+            )
+            bound.apply_defaults()
+            return dict(bound.arguments)
+    msg = (
+        "document_idempotency() found no IdempotencyMiddleware on the app. "
+        "Add it with app.add_middleware(IdempotencyMiddleware, ...) first."
+    )
+    raise TypeError(msg)
+
+
+def _annotate_schema(schema: dict[str, Any], options: dict[str, Any]) -> None:
+    """Add the header and the middleware's responses to covered operations."""
+    methods = {method.lower() for method in options["methods"]}
+    header = options["header"]
+    fingerprint_body = options["fingerprint_body"]
+    parameter = {
+        "name": header,
+        "in": "header",
+        "required": options["require_key"],
+        "schema": {"type": "string", "maxLength": _MAX_KEY_LENGTH},
+        "description": (
+            "Key that makes this request safe to retry. A repeat within the "
+            "replay window returns the first response instead of running the "
+            "operation again."
+        ),
+    }
+    responses = {
+        "400": f"`{header}` is missing or longer than {_MAX_KEY_LENGTH} characters."
+        if options["require_key"]
+        else f"`{header}` is longer than {_MAX_KEY_LENGTH} characters.",
+        "409": (
+            f"A request with this `{header}` is still in flight. Retry after "
+            f"the delay in `Retry-After`."
+        ),
+    }
+    if fingerprint_body:
+        responses["413"] = "Request body too large to fingerprint."
+        responses["422"] = (
+            f"This `{header}` was already used with a different request "
+            f"payload."
+        )
+
+    for path_item in schema.get("paths", {}).values():
+        for method, operation in path_item.items():
+            if method.lower() not in methods & _OPERATION_METHODS:
+                continue
+            _add_parameter(operation, path_item, parameter)
+            for status, description in responses.items():
+                _merge_response(operation, status, description)
+
+
+def _add_parameter(
+    operation: dict[str, Any],
+    path_item: dict[str, Any],
+    parameter: dict[str, Any],
+) -> None:
+    """Add the header parameter unless the operation already declares it.
+
+    OpenAPI keys a parameter by name and location, and forbids the same
+    pair twice, so a declaration already present at either level wins.
+    """
+    name = parameter["name"].lower()
+    declared = [
+        *operation.get("parameters", ()),
+        *path_item.get("parameters", ()),
+    ]
+    if any(
+        existing.get("in") == "header"
+        and str(existing.get("name", "")).lower() == name
+        for existing in declared
+    ):
+        return
+    operation.setdefault("parameters", []).append(parameter)
+
+
+def _merge_response(
+    operation: dict[str, Any], status: str, description: str
+) -> None:
+    """Describe a status the middleware returns, keeping what is there.
+
+    FastAPI generates a `422` carrying the validation error schema. That
+    entry keeps its schema and gains this description, so neither case is
+    lost and a second call adds nothing.
+    """
+    responses = operation.setdefault("responses", {})
+    existing = responses.get(status)
+    if existing is None:
+        responses[status] = {"description": description}
+        return
+    current = existing.get("description", "")
+    if description not in current:
+        existing["description"] = f"{current}\n\n{description}".strip()
 
 
 _OUT_OF_CONTEXT_HINT = (

--- a/grelmicro/integrations/fastapi.py
+++ b/grelmicro/integrations/fastapi.py
@@ -1,22 +1,30 @@
 """FastAPI integration: middleware, install helper, and health router."""
 
+import hashlib
 import logging
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Annotated, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, TypedDict, cast
 
 from pydantic import BaseModel
 from typing_extensions import Doc
 
 from grelmicro._json import json_dumps_bytes
+from grelmicro.errors import OutOfContextError
 from grelmicro.health._checks import HealthChecks
 from grelmicro.health._models import HealthStatus
+from grelmicro.idempotency.errors import (
+    IdempotencyConflictError,
+    IdempotencyWaitTimeoutError,
+)
 
 if TYPE_CHECKING:
     from collections.abc import (
         AsyncIterator,
         Awaitable,
         Callable,
+        Collection,
         MutableMapping,
+        Sequence,
     )
 
     from fastapi import APIRouter
@@ -24,6 +32,7 @@ if TYPE_CHECKING:
     from starlette.applications import Starlette
 
     from grelmicro import Grelmicro
+    from grelmicro.idempotency import Idempotency
     from grelmicro.trace._component import Trace
 
     Scope = MutableMapping[str, Any]
@@ -36,6 +45,8 @@ __all__ = [
     "CheckResultResponse",
     "GrelmicroMiddleware",
     "HealthzResponse",
+    "IdempotencyMiddleware",
+    "StoredResponse",
     "health_router",
     "install",
 ]
@@ -205,6 +216,524 @@ def install(
     else:
         micro._on_ambient_disabled()  # noqa: SLF001
     _instrument_app(app, micro)
+
+
+_MAX_KEY_LENGTH = 255
+"""Longest accepted idempotency key, in characters.
+
+A longer key is answered with `400`.
+"""
+
+_REPLAY_HEADER = b"idempotent-replayed"
+"""Response header marking a replayed response."""
+
+_MIN_CONTENT_STATUS = 200
+"""Lowest status that may carry content."""
+
+_BODYLESS_STATUSES = frozenset({204, 304})
+"""Statuses that carry no content, so a replay sends no Content-Length."""
+
+_KEY_SEPARATOR = "\x1f"
+"""Separator joining the parts of a stored key."""
+
+
+class StoredResponse(TypedDict):
+    """The response `IdempotencyMiddleware` is about to store.
+
+    Handed to `skip` so a handler's own rule decides whether a response
+    replays. `headers` maps lowercased names to their value, keeping the
+    last of a repeated name.
+    """
+
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+
+class _Entry(TypedDict):
+    """A stored response as it rides the cache.
+
+    Header values and the body are `latin-1` strings, which round-trip
+    any byte sequence through the cache serializers without loss.
+    """
+
+    status: int
+    headers: "Sequence[Sequence[str]]"
+    body: str
+
+
+class IdempotencyMiddleware:
+    """Replay a stored HTTP response when a request repeats its idempotency key.
+
+    A request whose method is listed in `methods` and which carries the
+    `header` runs once. A retry with the same key replays the stored
+    status, headers, and body without reaching the handler, and carries
+    `idempotent-replayed: true`. A request without the header passes
+    straight through, so adding the middleware changes nothing until a
+    client opts in.
+
+    ```python
+    from fastapi import FastAPI
+
+    from grelmicro import Grelmicro
+    from grelmicro.idempotency import Idempotency
+    from grelmicro.integrations.fastapi import IdempotencyMiddleware
+
+    micro = Grelmicro(uses=[...])
+    app = FastAPI()
+
+    app.add_middleware(
+        IdempotencyMiddleware, idempotency=Idempotency("http", ttl=3600)
+    )
+    micro.install(app)
+    ```
+
+    Add it before `micro.install(app)`. The framework runs the last
+    middleware added first, so installing last puts the grelmicro request
+    scope outside this middleware, which is what lets it resolve the
+    `Cache` backend.
+
+    A duplicate that arrives while the first execution is in flight waits
+    for it and replays its response. The wait folds across replicas when
+    a `Coordination` lock backend is configured, and in-process
+    otherwise. It is bounded by `wait_timeout`.
+
+    Every response the app returns is stored, errors included. A handler
+    that raises an unhandled exception stores nothing, so the framework's
+    `500` never replays.
+
+    Four kinds of response are not stored, and each one lets a retry
+    re-run the handler: one carrying `Set-Cookie`, one carrying
+    `Content-Encoding`, one declaring trailers, and one whose body is
+    over `max_body_size`. All four are logged. Pass `skip` to add a rule
+    of your own.
+
+    Background tasks run after the response is sent, so a replay can be
+    served while the original request's background work is still in
+    flight.
+
+    The middleware is pure ASGI and works with any ASGI framework
+    (Starlette, Litestar, ...). It acts on `http` scopes and passes every
+    other scope through untouched.
+    """
+
+    def __init__(
+        self,
+        app: Annotated[
+            "ASGIApp",
+            Doc("The next ASGI application in the middleware chain."),
+        ],
+        *,
+        idempotency: Annotated[
+            "Idempotency[Any]",
+            Doc(
+                "The `Idempotency` that stores responses. Its `ttl` sets "
+                "how long a key replays."
+            ),
+        ],
+        header: Annotated[
+            str,
+            Doc("Request header carrying the idempotency key."),
+        ] = "Idempotency-Key",
+        methods: Annotated[
+            "Collection[str]",
+            Doc(
+                "Methods that take an idempotency key. Every other method "
+                "passes through."
+            ),
+        ] = ("POST",),
+        key_maker: Annotated[
+            "Callable[[Scope, str], str] | None",
+            Doc(
+                """
+                Build the stored key from the ASGI scope and the client key.
+
+                Defaults to the method, the path, the query string, and
+                the client key, so two routes never replay each other.
+                **Set this in any multi-tenant app**, folding in the
+                caller identity. Without it a client that learns another
+                client's key replays their response.
+                """
+            ),
+        ] = None,
+        skip: Annotated[
+            "Callable[[StoredResponse], bool] | None",
+            Doc(
+                """
+                Predicate receiving the response. Return `True` to not store it.
+
+                Mirrors `skip` on `@cached`. Use it for a response that
+                is technically replayable but should not be, such as one
+                whose body embeds a timestamp the caller must not see
+                twice. Responses that are never safe to replay are
+                dropped before this runs.
+                """
+            ),
+        ] = None,
+        require_key: Annotated[
+            bool,
+            Doc(
+                "Answer `400` when a method in `methods` arrives without "
+                "the header, instead of passing it through."
+            ),
+        ] = False,
+        fingerprint_body: Annotated[
+            bool,
+            Doc(
+                """
+                Hash the request body and store the hash with the response.
+
+                A key reused with a different body then gets `422` instead
+                of a wrong replay. Buffers the request body before the
+                handler runs, and answers `413` when it is over
+                `max_body_size`.
+                """
+            ),
+        ] = False,
+        max_body_size: Annotated[
+            int,
+            Doc(
+                "Largest body held in memory, in bytes. A larger response "
+                "is sent to the client and not stored. With "
+                "`fingerprint_body`, a larger request body is answered "
+                "with `413`."
+            ),
+        ] = 1024 * 1024,
+        wait_timeout: Annotated[
+            float,
+            Doc(
+                """
+                Seconds a duplicate waits for an execution already in flight.
+
+                Past it the duplicate is answered with `409` and a
+                `Retry-After` header.
+                """
+            ),
+        ] = 10.0,
+    ) -> None:
+        """Initialize the middleware with the idempotency store and policy."""
+        self.app = app
+        self._idempotency = idempotency
+        self._header = header.lower().encode("latin-1")
+        self._header_name = header
+        self._methods = frozenset(method.upper() for method in methods)
+        self._key_maker = key_maker
+        self._skip = skip
+        self._require_key = require_key
+        self._fingerprint_body = fingerprint_body
+        self._max_body_size = max_body_size
+        self._wait_timeout = wait_timeout
+
+    async def __call__(
+        self, scope: "Scope", receive: "Receive", send: "Send"
+    ) -> None:
+        """Replay, execute, or pass the request through."""
+        if scope["type"] != "http" or scope["method"] not in self._methods:
+            await self.app(scope, receive, send)
+            return
+
+        key = _header_value(scope["headers"], self._header)
+        if not key:
+            if self._require_key:
+                await _send_error(
+                    send, 400, f"Missing {self._header_name} header."
+                )
+                return
+            await self.app(scope, receive, send)
+            return
+
+        if len(key) > _MAX_KEY_LENGTH:
+            await _send_error(
+                send,
+                400,
+                f"{self._header_name} exceeds {_MAX_KEY_LENGTH} characters.",
+            )
+            return
+
+        fingerprint = None
+        if self._fingerprint_body:
+            body, too_large, receive = await _buffer_request(
+                receive, self._max_body_size
+            )
+            if too_large:
+                await _send_error(
+                    send, 413, "Request body too large to fingerprint."
+                )
+                return
+            if body is not None:
+                fingerprint = hashlib.sha256(body).hexdigest()
+
+        await self._execute(
+            scope, receive, send, self._storage_key(scope, key), fingerprint
+        )
+
+    async def _execute(
+        self,
+        scope: "Scope",
+        receive: "Receive",
+        send: "Send",
+        storage_key: str,
+        fingerprint: str | None,
+    ) -> None:
+        """Run the request under the idempotency block, or replay it."""
+        block = self._idempotency(
+            storage_key,
+            fingerprint=fingerprint,
+            wait_timeout=self._wait_timeout,
+        )
+        try:
+            operation = await block.__aenter__()
+        except IdempotencyConflictError:
+            await _send_error(
+                send,
+                422,
+                f"{self._header_name} was already used with a different "
+                f"request payload.",
+            )
+            return
+        except IdempotencyWaitTimeoutError:
+            await _send_error(
+                send,
+                409,
+                f"A request with this {self._header_name} is still in "
+                f"flight. Retry shortly.",
+                headers=[(b"retry-after", b"1")],
+            )
+            return
+        except OutOfContextError as exc:
+            raise OutOfContextError(_OUT_OF_CONTEXT_HINT) from exc
+
+        try:
+            if operation.replayed:
+                await _send_stored(
+                    send, operation.result(), head=scope["method"] == "HEAD"
+                )
+            else:
+                capture = _ResponseCapture(
+                    send, self._max_body_size, self._skip
+                )
+                await self.app(scope, receive, capture)
+                if capture.stored is not None:
+                    operation.store(capture.stored)
+        except BaseException as exc:
+            await block.__aexit__(type(exc), exc, exc.__traceback__)
+            raise
+        else:
+            await block.__aexit__(None, None, None)
+
+    def _storage_key(self, scope: "Scope", key: str) -> str:
+        """Build the stored key, scoped by route unless `key_maker` says otherwise."""
+        if self._key_maker is not None:
+            return self._key_maker(scope, key)
+        parts = [scope["method"], scope["path"]]
+        query = scope.get("query_string", b"")
+        if query:
+            parts.append(query.decode("latin-1"))
+        parts.append(key)
+        return _KEY_SEPARATOR.join(parts)
+
+
+_OUT_OF_CONTEXT_HINT = (
+    "IdempotencyMiddleware resolved no cache backend. Add it before "
+    "micro.install(app) so the grelmicro request scope wraps it, register "
+    "a Cache component, or pass an explicit cache= to Idempotency."
+)
+
+
+class _ResponseCapture:
+    """Forward an ASGI response downstream while copying it for storage.
+
+    Each chunk reaches the client as the handler produces it, so storing
+    a response adds no latency. `stored` stays None until the final body
+    message arrives, so a response torn off midway is never replayed.
+    """
+
+    def __init__(
+        self,
+        send: "Send",
+        max_body_size: int,
+        skip: "Callable[[StoredResponse], bool] | None" = None,
+    ) -> None:
+        """Initialize the capture around the downstream `send`."""
+        self._send = send
+        self._max_body_size = max_body_size
+        self._skip = skip
+        self._status = 0
+        self._headers: list[tuple[str, str]] = []
+        self._chunks: list[bytes] = []
+        self._size = 0
+        self._storable = False
+        self.stored: _Entry | None = None
+
+    async def __call__(self, message: "Message") -> None:
+        """Capture the message, then forward it downstream."""
+        if message["type"] == "http.response.start":
+            self._start(message)
+        elif message["type"] == "http.response.body":
+            self._body(message)
+        await self._send(message)
+
+    def _start(self, message: "Message") -> None:
+        """Record the status and headers, and decide whether to store."""
+        blockers: list[str] = []
+        for name, _value in message["headers"]:
+            lowered = name.lower()
+            if lowered == b"set-cookie":
+                blockers.append("Set-Cookie")
+            elif lowered == b"content-encoding":
+                blockers.append("Content-Encoding")
+        if message.get("trailers"):
+            blockers.append("trailers")
+        self._status = message["status"]
+        # Content-Length is recomputed on replay, so a stored value that
+        # drifts from the stored body can never reach a client.
+        self._headers = [
+            (name.decode("latin-1"), value.decode("latin-1"))
+            for name, value in message["headers"]
+            if name.lower() != b"content-length"
+        ]
+        self._storable = not blockers
+        if blockers:
+            _logger.warning(
+                "Idempotent response not stored: it carries %s. A retry with "
+                "the same key will run the handler again.",
+                " and ".join(blockers),
+            )
+
+    def _body(self, message: "Message") -> None:
+        """Accumulate the body, or give up once it outgrows the limit."""
+        if not self._storable:
+            return
+        chunk = message.get("body", b"")
+        self._size += len(chunk)
+        if self._size > self._max_body_size:
+            self._storable = False
+            self._chunks.clear()
+            _logger.warning(
+                "Idempotent response not stored: body exceeds max_body_size "
+                "(%d bytes). A retry with the same key will run the handler "
+                "again.",
+                self._max_body_size,
+            )
+            return
+        self._chunks.append(chunk)
+        if message.get("more_body", False):
+            return
+        body = b"".join(self._chunks)
+        if self._skip is not None and self._skip(
+            StoredResponse(
+                status=self._status,
+                headers=dict(self._headers),
+                body=body,
+            )
+        ):
+            return
+        self.stored = _Entry(
+            status=self._status,
+            headers=self._headers,
+            body=body.decode("latin-1"),
+        )
+
+
+def _header_value(
+    headers: "Sequence[tuple[bytes, bytes]]", name: bytes
+) -> str | None:
+    """Return the first value of `name`, or None when it is absent."""
+    for raw_name, raw_value in headers:
+        if raw_name.lower() == name:
+            return raw_value.decode("latin-1").strip()
+    return None
+
+
+async def _buffer_request(
+    receive: "Receive", max_body_size: int
+) -> "tuple[bytes | None, bool, Receive]":
+    """Read the request body, and return it with a receive that replays it.
+
+    Returns `(body, too_large, receive)`. `body` is None when the client
+    disconnected before the last chunk, so the caller fingerprints
+    nothing rather than hashing a truncated payload as if it were whole.
+    `too_large` reports a body over `max_body_size`, which the caller
+    answers with `413` instead of buffering without bound.
+
+    The returned receive replays the consumed messages one for one,
+    trailing disconnect included, so the app downstream reads exactly
+    what the client sent.
+    """
+    consumed: list[Message] = []
+    chunks: list[bytes] = []
+    size = 0
+    complete = False
+    while True:
+        message = await receive()
+        consumed.append(message)
+        if message["type"] != "http.request":
+            break
+        chunk = message.get("body", b"")
+        size += len(chunk)
+        if size > max_body_size:
+            return None, True, receive
+        chunks.append(chunk)
+        if not message.get("more_body", False):
+            complete = True
+            break
+    pending = iter(consumed)
+
+    async def replay_receive() -> "Message":
+        message = next(pending, None)
+        if message is None:
+            return await receive()
+        return message
+
+    return (b"".join(chunks) if complete else None), False, replay_receive
+
+
+async def _send_stored(send: "Send", stored: _Entry, *, head: bool) -> None:
+    """Send a stored response, marked as a replay.
+
+    Content-Length is recomputed from the stored body, and left off the
+    statuses that carry no content, so a replay stays a valid response.
+    """
+    body = stored["body"].encode("latin-1")
+    status = stored["status"]
+    headers = [
+        (name.encode("latin-1"), value.encode("latin-1"))
+        for name, value in stored["headers"]
+    ]
+    if status >= _MIN_CONTENT_STATUS and status not in _BODYLESS_STATUSES:
+        headers.append((b"content-length", str(len(body)).encode("latin-1")))
+    headers.append((_REPLAY_HEADER, b"true"))
+    await send(
+        {
+            "type": "http.response.start",
+            "status": stored["status"],
+            "headers": headers,
+        }
+    )
+    await send({"type": "http.response.body", "body": b"" if head else body})
+
+
+async def _send_error(
+    send: "Send",
+    status: int,
+    detail: str,
+    *,
+    headers: "Sequence[tuple[bytes, bytes]]" = (),
+) -> None:
+    """Send a JSON error the middleware produced itself."""
+    body = json_dumps_bytes({"detail": detail})
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode("latin-1")),
+                *headers,
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
 
 
 _NO_STORE_HEADERS = {"Cache-Control": "no-store"}

--- a/grelmicro/integrations/fastapi.py
+++ b/grelmicro/integrations/fastapi.py
@@ -534,21 +534,6 @@ class IdempotencyMiddleware:
         return _KEY_SEPARATOR.join(parts)
 
 
-_OPERATION_METHODS = frozenset(
-    {
-        "get",
-        "put",
-        "post",
-        "delete",
-        "options",
-        "head",
-        "patch",
-        "trace",
-    }
-)
-"""Path item keys that are operations, as opposed to `parameters` or `servers`."""
-
-
 def document_idempotency(
     app: Annotated[
         "FastAPI",
@@ -557,7 +542,7 @@ def document_idempotency(
 ) -> None:
     """Describe the installed `IdempotencyMiddleware` in the OpenAPI schema.
 
-    A middleware runs below the routing layer, so nothing it does reaches
+    A middleware runs outside the routing layer, so nothing it does reaches
     the generated schema and a client built from that schema never learns
     the header exists. This reads the installed middleware and annotates
     every operation it covers with the header parameter and the responses
@@ -574,8 +559,8 @@ def document_idempotency(
     document_idempotency(app)
     ```
 
-    Call order does not matter. The schema is annotated the next time it
-    is built, so routes added afterwards are covered too.
+    Call it any time after `add_middleware`. The schema is annotated the
+    next time it is built, so routes added afterwards are covered too.
 
     An operation that already declares the header keeps its own
     declaration. A `422` that FastAPI generated for request validation
@@ -625,7 +610,10 @@ def _idempotency_options(app: "FastAPI") -> dict[str, Any]:
     import inspect  # noqa: PLC0415
 
     for middleware in app.user_middleware:
-        if middleware.cls is IdempotencyMiddleware:
+        # `add_middleware` prepends, so the first match is the last added,
+        # which is the outermost at runtime and answers first on the wire.
+        cls = middleware.cls
+        if isinstance(cls, type) and issubclass(cls, IdempotencyMiddleware):
             # Every parameter after `app` is keyword-only, so `add_middleware`
             # can only have passed them by keyword.
             bound = inspect.signature(IdempotencyMiddleware).bind_partial(
@@ -653,7 +641,7 @@ def _annotate_schema(schema: dict[str, Any], options: dict[str, Any]) -> None:
         "description": (
             "Key that makes this request safe to retry. A repeat within the "
             "replay window returns the first response instead of running the "
-            "operation again."
+            f"operation again. Up to {_MAX_KEY_LENGTH} ASCII characters."
         ),
     }
     responses = {
@@ -674,7 +662,10 @@ def _annotate_schema(schema: dict[str, Any], options: dict[str, Any]) -> None:
 
     for path_item in schema.get("paths", {}).values():
         for method, operation in path_item.items():
-            if method.lower() not in methods & _OPERATION_METHODS:
+            # Every non-operation key of a path item (`parameters`,
+            # `servers`, `summary`, `$ref`) holds a list or a string, so a
+            # mapping under a covered method is an operation.
+            if method.lower() not in methods or not isinstance(operation, dict):
                 continue
             _add_parameter(operation, path_item, parameter)
             for status, description in responses.items():
@@ -702,7 +693,8 @@ def _add_parameter(
         for existing in declared
     ):
         return
-    operation.setdefault("parameters", []).append(parameter)
+    # A copy per operation, so post-processing one never edits the rest.
+    operation.setdefault("parameters", []).append(dict(parameter))
 
 
 def _merge_response(

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -203,6 +203,9 @@
       "()": "(error)"
     },
     "IdempotencyStateError": null,
+    "IdempotencyWaitTimeoutError": {
+      "()": "(*, name, key, timeout)"
+    },
     "Operation": {
       "()": "(*, replayed, response)"
     },
@@ -221,6 +224,10 @@
     "HealthzResponse": {
       "()": "(*, status, checks)"
     },
+    "IdempotencyMiddleware": {
+      "()": "(app, *, idempotency, header=..., methods=..., key_maker=..., skip=..., require_key=..., fingerprint_body=..., max_body_size=..., wait_timeout=...)"
+    },
+    "StoredResponse": null,
     "health_router": {
       "()": "(registry=..., *, prefix=..., show_details=..., healthz_dependencies=...)"
     },

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -228,6 +228,9 @@
       "()": "(app, *, idempotency, header=..., methods=..., key_maker=..., skip=..., require_key=..., fingerprint_body=..., max_body_size=..., wait_timeout=...)"
     },
     "StoredResponse": null,
+    "document_idempotency": {
+      "()": "(app)"
+    },
     "health_router": {
       "()": "(registry=..., *, prefix=..., show_details=..., healthz_dependencies=...)"
     },

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -718,3 +718,30 @@ async def test_idempotency_block_propagates_a_backend_timeout() -> None:
 
     # Assert
     assert not isinstance(exc_info.value, IdempotencyWaitTimeoutError)
+
+
+async def test_idempotency_run_waits_out_the_timeout() -> None:
+    """`run` bounds the wait the same way the block does."""
+    # Arrange
+    wait_timeout = 0.05
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    idem: Idempotency = Idempotency("charge", ttl=60)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow() -> dict[str, bool]:
+        started.set()
+        await release.wait()
+        return {"ok": True}
+
+    # Act
+    async with micro:
+        task = asyncio.create_task(idem.run("key-1", slow))
+        await started.wait()
+        with pytest.raises(IdempotencyWaitTimeoutError):
+            await idem.run("key-1", slow, wait_timeout=wait_timeout)
+        release.set()
+        result = await task
+
+    # Assert
+    assert result == {"ok": True}

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 from grelmicro import Grelmicro
 from grelmicro._config import reconfigurable_instances, reconfigure_all
+from grelmicro.cache import Cache
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.serializers import JsonSerializer
 from grelmicro.cache.ttl import TTLCache
@@ -27,6 +28,7 @@ from grelmicro.idempotency import (
     IdempotencyConflictError,
     IdempotencySettingsValidationError,
     IdempotencyStateError,
+    IdempotencyWaitTimeoutError,
     idempotent,
 )
 
@@ -658,3 +660,61 @@ def test_settings_error_is_settings_validation_error() -> None:
     assert issubclass(
         IdempotencySettingsValidationError, SettingsValidationError
     )
+
+
+async def test_idempotency_block_waits_out_the_timeout() -> None:
+    """A duplicate past `wait_timeout` raises the wait error."""
+    # Arrange
+    wait_timeout = 0.05
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    idem: Idempotency = Idempotency("charge", ttl=60)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def first() -> None:
+        async with idem("key-1") as operation:
+            started.set()
+            await release.wait()
+            operation.store({"ok": True})
+
+    # Act
+    async with micro:
+        task = asyncio.create_task(first())
+        await started.wait()
+        with pytest.raises(IdempotencyWaitTimeoutError) as exc_info:
+            async with idem("key-1", wait_timeout=wait_timeout):
+                pass  # pragma: no cover
+        release.set()
+        await task
+
+    # Assert
+    assert exc_info.value.timeout == wait_timeout
+    assert isinstance(exc_info.value, TimeoutError)
+
+
+async def test_idempotency_block_propagates_a_backend_timeout() -> None:
+    """A `TimeoutError` from inside the block is not a wait timeout."""
+    # Arrange
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    idem: Idempotency = Idempotency("charge", ttl=60)
+    calls = 0
+    original = idem._replay
+
+    async def flaky(key: str, fingerprint: str | None) -> object:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise TimeoutError
+        return await original(key, fingerprint)
+
+    # Act
+    async with micro:
+        with (
+            patch.object(idem, "_replay", flaky),
+            pytest.raises(TimeoutError) as exc_info,
+        ):
+            async with idem("key-1", wait_timeout=5):
+                pass  # pragma: no cover
+
+    # Assert
+    assert not isinstance(exc_info.value, IdempotencyWaitTimeoutError)

--- a/tests/test_fastapi_idempotency.py
+++ b/tests/test_fastapi_idempotency.py
@@ -1,0 +1,781 @@
+"""Tests for the HTTP idempotency middleware."""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from fastapi import FastAPI, Response
+from fastapi.testclient import TestClient
+from starlette.background import BackgroundTasks
+from starlette.responses import StreamingResponse
+from starlette.status import (
+    HTTP_200_OK,
+    HTTP_201_CREATED,
+    HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
+    HTTP_409_CONFLICT,
+    HTTP_413_CONTENT_TOO_LARGE,
+    HTTP_422_UNPROCESSABLE_CONTENT,
+    HTTP_502_BAD_GATEWAY,
+)
+
+from grelmicro import Grelmicro
+from grelmicro.cache import Cache
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.errors import OutOfContextError
+from grelmicro.idempotency import Idempotency
+from grelmicro.integrations.fastapi import IdempotencyMiddleware
+
+if TYPE_CHECKING:
+    from collections.abc import (
+        AsyncIterator,
+        Awaitable,
+        Callable,
+        Iterator,
+        MutableMapping,
+    )
+
+    Scope = MutableMapping[str, Any]
+    Message = MutableMapping[str, Any]
+    Receive = Callable[[], Awaitable[Message]]
+    Send = Callable[[Message], Awaitable[None]]
+
+pytestmark = [pytest.mark.timeout(10)]
+
+KEY = {"Idempotency-Key": "key-1"}
+LARGE_BODY = b"x" * 4096
+
+
+def _register_result_routes(app: FastAPI, calls: dict[str, int]) -> None:
+    """Register the routes covering ordinary results and failures."""
+
+    @app.post("/charge")
+    async def charge() -> dict[str, int]:
+        calls["count"] += 1
+        return {"call": calls["count"]}
+
+    @app.post("/fail")
+    async def fail() -> Response:
+        calls["count"] += 1
+        return Response(
+            content=b'{"detail":"downstream gone"}',
+            status_code=502,
+            media_type="application/json",
+        )
+
+    @app.post("/raise")
+    async def raises() -> None:
+        calls["count"] += 1
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    @app.post("/created")
+    async def created() -> Response:
+        calls["count"] += 1
+        return Response(status_code=201, headers={"Location": "/orders/1"})
+
+    @app.post("/text")
+    async def text() -> Response:
+        calls["count"] += 1
+        return Response(content="plain", media_type="text/plain")
+
+
+def _register_storage_routes(app: FastAPI, calls: dict[str, int]) -> None:
+    """Register the routes covering the storage rules."""
+
+    @app.post("/cookie")
+    async def cookie() -> Response:
+        calls["count"] += 1
+        response = Response(content=b"{}", media_type="application/json")
+        response.set_cookie("session", "abc")
+        return response
+
+    @app.post("/opt-out")
+    async def opt_out() -> Response:
+        calls["count"] += 1
+        return Response(
+            content=b'{"store":false}', media_type="application/json"
+        )
+
+    @app.post("/large")
+    async def large() -> Response:
+        calls["count"] += 1
+        return Response(content=LARGE_BODY, media_type="text/plain")
+
+    @app.post("/background")
+    async def background() -> Response:
+        calls["count"] += 1
+        tasks = BackgroundTasks()
+        tasks.add_task(lambda: None)
+        return Response(content=b"{}", media_type="application/json")
+
+    @app.post("/encoded")
+    async def encoded() -> Response:
+        calls["count"] += 1
+        return Response(
+            content=gzip.compress(b"{}"),
+            media_type="application/json",
+            headers={"Content-Encoding": "gzip"},
+        )
+
+    @app.post("/stream")
+    async def stream() -> StreamingResponse:
+        calls["count"] += 1
+
+        async def chunks() -> AsyncIterator[bytes]:
+            yield b"one "
+            yield b"two"
+
+        return StreamingResponse(chunks(), media_type="text/plain")
+
+    @app.post("/no-content")
+    async def no_content() -> Response:
+        calls["count"] += 1
+        return Response(status_code=204)
+
+    @app.get("/read")
+    async def read() -> dict[str, int]:
+        calls["count"] += 1
+        return {"call": calls["count"]}
+
+
+def build_app(**options: Any) -> FastAPI:  # noqa: ANN401
+    """Build an app whose handlers exercise the middleware's storage rules."""
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    app = FastAPI()
+    app.add_middleware(
+        IdempotencyMiddleware,
+        idempotency=Idempotency("http", ttl=60),
+        **options,
+    )
+    micro.install(app)
+    calls = {"count": 0}
+    app.state.calls = calls
+    _register_result_routes(app, calls)
+    _register_storage_routes(app, calls)
+    return app
+
+
+@pytest.fixture
+def client_factory() -> Iterator[
+    Callable[..., tuple[TestClient, dict[str, int]]]
+]:
+    """Yield a factory building a started client and its call counter."""
+    clients: list[TestClient] = []
+
+    def factory(**options: Any) -> tuple[TestClient, dict[str, int]]:  # noqa: ANN401
+        app = build_app(**options)
+        client = TestClient(app)
+        client.__enter__()
+        clients.append(client)
+        return client, app.state.calls
+
+    yield factory
+    for client in clients:
+        client.__exit__(None, None, None)
+
+
+def test_middleware_repeated_key_replays_stored_response(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A retry with the same key replays the response without re-running."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    first = client.post("/charge", headers=KEY)
+    second = client.post("/charge", headers=KEY)
+    # Assert
+    assert first.json() == {"call": 1}
+    assert second.json() == {"call": 1}
+    assert calls == {"count": 1}
+    assert "idempotent-replayed" not in first.headers
+    assert second.headers["idempotent-replayed"] == "true"
+
+
+def test_middleware_request_without_key_passes_through(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A request with no key runs every time and stores nothing."""
+    # Arrange
+    client, _calls = client_factory()
+    # Act
+    client.post("/charge")
+    second = client.post("/charge")
+    # Assert
+    assert second.json() == {"call": 2}
+
+
+def test_middleware_unlisted_method_passes_through(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A GET carrying a key is untouched, because only POST is listed."""
+    # Arrange
+    client, _calls = client_factory()
+    # Act
+    client.get("/read", headers=KEY)
+    second = client.get("/read", headers=KEY)
+    # Assert
+    assert second.json() == {"call": 2}
+
+
+def test_middleware_different_key_executes_again(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A different key is a different operation."""
+    # Arrange
+    client, _calls = client_factory()
+    # Act
+    client.post("/charge", headers=KEY)
+    second = client.post("/charge", headers={"Idempotency-Key": "key-2"})
+    # Assert
+    assert second.json() == {"call": 2}
+
+
+def test_middleware_same_key_on_another_route_executes_again(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """The stored key is scoped per route, so routes never cross-replay."""
+    # Arrange
+    client, _calls = client_factory()
+    # Act
+    client.post("/charge", headers=KEY)
+    other = client.post("/created", headers=KEY)
+    # Assert
+    assert other.status_code == HTTP_201_CREATED
+
+
+def test_middleware_query_string_is_part_of_the_key(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A different query string is a different operation."""
+    # Arrange
+    client, _calls = client_factory()
+    # Act
+    client.post("/charge?dry_run=1", headers=KEY)
+    second = client.post("/charge", headers=KEY)
+    # Assert
+    assert second.json() == {"call": 2}
+
+
+def test_middleware_key_maker_isolates_two_callers(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """One caller never replays another caller's stored response."""
+    # Arrange
+    client, _calls = client_factory(
+        key_maker=lambda scope, key: (
+            dict(scope["headers"]).get(b"x-tenant", b"").decode()
+            + "|"
+            + scope["path"]
+            + "|"
+            + key
+        )
+    )
+    # Act
+    first = client.post("/charge", headers={**KEY, "X-Tenant": "a"})
+    second = client.post("/charge", headers={**KEY, "X-Tenant": "b"})
+    # Assert
+    assert first.json() == {"call": 1}
+    assert second.json() == {"call": 2}
+
+
+def test_middleware_error_response_is_replayed(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A returned 5xx is stored, so a retry cannot re-run the side effect."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    first = client.post("/fail", headers=KEY)
+    second = client.post("/fail", headers=KEY)
+    # Assert
+    assert first.status_code == HTTP_502_BAD_GATEWAY
+    assert second.status_code == HTTP_502_BAD_GATEWAY
+    assert second.headers["idempotent-replayed"] == "true"
+    assert calls == {"count": 1}
+
+
+def test_middleware_raised_exception_stores_nothing(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A handler that raises leaves the key free for a fresh retry."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    with pytest.raises(RuntimeError):
+        client.post("/raise", headers=KEY)
+    with pytest.raises(RuntimeError):
+        client.post("/raise", headers=KEY)
+    # Assert
+    assert calls == {"count": 2}
+
+
+def test_middleware_empty_body_response_is_replayed(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A 201 with no body replays, which JSON-only storage would miss."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    client.post("/created", headers=KEY)
+    second = client.post("/created", headers=KEY)
+    # Assert
+    assert second.status_code == HTTP_201_CREATED
+    assert second.headers["location"] == "/orders/1"
+    assert second.headers["idempotent-replayed"] == "true"
+    assert calls == {"count": 1}
+
+
+def test_middleware_non_json_response_is_replayed(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """Bodies are opaque bytes, so a text response replays like any other."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    client.post("/text", headers=KEY)
+    second = client.post("/text", headers=KEY)
+    # Assert
+    assert second.text == "plain"
+    assert calls == {"count": 1}
+
+
+def test_middleware_set_cookie_response_is_not_stored(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """Replaying a cookie would leak a session, so the response is skipped."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    client.post("/cookie", headers=KEY)
+    second = client.post("/cookie", headers=KEY)
+    # Assert
+    assert calls == {"count": 2}
+    assert "idempotent-replayed" not in second.headers
+
+
+def test_middleware_skip_predicate_blocks_storage(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """`skip` sees the finished response and can refuse to store it."""
+    # Arrange
+    client, calls = client_factory(
+        skip=lambda response: b'"store":false' in response["body"]
+    )
+    # Act
+    client.post("/opt-out", headers=KEY)
+    client.post("/opt-out", headers=KEY)
+    # Assert
+    assert calls == {"count": 2}
+
+
+def test_middleware_skip_predicate_allows_other_responses(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A response the predicate passes still replays."""
+    # Arrange
+    client, calls = client_factory(
+        skip=lambda response: response["status"] != HTTP_200_OK
+    )
+    # Act
+    client.post("/charge", headers=KEY)
+    second = client.post("/charge", headers=KEY)
+    # Assert
+    assert second.headers["idempotent-replayed"] == "true"
+    assert calls == {"count": 1}
+
+
+def test_middleware_oversized_response_is_not_stored(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A body over max_body_size streams through unstored."""
+    # Arrange
+    client, calls = client_factory(max_body_size=1024)
+    # Act
+    first = client.post("/large", headers=KEY)
+    client.post("/large", headers=KEY)
+    # Assert
+    assert first.content == LARGE_BODY
+    assert calls == {"count": 2}
+
+
+def test_middleware_background_task_response_is_replayed(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A response with a background task still stores and replays."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    client.post("/background", headers=KEY)
+    second = client.post("/background", headers=KEY)
+    # Assert
+    assert second.headers["idempotent-replayed"] == "true"
+    assert calls == {"count": 1}
+
+
+def test_middleware_missing_key_rejected_when_required(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """`require_key` turns a missing header into a 400."""
+    # Arrange
+    client, calls = client_factory(require_key=True)
+    # Act
+    response = client.post("/charge")
+    # Assert
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert "Idempotency-Key" in response.json()["detail"]
+    assert calls == {"count": 0}
+
+
+def test_middleware_oversized_key_rejected(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """An unbounded key would grow the store, so it is rejected."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    response = client.post("/charge", headers={"Idempotency-Key": "x" * 256})
+    # Assert
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert calls == {"count": 0}
+
+
+def test_middleware_reused_key_with_new_body_conflicts(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """`fingerprint_body` answers 422 when the payload changed."""
+    # Arrange
+    client, calls = client_factory(fingerprint_body=True)
+    # Act
+    first = client.post("/charge", headers=KEY, content=b'{"a":1}')
+    second = client.post("/charge", headers=KEY, content=b'{"a":2}')
+    # Assert
+    assert first.status_code == HTTP_200_OK
+    assert second.status_code == HTTP_422_UNPROCESSABLE_CONTENT
+    assert calls == {"count": 1}
+
+
+def test_middleware_reused_key_with_same_body_replays(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """The buffered body reaches the handler and the same payload replays."""
+    # Arrange
+    client, calls = client_factory(fingerprint_body=True)
+    # Act
+    client.post("/charge", headers=KEY, content=b'{"a":1}')
+    second = client.post("/charge", headers=KEY, content=b'{"a":1}')
+    # Assert
+    assert second.headers["idempotent-replayed"] == "true"
+    assert calls == {"count": 1}
+
+
+def test_middleware_oversized_body_rejected_when_fingerprinting(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A body too large to hash is a 413 rather than an unbounded buffer."""
+    # Arrange
+    client, calls = client_factory(fingerprint_body=True, max_body_size=16)
+    # Act
+    response = client.post("/charge", headers=KEY, content=b"x" * 64)
+    # Assert
+    assert response.status_code == HTTP_413_CONTENT_TOO_LARGE
+    assert calls == {"count": 0}
+
+
+def test_middleware_bodyless_status_replays_without_content_length(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A 204 replay carries no Content-Length, which its status forbids."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    client.post("/no-content", headers=KEY)
+    second = client.post("/no-content", headers=KEY)
+    # Assert
+    assert second.status_code == HTTP_204_NO_CONTENT
+    assert "content-length" not in second.headers
+    assert second.headers["idempotent-replayed"] == "true"
+    assert calls == {"count": 1}
+
+
+def test_middleware_content_encoding_response_is_not_stored(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """Encoded bytes must not reach a client that never negotiated them."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    client.post("/encoded", headers=KEY)
+    client.post("/encoded", headers=KEY)
+    # Assert
+    assert calls == {"count": 2}
+
+
+def test_middleware_streaming_response_is_replayed(
+    client_factory: Callable[..., tuple[TestClient, dict[str, int]]],
+) -> None:
+    """A chunked response is stored whole once its last chunk arrives."""
+    # Arrange
+    client, calls = client_factory()
+    # Act
+    first = client.post("/stream", headers=KEY)
+    second = client.post("/stream", headers=KEY)
+    # Assert
+    assert first.text == "one two"
+    assert second.text == "one two"
+    assert calls == {"count": 1}
+
+
+def test_middleware_without_grelmicro_scope_names_the_fix() -> None:
+    """The out-of-context error tells the reader about the install order."""
+    # Arrange
+    app = FastAPI()
+    app.add_middleware(
+        IdempotencyMiddleware, idempotency=Idempotency("http", ttl=60)
+    )
+
+    @app.post("/charge")
+    async def charge() -> dict[str, str]:
+        return {"status": "ok"}
+
+    # Act
+    with (
+        TestClient(app) as client,
+        pytest.raises(OutOfContextError, match=r"micro\.install"),
+    ):
+        client.post("/charge", headers=KEY)
+
+
+async def _drive(
+    middleware: IdempotencyMiddleware, messages: list[Message]
+) -> list[Message]:
+    """Run one request through the middleware and collect what it sends."""
+    incoming = iter(messages)
+    sent: list[Message] = []
+
+    async def receive() -> Message:
+        return next(incoming, {"type": "http.disconnect"})
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    scope: Scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/charge",
+        "headers": [(b"idempotency-key", b"key-1")],
+    }
+    await middleware(scope, receive, send)
+    return sent
+
+
+async def test_middleware_hashes_a_chunked_request_body() -> None:
+    """A multi-chunk body is buffered whole and replayed to the handler."""
+    # Arrange
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    seen: list[bytes] = []
+
+    async def app(
+        scope: Scope,  # noqa: ARG001
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        chunks = []
+        while True:
+            message = await receive()
+            chunks.append(message.get("body", b""))
+            if not message.get("more_body", False):
+                break
+        seen.append(b"".join(chunks))
+        # A second read falls through to the original receive.
+        assert (await receive())["type"] == "http.disconnect"
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    middleware = IdempotencyMiddleware(
+        app,
+        idempotency=Idempotency("http", ttl=60),
+        fingerprint_body=True,
+    )
+    # Act
+    async with micro:
+        sent = await _drive(
+            middleware,
+            [
+                {"type": "http.request", "body": b"one ", "more_body": True},
+                {"type": "http.request", "body": b"two", "more_body": False},
+            ],
+        )
+    # Assert
+    assert seen == [b"one two"]
+    assert sent[0]["status"] == HTTP_200_OK
+
+
+async def test_middleware_disconnect_before_body_is_not_fingerprinted() -> None:
+    """A truncated body is never hashed as if it were whole."""
+    # Arrange
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+
+    async def app(
+        scope: Scope,  # noqa: ARG001
+        receive: Receive,  # noqa: ARG001
+        send: Send,
+    ) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    middleware = IdempotencyMiddleware(
+        app,
+        idempotency=Idempotency("http", ttl=60),
+        fingerprint_body=True,
+    )
+    # Act
+    async with micro:
+        sent = await _drive(middleware, [{"type": "http.disconnect"}])
+    # Assert
+    assert sent[0]["status"] == HTTP_200_OK
+
+
+async def test_middleware_forwards_unknown_response_messages() -> None:
+    """A message that is neither start nor body passes through untouched."""
+    # Arrange
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+
+    async def app(
+        scope: Scope,  # noqa: ARG001
+        receive: Receive,  # noqa: ARG001
+        send: Send,
+    ) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"trailer", b"expires")],
+                "trailers": True,
+            }
+        )
+        await send({"type": "http.response.body", "body": b"{}"})
+        await send(
+            {
+                "type": "http.response.trailers",
+                "headers": [(b"expires", b"0")],
+            }
+        )
+
+    middleware = IdempotencyMiddleware(
+        app, idempotency=Idempotency("http", ttl=60)
+    )
+    # Act
+    async with micro:
+        sent = await _drive(
+            middleware,
+            [{"type": "http.request", "body": b"", "more_body": False}],
+        )
+    # Assert
+    assert sent[-1]["type"] == "http.response.trailers"
+    assert not any(
+        message.get("headers")
+        and any(
+            name == b"idempotent-replayed" for name, _ in message["headers"]
+        )
+        for message in sent
+    )
+
+
+async def test_middleware_duplicate_in_flight_waits_and_replays() -> None:
+    """A duplicate mid-flight waits for the first, then replays it."""
+    # Arrange
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    app = FastAPI()
+    app.add_middleware(
+        IdempotencyMiddleware, idempotency=Idempotency("http", ttl=60)
+    )
+    micro.install(app)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    @app.post("/slow")
+    async def slow() -> dict[str, int]:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return {"call": calls}
+
+    async with micro:
+        from httpx import ASGITransport, AsyncClient  # noqa: PLC0415
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            # Act
+            first = asyncio.create_task(client.post("/slow", headers=KEY))
+            await started.wait()
+            second = asyncio.create_task(client.post("/slow", headers=KEY))
+            await asyncio.sleep(0)
+            release.set()
+            first_response, second_response = await asyncio.gather(
+                first, second
+            )
+
+    # Assert
+    assert first_response.json() == {"call": 1}
+    assert second_response.json() == {"call": 1}
+    assert second_response.headers["idempotent-replayed"] == "true"
+    assert calls == 1
+
+
+async def test_middleware_duplicate_in_flight_times_out_with_conflict() -> None:
+    """A duplicate past `wait_timeout` gets 409 instead of holding the socket."""
+    # Arrange
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    app = FastAPI()
+    app.add_middleware(
+        IdempotencyMiddleware,
+        idempotency=Idempotency("http", ttl=60),
+        wait_timeout=0.05,
+    )
+    micro.install(app)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @app.post("/slow")
+    async def slow() -> dict[str, str]:
+        started.set()
+        await release.wait()
+        return {"status": "done"}
+
+    async with micro:
+        from httpx import ASGITransport, AsyncClient  # noqa: PLC0415
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            # Act
+            first = asyncio.create_task(client.post("/slow", headers=KEY))
+            await started.wait()
+            second = await client.post("/slow", headers=KEY)
+            release.set()
+            await first
+
+    # Assert
+    assert second.status_code == HTTP_409_CONFLICT
+    assert second.headers["retry-after"] == "1"

--- a/tests/test_fastapi_idempotency.py
+++ b/tests/test_fastapi_idempotency.py
@@ -911,3 +911,82 @@ def test_document_idempotency_raises_without_fastapi() -> None:
     if "grelmicro.integrations.fastapi" in sys.modules:
         del sys.modules["grelmicro.integrations.fastapi"]
     importlib.import_module("grelmicro.integrations.fastapi")  # restore
+
+
+def test_document_idempotency_covers_a_custom_method() -> None:
+    """A method the middleware covers is annotated, standard or not."""
+    # Arrange
+    app = build_app(methods=("POST", "PURGE"))
+
+    async def purge() -> dict[str, bool]:
+        return {"purged": True}
+
+    app.add_api_route("/thing", purge, methods=["PURGE"])
+    document_idempotency(app)
+    # Act
+    operation = app.openapi()["paths"]["/thing"]["purge"]
+    # Assert
+    assert [p["name"] for p in operation["parameters"]] == ["Idempotency-Key"]
+    assert "409" in operation["responses"]
+
+
+def test_document_idempotency_finds_a_subclass() -> None:
+    """A subclass of the middleware is still the middleware."""
+
+    # Arrange
+    class TenantIdempotencyMiddleware(IdempotencyMiddleware):
+        """A project's own subclass."""
+
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    app = FastAPI()
+    app.add_middleware(
+        TenantIdempotencyMiddleware, idempotency=Idempotency("http", ttl=60)
+    )
+    micro.install(app)
+
+    @app.post("/charge")
+    async def charge() -> dict[str, bool]:
+        return {"ok": True}
+
+    document_idempotency(app)
+    # Act
+    operation = app.openapi()["paths"]["/charge"]["post"]
+    # Assert
+    assert [p["name"] for p in operation["parameters"]] == ["Idempotency-Key"]
+
+
+def test_document_idempotency_ignores_a_callable_middleware() -> None:
+    """A non-class middleware factory never breaks the lookup."""
+
+    # Arrange
+    def passthrough(app: Any) -> Any:  # noqa: ANN401
+        return app
+
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    app = FastAPI()
+    app.add_middleware(IdempotencyMiddleware, idempotency=Idempotency("http"))
+    app.add_middleware(passthrough)
+    micro.install(app)
+
+    @app.post("/charge")
+    async def charge() -> dict[str, bool]:
+        return {"ok": True}
+
+    document_idempotency(app)
+    # Act
+    operation = app.openapi()["paths"]["/charge"]["post"]
+    # Assert
+    assert [p["name"] for p in operation["parameters"]] == ["Idempotency-Key"]
+
+
+def test_document_idempotency_gives_each_operation_its_own_parameter() -> None:
+    """Editing one injected parameter never edits another operation's."""
+    # Arrange
+    app = _documented_app()
+    schema = app.openapi()
+    # Act
+    charge = schema["paths"]["/charge"]["post"]["parameters"][-1]
+    created = schema["paths"]["/created"]["post"]["parameters"][-1]
+    charge["description"] = "edited"
+    # Assert
+    assert created["description"] != "edited"

--- a/tests/test_fastapi_idempotency.py
+++ b/tests/test_fastapi_idempotency.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import gzip
-from typing import TYPE_CHECKING, Any
+import importlib
+import json
+import sys
+from typing import TYPE_CHECKING, Annotated, Any
+from unittest.mock import patch
 
 import pytest
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, Header, Response
 from fastapi.testclient import TestClient
+from starlette.applications import Starlette
 from starlette.background import BackgroundTasks
 from starlette.responses import StreamingResponse
 from starlette.status import (
@@ -25,9 +30,12 @@ from starlette.status import (
 from grelmicro import Grelmicro
 from grelmicro.cache import Cache
 from grelmicro.cache.memory import MemoryCacheAdapter
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import DependencyNotFoundError, OutOfContextError
 from grelmicro.idempotency import Idempotency
-from grelmicro.integrations.fastapi import IdempotencyMiddleware
+from grelmicro.integrations.fastapi import (
+    IdempotencyMiddleware,
+    document_idempotency,
+)
 
 if TYPE_CHECKING:
     from collections.abc import (
@@ -779,3 +787,127 @@ async def test_middleware_duplicate_in_flight_times_out_with_conflict() -> None:
     # Assert
     assert second.status_code == HTTP_409_CONFLICT
     assert second.headers["retry-after"] == "1"
+
+
+def _documented_app(**options: Any) -> FastAPI:  # noqa: ANN401
+    """Build an app whose schema is annotated by `document_idempotency`."""
+    app = build_app(**options)
+
+    @app.post("/declared")
+    async def declared(
+        key: Annotated[str, Header(alias="Idempotency-Key")],
+    ) -> dict[str, str]:
+        return {"key": key}
+
+    document_idempotency(app)
+    return app
+
+
+def test_document_idempotency_adds_the_header_and_responses() -> None:
+    """A covered operation gains the header parameter and the responses."""
+    # Arrange
+    app = _documented_app(fingerprint_body=True)
+    # Act
+    operation = app.openapi()["paths"]["/charge"]["post"]
+    # Assert
+    assert ("Idempotency-Key", "header") in [
+        (p["name"], p["in"]) for p in operation["parameters"]
+    ]
+    assert {"400", "409", "413", "422"} <= set(operation["responses"])
+
+
+def test_document_idempotency_leaves_other_methods_alone() -> None:
+    """A method the middleware ignores keeps its schema untouched."""
+    # Arrange
+    app = _documented_app()
+    # Act
+    operation = app.openapi()["paths"]["/read"]["get"]
+    # Assert
+    assert not [
+        p for p in operation.get("parameters", []) if p["in"] == "header"
+    ]
+    assert "409" not in operation["responses"]
+
+
+def test_document_idempotency_keeps_a_declared_header() -> None:
+    """An operation that declares the header keeps its own declaration."""
+    # Arrange
+    app = _documented_app()
+    # Act
+    parameters = app.openapi()["paths"]["/declared"]["post"]["parameters"]
+    headers = [p for p in parameters if p["in"] == "header"]
+    # Assert
+    assert len(headers) == 1
+    assert headers[0]["required"] is True
+
+
+def test_document_idempotency_keeps_the_validation_error_schema() -> None:
+    """The auto-generated 422 keeps its schema and gains the description."""
+    # Arrange
+    app = _documented_app(fingerprint_body=True)
+    # Act
+    # `/declared` validates a required header, so FastAPI generates a 422.
+    response = app.openapi()["paths"]["/declared"]["post"]["responses"]["422"]
+    # Assert
+    assert "application/json" in response["content"]
+    assert "Validation Error" in response["description"]
+    assert "different request payload" in response["description"]
+
+
+def test_document_idempotency_is_stable_across_calls() -> None:
+    """Rebuilding the schema does not duplicate the injected entries."""
+    # Arrange
+    app = _documented_app(fingerprint_body=True)
+    # Act
+    first = json.dumps(app.openapi())
+    cached = json.dumps(app.openapi())  # served from the cache, annotated once
+    app.openapi_schema = None
+    rebuilt = json.dumps(app.openapi())  # regenerated from the routes
+    # Assert
+    assert cached == first
+    assert rebuilt == first
+
+
+def test_document_idempotency_marks_a_required_key() -> None:
+    """`require_key` makes the documented parameter required."""
+    # Arrange
+    app = _documented_app(require_key=True)
+    # Act
+    parameters = app.openapi()["paths"]["/charge"]["post"]["parameters"]
+    header = next(p for p in parameters if p["in"] == "header")
+    # Assert
+    assert header["required"] is True
+
+
+def test_document_idempotency_rejects_an_app_without_the_middleware() -> None:
+    """A clear error beats silently documenting nothing."""
+    # Arrange
+    app = FastAPI()
+    # Act / Assert
+    with pytest.raises(TypeError, match="no IdempotencyMiddleware"):
+        document_idempotency(app)
+
+
+def test_document_idempotency_rejects_a_plain_starlette_app() -> None:
+    """Only FastAPI builds an OpenAPI schema to annotate."""
+    # Arrange
+    app = Starlette()
+    # Act / Assert
+    with pytest.raises(TypeError, match="needs a FastAPI app"):
+        document_idempotency(app)  # ty: ignore[invalid-argument-type]
+
+
+def test_document_idempotency_raises_without_fastapi() -> None:
+    """`document_idempotency` reports the missing dependency."""
+    # Arrange
+    with patch.dict(sys.modules, {"fastapi": None}):
+        if "grelmicro.integrations.fastapi" in sys.modules:
+            del sys.modules["grelmicro.integrations.fastapi"]
+        module = importlib.import_module("grelmicro.integrations.fastapi")
+        # Act / Assert
+        with pytest.raises(DependencyNotFoundError):
+            module.document_idempotency(None)  # ty: ignore[invalid-argument-type]
+
+    if "grelmicro.integrations.fastapi" in sys.modules:
+        del sys.modules["grelmicro.integrations.fastapi"]
+    importlib.import_module("grelmicro.integrations.fastapi")  # restore


### PR DESCRIPTION
Closes #503.

`Idempotency` wraps a function. The most common place to apply an idempotency key is the HTTP layer, so this adds a pure-ASGI middleware that replays a whole response when a request repeats its `Idempotency-Key`.

```python
app.add_middleware(
    IdempotencyMiddleware, idempotency=Idempotency("http", ttl=3600)
)
micro.install(app)


@app.post("/charge")
async def charge(amount: int) -> dict[str, int]:
    return {"amount": amount}   # handler untouched
```

## API

Named after the cache module rather than inventing vocabulary: `key_maker` and `skip` mean the same thing here as on `@cached`. `skip` is the `store_predicate` the issue asked for.

| Parameter | Default |
|---|---|
| `idempotency` | required |
| `header` | `"Idempotency-Key"` |
| `methods` | `("POST",)` |
| `key_maker` | `None`, defaults to method + path + query + key |
| `skip` | `None` |
| `require_key` | `False` |
| `fingerprint_body` | `False` |
| `max_body_size` | `1048576` |
| `wait_timeout` | `10.0` |

## Behaviour worth reviewing

**Errors are stored and replayed.** A handler that writes and then fails on the way out leaves a stored failure, so the retry does not run the write again. This follows the [Idempotency-Key draft](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/) ("the result of the previously completed operation, success or an error"). A raised unhandled exception stores nothing, since the framework converts it outside the middleware.

**A duplicate in flight waits rather than getting a `409` immediately.** It then replays the real answer. The wait is bounded by `wait_timeout` and falls back to `409` with `Retry-After`, so a duplicate behind a slow original never holds a connection past a proxy read timeout.

**Bodies are opaque bytes.** A `201 Created` with an empty body and a `Location` header replays like anything else. Only four kinds of response are refused: `Set-Cookie`, `Content-Encoding`, declared trailers, and a body over `max_body_size`. All four are logged, because a silent skip looks identical to working idempotency.

**Keys are scoped per route.** `key_maker` folds in the caller identity, which the draft's security considerations require for a multi-tenant deployment. The docs carry a warning admonition.

## Also in this PR

Two bugs in the existing single-flight path, both found while adding the bounded wait:

- The distributed lock was bound to the block before it was held, so a cancelled acquire made cleanup call `release()` on a lock it did not own, raising `LockNotOwnedError` over the original error.
- `_release` awaited the distributed release before the in-process one, so a cancellation there left the key locked for the life of the process.

`Idempotency.__call__` gains `wait_timeout=`, and `IdempotencyWaitTimeoutError` (a `TimeoutError` subclass) distinguishes a single-flight wait from a backend that timed out inside the block.

## Verification

Full pre-commit passes: ruff, ty, mypy, unit, integration, `mkdocs build --strict`, and coverage at 100% on every changed file. 32 new tests, including replay, error replay, each storage rule, key scoping, `skip`, fingerprint conflict, `413`, a chunked request body, a client disconnect mid-body, a `204` replay carrying no `Content-Length`, and both the waiting and timing-out duplicate.

The API was checked against the IETF draft, Stripe, `asgi-idempotency-header`, `idempo`, `django_idempotency`, and `spring-idempotency-kit`, then reviewed adversarially. That review changed three defaults and found the two lock bugs above.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b