### PR TITLE
📝 Add a migration page with one note per minor

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Docs
+
+* 📝 Add a [migration page](migration.md), one note per minor from 0.30 onward, listing only what an upgrade requires. It leads with a symptom table, so an adopter several versions behind can match the error they see instead of reconstructing the path from every release's notes. ([#608](https://github.com/grelinfo/grelmicro/issues/608))
+
 ## 0.32.9 - 2026-07-30
 
 ### Fixed

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,137 @@
+# Migration
+
+One note per minor release, listing only what you have to change. Each entry
+names the symptom first, so you can match what you are seeing rather than
+read the whole page.
+
+This page covers **0.30 onward**. For an older version, read the `Breaking`
+sections in the [changelog](changelog.md), newest first.
+
+In `0.x` the minor is the breaking position: a `0.x.0` release may change the
+public API, and a `0.x.y` release is a safe patch. So an upgrade within one
+minor never needs this page.
+
+## Find your symptom
+
+| Symptom | Release | Fix |
+|---|---|---|
+| `AttributeError: 'Operation' object has no attribute 'response'` | 0.30 | [Use `result()`](#0-30-operation-result) |
+| A password or URL reads back as `SecretStr(...)` or `***` | 0.31, 0.32 | [Call `.get_secret_value()`](#0-31-secret-credentials) |
+| Metrics stopped arriving after upgrading, with no error | 0.31 | [Set an endpoint](#0-31-metrics-auto-exporter) |
+| `TypeError: ... unexpected keyword argument 'path'` on a SQLite adapter | 0.32 | [Pass `provider=`](#0-32-sqlite-provider) |
+| `SettingsValidationError` where you caught `CoordinationSettingsValidationError` | 0.32 | [Catch the base error](#0-32-sqlite-provider) |
+| An open circuit closed once, just after upgrading | 0.32.2 | [Expected, happens once](#0-32-2-circuit-breaker-state) |
+
+## 0.32
+
+### SQLite adapters take a provider, not a path {#0-32-sqlite-provider}
+
+`SQLiteLockAdapter` and `SQLiteScheduleAdapter` now take `provider=`, like
+every other SQLite adapter.
+
+```python
+# Before
+SQLiteLockAdapter("app.db")
+
+# After
+SQLiteLockAdapter(provider=SQLiteProvider("app.db"))
+```
+
+Better still, pass the provider to the component and let it build both:
+
+```python
+sqlite = SQLiteProvider("app.db")
+micro = Grelmicro(uses=[Coordination(sqlite)])
+```
+
+That also shares one connection across every component on the same file,
+where the old form opened its own.
+
+A missing path now raises `SettingsValidationError` instead of
+`CoordinationSettingsValidationError`. If you catch the latter, catch the
+base error.
+
+### URL and header fields hide their credentials {#0-32-secret-urls}
+
+`url` on `PostgresConfig` and `RedisConfig`, and `endpoint` on `TraceConfig`
+and `MetricsConfig`, are now `SecretUrl`. Each `headers` value on
+`TraceConfig` and `MetricsConfig` is now a `SecretStr`.
+
+Passing a plain string still works. Only reading the value back changes:
+
+```python
+# Before
+dsn = config.url
+
+# After
+dsn = config.url.get_secret_value()
+```
+
+Nothing changes on the wire. The point is that `repr()`, `model_dump()` and
+a `ValidationError` no longer carry the password.
+
+## 0.31
+
+### Credential fields hide their value {#0-31-secret-credentials}
+
+`basic_auth_password` on `TraceConfig` and `MetricsConfig`, and `password` on
+`PostgresConfig` and `RedisConfig`, are now `SecretStr`. Same shape as the
+0.32 change above: passing a plain string still works, reading it back needs
+`.get_secret_value()`.
+
+### `Metrics()` no longer defaults to localhost {#0-31-metrics-auto-exporter}
+
+`Metrics()` now defaults to the `auto` exporter. With an endpoint configured
+it exports over OTLP HTTP. Without one it auto-disables into a true no-op,
+where it previously fell back to `localhost:4318`.
+
+**This one fails quietly.** If you relied on the implicit localhost default,
+metrics simply stop arriving and nothing raises. Set the endpoint
+explicitly:
+
+```python
+Metrics(endpoint="http://localhost:4318")
+```
+
+Or from the environment, `GREL_METRICS_ENDPOINT`.
+
+The upside is that you can now register `Metrics()` unconditionally: an
+auto-disabled `Metrics` installs no provider and never conflicts with a
+second app.
+
+## 0.30
+
+### `Operation.response` became `result()` {#0-30-operation-result}
+
+The idempotency `Operation.response` attribute is now a `result()` method,
+typed as the stored type so a replay branch returns it without a cast.
+
+```python
+async with idem(key) as op:
+    if op.replayed:
+        return op.result()  # was: op.response
+    ...
+```
+
+It is valid **only** on a replay. Calling it on a first execution raises
+`IdempotencyStateError`, so keep it behind `if op.replayed:`.
+
+## 0.32.2, not breaking but worth knowing {#0-32-2-circuit-breaker-state}
+
+Circuit breakers now reclaim their stored state instead of keeping it
+forever. Rows written before 0.32.2 carry no activity timestamp, so an
+already-open circuit on Postgres or SQLite reads as expired the first time
+the new code touches it and starts again from `CLOSED`.
+
+This happens once, on the first call after the upgrade. Circuits held open
+by `isolate()` are unaffected.
+
+## About deprecation
+
+Before 1.0 a rename is a clean cut: the old name is removed in the same
+release the new one appears, with no deprecation cycle and no alias. That
+keeps a fast-moving `0.x` from accumulating shims, and it is why this page
+exists instead.
+
+After 1.0, `1.x` follows standard semver and breaking changes go through a
+deprecation cycle.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,7 +9,9 @@ sections in the [changelog](changelog.md), newest first.
 
 In `0.x` the minor is the breaking position: a `0.x.0` release may change the
 public API, and a `0.x.y` release is a safe patch. So an upgrade within one
-minor never needs this page.
+minor rarely needs this page. The one exception so far is
+[0.32.2](#0-32-2-circuit-breaker-state), which changes no API but does change
+what an already-open circuit does once.
 
 ## Find your symptom
 
@@ -18,7 +20,7 @@ minor never needs this page.
 | `AttributeError: 'Operation' object has no attribute 'response'` | 0.30 | [Use `result()`](#0-30-operation-result) |
 | A password or URL reads back as `SecretStr(...)` or `***` | 0.31, 0.32 | [Call `.get_secret_value()`](#0-31-secret-credentials) |
 | Metrics stopped arriving after upgrading, with no error | 0.31 | [Set an endpoint](#0-31-metrics-auto-exporter) |
-| `TypeError: ... unexpected keyword argument 'path'` on a SQLite adapter | 0.32 | [Pass `provider=`](#0-32-sqlite-provider) |
+| `TypeError` on a SQLite adapter, either `unexpected keyword argument 'path'` or `takes 1 positional argument` | 0.32 | [Pass `provider=`](#0-32-sqlite-provider) |
 | `SettingsValidationError` where you caught `CoordinationSettingsValidationError` | 0.32 | [Catch the base error](#0-32-sqlite-provider) |
 | An open circuit closed once, just after upgrading | 0.32.2 | [Expected, happens once](#0-32-2-circuit-breaker-state) |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ validation:
 nav:
 - grelmicro: index.md
 - installation.md
+- migration.md
 - User Guide:
     - first-steps.md
     - wiring.md
@@ -159,6 +160,9 @@ extra_css:
 
 markdown_extensions:
   - admonition
+  # Explicit heading ids, so the migration page's symptom table can link
+  # to stable anchors instead of slugs that drift when a heading is reworded.
+  - attr_list
   - pymdownx.details
   - pymdownx.highlight
   - pymdownx.superfences:


### PR DESCRIPTION
Closes #608, from #591 item 5.

An adopter several versions behind had to reconstruct the upgrade path by reading every release's notes and working out which entries applied to them. Four breaking changes landed across three minors, each clearly changelogged, none consolidated.

## The page

[`docs/migration.md`](https://grelmicro.grel.info/migration/), one note per minor from 0.30 onward, listing only what an upgrade requires.

It leads with a **symptom table**, because an adopter usually arrives holding an error rather than a version number:

| Symptom | Release |
|---|---|
| `AttributeError: 'Operation' object has no attribute 'response'` | 0.30 |
| A password or URL reads back as `SecretStr(...)` or `***` | 0.31, 0.32 |
| Metrics stopped arriving after upgrading, with no error | 0.31 |
| `TypeError: ... unexpected keyword argument 'path'` on a SQLite adapter | 0.32 |
| `SettingsValidationError` where you caught `CoordinationSettingsValidationError` | 0.32 |
| An open circuit closed once, just after upgrading | 0.32.2 |

The `Metrics()` row matters most: that break **fails quietly**. An app relying on the old implicit `localhost:4318` default just stops exporting, with nothing raised. It is the one entry an adopter cannot discover from an error message.

## Verified, not transcribed

Every step was checked against the shipped code rather than copied from the changelog:

- `SQLiteLockAdapter` parameters are `provider, env_prefix, table_name`, no `path`
- `Operation.result()` exists, `Operation.response` does not
- `PostgresConfig(url=...).url` is a `SecretUrl`, `get_secret_value()` works, and `repr()` hides the password
- `MetricsConfig().exporter` is `auto`

## Scope

0.30 onward, stated on the page, with older minors pointed at the changelog's `Breaking` sections. That is the range a current adopter plausibly upgrades from, and bounding it explicitly beats a page that trails off.

## One config change

`attr_list` is now enabled. The symptom table links to explicit heading ids so an anchor survives a heading being reworded, and without the extension those ids render as literal text. `mkdocs build --strict` confirms every anchor resolves.

## Not in scope

The deprecation-shim half of #591 item 5 is filed separately as **#613**, because it is a policy decision rather than a documentation task, and the issue asked for it to be decided explicitly instead of folded in.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b