### PR TITLE
✨ Add refresh() to recompute one cached entry on demand

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -293,6 +293,41 @@ Arguments not named in the template do not affect the key, so calls that differ 
 --8<-- "cache/key.py"
 ```
 
+### On-demand refresh
+
+`refresh()` recomputes for the given arguments, overwrites the stored entry, and returns the new value. It skips the read, so a live entry is replaced rather than served.
+
+```python title="refresh.py"
+--8<-- "cache/refresh.py"
+```
+
+Use it where a caller asks for fresh data, such as an endpoint honouring `Cache-Control: no-cache`:
+
+```python
+@app.post("/reports/{user_id}")
+async def report(user_id: int, cache_control: Annotated[str, Header()] = "") -> dict:
+    if "no-cache" in cache_control:
+        return await get_report.refresh(user_id)
+    return await get_report(user_id)
+```
+
+Two things differ from a normal miss:
+
+- **Refreshes do not fold.** A miss folds concurrent callers into one execution, but concurrent refreshes each run the function, one at a time per key. A refresh never returns a value computed before the call started, so writing to the database and then refreshing cannot hand you pre-write data.
+- **Errors propagate**, even under `stale_ttl`. Serving the stale value would return the exact entry the caller asked to bypass. Compose it yourself when you want that:
+
+```python
+try:
+    return await get_report.refresh(user_id)
+except UpstreamError:
+    return await get_report(user_id)
+```
+
+A refresh honours `skip`, `tags`, and the `stale_ttl` reserve, so the stored entry stays consistent with what a normal miss would have written. On a sync function `refresh()` returns the value directly, matching the call it mirrors.
+
+!!! tip "Refreshing one key, not the whole cache"
+    `cache_clear()` is bound to the whole `TTLCache`, so on a cache shared between functions it removes every function's entries. `refresh()` touches one key.
+
 ### Stampede Protection
 
 A cache stampede (or "dog-pile") happens when many callers miss the same key at once and all recompute it together. By default `@cached` folds those misses in-process (`lock="local"`). Raise it to `lock=True` to fold across replicas, drop it to `lock=False` to opt out, and add `early=` to refresh hot keys before they expire:
@@ -363,6 +398,14 @@ A flaky upstream then degrades to slightly stale data instead of an error storm.
 | `early` | `float` in `[0, 1)` | `None` | Probabilistic early refresh in the late TTL window. |
 | `stale_ttl` | `float` | `None` | Serve-stale-on-error budget in seconds. Serve the last good value for this long past the TTL when a recompute fails. |
 | `tags` | `Sequence[str]` | `()` | Tags to attach to each result. Templates like `"user:{user_id}"` fill in from the arguments. Invalidate with `cache.delete_tags(...)`. |
+
+### Decorated Function Helpers
+
+| Helper | Returns | Description |
+|---|---|---|
+| `refresh(*args, **kwargs)` | the new value | Recompute for these arguments and overwrite the stored entry. |
+| `cache_info()` | `CacheInfo` | Statistics for the whole cache backing this function. |
+| `cache_clear()` | awaitable | Remove every entry from that cache. Always a coroutine, even for a sync function. |
 
 ## Redis Backend Configuration
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -313,7 +313,7 @@ async def report(user_id: int, cache_control: Annotated[str, Header()] = "") -> 
 
 Two things differ from a normal miss:
 
-- **Refreshes do not fold.** A miss folds concurrent callers into one execution, but concurrent refreshes each run the function, one at a time per key. A refresh never returns a value computed before the call started, so writing to the database and then refreshing cannot hand you pre-write data.
+- **Refreshes do not fold.** A miss folds concurrent callers into one execution, but every refresh runs the function itself. A refresh never returns a value computed before the call started, so writing to the database and then refreshing cannot hand you pre-write data. Under the default `lock`, refreshes for one key also serialize within the process, and with `lock=True` and a lock backend they serialize across replicas. Under `lock=False` they run in parallel and the last write wins.
 - **Errors propagate**, even under `stale_ttl`. Serving the stale value would return the exact entry the caller asked to bypass. Compose it yourself when you want that:
 
 ```python
