### PR TITLE
👷 Enforce the coverage total on the pull request that changes code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,12 +141,15 @@ jobs:
     name: Tests
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
-    # PRs and pushes to main run the light tier (unit, Python 3.12). The
-    # nightly schedule and manual dispatch run the full tier (matrix, slow,
-    # integration, demo). Release runs the full tier before publishing.
+    # PRs and pushes to main run the unit tier on Python 3.12, plus the slow
+    # and integration tiers whenever code changed, because the 100% coverage
+    # total is only measurable once all three have run. The nightly schedule
+    # and manual dispatch run the full tier (matrix, demo). Release runs the
+    # full tier before publishing.
     uses: ./.github/workflows/reusable-tests.yml
     with:
       full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      coverage: ${{ needs.changes.outputs.code == 'true' }}
     permissions:
       contents: read
     secrets:

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -6,6 +6,14 @@ on:
         description: 'Run the full matrix with the slow, integration, and demo tiers.'
         type: boolean
         default: false
+      coverage:
+        description: >-
+          Run the slow and integration tiers on the primary Python and enforce
+          the combined 100% total. Implied by `full`. Set it on a pull request
+          that touches code, so a coverage regression fails there instead of
+          in the next nightly. It leaves the matrix and the demo tier alone.
+        type: boolean
+        default: false
       ref:
         description: 'Git ref to check out and test. Defaults to the triggering ref.'
         type: string
@@ -57,7 +65,7 @@ jobs:
       - name: Run Slow Tests
         # Exit code 5 means "no tests collected", which is fine while the
         # slow tier is empty.
-        if: ${{ inputs.full }}
+        if: ${{ inputs.full || inputs.coverage }}
         run: |
           set +e
           pytest -x -m "slow and not integration" --cov --cov-append --junitxml=junit.xml -o junit_family=legacy
@@ -67,28 +75,28 @@ jobs:
             exit "$status"
           fi
       - name: Upload Slow Test Coverage to Codecov
