### PR TITLE
🔖 Prepare the 0.32.8 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.32.8 - 2026-07-30
 
 ### Internal
 


### PR DESCRIPTION
Dates the changelog section for 0.32.8.

## Scope

CI and documentation only. Verified rather than assumed: I built from main and compared against the published 0.32.7 wheel, and the file list is identical with **every shipped `.py` file byte-identical**. The four files changed since 0.32.7 are `.github/workflows/reusable-tests.yml`, `codecov.yml`, `CONTRIBUTING.md` and `docs/changelog.md`. Nothing under `grelmicro/`.

So this publishes a package functionally identical to 0.32.7. I flagged that and the maintainer chose to release anyway, which is recorded here so the empty release notes are not a mystery later.

The substance shipped in #603: CI never actually enforced the 100% coverage claim, because every tier reset coverage instead of accumulating and no `fail-under` gate existed in the workflows at all.

## Verification

Full tier dispatched on main before tagging: Lint, Workflow Lint, Docs, Demo Smoke, and Tests on 3.12, 3.13 and 3.14, all green, with the new `Enforce Combined Coverage` step passing on main for the first time and logging `TOTAL ... 100%`.

**0.32.8, a patch.** No API change, no behaviour change.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b