@@ -323,7 +323,9 @@ except UpstreamError:
     return await get_report(user_id)
 ```
 
-A refresh honours `skip`, `tags`, and the `stale_ttl` reserve, so the stored entry stays consistent with what a normal miss would have written. On a sync function `refresh()` returns the value directly, matching the call it mirrors.
+A refresh honours `skip`, `tags`, and the `stale_ttl` reserve, so the stored entry stays consistent with what a normal miss would have written. A result the `skip` predicate rejects is not stored, so the previous entry stays and keeps being served. On a sync function `refresh()` returns the value directly, matching the call it mirrors.
+
+Refreshing a key that was never cached simply computes and stores it. A refresh reads nothing, so it counts as neither a hit nor a miss in `cache_info()`. It works on the private `@cached(ttl=...)` form too.
 
 !!! tip "Refreshing one key, not the whole cache"
     `cache_clear()` is bound to the whole `TTLCache`, so on a cache shared between functions it removes every function's entries. `refresh()` touches one key.
@@ -403,7 +405,7 @@ A flaky upstream then degrades to slightly stale data instead of an error storm.
 
 | Helper | Returns | Description |
 |---|---|---|
-| `refresh(*args, **kwargs)` | the new value | Recompute for these arguments and overwrite the stored entry. |
+| `refresh(*args, **kwargs)` | the new value | Recompute for these arguments and overwrite the stored entry. On a method, call it as `Class.method.refresh(obj, ...)`. |
 | `cache_info()` | `CacheInfo` | Statistics for the whole cache backing this function. |
 | `cache_clear()` | awaitable | Remove every entry from that cache. Always a coroutine, even for a sync function. |
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+* ✨ Add `refresh()` to a `@cached` function. It recomputes for the given arguments, overwrites the stored entry, and returns the new value, so an endpoint honouring `Cache-Control: no-cache` keeps the decorator's key handling and tag invalidation. Concurrent refreshes each recompute rather than folding, and an error propagates instead of serving stale. ([#500](https://github.com/grelinfo/grelmicro/issues/500))
+
 * ✨ Add `IdempotencyMiddleware`. A request carrying an `Idempotency-Key` header runs once, and a retry replays the stored response without reaching the handler. Pure ASGI, so it works on FastAPI, Starlette, and Litestar alike. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 * ✨ Bound the single-flight wait with `wait_timeout=` on an `Idempotency` block and on `run()`. A duplicate that waits longer than that raises `IdempotencyWaitTimeoutError`, which subclasses `TimeoutError`, instead of holding the caller indefinitely. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 
@@ -11,6 +13,7 @@
 
 ### Fixed
 
+* 🐛 Type the helpers a `@cached` function exposes. `cached()` returned a plain `Callable`, so `cache_info()` and `cache_clear()` were documented but invisible to type checkers, and calling them failed a downstream `ty` or `mypy` run. It now returns `CachedFunction`. ([#500](https://github.com/grelinfo/grelmicro/issues/500))
 * 🐛 Release the single-flight lock correctly when an `Idempotency` block is cancelled while acquiring it. The lock was bound to the block before it was held, so the cleanup path tried to release a lock the block did not own and raised `LockNotOwnedError` over the original error. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 * 🐛 Release the in-process idempotency lock even when the distributed release is cancelled mid-flight. A cancellation there left the key locked for the life of the process. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 

--- a/docs/snippets/cache/refresh.py
+++ b/docs/snippets/cache/refresh.py
@@ -1,0 +1,20 @@
+from grelmicro import Grelmicro
+from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
+from grelmicro.cache.memory import MemoryCacheAdapter
+
+micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+
+cache = TTLCache(ttl=300, serializer=JsonSerializer())
+
+
+@cached(cache, key="report:{user_id}")
+async def get_report(user_id: int) -> dict:
+    return {"user_id": user_id}
+
+
+async def main() -> None:
+    async with micro:
+        await get_report(42)  # computed, then stored
+        await get_report(42)  # served from the cache
+        # Skips the read, recomputes, and overwrites the entry.
+        await get_report.refresh(42)

--- a/grelmicro/cache/__init__.py
+++ b/grelmicro/cache/__init__.py
@@ -2,7 +2,7 @@
 
 from grelmicro.cache._component import Cache
 from grelmicro.cache._protocol import CacheBackend
-from grelmicro.cache.cached import cached
+from grelmicro.cache.cached import CachedFunction, cached
 from grelmicro.cache.errors import CacheError, CacheSettingsValidationError
 from grelmicro.cache.serializers import (
     CacheSerializer,
@@ -19,6 +19,7 @@ __all__ = [
     "CacheInfo",
     "CacheSerializer",
     "CacheSettingsValidationError",
+    "CachedFunction",
     "JsonSerializer",
     "PickleSerializer",
     "PydanticSerializer",

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -10,7 +10,16 @@ import threading
 import time
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
-from typing import Annotated, Any, Literal, NamedTuple, ParamSpec, TypeVar
+from typing import (
+    Annotated,
+    Any,
+    Literal,
+    NamedTuple,
+    ParamSpec,
+    Protocol,
+    TypeVar,
+    cast,
+)
 
 from typing_extensions import Doc
 
@@ -24,7 +33,12 @@ from grelmicro.cache._stampede import (
 )
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.serializers import PickleSerializer
-from grelmicro.cache.ttl import _CACHE_PREFIX, _XFETCH_SUFFIX, TTLCache
+from grelmicro.cache.ttl import (
+    _CACHE_PREFIX,
+    _XFETCH_SUFFIX,
+    CacheInfo,
+    TTLCache,
+)
 from grelmicro.coordination.lock import Lock
 from grelmicro.metrics import _emit
 
@@ -34,6 +48,68 @@ from grelmicro.metrics import _emit
 # ``ParamSpec``/``TypeVar`` is the working pattern.
 P = ParamSpec("P")
 R = TypeVar("R")
+
+
+class CachedFunction(Protocol[P, R]):
+    """A function wrapped by `@cached`.
+
+    Calling it reads through the cache. The helpers alongside it act on
+    the whole `TTLCache` backing the function, not on one entry.
+    """
+
+    __wrapped__: Callable[P, R]
+    """The undecorated function."""
+
+    __name__: str
+    """The undecorated function's name."""
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Return the cached result, computing it on a miss."""
+        ...
+
+    def refresh(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Recompute for these arguments, store the result, and return it.
+
+        Skips the read, so a live entry is replaced rather than served.
+        Use it for a caller-driven refresh, such as an endpoint honouring
+        `Cache-Control: no-cache`.
+
+        Concurrent refreshes for one key run one at a time and each one
+        recomputes, so a refresh never returns a value computed before
+        the call started. An error propagates, even under `stale_ttl`,
+        because a caller asking for fresh data is not served the value it
+        asked to bypass.
+
+        Returns a coroutine for an async function and the value itself
+        for a sync one, matching the call it mirrors.
+        """
+        ...
+
+    def cache_info(self) -> CacheInfo:
+        """Return statistics for the whole cache backing this function."""
+        ...
+
+    def cache_clear(self) -> Any:  # noqa: ANN401
+        """Remove every entry from the cache backing this function.
+
+        Always a coroutine, even for a sync function, so it must be
+        awaited.
+        """
+        ...
+
+    def __get__(
+        self,
+        instance: Any,  # noqa: ANN401
+        owner: Any = None,  # noqa: ANN401
+        /,
+    ) -> Any:  # noqa: ANN401
+        """Bind as a method.
+
+        Typed as `Any` because a signature carrying `ParamSpec` cannot
+        also express descriptor binding.
+        """
+        ...
+
 
 _SENTINEL = object()
 
@@ -293,14 +369,17 @@ def cached(  # noqa: PLR0913, C901
             """,
         ),
     ] = (),
-) -> Callable[[Callable[P, R]], Callable[P, R]]:
+) -> Callable[[Callable[P, R]], CachedFunction[P, R]]:
     """Cache decorator for sync and async functions.
 
     Automatically detects whether the decorated function is sync or
     async and wraps it accordingly.
 
-    The decorated function exposes ``cache_info()`` and
-    ``cache_clear()`` helpers (matching ``functools.lru_cache``).
+    The decorated function exposes ``refresh()``, which recomputes for
+    the given arguments and overwrites the stored entry, plus
+    ``cache_info()`` and ``cache_clear()``. The last two act on the whole
+    `TTLCache`, so on a cache shared between functions they report and
+    clear every function's entries, not only this one's.
     ``cache_clear()`` is always a coroutine (must be awaited).
 
     Pass a ``TTLCache`` as ``cache`` to share one store across
@@ -340,7 +419,7 @@ def cached(  # noqa: PLR0913, C901
 
     def decorator(
         func: Callable[P, R],
-    ) -> Callable[P, R]:
+    ) -> CachedFunction[P, R]:
         is_async_func = inspect.iscoroutinefunction(func)
         if is_private_cache and not is_async_func:
             msg = (
@@ -400,7 +479,7 @@ def cached(  # noqa: PLR0913, C901
             )
         wrapper.cache_info = cache.cache_info
         wrapper.cache_clear = cache.clear
-        return wrapper
+        return cast("CachedFunction[P, R]", wrapper)
 
     return decorator
 
@@ -487,7 +566,7 @@ def _serve_stale_sync(cache: TTLCache, key: str, loop: Any) -> tuple[bool, Any]:
 # --- Async function ---
 
 
-def _build_async_wrapper(
+def _build_async_wrapper(  # noqa: C901
     func: Any,  # noqa: ANN401
     cache: TTLCache,
     key_maker: Any,  # noqa: ANN401
@@ -561,7 +640,32 @@ def _build_async_wrapper(
                 return value
             raise
 
-    return async_wrapper
+    async def async_refresh(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        key = _make_key(func, args, kwargs, key_maker, typed=typed)
+
+        async def recompute() -> Any:  # noqa: ANN401
+            return await _compute_and_cache(
+                func,
+                args,
+                kwargs,
+                cache,
+                key,
+                skip,
+                early=early,
+                stale_ttl=stale_ttl,
+                tag_spec=tag_spec,
+            )
+
+        if not per_key:
+            return await recompute()
+        # Serialized, never folded: each caller runs the function itself,
+        # so a refresh never returns a value computed before it started.
+        async with await guard.get_lock(key):
+            return await recompute()
+
+    wrapper: Any = async_wrapper
+    wrapper.refresh = async_refresh
+    return wrapper
 
 
 async def _maybe_refresh_async(
@@ -671,6 +775,31 @@ def _build_sync_wrapper(  # noqa: C901
                 key_locks.move_to_end(key)
             return the_lock
 
+    def sync_refresh(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        key = _make_key(func, args, kwargs, key_maker, typed=typed)
+        loop = cache._get_backend()._loop  # noqa: SLF001
+        if loop is None:
+            raise_backend_not_open("The cache")
+
+        def recompute() -> Any:  # noqa: ANN401
+            return _compute_and_cache_sync(
+                func,
+                args,
+                kwargs,
+                cache,
+                key,
+                skip,
+                loop,
+                early=early,
+                stale_ttl=stale_ttl,
+                tag_spec=tag_spec,
+            )
+
+        if not per_key:
+            return recompute()
+        with get_key_lock(key):
+            return recompute()
+
     @functools.wraps(func)
     def sync_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, C901
         key = _make_key(func, args, kwargs, key_maker, typed=typed)
@@ -754,7 +883,9 @@ def _build_sync_wrapper(  # noqa: C901
                 return value
             raise
 
-    return sync_wrapper
+    wrapper: Any = sync_wrapper
+    wrapper.refresh = sync_refresh
+    return wrapper
 
 
 def _run(coro: Any, loop: Any) -> Any:  # noqa: ANN401

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -9,7 +9,7 @@ import random
 import threading
 import time
 from collections import OrderedDict
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from typing import (
     Annotated,
     Any,
@@ -74,11 +74,19 @@ class CachedFunction(Protocol[P, R]):
         Use it for a caller-driven refresh, such as an endpoint honouring
         `Cache-Control: no-cache`.
 
-        Concurrent refreshes for one key run one at a time and each one
-        recomputes, so a refresh never returns a value computed before
-        the call started. An error propagates, even under `stale_ttl`,
-        because a caller asking for fresh data is not served the value it
-        asked to bypass.
+        Each caller recomputes, so a refresh never returns a value
+        computed before the call started. Under the default `lock`,
+        refreshes for one key also serialize, within the process and,
+        with `lock=True` and a lock backend, across replicas. An error
+        propagates, even under `stale_ttl`, because a caller asking for
+        fresh data is not served the value it asked to bypass.
+
+        A result the `skip` predicate rejects is not stored, so the
+        previous entry stays and keeps being served.
+
+        Accessed on an instance, call it as `Class.method.refresh(obj,
+        ...)`. Attribute access on a bound method does not bind `self`
+        for the helper.
 
         Returns a coroutine for an async function and the value itself
         for a sync one, matching the call it mirrors.
@@ -89,7 +97,7 @@ class CachedFunction(Protocol[P, R]):
         """Return statistics for the whole cache backing this function."""
         ...
 
-    def cache_clear(self) -> Any:  # noqa: ANN401
+    def cache_clear(self) -> Awaitable[None]:
         """Remove every entry from the cache backing this function.
 
         Always a coroutine, even for a sync function, so it must be
@@ -660,7 +668,12 @@ def _build_async_wrapper(  # noqa: C901
             return await recompute()
         # Serialized, never folded: each caller runs the function itself,
         # so a refresh never returns a value computed before it started.
+        # The locks nest in the same order as a miss, so the two never
+        # deadlock against each other.
         async with await guard.get_lock(key):
+            if auto_distributed and _has_lock_backend():
+                async with Lock(_stampede_lock_name(key)):
+                    return await recompute()
             return await recompute()
 
     wrapper: Any = async_wrapper
@@ -798,6 +811,23 @@ def _build_sync_wrapper(  # noqa: C901
         if not per_key:
             return recompute()
         with get_key_lock(key):
+            if auto_distributed and _has_lock_backend():
+                return _run(
+                    _distributed_orchestrate(
+                        func,
+                        args,
+                        kwargs,
+                        cache,
+                        key,
+                        skip,
+                        loop,
+                        early=early,
+                        stale_ttl=stale_ttl,
+                        tag_spec=tag_spec,
+                        peek=False,
+                    ),
+                    loop,
+                )
             return recompute()
 
     @functools.wraps(func)
@@ -893,7 +923,7 @@ def _run(coro: Any, loop: Any) -> Any:  # noqa: ANN401
     return asyncio.run_coroutine_threadsafe(coro, loop).result()
 
 
-async def _distributed_orchestrate(
+async def _distributed_orchestrate(  # noqa: PLR0913
     func: Callable[..., Any],
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
@@ -905,17 +935,20 @@ async def _distributed_orchestrate(
     early: float | None,
     stale_ttl: float | None,
     tag_spec: _TagSpec,
+    peek: bool = True,
 ) -> Any:  # noqa: ANN401
     """Hold the cross-replica lock and recompute, all in one loop task.
 
     The blocking function runs in an executor so it does not stall the
     loop, while the `Lock` acquire and release stay on the same task so
-    ownership holds.
+    ownership holds. A refresh passes `peek=False`, so it recomputes
+    instead of returning an entry another caller just stored.
     """
     async with Lock(_stampede_lock_name(key)):
-        result = await cache._peek(key, _SENTINEL)  # noqa: SLF001
-        if result is not _SENTINEL:
-            return result
+        if peek:
+            result = await cache._peek(key, _SENTINEL)  # noqa: SLF001
+            if result is not _SENTINEL:
+                return result
         started = time.perf_counter()
         result = await loop.run_in_executor(None, lambda: func(*args, **kwargs))
         delta = time.perf_counter() - started

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -55,6 +55,9 @@
     "CacheSettingsValidationError": {
       "()": "(error)"
     },
+    "CachedFunction": {
+      "()": "(*args, **kwargs)"
+    },
     "JsonSerializer": {
       "()": "()"
     },

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -230,7 +230,7 @@ class TestAsyncCachedCacheControl:
         await fetch(1)  # miss
         await fetch(2)  # miss
         await fetch(1)  # hit
-        info = fetch.cache_info()  # ty: ignore[unresolved-attribute]
+        info = fetch.cache_info()
 
         # Assert
         assert info.hits == EXPECTED_HITS_1
@@ -247,7 +247,7 @@ class TestAsyncCachedCacheControl:
             return x
 
         # Assert
-        assert inspect.iscoroutinefunction(fetch.cache_clear)  # ty: ignore[unresolved-attribute]
+        assert inspect.iscoroutinefunction(fetch.cache_clear)
 
     async def test_cache_clear_empties_the_cache(self) -> None:
         """Awaiting cache_clear() causes subsequent calls to recompute."""
@@ -265,7 +265,7 @@ class TestAsyncCachedCacheControl:
         assert call_count == EXPECTED_CALL_COUNT_1
 
         # Act
-        await fetch.cache_clear()  # ty: ignore[unresolved-attribute]
+        await fetch.cache_clear()
         await fetch(1)
 
         # Assert: recomputed after clear
@@ -282,13 +282,13 @@ class TestAsyncCachedCacheControl:
 
         await fetch(1)
         await fetch(2)
-        assert fetch.cache_info().currsize == EXPECTED_CURRSIZE_2  # ty: ignore[unresolved-attribute]
+        assert fetch.cache_info().currsize == EXPECTED_CURRSIZE_2
 
         # Act
-        await fetch.cache_clear()  # ty: ignore[unresolved-attribute]
+        await fetch.cache_clear()
 
         # Assert
-        assert fetch.cache_info().currsize == 0  # ty: ignore[unresolved-attribute]
+        assert fetch.cache_info().currsize == 0
 
 
 class TestAsyncCachedFunctionMetadata:
@@ -771,7 +771,7 @@ class TestSyncCachedCacheControl:
         # Act
         await asyncio.to_thread(lambda: compute(1))  # miss
         await asyncio.to_thread(lambda: compute(1))  # hit
-        info = compute.cache_info()  # ty: ignore[unresolved-attribute]
+        info = compute.cache_info()
 
         # Assert
         assert info.hits == EXPECTED_HITS_1
@@ -793,7 +793,7 @@ class TestSyncCachedCacheControl:
         assert call_count == EXPECTED_CALL_COUNT_1
 
         # Act: cache_clear is always a coroutine
-        await compute.cache_clear()  # ty: ignore[unresolved-attribute]
+        await compute.cache_clear()
         await asyncio.to_thread(lambda: compute(1))
 
         # Assert: recomputed after clear
@@ -1834,10 +1834,10 @@ class TestPrivateCacheForm:
             return expected_value
 
         assert await get_value() == expected_value
-        info = get_value.cache_info()  # ty: ignore[unresolved-attribute]
+        info = get_value.cache_info()
         assert info.hits == 0
         assert info.misses == EXPECTED_MISSES_1
-        await get_value.cache_clear()  # ty: ignore[unresolved-attribute]
+        await get_value.cache_clear()
 
     async def test_maxsize_bounds_private_cache(self) -> None:
         """maxsize= bounds the private cache and evicts the oldest entry."""
@@ -1880,3 +1880,220 @@ def test_private_cache_rejects_sync_function() -> None:
         @cached(ttl=30)
         def sync_fn() -> int:
             return 1
+
+
+EXPECTED_CALL_COUNT_3 = 3
+EXPECTED_REFRESH_FLEET = 5
+
+
+class TestAsyncCachedRefresh:
+    """Test the `refresh` helper on an async cached function."""
+
+    async def test_refresh_recomputes_and_overwrites(self) -> None:
+        """`refresh` skips the read, stores the new value, and returns it."""
+        # Arrange
+        cache = _make_cache()
+        call_count = 0
+
+        @cached(cache)
+        async def compute(_x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        # Act
+        first = await compute(1)
+        refreshed = await compute.refresh(1)
+        after = await compute(1)
+
+        # Assert
+        assert first == EXPECTED_CALL_COUNT_1
+        assert refreshed == EXPECTED_CALL_COUNT_2
+        assert after == EXPECTED_CALL_COUNT_2
+        assert call_count == EXPECTED_CALL_COUNT_2
+
+    async def test_refresh_populates_a_cold_key(self) -> None:
+        """`refresh` on a key that was never cached simply computes it."""
+        # Arrange
+        cache = _make_cache()
+        call_count = 0
+
+        @cached(cache)
+        async def compute(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return x * 2
+
+        # Act
+        refreshed = await compute.refresh(5)
+        cached_value = await compute(5)
+
+        # Assert
+        assert refreshed == EXPECTED_DOUBLE_5
+        assert cached_value == EXPECTED_DOUBLE_5
+        assert call_count == EXPECTED_CALL_COUNT_1
+
+    async def test_concurrent_refreshes_do_not_fold(self) -> None:
+        """Every refresher recomputes, so none returns a pre-call value."""
+        # Arrange
+        cache = _make_cache()
+        call_count = 0
+
+        @cached(cache)
+        async def compute(_x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0)
+            return call_count
+
+        # Act
+        results = await asyncio.gather(
+            *(compute.refresh(1) for _ in range(EXPECTED_REFRESH_FLEET))
+        )
+
+        # Assert
+        assert call_count == EXPECTED_REFRESH_FLEET
+        assert sorted(results) == list(range(1, EXPECTED_REFRESH_FLEET + 1))
+
+    async def test_refresh_without_lock_still_recomputes(self) -> None:
+        """`lock=False` opts out of serializing, and refresh still writes."""
+        # Arrange
+        cache = _make_cache()
+        call_count = 0
+
+        @cached(cache, lock=False)
+        async def compute(_x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        # Act
+        await compute(1)
+        refreshed = await compute.refresh(1)
+
+        # Assert
+        assert refreshed == EXPECTED_CALL_COUNT_2
+
+    async def test_refresh_error_propagates_past_stale_ttl(self) -> None:
+        """A caller asking for fresh data is not handed the stale value."""
+        # Arrange
+        cache = _make_cache()
+        fail = False
+
+        @cached(cache, stale_ttl=60)
+        async def compute(x: int) -> int:  # noqa: ARG001
+            if fail:
+                msg = "upstream down"
+                raise RuntimeError(msg)
+            return 1
+
+        await compute(1)
+        fail = True
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="upstream down"):
+            await compute.refresh(1)
+        # The stored entry is untouched, so a normal call still serves it.
+        assert await compute(1) == EXPECTED_CALL_COUNT_1
+
+    async def test_refresh_honours_skip(self) -> None:
+        """A result the skip predicate rejects is not stored."""
+        # Arrange
+        cache = _make_cache()
+        value = 1
+
+        @cached(cache, skip=lambda result: result is None)
+        async def compute(x: int) -> int | None:  # noqa: ARG001
+            return value
+
+        await compute(1)
+        value = None  # type: ignore[assignment]
+
+        # Act
+        refreshed = await compute.refresh(1)
+
+        # Assert
+        assert refreshed is None
+        assert await compute(1) == EXPECTED_CALL_COUNT_1
+
+    async def test_refresh_honours_tags(self) -> None:
+        """A refreshed entry keeps its tags, so tag invalidation still hits."""
+        # Arrange
+        cache = _make_cache()
+        call_count = 0
+
+        @cached(cache, key="v:{x}", tags=["all"])
+        async def compute(x: int) -> int:  # noqa: ARG001
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        await compute(1)
+        await compute.refresh(1)
+
+        # Act
+        await cache.delete_tags("all")
+        after = await compute(1)
+
+        # Assert
+        assert after == EXPECTED_CALL_COUNT_3
+
+
+class TestSyncCachedRefresh:
+    """Test the `refresh` helper on a sync cached function."""
+
+    async def test_refresh_recomputes_and_overwrites(self) -> None:
+        """A sync `refresh` returns the value directly, not a coroutine."""
+        # Arrange
+        cache = _make_cache()
+        call_count = 0
+
+        @cached(cache)
+        def compute(_x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        # Act
+        first = await asyncio.to_thread(lambda: compute(1))
+        refreshed = await asyncio.to_thread(lambda: compute.refresh(1))
+        after = await asyncio.to_thread(lambda: compute(1))
+
+        # Assert
+        assert first == EXPECTED_CALL_COUNT_1
+        assert refreshed == EXPECTED_CALL_COUNT_2
+        assert after == EXPECTED_CALL_COUNT_2
+
+    async def test_refresh_without_lock_still_recomputes(self) -> None:
+        """`lock=False` skips the per-key lock on the sync path too."""
+        # Arrange
+        cache = _make_cache()
+        call_count = 0
+
+        @cached(cache, lock=False)
+        def compute(_x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        # Act
+        await asyncio.to_thread(lambda: compute(1))
+        refreshed = await asyncio.to_thread(lambda: compute.refresh(1))
+
+        # Assert
+        assert refreshed == EXPECTED_CALL_COUNT_2
+
+    async def test_refresh_requires_an_open_backend(self) -> None:
+        """A closed backend reports the same error a normal call would."""
+        # Arrange
+        cache = TTLCache(
+            ttl=60, backend=MemoryCacheAdapter(), serializer=JsonSerializer()
+        )
+
+        @cached(cache)
+        def compute(x: int) -> int:
+            return x
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="The cache"):
+            await asyncio.to_thread(lambda: compute.refresh(1))

--- a/tests/cache/test_cached.py
+++ b/tests/cache/test_cached.py
@@ -2097,3 +2097,78 @@ class TestSyncCachedRefresh:
         # Act / Assert
         with pytest.raises(RuntimeError, match="The cache"):
             await asyncio.to_thread(lambda: compute.refresh(1))
+
+
+class TestCachedRefreshDistributed:
+    """Test refresh under a cross-replica lock backend."""
+
+    async def test_refresh_serializes_across_replicas(self) -> None:
+        """With `lock=True`, refreshes take the cross-replica lock too."""
+        # Arrange
+        cache = _make_cache()
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+        call_count = 0
+
+        @cached(cache, lock=True)
+        async def compute(_x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0)
+            return call_count
+
+        # Act
+        async with micro:
+            results = await asyncio.gather(
+                *(compute.refresh(1) for _ in range(EXPECTED_REFRESH_FLEET))
+            )
+
+        # Assert: still one execution per caller, never folded.
+        assert call_count == EXPECTED_REFRESH_FLEET
+        assert sorted(results) == list(range(1, EXPECTED_REFRESH_FLEET + 1))
+
+    async def test_sync_refresh_serializes_across_replicas(self) -> None:
+        """The sync path takes the cross-replica lock the same way."""
+        # Arrange
+        cache = _make_cache()
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+        call_count = 0
+
+        @cached(cache, lock=True)
+        def compute(_x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        # Act
+        async with micro:
+            first = await asyncio.to_thread(lambda: compute.refresh(1))
+            second = await asyncio.to_thread(lambda: compute.refresh(1))
+
+        # Assert
+        assert first == EXPECTED_CALL_COUNT_1
+        assert second == EXPECTED_CALL_COUNT_2
+
+
+class TestCachedRefreshPrivateCache:
+    """Test refresh on the private per-function cache form."""
+
+    async def test_refresh_on_private_cache(self) -> None:
+        """`@cached(ttl=...)` supports refresh with no app or backend setup."""
+        # Arrange
+        call_count = 0
+
+        @cached(ttl=30)
+        async def compute(_x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        # Act
+        first = await compute(1)
+        refreshed = await compute.refresh(1)
+        after = await compute(1)
+
+        # Assert
+        assert first == EXPECTED_CALL_COUNT_1
+        assert refreshed == EXPECTED_CALL_COUNT_2
+        assert after == EXPECTED_CALL_COUNT_2

--- a/tests/typechecking/cache.py
+++ b/tests/typechecking/cache.py
@@ -6,7 +6,7 @@ against the original parameters and return type.
 
 from typing import assert_type
 
-from grelmicro.cache import TTLCache, cached
+from grelmicro.cache import CacheInfo, TTLCache, cached
 
 
 async def load(user_id: int, *, fresh: bool = False) -> list[str]:
@@ -21,6 +21,30 @@ async def call_cached() -> None:
     """Awaiting a cached coroutine yields the original return type."""
     assert_type(await memoized(1), list[str])
     assert_type(await memoized(1, fresh=True), list[str])
+
+
+def sync_load(user_id: int) -> list[str]:
+    """Load values synchronously, pinning the sync wrapper's types."""
+    return [str(user_id)]
+
+
+sync_memoized = cached(ttl=60)(sync_load)
+
+
+async def call_refresh() -> None:
+    """`refresh` mirrors the call it replaces, awaitable for a coroutine."""
+    assert_type(await memoized.refresh(1), list[str])
+    assert_type(await memoized.refresh(1, fresh=True), list[str])
+
+
+def call_sync_refresh() -> None:
+    """Return the value itself from a sync function's `refresh`."""
+    assert_type(sync_memoized.refresh(1), list[str])
+
+
+def call_helpers() -> None:
+    """Expose the wrapper helpers to a type checker."""
+    assert_type(memoized.cache_info(), CacheInfo)
 
 
 async def use_ttl_cache() -> None:


### PR DESCRIPTION
Closes #500.

```python
@cached(cache, key="report:{user_id}")
async def get_report(user_id: int) -> dict: ...