-        if: ${{ inputs.full }}
+        if: ${{ inputs.full || inputs.coverage }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           flags: "slow,python${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Slow Test Results to Codecov
-        if: ${{ inputs.full }}
+        if: ${{ inputs.full || inputs.coverage }}
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           flags: "slow,python${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Run Integration Tests
-        if: ${{ inputs.full }}
+        if: ${{ inputs.full || inputs.coverage }}
         run: pytest -x -m integration --cov --cov-append --junitxml=junit.xml -o junit_family=legacy
       - name: Upload Integration Test Coverage to Codecov
-        if: ${{ inputs.full }}
+        if: ${{ inputs.full || inputs.coverage }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           flags: "integration,python${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Integration Test Results to Codecov
-        if: ${{ inputs.full }}
+        if: ${{ inputs.full || inputs.coverage }}
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           flags: "integration,python${{ matrix.python }}"
@@ -100,7 +108,7 @@ jobs:
         # others (`outbox/_uuid.py` vendors UUIDv7 for 3.12 and 3.13 and
         # re-exports the stdlib on 3.14), so the total is below 100 there by
         # design.
-        if: ${{ inputs.full && matrix.python == '3.12' }}
+        if: ${{ (inputs.full || inputs.coverage) && matrix.python == '3.12' }}
         run: coverage report --fail-under=100
 
   demo:

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -53,11 +53,13 @@ jobs:
       - name: Run Unit Tests
         run: pytest -x -m "not integration and not slow" --cov --junitxml=junit.xml -o junit_family=legacy
       - name: Upload Unit Test Coverage to Codecov
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           flags: "unit,python${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Unit Test Results to Codecov
+        continue-on-error: true
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           flags: "unit,python${{ matrix.python }}"
@@ -76,12 +78,14 @@ jobs:
           fi
       - name: Upload Slow Test Coverage to Codecov
         if: ${{ inputs.full || inputs.coverage }}
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           flags: "slow,python${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Slow Test Results to Codecov
         if: ${{ inputs.full || inputs.coverage }}
+        continue-on-error: true
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           flags: "slow,python${{ matrix.python }}"
@@ -91,12 +95,14 @@ jobs:
         run: pytest -x -m integration --cov --cov-append --junitxml=junit.xml -o junit_family=legacy
       - name: Upload Integration Test Coverage to Codecov
         if: ${{ inputs.full || inputs.coverage }}
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           flags: "integration,python${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Integration Test Results to Codecov
         if: ${{ inputs.full || inputs.coverage }}
+        continue-on-error: true
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           flags: "integration,python${{ matrix.python }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -426,10 +426,12 @@ class RateLimiter:
 - **100 % line + branch coverage** across unit + slow + integration is
   enforced twice: locally by the pre-commit `coverage-report` hook, and
   in CI by the `Enforce Combined Coverage` step, both running
-  `coverage report --fail-under=100`. Pull requests and pushes to `main`
-  run the unit tier, so they cannot check the total. The nightly schedule
-  and releases run all three tiers and do. The CI step is pinned to the
-  primary Python, because a version-split module such as
+  `coverage report --fail-under=100`. A pull request or push that touches
+  code runs all three tiers and enforces the total, so a regression fails
+  there rather than in the next nightly. The nightly schedule, a manual
+  dispatch, and a release add the Python matrix and the demo tier. The CI
+  step is pinned to the primary Python, because a version-split module
+  such as
   `outbox/_uuid.py` leaves dead code on the other interpreters and the
   total is below 100 % there by design.
 - Codecov's project status is **advisory**. A pull request measures the
@@ -574,11 +576,12 @@ fixed cadence.
 - **Resolve every conversation** before merge.
 - Merges are **squash** only, so `main` keeps a linear history.
 
-CI is tiered to keep feedback fast. Pull requests and pushes to `main`
-run the light tier (unit tests on the current Python). The nightly
-schedule and every release run the full tier (the Python matrix plus
-the slow, integration, and demo tiers), so a release is always tested
-against everything before it publishes.
+CI is tiered to keep feedback fast. A pull request or push that touches
+code runs the unit, slow, and integration tiers on the current Python and
+enforces the 100 % coverage total. A docs-only change skips the test job
+entirely. The nightly schedule and every release add the Python matrix and
+the demo tier, so a release is always tested against everything before it
+publishes.
 
 ### When a required check is missing
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,11 +4,11 @@ coverage:
   status:
     project:
       default:
-        # Advisory only. A pull request measures the unit tier alone while a
-        # nightly or release run measures unit + slow + integration, so
-        # comparing a head against a base built from a different tier
-        # flip-flops. The enforced total is the `Enforce Combined Coverage`
-        # step in reusable-tests.yml.
+        # Advisory only. A code-touching run measures unit + slow +
+        # integration, but a docs-only push to `main` measures the unit tier
+        # alone, so a head can still be compared against a base built from a
+        # different tier and flip-flop. The enforced total is the `Enforce
+        # Combined Coverage` step in reusable-tests.yml.
         informational: true
       unit:
         target: 90% # unit test coverage

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 * 👷 Enforce the coverage total on the pull request that changes code, not in the next nightly. The slow and integration tiers now run on a code-touching pull request or push, on the primary Python only, so the combined 100% total is measurable there. The Python matrix and the demo tier stay on the nightly, dispatch, and release paths. About two minutes per pull request. ([#602](https://github.com/grelinfo/grelmicro/issues/602))
 
+* 👷 Stop a Codecov upload from failing CI. The test-results action crashed on a transient network error, which fails the step whatever `fail_ci_if_error` says, so a green test run with a passing coverage gate was reported as a failure. Uploads are telemetry and now cannot gate a build. ([#602](https://github.com/grelinfo/grelmicro/issues/602))
+
 ### Docs
 
 * 📝 Add a [migration page](migration.md), one note per minor from 0.30 onward, listing only what an upgrade requires. It leads with a symptom table, so an adopter several versions behind can match the error they see instead of reconstructing the path from every release's notes. ([#608](https://github.com/grelinfo/grelmicro/issues/608))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+* 👷 Enforce the coverage total on the pull request that changes code, not in the next nightly. The slow and integration tiers now run on a code-touching pull request or push, on the primary Python only, so the combined 100% total is measurable there. The Python matrix and the demo tier stay on the nightly, dispatch, and release paths. About two minutes per pull request. ([#602](https://github.com/grelinfo/grelmicro/issues/602))
+
 ### Docs
 
 * 📝 Add a [migration page](migration.md), one note per minor from 0.30 onward, listing only what an upgrade requires. It leads with a symptom table, so an adopter several versions behind can match the error they see instead of reconstructing the path from every release's notes. ([#608](https://github.com/grelinfo/grelmicro/issues/608))


### PR DESCRIPTION
Closes #602, the follow-up left open when the coverage gate landed.

The 100% total is only measurable once unit, slow and integration have all run. Only the nightly and release did that, so a coverage regression was caught by the nightly rather than by the pull request that caused it.

## What changes

A new `coverage` input on `reusable-tests.yml` runs the slow and integration tiers **on the primary Python only** and enforces the combined total. `ci.yml` passes it whenever the `code` path filter matches.

The matrix and the demo tier deliberately stay where they were. The coverage gate is already pinned to 3.12, because `outbox/_uuid.py` is version-split and leaves dead code on the others, so three Pythons buy nothing for this purpose.

| Trigger | matrix | unit | slow | integration | gate | demo |
|---|---|---|---|---|---|---|
| PR touching code | 3.12 only | yes | yes | yes | yes | no |
| PR touching only docs | test job skipped entirely | | | | | |
| push to main touching code | 3.12 only | yes | yes | yes | yes | no |
| nightly, dispatch, release | 3 versions | yes | yes | yes | 3.12 | yes |

## Cost

About **two minutes** per code-touching pull request, measured from the tier timings in run 30540539609: slow 16s, integration 88s, uploads 18s, gate 1s. PR wall clock goes from roughly 1m40s to 4m.

Worth it: the project advertises 100% coverage, and until now nothing in CI checked it on the change that could break it. The local pre-commit hook does, but pre-commit.ci skips that hook, so a contributor without local hooks had no gate at all.

## Verified rather than assumed

- The gate is reachable on a pull request: the matrix is `["3.12"]` there, so `matrix.python == '3.12'` holds.
- `release.yml` passes only `full` and `ref`. An omitted optional boolean input takes its declared `default: false`, so nothing errors, and `full: true` still implies the tiers and the gate.
- The `--cov-append` chain holds: the unit step is unconditional and writes the base with a plain `--cov`, and a slow tier exiting 5 with no tests collected appends nothing rather than truncating.
- Codecov flags are unaffected: the `unit` upload still happens before any append, so the 90% `unit` status keeps measuring the same thing.

## Doc drift fixed in the same pass

Three passages said the opposite of the new behaviour, one of them added yesterday: two in `CONTRIBUTING.md` and the `codecov.yml` comment. All three now describe what actually runs. `codecov.yml` keeps `informational: true`, because a docs-only push to `main` still measures the unit tier alone, so a base can still come from a different tier.

## Accepted costs, not oversights

- The `code` filter includes `pyproject.toml`, `uv.lock` and `.github/workflows/**`, so a dependency or pipeline change also runs the tiers. That is deliberate: those are exactly the changes most likely to break integration.
- A merged pull request runs the tiers twice, once on the merge ref and once on the push to `main`. The second is not waste, it enforces the total on the squash commit after `main` may have moved, which pushes never did before.

The #613 deprecation decision is a separate PR, since it is a policy question rather than CI.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b