### PR TITLE
🚨 Satisfy ty 0.0.62 narrowing and list the new symbols in the reference

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -13,6 +13,7 @@
         - CacheInfo
         - CacheSerializer
         - CacheSettingsValidationError
+        - CachedFunction
         - JsonSerializer
         - PickleSerializer
         - PydanticSerializer

--- a/docs/reference/idempotency.md
+++ b/docs/reference/idempotency.md
@@ -12,6 +12,8 @@
         - IdempotencyConfig
         - IdempotencyConflictError
         - IdempotencyError
+        - IdempotencySettingsValidationError
         - IdempotencyStateError
+        - IdempotencyWaitTimeoutError
         - Operation
         - idempotent

--- a/grelmicro/config/_external.py
+++ b/grelmicro/config/_external.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import os
 from contextlib import AsyncExitStack, suppress
-from typing import TYPE_CHECKING, Annotated, Self
+from typing import TYPE_CHECKING, Annotated, Self, cast
 
 from typing_extensions import Doc
 
@@ -55,7 +55,12 @@ def _coerce_source(value: ConfigBackend | str | PathLike[str]) -> ConfigBackend:
             not installed (for example a URL without the matching extra).
     """
     if isinstance(value, (str, os.PathLike)):
-        text = os.fspath(value)
+        # `isinstance` narrows to a bare `PathLike`, dropping the `[str]`
+        # the signature already guarantees and `os.fspath` needs. mypy
+        # narrows it correctly, so only ty needs the cast.
+        text = os.fspath(
+            cast("str | os.PathLike[str]", value)  # type: ignore[redundant-cast]
+        )
         scheme = _detect_scheme(text)
         if scheme == "file":
             return FileConfigAdapter(text)

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -513,8 +513,9 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
 
                 A duplicate arriving mid-flight waits for the first
                 execution to finish, then replays its response. When the
-                wait exceeds this many seconds, `TimeoutError` is raised
-                instead. When None (the default), the wait is unbounded.
+                wait exceeds this many seconds,
+                `IdempotencyWaitTimeoutError` is raised instead. When None
+                (the default), the wait is unbounded.
                 """,
             ),
         ] = None,

--- a/grelmicro/trace/_autoinstrument.py
+++ b/grelmicro/trace/_autoinstrument.py
@@ -60,8 +60,10 @@ def validate_directive(directive: InstrumentDirective, known: set[str]) -> None:
     )
 
     if isinstance(directive, Mapping):
+        # `str(key)` keeps the sort well defined: `isinstance` narrows the
+        # mapping to unknown key types, and the names only feed a message.
         bad_values = sorted(
-            key
+            str(key)
             for key, value in directive.items()
             if not isinstance(value, bool)
         )


### PR DESCRIPTION
Unblocks the `ty` bump in #590, and closes two API-reference gaps found in a pre-release review of everything since 0.32.6.

## ty 0.0.62

`ty` 0.0.62 tightened type narrowing and found two genuine errors in existing code, which is why #590's Lint job fails. The bump itself is fine, our code was not.

- `grelmicro/config/_external.py` — `isinstance(value, (str, os.PathLike))` narrows to a **bare** `PathLike`, dropping the `[str]` the signature already guarantees, so no `os.fspath` overload matches. A cast restores it. mypy narrows correctly and calls the cast redundant under `warn_unused_ignores`, so the line carries both a cast and a `# type: ignore[redundant-cast]`, the paired-suppression pattern this repo already uses.
- `grelmicro/trace/_autoinstrument.py` — `sorted(...)` over mapping keys that narrowing widened to `object`, which has no ordering. Now `sorted(str(key) ...)`, which also makes the error message's ordering well defined rather than accidental.

Verified against **ty 0.0.61 (pinned), ty 0.0.62 (the bump), and mypy**. I tried two suppression-free alternatives first, splitting the `isinstance` and calling `__fspath__()` directly, and both left ty unhappy.

## Reference gaps

Three exported symbols were missing from the API reference, so a reader following the changelog to the reference page found nothing:

- `CachedFunction`, new in #594 and named in the changelog.
- `IdempotencyWaitTimeoutError`, new in #593, which `docs/idempotency.md` tells users to catch.
- `IdempotencySettingsValidationError`, a pre-existing gap. The cache page lists its counterpart, so this was an inconsistency rather than a decision.

Also aligned one docstring: `Idempotency.__call__` said `wait_timeout` raises `TimeoutError` while `run()` said `IdempotencyWaitTimeoutError`. Both are true since it subclasses, but they should name the same error.

Full pre-commit passes: ruff, ty, mypy, unit, integration, `mkdocs build --strict`, coverage at 100%.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b