await get_report(42)             # cached
await get_report.refresh(42)     # recompute, overwrite, return the new value
```

An endpoint honouring `Cache-Control: no-cache` keeps the decorator's key handling, tags, and stampede protection instead of dropping to manual `get`/`set`.

## Why a wrapper attribute

The issue offered three shapes. The `bypass=` predicate is unusable: the default key is `sha256(repr((args, sorted(kwargs.items()))))`, so `get(1, force=True)` and `get(1)` key **differently**, and the forced call would write to a key no normal caller ever reads. It also forces the flag to be a real parameter of the decorated function, since the wrapper forwards everything. A contextvar is worse, transitively forcing every nested `@cached` call in scope.

The wrapper attribute is per-call, explicit, key-clean, and sits beside the `cache_info()` / `cache_clear()` helpers the wrapper already exposed.

Worth noting: aiocache does have `cache_read=False`, but its own `cached_stampede.decorator` drops that parameter, so the bypass does not compose with its stampede protection. That is the trap this avoids.

## Two semantics that are not a plain miss

**Refreshes do not fold.** The miss path double-checks the entry with `_peek` under every lock, so simply skipping the initial read would have returned the stale value and never called the function. `refresh()` goes straight to `_compute_and_cache` under the per-key lock. Concurrent refreshes serialize and each recomputes, so writing to the database and then refreshing cannot hand back pre-write data. Rails agrees: `force: true` never reads, so it never folds.

**Errors propagate, `stale_ttl` does not apply.** Serving stale would return the exact entry the caller asked to bypass, silently. Compose it yourself if you want that.

`refresh()` still honours `skip`, `tags`, the `stale_ttl` reserve, and the `early` metadata, so the stored entry matches what a normal miss would have written. On a sync function it returns the value directly.

## Fixes a shipped typing hole

`cached()` returned `Callable[P, R]`, so `cache_info()` and `cache_clear()` were advertised in the docstring but invisible to type checkers. `f.cache_info()` failed any downstream `ty` or `mypy` run, and grelmicro ships `py.typed`. It now returns an exported `CachedFunction[P, R]` Protocol covering `__call__`, `refresh`, `cache_info`, `cache_clear`, and `__wrapped__`, with a permissive `__get__` so decorating a method degrades to `Any` rather than erroring (full ParamSpec plus descriptor binding is not expressible, and typeshed's own `_lru_cache_wrapper` gives up parameter types to get it).

Ten `# ty: ignore[unresolved-attribute]` comments in the existing tests were suppressing exactly this hole and are now deleted.

Also corrected a misleading docstring: these helpers were said to match `functools.lru_cache`, but `cache_clear` is bound to `TTLCache.clear`, which removes **every** entry, so on a shared cache it wipes other functions' entries too.

## Verification

Full pre-commit passes: ruff, ty, mypy, unit, integration, `mkdocs build --strict`, coverage at 100%. New tests cover overwrite, cold key, the no-fold guarantee, `lock=False`, error propagation past `stale_ttl`, `skip`, tags, both sync paths, and the closed-backend error. `tests/typechecking/cache.py` pins the new types under both checkers.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b