### PR TITLE
🔖 Prepare the 0.32.7 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,23 +1,24 @@
 # Changelog
 
-## Unreleased
+## 0.32.7 - 2026-07-30
 
 ### Features
 
 * ✨ Add `refresh()` to a `@cached` function. It recomputes for the given arguments, overwrites the stored entry, and returns the new value, so an endpoint honouring `Cache-Control: no-cache` keeps the decorator's key handling and tag invalidation. Concurrent refreshes each recompute rather than folding, and an error propagates instead of serving stale. ([#500](https://github.com/grelinfo/grelmicro/issues/500))
-
 * ✨ Add `IdempotencyMiddleware`. A request carrying an `Idempotency-Key` header runs once, and a retry replays the stored response without reaching the handler. Pure ASGI, so it works on FastAPI, Starlette, and Litestar alike. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 * ✨ Bound the single-flight wait with `wait_timeout=` on an `Idempotency` block and on `run()`. A duplicate that waits longer than that raises `IdempotencyWaitTimeoutError`, which subclasses `TimeoutError`, instead of holding the caller indefinitely. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
-
 * ✨ Add `document_idempotency(app)`, which describes the installed `IdempotencyMiddleware` in the OpenAPI schema. A middleware is invisible to the generated schema, so a client built from it never learns the header exists. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 
 ### Fixed
 
-* 🐛 Accept a SQLAlchemy-style Postgres URL. `PostgresProvider` took `postgresql+asyncpg://` without complaint and then failed at connect time, so every adopter stripped the driver suffix by hand. The suffix is now dropped when the URL is resolved, from a keyword, the environment, or a config. ([#596](https://github.com/grelinfo/grelmicro/issues/596))
-
+* 🐛 Accept a SQLAlchemy-style Postgres URL. `PostgresProvider` took `postgresql+asyncpg://` without complaint and then failed at connect time, so every adopter stripped the driver suffix by hand. The suffix is now dropped when the URL is resolved, from a keyword, the environment, or a config, whatever the scheme's case. ([#596](https://github.com/grelinfo/grelmicro/issues/596))
 * 🐛 Type the helpers a `@cached` function exposes. `cached()` returned a plain `Callable`, so `cache_info()` and `cache_clear()` were documented but invisible to type checkers, and calling them failed a downstream `ty` or `mypy` run. It now returns `CachedFunction`. ([#500](https://github.com/grelinfo/grelmicro/issues/500))
 * 🐛 Release the single-flight lock correctly when an `Idempotency` block is cancelled while acquiring it. The lock was bound to the block before it was held, so the cleanup path tried to release a lock the block did not own and raised `LockNotOwnedError` over the original error. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
 * 🐛 Release the in-process idempotency lock even when the distributed release is cancelled mid-flight. A cancellation there left the key locked for the life of the process. ([#503](https://github.com/grelinfo/grelmicro/issues/503))
+
+### Internal
+
+* 🚨 Satisfy the stricter type narrowing in `ty` 0.0.62. Two existing call sites lost a type parameter through `isinstance`, which failed the lint gate on the dependency bump rather than in any user-visible way. ([#598](https://github.com/grelinfo/grelmicro/pull/598))
 
 ### Docs
 

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -89,6 +89,16 @@ A request without the header passes straight through. Adding the middleware chan
 
 Every response the app returns is stored, `4xx` and `5xx` included. A handler that writes to the database and then fails on the way out leaves a stored failure, so the retry gets that instead of running the write again.
 
+Store only what you want replayed. A transient `503` stored for the whole `ttl` keeps answering `503` long after the dependency recovers, so exclude the statuses that mean "try again later":
+
+```python
+app.add_middleware(
+    IdempotencyMiddleware,
+    idempotency=Idempotency("http"),
+    skip=lambda response: response["status"] in (429, 502, 503, 504),
+)
+```
+
 A handler that raises an unhandled exception is different. The framework turns it into a `500` outside the middleware, so nothing is stored and a retry runs fresh. A raised `HTTPException` is not an unhandled exception. The framework turns it into a response inside the middleware, so it is stored and replayed like any other.
 
 ### What is never stored

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -533,7 +533,9 @@ def _normalize_scheme(url: str) -> str:
     unrelated `+`.
     """
     scheme, separator, rest = url.partition("://")
-    if not separator or not scheme.startswith(_DRIVER_PREFIX):
+    # A URL scheme is case-insensitive, so match on the folded form and
+    # emit the lowercase spelling asyncpg expects.
+    if not separator or not scheme.lower().startswith(_DRIVER_PREFIX):
         return url
     return f"{_POSTGRESQL_SCHEME}{separator}{rest}"
 

--- a/tests/providers/test_postgres_provider.py
+++ b/tests/providers/test_postgres_provider.py
@@ -676,6 +676,18 @@ class TestSQLAlchemyDsn:
         # Assert
         assert provider.url == url
 
+    @pytest.mark.parametrize(
+        "scheme", ["POSTGRESQL+ASYNCPG", "PostgreSQL+AsyncPG"]
+    )
+    def test_an_uppercase_driver_scheme_is_dropped(self, scheme: str) -> None:
+        """A URL scheme is case-insensitive, so the suffix still goes."""
+        # Arrange
+        url = f"{scheme}://test_user:test_password@test_host:1234/test_db"
+        # Act
+        provider = PostgresProvider(url=url)
+        # Assert
+        assert provider.url == URL
+
     def test_multi_host_url_keeps_every_host(self) -> None:
         """Normalising the scheme leaves a multi-host URL intact."""
         # Arrange


### PR DESCRIPTION
Closes out the pre-release review of everything since 0.32.6 and dates the changelog section.

## Review findings fixed

- **An uppercase driver scheme was not normalised.** `POSTGRESQL+ASYNCPG://` kept its suffix. A URL scheme is case-insensitive per RFC 3986, so the match now folds the case and emits the lowercase spelling asyncpg expects. Tested on two spellings.
- **The transient-error trap is now documented.** A `503` stored by `IdempotencyMiddleware` replays for the whole `ttl`, long after the dependency recovers. The docs now show the `skip=` recipe that excludes retry-later statuses.

## Deferred findings filed rather than dropped

- #599 — let `install()` place `IdempotencyMiddleware` so the ordering trap cannot be expressed. Needs a design pass because `install` is shared with the FastStream path.
- #600 — decide and document what `@cached` does on a method. It half-works today: `self` lands in the default key, `refresh()` does not bind, and typing degrades to `Any`.

No `TODO`, `FIXME`, `XXX` or `HACK` markers anywhere in `grelmicro/`, `tests/`, `docs/`, `examples/` or `tools/`.

## Changelog

`## Unreleased` becomes `## 0.32.7 - 2026-07-30`, list spacing normalised, and an `### Internal` entry added for the `ty` 0.0.62 narrowing fix, which had shipped in #598 without one.

**0.32.7, a patch.** Every change since 0.32.6 is additive, or a fix whose old behaviour was a guaranteed failure, or typing-only with identical runtime. Nothing claims the `0.x.0` breaking position.

## Release tier verified locally

The Release workflow runs a tier PR CI skips, and a tag is immutable, so this was checked before tagging rather than after:

| | 3.12 | 3.13 | 3.14 |
|---|---|---|---|
| unit | pass | 3595 pass | 3595 pass |
| integration + slow | pass | 240 pass | 240 pass |

Plus the demo smoke: `docker compose up --wait` with all three containers healthy and `/livez`, `/readyz`, `/healthz` all returning 200. Full pre-commit green, coverage at 100%.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b