### PR TITLE
📝 Write down the pre-1.0 deprecation policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -529,6 +529,19 @@ stable. It is a maturity milestone, not a calendar or launch event. We
 cross it when the API has held steady and we are ready to commit to it,
 not before.
 
+Before `1.0`, a rename is a **clean cut**: the old name goes in the
+same release the new one arrives, with no `DeprecationWarning` and no
+alias. Put the entry under `### Breaking` and add a note to
+[`docs/migration.md`](docs/migration.md) saying what to change.
+
+That is deliberate. A deprecation cycle means carrying a shim, a test
+that proves the warning fires, and the discipline to remove both on
+schedule. Across a fast-moving `0.x` those shims accumulate, and the
+ones that are never removed are worse than the break they softened.
+`0.x.0` is already declared the breaking position, so the signal is
+there. What an adopter actually needs is to find the change quickly,
+which is what the migration page is for.
+
 After `1.0`, standard semver applies: breaking changes wait for the
 next `MAJOR`, and a removal goes through a `DeprecationWarning` cycle
 first. There is no fixed schedule for major versions, and a major

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@
 
 ### Docs
 
+* 📝 Write down the pre-1.0 deprecation policy. A rename before 1.0 is a clean cut, with the reasoning recorded so the question does not get re-litigated per rename. ([#613](https://github.com/grelinfo/grelmicro/issues/613))
 * 📝 Add a [migration page](migration.md), one note per minor from 0.30 onward, listing only what an upgrade requires. It leads with a symptom table, so an adopter several versions behind can match the error they see instead of reconstructing the path from every release's notes. ([#608](https://github.com/grelinfo/grelmicro/issues/608))
 
 ## 0.32.9 - 2026-07-30


### PR DESCRIPTION
Closes #613.

## The decision: keep clean cuts

A rename before 1.0 stays a clean cut. The old name goes in the same release the new one arrives, with no `DeprecationWarning` and no alias.

**This is not a new decision, it is an existing one that was never written down.** `CONTRIBUTING.md` documented only the post-1.0 half ("after 1.0 ... a removal goes through a `DeprecationWarning` cycle first"), while the pre-1.0 practice lived in individual changelog entries saying "No deprecation shim". So the question could be re-litigated per rename, which is what #591 did.

## Why not adopt one minor of deprecation

The adopter in #591 asked for a shim for one minor, having taken four breaking changes across three minors while upgrading from 0.29.2. That is a real cost and the request is reasonable. Against it:

- A deprecation cycle is not one shim. It is the shim, a test proving the warning fires, and the discipline to remove both on schedule. The third is where these policies rot, and a shim that outlives its cycle is worse than the break it softened.
- `0.x.0` already declares the breaking position, so the signal exists.
- What the adopter actually described needing was to **find** the changes, not to take them in two steps. That is what #614's migration page addresses, and it landed first.

If 1.0 were far away this would be a closer call. It is not.

## What changed

Thirteen lines in `CONTRIBUTING.md`, next to the existing post-1.0 paragraph: the rule, the reasoning, and the instruction to add a migration note with every breaking entry so the page stays current rather than being reconstructed later.

No code changes. The policy is what the project already does.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b