### PR TITLE
🔖 Prepare the 0.32.9 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.32.9 - 2026-07-30
 
 ### Fixed
 


### PR DESCRIPTION
Dates the changelog section for 0.32.9.

Unlike 0.32.8, this one carries real user-facing change: eight behavioural fixes in `grelmicro/`, all from #605, the silent-failure theme the production adopter in #591 rated highest. They reported the category, these are the fixes.

## Scope

Background work that runs outside a caller's stack had nowhere to raise, so seven sites failed invisibly: the cache background refresh, its task lifetime, the `Shield` cache read and write, the Postgres outbox listener, the relay and purge loops, and an outbox `wait_notify` that could spin the relay.

Two counters now carry the volume, `grelmicro.cache.early_refreshes` and `grelmicro.shield.cache_writes`, each with `outcome` and `error.type`.

## Verification

Full tier dispatched on main before tagging: Lint, Workflow Lint, Docs, Demo Smoke, and Tests on 3.12, 3.13 and 3.14, all green. The `Enforce Combined Coverage` step logged `TOTAL ... 100%` across unit, slow and integration.

This change went through three review rounds. Each found something the previous missed, including a log storm at full request rate, a crash reported only at shutdown, and tests that passed with the fix reverted.

**0.32.9, a patch.** No API change. Two new metric names, additive.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b