### PR TITLE
✨ Resolve the real client address behind a trusted proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ from fastapi import FastAPI, HTTPException, Request
 
 from grelmicro import Grelmicro
 from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
+from grelmicro.clientip import TrustedProxies, resolve_client_address
 from grelmicro.health import HealthChecks
 from grelmicro.log import configure as configure_logging
 from grelmicro.providers.redis import RedisProvider
@@ -241,10 +242,21 @@ async def read_root():
 
 
 # --- Rate Limiter: protect endpoints from overload ---
+# Behind a proxy, `request.client.host` is the proxy, so every caller would
+# share one bucket. Resolve the real client instead, trusting only your own
+# proxies. Drop the `trusted`/`client_key` lines if nothing fronts the app.
+trusted = TrustedProxies(["10.0.0.0/8"])
+
+
+def client_key(request: Request) -> str:
+    client = resolve_client_address(request.scope, trusted)
+    return client.key if client else "unknown"
+
+
 @app.get("/api")
 async def api_endpoint(request: Request):
     try:
-        await api_limiter.acquire_or_raise(key=request.client.host)
+        await api_limiter.acquire_or_raise(key=client_key(request))
     except RateLimitExceededError as exc:
         raise HTTPException(
             status_code=429,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Features
+
+* ✨ Add `grelmicro.clientip`, which resolves the real client address behind a reverse proxy. `X-Forwarded-For` is append-only, so its leftmost entry is attacker-controlled. The resolver reads the header only when the connecting peer is a trusted proxy, walks right to left, and returns the first entry no trusted proxy wrote. The trusted set is required and there is no wildcard. ([#609](https://github.com/grelinfo/grelmicro/issues/609))
+
+### Security
+
+* 🔒 Stop the health-detail example from showing details to everyone behind a proxy. It gated on `request.client.host` being private, which is the proxy's own address for every external caller, so `is_private` was true for all of them. It now resolves the client. The rate limiter example keyed on the same value, giving every caller one shared bucket. ([#609](https://github.com/grelinfo/grelmicro/issues/609))
+
 ### Internal
 
 * 👷 Enforce the coverage total on the pull request that changes code, not in the next nightly. The slow and integration tiers now run on a code-touching pull request or push, on the primary Python only, so the combined 100% total is measurable there. The Python matrix and the demo tier stay on the nightly, dispatch, and release paths. About two minutes per pull request. ([#602](https://github.com/grelinfo/grelmicro/issues/602))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,9 +4,12 @@
 
 ### Features
 
+* ✨ Add `ClientAddress.degraded`, which marks a result whose address is the connecting peer rather than the caller. Anything treating the address as an identity must refuse when it is set. ([#609](https://github.com/grelinfo/grelmicro/issues/609))
 * ✨ Add `grelmicro.clientip`, which resolves the real client address behind a reverse proxy. `X-Forwarded-For` is append-only, so its leftmost entry is attacker-controlled. The resolver reads the header only when the connecting peer is a trusted proxy, walks right to left, and returns the first entry no trusted proxy wrote. The trusted set is required and there is no wildcard. ([#609](https://github.com/grelinfo/grelmicro/issues/609))
 
 ### Security
+
+* 🔒 Refuse to show health details when the client address is a fallback. Resolving alone was not enough: a forged chain that could not be believed still returned the proxy's own private address, so the `is_private` check admitted everyone again. `ClientAddress.degraded` marks every such case. ([#609](https://github.com/grelinfo/grelmicro/issues/609))
 
 * 🔒 Stop the health-detail example from showing details to everyone behind a proxy. It gated on `request.client.host` being private, which is the proxy's own address for every external caller, so `is_private` was true for all of them. It now resolves the client. The rate limiter example keyed on the same value, giving every caller one shared bucket. ([#609](https://github.com/grelinfo/grelmicro/issues/609))
 

--- a/docs/clientip.md
+++ b/docs/clientip.md
@@ -1,0 +1,117 @@
+# Client IP
+
+Behind a reverse proxy, the address your app sees is the proxy's. The real
+client is in `X-Forwarded-For`, and reading that header naively is one of
+the most reliably exploited mistakes in web software.
+
+`X-Forwarded-For` is **append-only**. Its leftmost entry is whatever the
+original caller wrote, so an attacker sets it to anything. Only the
+entries your own proxies appended can be believed.
+
+```python title="clientip.py"
+--8<-- "clientip/clientip.py"
+```
+
+`TrustedProxies` takes your proxies' addresses. It is required, and there
+is no wildcard. To trust every peer, pass `["0.0.0.0/0", "::/0"]`, which
+someone reviewing a config will notice.
+
+## What it guarantees
+
+`ClientAddress.ip` is **always** an address the request actually came
+from, or one a verified trusted proxy vouched for. It is never text from
+the header, so it is safe as a rate limiter key or an audit record.
+
+The resolution reads the header only when the connecting peer is itself a
+trusted proxy. Otherwise anyone who can reach the app directly forges the
+whole chain.
+
+## Why it matters for a rate limiter
+
+Keying on a spoofable value means a caller sends a different
+`X-Forwarded-For` per request and never hits the limit. It also means an
+attacker can spoof *your* address and get you throttled.
+
+```python
+async def api(request: Request) -> dict:
+    client = resolve_client_address(request.scope, trusted)
+    await limiter.acquire_or_raise(key=client.key if client else "unknown")
+    ...
+```
+
+Use `.key` rather than `str(client.ip)`. It folds an IPv4-mapped address
+onto its IPv4 form, so one caller cannot occupy two buckets by connecting
+over a dual-stack socket.
+
+## Reading the outcome
+
+Every result carries a `reason`. Only `RESOLVED` means a trusted proxy
+vouched for the address, and everything else means the header could not be
+believed, so the verified peer was used instead.
+
+| Reason | What happened |
+|---|---|
+| `RESOLVED` | A trusted proxy vouched for this address. |
+| `NO_FORWARDED_HEADER` | Trusted peer, no header. The peer is the client. |
+| `UNTRUSTED_PEER` | The connecting peer is not a trusted proxy, so the header was ignored. |
+| `CHAIN_EXHAUSTED` | Every entry was a trusted proxy. |
+| `MALFORMED_ENTRY` | An entry was not a valid address. |
+| `HOP_LIMIT`, `TOO_MANY_ENTRIES`, `HEADER_TOO_LARGE` | A bound was hit. |
+
+A rate limiter can use `.key` whatever the reason. An audit log should
+record the reason, and a rising `CHAIN_EXHAUSTED` or `MALFORMED_ENTRY`
+rate is worth an alert: both mean something is sending chains your
+topology does not explain.
+
+!!! warning "A missing trusted set is not a safe default"
+    `resolve_client_address(scope)` does not exist. The trusted set is a
+    required argument, because the correct value depends on your topology
+    and no library can guess it. An empty `TrustedProxies([])` is legal
+    and means trust nothing, so the peer is always returned.
+
+## One value, read everywhere
+
+Two subsystems resolving the client separately will drift, and one will
+end up recording the proxy. `ClientAddressMiddleware` resolves once and
+caches the result on the request:
+
+```python
+from grelmicro.clientip import ClientAddressMiddleware, TrustedProxies
+
+app.add_middleware(
+    ClientAddressMiddleware, trusted=TrustedProxies(["10.0.0.0/8"])
+)
+```
+
+Handlers then read `request.state.client_address`. It is pure ASGI, so it
+works on any ASGI server.
+
+`overwrite_scope_client=True` additionally rewrites `scope["client"]`, for
+code that reads `request.client.host` and cannot be changed. It is off by
+default, because it discards the verified peer an audit record wants.
+
+## If you only run uvicorn
+
+Uvicorn implements the same algorithm, enabled with `--proxy-headers` and
+`--forwarded-allow-ips`. If that is your only deployment target, that is a
+fine answer and you do not need this module.
+
+Reach for this when you want the trusted set required rather than
+defaulted, the verified peer kept alongside the resolved address, a reason
+you can alert on, or one behaviour across uvicorn, hypercorn and granian,
+which differ in both algorithm and trust model.
+
+## Behaviour worth knowing
+
+**Every entry trusted.** Most implementations fall back to the leftmost
+entry. This one returns the verified peer with `CHAIN_EXHAUSTED`, because
+in that case no proxy vouched for the leftmost against an untrusted peer,
+which is exactly the value that must not become a rate limiter key.
+
+**A malformed entry stops the walk.** It is not skipped. Skipping lets an
+attacker insert padding to shift which entry gets chosen.
+
+**Configuration fails loudly.** `TrustedProxies(["10.0.0.1/8"])` raises,
+because it has host bits set. Some servers silently downgrade an entry
+like that to a string literal that then matches nothing, leaving you with
+an empty trusted set and no error.

--- a/docs/clientip.md
+++ b/docs/clientip.md
@@ -12,6 +12,17 @@ entries your own proxies appended can be believed.
 --8<-- "clientip/clientip.py"
 ```
 
+!!! danger "Turn off your server's own proxy handling first"
+    Uvicorn rewrites `scope["client"]` from `X-Forwarded-For` **by default**,
+    before any application middleware runs. If you leave it on, the address
+    this module treats as the verified peer is itself header-derived, and
+    every guarantee below is void: a caller who writes
+    `X-Forwarded-For: 6.6.6.6, 10.0.0.1` gets `6.6.6.6` back as `RESOLVED`.
+
+    Run uvicorn with `--no-proxy-headers`, or `Config(..., proxy_headers=False)`.
+    Hypercorn and granian only apply theirs when you wrap the app, so leave
+    those wrappers off.
+
 `TrustedProxies` takes your proxies' addresses. It is required, and there
 is no wildcard. To trust every peer, pass `["0.0.0.0/0", "::/0"]`, which
 someone reviewing a config will notice.
@@ -58,10 +69,22 @@ believed, so the verified peer was used instead.
 | `MALFORMED_ENTRY` | An entry was not a valid address. |
 | `HOP_LIMIT`, `TOO_MANY_ENTRIES`, `HEADER_TOO_LARGE` | A bound was hit. |
 
-A rate limiter can use `.key` whatever the reason. An audit log should
-record the reason, and a rising `CHAIN_EXHAUSTED` or `MALFORMED_ENTRY`
-rate is worth an alert: both mean something is sending chains your
-topology does not explain.
+A rate limiter can use `.key` whatever the reason, because every value is
+an address the caller cannot choose. Anything that treats the address as
+the caller's identity must check `degraded` first:
+
+```python
+if client is None or client.degraded:
+    return False  # the address is the proxy's, not the caller's
+```
+
+`degraded` is True whenever the chain could not be believed, so `ip` holds
+the connecting peer. Behind a proxy that peer is the proxy, whose address
+is private, which is how an allowlist accidentally admits everyone.
+
+An audit log should record the reason. A rising `CHAIN_EXHAUSTED` or
+`MALFORMED_ENTRY` rate is worth an alert, since both mean something is
+sending chains your topology does not explain.
 
 !!! warning "A missing trusted set is not a safe default"
     `resolve_client_address(scope)` does not exist. The trusted set is a
@@ -83,8 +106,9 @@ app.add_middleware(
 )
 ```
 
-Handlers then read `request.state.client_address`. It is pure ASGI, so it
-works on any ASGI server.
+Handlers then read `getattr(request.state, "client_address", None)`,
+which is None when the peer could not be resolved at all. It is pure ASGI,
+so it works on any ASGI server.
 
 `overwrite_scope_client=True` additionally rewrites `scope["client"]`, for
 code that reads `request.client.host` and cannot be changed. It is off by
@@ -92,9 +116,13 @@ default, because it discards the verified peer an audit record wants.
 
 ## If you only run uvicorn
 
-Uvicorn implements the same algorithm, enabled with `--proxy-headers` and
-`--forwarded-allow-ips`. If that is your only deployment target, that is a
-fine answer and you do not need this module.
+Uvicorn does something similar, controlled by `--forwarded-allow-ips`, and
+it is **on unless you disable it**. If uvicorn is your only deployment
+target, configuring it is a fine answer and you do not need this module.
+
+It is not the same algorithm. Under `--forwarded-allow-ips='*'` uvicorn
+returns the leftmost entry, it accepts values that are not addresses at
+all, and it reports port `0`.
 
 Reach for this when you want the trusted set required rather than
 defaulted, the verified peer kept alongside the resolved address, a reason
@@ -110,6 +138,10 @@ which is exactly the value that must not become a rate limiter key.
 
 **A malformed entry stops the walk.** It is not skipped. Skipping lets an
 attacker insert padding to shift which entry gets chosen.
+
+**A zone id is dropped.** `fe80::1%eth0` keys as `fe80::1`, so two hosts
+reached over different interfaces share one key. Link-local addresses are
+rarely a client identity, but it is worth knowing.
 
 **Configuration fails loudly.** `TrustedProxies(["10.0.0.1/8"])` raises,
 because it has host bits set. Some servers silently downgrade an entry

--- a/docs/index.md
+++ b/docs/index.md
@@ -170,6 +170,7 @@ from fastapi import FastAPI, HTTPException, Request
 
 from grelmicro import Grelmicro
 from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
+from grelmicro.clientip import TrustedProxies, resolve_client_address
 from grelmicro.health import HealthChecks
 from grelmicro.log import configure as configure_logging
 from grelmicro.providers.redis import RedisProvider
@@ -241,10 +242,21 @@ async def read_root():
 
 
 # --- Rate Limiter: protect endpoints from overload ---
+# Behind a proxy, `request.client.host` is the proxy, so every caller would
+# share one bucket. Resolve the real client instead, trusting only your own
+# proxies. Drop the `trusted`/`client_key` lines if nothing fronts the app.
+trusted = TrustedProxies(["10.0.0.0/8"])
+
+
+def client_key(request: Request) -> str:
+    client = resolve_client_address(request.scope, trusted)
+    return client.key if client else "unknown"
+
+
 @app.get("/api")
 async def api_endpoint(request: Request):
     try:
-        await api_limiter.acquire_or_raise(key=request.client.host)
+        await api_limiter.acquire_or_raise(key=client_key(request))
     except RateLimitExceededError as exc:
         raise HTTPException(
             status_code=429,

--- a/docs/reference/clientip.md
+++ b/docs/reference/clientip.md
@@ -1,0 +1,13 @@
+# Client IP
+
+- **Start here**: [Client IP guide](../clientip.md)
+- **Common recipes**: `resolve_client_address(request.scope, trusted)` returns the address a trusted proxy vouched for. `ClientAddressMiddleware` resolves it once per request so every consumer reads one value.
+
+::: grelmicro.clientip
+    options:
+      members:
+        - TrustedProxies
+        - ClientAddress
+        - ClientAddressReason
+        - ClientAddressMiddleware
+        - resolve_client_address

--- a/docs/snippets/clientip/clientip.py
+++ b/docs/snippets/clientip/clientip.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI, Request
+
+from grelmicro.clientip import TrustedProxies, resolve_client_address
+
+app = FastAPI()
+
+# Your own proxies. Required, and there is no wildcard.
+trusted = TrustedProxies(["10.0.0.0/8"])
+
+
+@app.get("/whoami")
+async def whoami(request: Request) -> dict[str, str]:
+    client = resolve_client_address(request.scope, trusted)
+    if client is None:
+        return {"client": "unknown"}
+    # `key` is safe to store or to use as a rate limiter bucket.
+    return {"client": client.key, "reason": client.reason}

--- a/docs/snippets/health/show_details.py
+++ b/docs/snippets/health/show_details.py
@@ -12,7 +12,11 @@ def from_private_network(request: Request) -> bool:
     # raw peer is the proxy's own private address, so checking it directly
     # reports every caller as private and shows details to the public.
     client = resolve_client_address(request.scope, trusted)
-    return bool(client and client.ip.is_private)
+    # `degraded` means the chain could not be believed, so the address is
+    # the proxy's again. Refuse, or a forged chain reopens the same hole.
+    if client is None or client.degraded:
+        return False
+    return client.ip.is_private
 
 
 # Hide details from everyone (default).

--- a/docs/snippets/health/show_details.py
+++ b/docs/snippets/health/show_details.py
@@ -1,12 +1,18 @@
-from ipaddress import ip_address
-
 from fastapi import Depends, Request
 
+from grelmicro.clientip import TrustedProxies, resolve_client_address
 from grelmicro.integrations.fastapi import health_router
+
+# Your own proxies. Required: without it a caller's own header is believed.
+trusted = TrustedProxies(["10.0.0.0/8"])
 
 
 def from_private_network(request: Request) -> bool:
-    return bool(request.client and ip_address(request.client.host).is_private)
+    # Resolve rather than reading `request.client.host`. Behind a proxy the
+    # raw peer is the proxy's own private address, so checking it directly
+    # reports every caller as private and shows details to the public.
+    client = resolve_client_address(request.scope, trusted)
+    return bool(client and client.ip.is_private)
 
 
 # Hide details from everyone (default).

--- a/grelmicro/clientip.py
+++ b/grelmicro/clientip.py
@@ -100,6 +100,21 @@ class ClientAddress:
         return self.reason is ClientAddressReason.RESOLVED
 
     @property
+    def degraded(self) -> bool:
+        """Whether this is a fallback rather than the caller's own address.
+
+        True when the forwarded chain could not be believed, so `ip` holds
+        the connecting peer instead. Behind a proxy that peer is the proxy,
+        so any check that treats it as the caller (an allowlist, a private
+        network test) must refuse when this is True.
+        """
+        return self.reason not in (
+            ClientAddressReason.RESOLVED,
+            ClientAddressReason.NO_FORWARDED_HEADER,
+            ClientAddressReason.UNTRUSTED_PEER,
+        )
+
+    @property
     def key(self) -> str:
         """Canonical form, safe to use as a rate limiter key.
 
@@ -196,6 +211,12 @@ def _compile_entry(entry: str | IPAddress | IPNetwork) -> IPNetwork:
         return _canonical_network(entry)
     if isinstance(entry, (IPv4Address, IPv6Address)):
         return _canonical_network(ip_network(_canonical(entry)))
+    if not isinstance(entry, str):
+        msg = (
+            f"TrustedProxies got {entry!r} of type {type(entry).__name__}. "
+            f"Pass a string, an ip_address, or an ip_network."
+        )
+        raise TypeError(msg)
     try:
         return _canonical_network(ip_network(entry))
     except ValueError as error:
@@ -237,7 +258,8 @@ def _split_host_port(  # noqa: PLR0911
 
 def _with_port(host: str, port: str) -> tuple[str, int | None] | None:
     """Attach a numeric port to `host`, or None when it is not one."""
-    if not port.isdigit() or not 0 <= int(port) <= _MAX_PORT:
+    # `isdigit` alone is true for Latin-1 superscripts, which `int` rejects.
+    if not (port.isascii() and port.isdigit()) or int(port) > _MAX_PORT:
         return None
     return host, int(port)
 
@@ -251,7 +273,7 @@ def _collect_header(
     for name, value in headers:
         if name.lower() != _FORWARDED_FOR:
             continue
-        total += len(value)
+        total += len(value) + 1
         if total > limit:
             return None
         parts.append(value)
@@ -309,7 +331,10 @@ def resolve_client_address(  # noqa: C901, PLR0911
     if not entries:
         return from_peer(ClientAddressReason.NO_FORWARDED_HEADER)
     if len(entries) > trusted._max_entries:  # noqa: SLF001
-        return from_peer(ClientAddressReason.TOO_MANY_ENTRIES)
+        # Keep the rightmost entries, the ones our own proxies wrote.
+        # Discarding the header instead would let prepended padding force
+        # every caller onto the proxy's key.
+        entries = entries[-trusted._max_entries :]  # noqa: SLF001
 
     hops = 0
     for entry in reversed(entries):
@@ -330,7 +355,7 @@ def resolve_client_address(  # noqa: C901, PLR0911
             )
         hops += 1
         max_hops = trusted._max_hops  # noqa: SLF001
-        if max_hops is not None and hops >= max_hops:
+        if max_hops is not None and hops > max_hops:
             return from_peer(ClientAddressReason.HOP_LIMIT, hops)
     return from_peer(ClientAddressReason.CHAIN_EXHAUSTED, hops)
 

--- a/grelmicro/clientip.py
+++ b/grelmicro/clientip.py
@@ -1,0 +1,398 @@
+"""Client IP resolution behind trusted proxies.
+
+`X-Forwarded-For` is append-only, so its leftmost entry is whatever the
+original caller claimed. Reading it is the flaw behind a long line of
+spoofing advisories. This module resolves the address a trusted proxy
+actually vouched for, and never returns anything else.
+
+Read more in the [Client IP](../clientip.md) docs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from ipaddress import (
+    IPv4Address,
+    IPv4Network,
+    IPv6Address,
+    IPv6Network,
+    ip_address,
+    ip_network,
+)
+from typing import TYPE_CHECKING, Annotated, Any
+
+from typing_extensions import Doc
+
+if TYPE_CHECKING:
+    from collections.abc import (
+        Awaitable,
+        Callable,
+        Iterable,
+        MutableMapping,
+        Sequence,
+    )
+
+    Scope = MutableMapping[str, Any]
+    Message = MutableMapping[str, Any]
+    Receive = Callable[[], Awaitable[Message]]
+    Send = Callable[[Message], Awaitable[None]]
+    ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+
+    IPAddress = IPv4Address | IPv6Address
+    IPNetwork = IPv4Network | IPv6Network
+
+__all__ = [
+    "ClientAddress",
+    "ClientAddressMiddleware",
+    "ClientAddressReason",
+    "TrustedProxies",
+    "resolve_client_address",
+]
+
+_FORWARDED_FOR = b"x-forwarded-for"
+
+_MAX_PORT = 65535
+
+_IPV4_MAPPED_PREFIX = 96
+"""Prefix length at which an IPv6 network is wholly IPv4-mapped space."""
+
+
+class ClientAddressReason(StrEnum):
+    """Why `ClientAddress.ip` holds the address it holds.
+
+    Only `RESOLVED` means a trusted proxy vouched for the address. Every
+    other value means the header could not be believed and the verified
+    transport peer was used instead, which a caller can log or reject.
+    """
+
+    RESOLVED = "resolved"
+    NO_FORWARDED_HEADER = "no-forwarded-header"
+    UNTRUSTED_PEER = "untrusted-peer"
+    CHAIN_EXHAUSTED = "chain-exhausted"
+    HOP_LIMIT = "hop-limit"
+    MALFORMED_ENTRY = "malformed-entry"
+    HEADER_TOO_LARGE = "header-too-large"
+    TOO_MANY_ENTRIES = "too-many-entries"
+
+
+@dataclass(frozen=True, slots=True)
+class ClientAddress:
+    """A resolved client address, with how it was reached."""
+
+    ip: Annotated[
+        IPAddress,
+        Doc("The address. Always parsed, never raw header text."),
+    ]
+    port: Annotated[int | None, Doc("The source port, when one was given.")]
+    reason: Annotated[
+        ClientAddressReason,
+        Doc("Why this address was chosen. `RESOLVED` is the trusted case."),
+    ]
+    hops: Annotated[
+        int,
+        Doc("Trusted proxies skipped before landing on this address."),
+    ]
+
+    @property
+    def forwarded(self) -> bool:
+        """Whether a trusted proxy vouched for this address."""
+        return self.reason is ClientAddressReason.RESOLVED
+
+    @property
+    def key(self) -> str:
+        """Canonical form, safe to use as a rate limiter key.
+
+        An IPv4-mapped address folds onto its IPv4 form, so one caller
+        never occupies two buckets.
+        """
+        return self.ip.compressed
+
+
+def _canonical(address: IPAddress) -> IPAddress:
+    """Fold an IPv4-mapped address to IPv4 and drop any zone id."""
+    if isinstance(address, IPv6Address):
+        if address.ipv4_mapped is not None:
+            return address.ipv4_mapped
+        if address.scope_id is not None:
+            return IPv6Address(address.packed)
+    return address
+
+
+def _canonical_network(network: IPNetwork) -> IPNetwork:
+    """Fold a wholly IPv4-mapped IPv6 network to its IPv4 equivalent."""
+    if (
+        isinstance(network, IPv6Network)
+        and network.prefixlen >= _IPV4_MAPPED_PREFIX
+        and network.network_address.ipv4_mapped is not None
+    ):
+        host = network.network_address.ipv4_mapped
+        return IPv4Network(
+            (host, network.prefixlen - _IPV4_MAPPED_PREFIX), strict=False
+        )
+    return network
+
+
+class TrustedProxies:
+    """The proxies whose `X-Forwarded-For` entries may be believed.
+
+    Build one at startup and reuse it. Every entry is parsed strictly, so
+    a typo fails here rather than becoming a rule that silently matches
+    nothing.
+
+    There is no wildcard. To trust every peer, pass `["0.0.0.0/0", "::/0"]`,
+    which is visible in a configuration review in a way a `*` is not.
+    """
+
+    __slots__ = ("_max_entries", "_max_header_bytes", "_max_hops", "_networks")
+
+    def __init__(
+        self,
+        networks: Annotated[
+            Iterable[str | IPAddress | IPNetwork],
+            Doc(
+                """
+                Addresses and CIDR ranges of your own proxies.
+
+                Required, with no default. An empty iterable is legal and
+                means trust nothing, so resolution always returns the
+                transport peer.
+                """
+            ),
+        ],
+        /,
+        *,
+        max_hops: Annotated[
+            int | None,
+            Doc(
+                "Most trusted proxies to walk past. Bounds a forged chain. "
+                "None means no cap."
+            ),
+        ] = None,
+        max_entries: Annotated[
+            int,
+            Doc("Most header entries to parse before giving up."),
+        ] = 64,
+        max_header_bytes: Annotated[
+            int,
+            Doc("Most header bytes to parse before giving up."),
+        ] = 8192,
+    ) -> None:
+        """Compile the trusted set, rejecting anything unparsable."""
+        self._networks = tuple(_compile_entry(entry) for entry in networks)
+        self._max_hops = max_hops
+        self._max_entries = max_entries
+        self._max_header_bytes = max_header_bytes
+
+    def __contains__(self, address: IPAddress) -> bool:
+        """Whether `address` belongs to a trusted proxy."""
+        canonical = _canonical(address)
+        return any(canonical in network for network in self._networks)
+
+
+def _compile_entry(entry: str | IPAddress | IPNetwork) -> IPNetwork:
+    """Parse one trusted-set entry, or raise naming it."""
+    if isinstance(entry, (IPv4Network, IPv6Network)):
+        return _canonical_network(entry)
+    if isinstance(entry, (IPv4Address, IPv6Address)):
+        return _canonical_network(ip_network(_canonical(entry)))
+    try:
+        return _canonical_network(ip_network(entry))
+    except ValueError as error:
+        msg = (
+            f"TrustedProxies got {entry!r}, which is not an IP address or "
+            f"CIDR range: {error}. There is no wildcard, pass "
+            f'["0.0.0.0/0", "::/0"] to trust every peer.'
+        )
+        raise ValueError(msg) from None
+
+
+def _split_host_port(  # noqa: PLR0911
+    value: str,
+) -> tuple[str, int | None] | None:
+    """Split a forwarded entry into host and port, or None if malformed.
+
+    A bare IPv6 literal always carries at least two colons, so the count
+    disambiguates it from `host:port` without splitting on the last colon.
+    """
+    if value.startswith("["):
+        end = value.find("]")
+        if end == -1:
+            return None
+        host = value[1:end]
+        rest = value[end + 1 :]
+        if not rest:
+            return host, None
+        if not rest.startswith(":"):
+            return None
+        return _with_port(host, rest[1:])
+    colons = value.count(":")
+    if colons > 1:
+        return value, None
+    if colons == 1:
+        host, _, port = value.partition(":")
+        return _with_port(host, port)
+    return value, None
+
+
+def _with_port(host: str, port: str) -> tuple[str, int | None] | None:
+    """Attach a numeric port to `host`, or None when it is not one."""
+    if not port.isdigit() or not 0 <= int(port) <= _MAX_PORT:
+        return None
+    return host, int(port)
+
+
+def _collect_header(
+    headers: Sequence[tuple[bytes, bytes]], limit: int
+) -> bytes | None:
+    """Join every `X-Forwarded-For` value, or None past `limit` bytes."""
+    parts: list[bytes] = []
+    total = 0
+    for name, value in headers:
+        if name.lower() != _FORWARDED_FOR:
+            continue
+        total += len(value)
+        if total > limit:
+            return None
+        parts.append(value)
+    if not parts:
+        return b""
+    return b",".join(parts)
+
+
+def resolve_client_address(  # noqa: C901, PLR0911
+    scope: Annotated[Scope, Doc("The ASGI scope of the request.")],
+    trusted: Annotated[
+        TrustedProxies,
+        Doc("The proxies whose forwarded entries may be believed."),
+    ],
+) -> ClientAddress | None:
+    """Resolve the client address a trusted proxy vouched for.
+
+    Returns None when the transport peer is absent or unparsable, which
+    a caller must handle rather than being handed a fabricated address.
+
+    The header is read only when the peer itself is trusted, and the walk
+    runs right to left, because the rightmost entries are the ones your
+    own proxies wrote. The first entry that is not a trusted proxy is the
+    client. A malformed entry stops the walk rather than being skipped,
+    since skipping lets padding shift which entry is chosen.
+
+    When every entry is trusted, the peer is returned with
+    `CHAIN_EXHAUSTED` rather than the leftmost entry. No trusted proxy
+    vouched for that entry against an untrusted peer, so it is exactly
+    the value that must not become a rate limiter key.
+    """
+    client = scope.get("client")
+    if not client:
+        return None
+    try:
+        peer = _canonical(ip_address(client[0]))
+    except ValueError:
+        return None
+    port = client[1] if len(client) > 1 else None
+
+    def from_peer(reason: ClientAddressReason, hops: int = 0) -> ClientAddress:
+        return ClientAddress(ip=peer, port=port, reason=reason, hops=hops)
+
+    if peer not in trusted:
+        return from_peer(ClientAddressReason.UNTRUSTED_PEER)
+
+    raw = _collect_header(
+        scope.get("headers", ()),
+        trusted._max_header_bytes,  # noqa: SLF001
+    )
+    if raw is None:
+        return from_peer(ClientAddressReason.HEADER_TOO_LARGE)
+    entries = [part.strip() for part in raw.split(b",")]
+    entries = [part for part in entries if part]
+    if not entries:
+        return from_peer(ClientAddressReason.NO_FORWARDED_HEADER)
+    if len(entries) > trusted._max_entries:  # noqa: SLF001
+        return from_peer(ClientAddressReason.TOO_MANY_ENTRIES)
+
+    hops = 0
+    for entry in reversed(entries):
+        split = _split_host_port(entry.decode("latin-1"))
+        if split is None:
+            return from_peer(ClientAddressReason.MALFORMED_ENTRY, hops)
+        host, entry_port = split
+        try:
+            address = _canonical(ip_address(host))
+        except ValueError:
+            return from_peer(ClientAddressReason.MALFORMED_ENTRY, hops)
+        if address not in trusted:
+            return ClientAddress(
+                ip=address,
+                port=entry_port,
+                reason=ClientAddressReason.RESOLVED,
+                hops=hops,
+            )
+        hops += 1
+        max_hops = trusted._max_hops  # noqa: SLF001
+        if max_hops is not None and hops >= max_hops:
+            return from_peer(ClientAddressReason.HOP_LIMIT, hops)
+    return from_peer(ClientAddressReason.CHAIN_EXHAUSTED, hops)
+
+
+class ClientAddressMiddleware:
+    """Resolve the client address once and cache it on the request.
+
+    Stores a `ClientAddress` under `scope["state"]["client_address"]`, so
+    every handler and every other middleware reads one value instead of
+    each resolving its own and drifting apart.
+
+    ```python
+    from grelmicro.clientip import ClientAddressMiddleware, TrustedProxies
+
+    app.add_middleware(
+        ClientAddressMiddleware, trusted=TrustedProxies(["10.0.0.0/8"])
+    )
+    ```
+
+    Pure ASGI, so it works on any ASGI server. It acts on `http` and
+    `websocket` scopes and passes every other scope through untouched.
+    """
+
+    def __init__(
+        self,
+        app: Annotated[ASGIApp, Doc("The next ASGI application in the chain.")],
+        *,
+        trusted: Annotated[
+            TrustedProxies,
+            Doc("The proxies whose forwarded entries may be believed."),
+        ],
+        overwrite_scope_client: Annotated[
+            bool,
+            Doc(
+                """
+                Also rewrite `scope["client"]` with the resolved address.
+
+                Off by default, because it discards the verified transport
+                peer that an audit record wants, and because a server that
+                already rewrites it would then be running the walk twice.
+                Turn it on for code that reads `request.client.host` and
+                cannot be changed.
+                """
+            ),
+        ] = False,
+    ) -> None:
+        """Initialize the middleware with the trusted set."""
+        self.app = app
+        self.trusted = trusted
+        self.overwrite_scope_client = overwrite_scope_client
+
+    async def __call__(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> None:
+        """Resolve and cache the client address, then pass through."""
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+        resolved = resolve_client_address(scope, self.trusted)
+        if resolved is not None:
+            state = scope.setdefault("state", {})
+            state["client_address"] = resolved
+            if self.overwrite_scope_client:
+                scope["client"] = (resolved.key, resolved.port or 0)
+        await self.app(scope, receive, send)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
         - resilience/timeout.md
         - resilience/composition.md
     - health.md
+    - clientip.md
     - logging.md
     - tracing.md
     - metrics.md
@@ -93,6 +94,7 @@ nav:
     - benchmarks.md
 - API Reference:
     - reference/cache.md
+    - reference/clientip.md
     - reference/clock.md
     - reference/config.md
     - reference/fastapi.md

--- a/tests/test_clientip.py
+++ b/tests/test_clientip.py
@@ -287,14 +287,29 @@ class TestDualStack:
 class TestLimits:
     """Bounds that keep a hostile header from costing anything."""
 
-    def test_too_many_entries(self) -> None:
-        """A huge chain is refused rather than truncated."""
+    def test_long_chain_keeps_the_trusted_end(self) -> None:
+        """The rightmost entries are the ones our own proxies wrote."""
         # Arrange
         header = ", ".join(["10.0.0.1"] * 200)
         # Act
         result = resolve(forwarded=header, max_entries=64)
         # Assert
-        assert result.reason is ClientAddressReason.TOO_MANY_ENTRIES
+        assert result.reason is ClientAddressReason.CHAIN_EXHAUSTED
+
+    def test_padding_cannot_force_the_proxy_bucket(self) -> None:
+        """Prepended padding must not discard the real entry.
+
+        Rejecting the whole header would key every padded request on the
+        proxy, letting an attacker both evade a per-IP limit and drain the
+        bucket every other caller behind that proxy shares.
+        """
+        # Arrange
+        header = ", ".join(["9.9.9.9"] * 200 + ["8.8.8.8", "10.0.0.6"])
+        # Act
+        result = resolve(forwarded=header, max_entries=64)
+        # Assert
+        assert result.key == "8.8.8.8"
+        assert result.reason is ClientAddressReason.RESOLVED
 
     def test_header_too_large(self) -> None:
         """An oversized header is refused before any entry is parsed."""
@@ -303,15 +318,22 @@ class TestLimits:
         # Assert
         assert result.reason is ClientAddressReason.HEADER_TOO_LARGE
 
-    def test_hop_limit(self) -> None:
-        """A cap bounds how far a forged chain can be walked."""
+    def test_hop_limit_bounds_a_forged_chain(self) -> None:
+        """A cap stops the walk once too many proxies have been passed."""
         # Arrange
         header = ", ".join(["10.0.0.1"] * 10)
         # Act
         result = resolve(forwarded=header, max_hops=2)
         # Assert
         assert result.reason is ClientAddressReason.HOP_LIMIT
-        assert result.hops == EXPECTED_HOPS
+
+    def test_hop_limit_permits_exactly_that_many(self) -> None:
+        """`max_hops=2` allows a real two-proxy chain to resolve."""
+        # Arrange / Act
+        result = resolve(forwarded="1.2.3.4, 10.0.0.6, 10.0.0.7", max_hops=2)
+        # Assert
+        assert result.key == "1.2.3.4"
+        assert result.reason is ClientAddressReason.RESOLVED
 
 
 class TestTrustedProxiesConfig:
@@ -439,3 +461,60 @@ class TestMiddleware:
         await middleware(scope(peer=None), _receive, _send)
         # Assert
         assert "client_address" not in seen
+
+
+class TestHostilePorts:
+    """A port that is digit-like but not an integer used to crash."""
+
+    @pytest.mark.parametrize(
+        "entry",
+        ["1.2.3.4:\xb2", "1.2.3.4:8\xb2", "[2001:db8::1]:\xb9"],
+    )
+    def test_superscript_port_does_not_raise(self, entry: str) -> None:
+        """`str.isdigit()` is true for these, but `int()` rejects them."""
+        # Arrange / Act
+        result = resolve(forwarded=entry)
+        # Assert
+        assert result.reason is ClientAddressReason.MALFORMED_ENTRY
+
+
+class TestDegraded:
+    """`degraded` marks a fallback, so callers need not list reasons."""
+
+    @pytest.mark.parametrize(
+        ("forwarded", "expected"),
+        [
+            ("1.2.3.4", False),
+            (None, False),
+            ("10.1.1.1, 10.2.2.2", True),
+            ("1.2.3.4, junk, 10.0.0.6", True),
+        ],
+    )
+    def test_flags_fallbacks(
+        self,
+        forwarded: str | None,
+        expected: bool,  # noqa: FBT001
+    ) -> None:
+        """A fallback holds the proxy address, not the caller's."""
+        # Arrange / Act
+        result = resolve(forwarded=forwarded)
+        # Assert
+        assert result.degraded is expected
+
+    def test_untrusted_peer_is_not_degraded(self) -> None:
+        """A direct caller's own address is the caller's address."""
+        # Arrange / Act
+        result = resolve(peer="9.9.9.9")
+        # Assert
+        assert result.degraded is False
+
+
+class TestConfigTypes:
+    """The trusted set rejects what the docs say it rejects."""
+
+    @pytest.mark.parametrize("entry", [16909060, b"\x01\x02\x03\x04", None])
+    def test_rejects_non_string_scalars(self, entry: object) -> None:
+        """`ip_network` accepts ints and bytes, which is not what we mean."""
+        # Act / Assert
+        with pytest.raises(TypeError, match="Pass a string"):
+            TrustedProxies([entry])  # ty: ignore[invalid-argument-type]

--- a/tests/test_clientip.py
+++ b/tests/test_clientip.py
@@ -1,0 +1,441 @@
+"""Tests for trusted-proxy client IP resolution.
+
+The adversarial cases are the point. Each one corresponds to a published
+spoofing advisory or to a parsing bug found in a widely used server.
+"""
+
+from __future__ import annotations
+
+from ipaddress import ip_address, ip_network
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, MutableMapping
+
+    Scope = MutableMapping[str, Any]
+    Message = MutableMapping[str, Any]
+    Receive = Callable[[], Awaitable[Message]]
+    Send = Callable[[Message], Awaitable[None]]
+
+from grelmicro.clientip import (
+    ClientAddressMiddleware,
+    ClientAddressReason,
+    TrustedProxies,
+    resolve_client_address,
+)
+
+TRUSTED = ["10.0.0.0/8"]
+EXPECTED_HOPS = 2
+PEER = "10.0.0.5"
+
+
+def scope(
+    peer: str | None = PEER,
+    forwarded: str | list[str] | None = None,
+    *,
+    scope_type: str = "http",
+    port: int = 1234,
+) -> dict[str, Any]:
+    """Build an ASGI scope with the given peer and forwarded header."""
+    values = [forwarded] if isinstance(forwarded, str) else (forwarded or [])
+    headers = [(b"x-forwarded-for", value.encode()) for value in values]
+    built: dict[str, Any] = {"type": scope_type, "headers": headers}
+    if peer is not None:
+        built["client"] = (peer, port)
+    return built
+
+
+def resolve(
+    peer: str | None = PEER,
+    forwarded: str | list[str] | None = None,
+    trusted: list[str] | None = None,
+    **kwargs: Any,  # noqa: ANN401
+) -> Any:  # noqa: ANN401
+    """Resolve against a trusted set built from `trusted`."""
+    return resolve_client_address(
+        scope(peer, forwarded),
+        TrustedProxies(TRUSTED if trusted is None else trusted, **kwargs),
+    )
+
+
+class TestSpoofing:
+    """Every case here is a published vulnerability class."""
+
+    def test_untrusted_peer_cannot_forge(self) -> None:
+        """A direct caller's header is ignored entirely."""
+        # Arrange / Act
+        result = resolve(peer="9.9.9.9", forwarded="1.2.3.4")
+        # Assert
+        assert result.key == "9.9.9.9"
+        assert result.reason is ClientAddressReason.UNTRUSTED_PEER
+
+    def test_leftmost_entry_never_wins(self) -> None:
+        """The client-supplied prefix loses to the proxy-written entry."""
+        # Arrange / Act
+        result = resolve(forwarded="9.9.9.9, 1.2.3.4")
+        # Assert
+        assert result.key == "1.2.3.4"
+        assert result.reason is ClientAddressReason.RESOLVED
+
+    def test_all_trusted_chain_returns_the_peer(self) -> None:
+        """No proxy vouched for the leftmost, so it must not be used."""
+        # Arrange / Act
+        result = resolve(forwarded="10.1.1.1, 10.2.2.2")
+        # Assert
+        assert result.key == PEER
+        assert result.reason is ClientAddressReason.CHAIN_EXHAUSTED
+
+    def test_padding_stops_the_walk(self) -> None:
+        """Injected garbage must not shift which entry is chosen."""
+        # Arrange / Act
+        result = resolve(forwarded="1.2.3.4, garbage, 10.0.0.6")
+        # Assert
+        assert result.key == PEER
+        assert result.reason is ClientAddressReason.MALFORMED_ENTRY
+
+    def test_non_ip_text_never_reaches_the_caller(self) -> None:
+        """A rate limiter key can never become attacker-chosen text."""
+        # Arrange / Act
+        result = resolve(forwarded="<script>alert(1)</script>")
+        # Assert
+        assert result.key == PEER
+        assert result.reason is ClientAddressReason.MALFORMED_ENTRY
+
+    def test_wildcard_trust_still_refuses_the_leftmost(self) -> None:
+        """Even trusting everything does not make the leftmost usable."""
+        # Arrange / Act
+        result = resolve(
+            forwarded="1.2.3.4, 5.6.7.8", trusted=["0.0.0.0/0", "::/0"]
+        )
+        # Assert
+        assert result.key == PEER
+        assert result.reason is ClientAddressReason.CHAIN_EXHAUSTED
+
+
+class TestResolution:
+    """The ordinary paths."""
+
+    def test_single_entry(self) -> None:
+        """One entry from a trusted peer is the client."""
+        # Arrange / Act
+        result = resolve(forwarded="1.2.3.4")
+        # Assert
+        assert result.key == "1.2.3.4"
+        assert result.hops == 0
+        assert result.forwarded is True
+
+    def test_counts_hops_past_trusted_proxies(self) -> None:
+        """Each trusted proxy skipped is counted."""
+        # Arrange / Act
+        result = resolve(forwarded="1.2.3.4, 10.0.0.5, 10.0.0.6")
+        # Assert
+        assert result.key == "1.2.3.4"
+        assert result.hops == EXPECTED_HOPS
+
+    def test_multiple_header_instances_join_in_order(self) -> None:
+        """Repeated header lines behave as one comma-joined line."""
+        # Arrange / Act
+        split = resolve(forwarded=["1.2.3.4", "10.0.0.6"])
+        joined = resolve(forwarded="1.2.3.4, 10.0.0.6")
+        # Assert
+        assert split == joined
+        assert split.key == "1.2.3.4"
+
+    def test_no_header_returns_the_peer(self) -> None:
+        """A trusted peer with no header is the client itself."""
+        # Arrange / Act
+        result = resolve()
+        # Assert
+        assert result.key == PEER
+        assert result.reason is ClientAddressReason.NO_FORWARDED_HEADER
+        assert result.forwarded is False
+
+    def test_missing_peer_is_unresolvable(self) -> None:
+        """No address is invented when the transport peer is absent."""
+        # Arrange / Act
+        result = resolve(peer=None)
+        # Assert
+        assert result is None
+
+    def test_unparseable_peer_is_unresolvable(self) -> None:
+        """A peer that is not an address resolves to nothing."""
+        # Arrange / Act
+        result = resolve(peer="not-an-ip")
+        # Assert
+        assert result is None
+
+    def test_empty_trusted_set_always_returns_the_peer(self) -> None:
+        """Trusting nothing is legal and means the header is never read."""
+        # Arrange / Act
+        result = resolve(forwarded="1.2.3.4", trusted=[])
+        # Assert
+        assert result.key == PEER
+        assert result.reason is ClientAddressReason.UNTRUSTED_PEER
+
+
+class TestParsing:
+    """Address and port forms seen in real deployments."""
+
+    @pytest.mark.parametrize(
+        ("entry", "expected", "port"),
+        [
+            ("[2001:db8::1]:1234", "2001:db8::1", 1234),
+            ("[2001:db8::1]", "2001:db8::1", None),
+            ("2001:db8::1", "2001:db8::1", None),
+            ("2001:db8::1:8080", "2001:db8::1:8080", None),
+            ("1.2.3.4:5678", "1.2.3.4", 5678),
+            ("1.2.3.4", "1.2.3.4", None),
+        ],
+    )
+    def test_valid_forms(
+        self, entry: str, expected: str, port: int | None
+    ) -> None:
+        """A bare IPv6 is never split on its last colon."""
+        # Arrange / Act
+        result = resolve(forwarded=entry)
+        # Assert
+        assert result.key == expected
+        assert result.port == port
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "[2001:db8::1",
+            "[2001:db8::1]x",
+            "[2001:db8::1]:abc",
+            "1.2.3.4:99999",
+            "1",
+            "010.1.1.1",
+            "127.1",
+            "0x7f.0.0.1",
+            "10.0.0.0/8",
+        ],
+    )
+    def test_rejected_forms(self, entry: str) -> None:
+        """Lenient parsing is what turns `1` into `0.0.0.1` elsewhere."""
+        # Arrange / Act
+        result = resolve(forwarded=entry)
+        # Assert
+        assert result.reason is ClientAddressReason.MALFORMED_ENTRY
+
+    @pytest.mark.parametrize("header", ["1.2.3.4, ", ", ,1.2.3.4", " 1.2.3.4 "])
+    def test_empty_elements_are_dropped(self, header: str) -> None:
+        """A trailing comma defeats resolution in some servers."""
+        # Arrange / Act
+        result = resolve(forwarded=header)
+        # Assert
+        assert result.key == "1.2.3.4"
+
+    def test_unrelated_headers_are_skipped(self) -> None:
+        """Other headers do not interfere with the scan."""
+        # Arrange
+        built = scope(forwarded="1.2.3.4")
+        built["headers"] = [
+            (b"user-agent", b"probe"),
+            *built["headers"],
+            (b"accept", b"*/*"),
+        ]
+        # Act
+        result = resolve_client_address(built, TrustedProxies(TRUSTED))
+        # Assert
+        assert result is not None
+        assert result.key == "1.2.3.4"
+
+    def test_empty_header_is_no_header(self) -> None:
+        """An empty value is not a malformed entry."""
+        # Arrange / Act
+        result = resolve(forwarded="")
+        # Assert
+        assert result.reason is ClientAddressReason.NO_FORWARDED_HEADER
+
+
+class TestDualStack:
+    """IPv4-mapped addresses must not split one caller into two buckets."""
+
+    def test_mapped_peer_matches_an_ipv4_network(self) -> None:
+        """A dual-stack listener still trusts the same proxy."""
+        # Arrange / Act
+        result = resolve(peer="::ffff:10.0.0.5", forwarded="1.2.3.4")
+        # Assert
+        assert result.key == "1.2.3.4"
+
+    def test_mapped_entry_folds_onto_its_ipv4_key(self) -> None:
+        """The same caller gets one rate limiter bucket, not two."""
+        # Arrange / Act
+        mapped = resolve(forwarded="::ffff:1.2.3.4")
+        plain = resolve(forwarded="1.2.3.4")
+        # Assert
+        assert mapped.key == plain.key == "1.2.3.4"
+
+    def test_mapped_network_trusts_a_plain_peer(self) -> None:
+        """Normalisation works in both directions."""
+        # Arrange / Act
+        result = resolve(forwarded="1.2.3.4", trusted=["::ffff:10.0.0.0/104"])
+        # Assert
+        assert result.key == "1.2.3.4"
+
+    def test_zone_id_is_dropped_from_the_key(self) -> None:
+        """A scoped address is still comparable and keyable."""
+        # Arrange / Act
+        trusted = TrustedProxies(["fe80::/10"])
+        # Assert
+        assert ip_address("fe80::1%eth0") in trusted
+
+
+class TestLimits:
+    """Bounds that keep a hostile header from costing anything."""
+
+    def test_too_many_entries(self) -> None:
+        """A huge chain is refused rather than truncated."""
+        # Arrange
+        header = ", ".join(["10.0.0.1"] * 200)
+        # Act
+        result = resolve(forwarded=header, max_entries=64)
+        # Assert
+        assert result.reason is ClientAddressReason.TOO_MANY_ENTRIES
+
+    def test_header_too_large(self) -> None:
+        """An oversized header is refused before any entry is parsed."""
+        # Arrange / Act
+        result = resolve(forwarded="1.2.3.4" * 5000, max_header_bytes=1024)
+        # Assert
+        assert result.reason is ClientAddressReason.HEADER_TOO_LARGE
+
+    def test_hop_limit(self) -> None:
+        """A cap bounds how far a forged chain can be walked."""
+        # Arrange
+        header = ", ".join(["10.0.0.1"] * 10)
+        # Act
+        result = resolve(forwarded=header, max_hops=2)
+        # Assert
+        assert result.reason is ClientAddressReason.HOP_LIMIT
+        assert result.hops == EXPECTED_HOPS
+
+
+class TestTrustedProxiesConfig:
+    """A typo must fail at startup, not silently match nothing."""
+
+    @pytest.mark.parametrize(
+        "entry", ["10.0.0.1/8", "not-an-ip", "*", "/unix/socket", ""]
+    )
+    def test_rejects_bad_entries(self, entry: str) -> None:
+        """Uvicorn and granian downgrade these to dead string literals."""
+        # Act / Assert
+        with pytest.raises(ValueError, match="not an IP address"):
+            TrustedProxies([entry])
+
+    def test_accepts_parsed_objects(self) -> None:
+        """Addresses and networks can be passed already parsed."""
+        # Arrange / Act
+        trusted = TrustedProxies(
+            [ip_network("10.0.0.0/8"), ip_address("192.168.1.1")]
+        )
+        # Assert
+        assert ip_address("10.1.2.3") in trusted
+        assert ip_address("192.168.1.1") in trusted
+        assert ip_address("8.8.8.8") not in trusted
+
+    def test_error_names_the_entry_and_the_alternative(self) -> None:
+        """The message says what to pass instead of a wildcard."""
+        # Act / Assert
+        with pytest.raises(ValueError, match=r"0\.0\.0\.0/0"):
+            TrustedProxies(["*"])
+
+
+async def _receive() -> Message:
+    """Return a request message. Never called by these tests."""
+    return {"type": "http.request"}  # pragma: no cover
+
+
+async def _send(message: Message) -> None:
+    """Discard the message. Never called by these tests."""
+
+
+class TestMiddleware:
+    """The caching wrapper."""
+
+    async def test_caches_the_resolved_address(self) -> None:
+        """Every consumer reads one value instead of resolving its own."""
+        # Arrange
+        seen: dict[str, Any] = {}
+
+        async def app(
+            scope: Scope,
+            receive: Receive,  # noqa: ARG001
+            send: Send,  # noqa: ARG001
+        ) -> None:
+            seen.update(scope["state"])
+
+        middleware = ClientAddressMiddleware(
+            app, trusted=TrustedProxies(TRUSTED)
+        )
+        # Act
+        await middleware(scope(forwarded="1.2.3.4"), _receive, _send)
+        # Assert
+        assert seen["client_address"].key == "1.2.3.4"
+
+    async def test_passes_other_scopes_through(self) -> None:
+        """A lifespan scope is never touched."""
+        # Arrange
+        seen: list[str] = []
+
+        async def app(
+            scope: Scope,
+            receive: Receive,  # noqa: ARG001
+            send: Send,  # noqa: ARG001
+        ) -> None:
+            seen.append(scope["type"])
+
+        middleware = ClientAddressMiddleware(
+            app, trusted=TrustedProxies(TRUSTED)
+        )
+        # Act
+        await middleware({"type": "lifespan"}, _receive, _send)
+        # Assert
+        assert seen == ["lifespan"]
+
+    async def test_overwrite_scope_client_is_opt_in(self) -> None:
+        """The verified peer is kept unless the shim is asked for."""
+        # Arrange
+        captured: dict[str, Any] = {}
+
+        async def app(
+            scope: Scope,
+            receive: Receive,  # noqa: ARG001
+            send: Send,  # noqa: ARG001
+        ) -> None:
+            captured["client"] = scope["client"]
+
+        default = ClientAddressMiddleware(app, trusted=TrustedProxies(TRUSTED))
+        shim = ClientAddressMiddleware(
+            app, trusted=TrustedProxies(TRUSTED), overwrite_scope_client=True
+        )
+        # Act
+        await default(scope(forwarded="1.2.3.4"), _receive, _send)
+        untouched = captured["client"]
+        await shim(scope(forwarded="1.2.3.4"), _receive, _send)
+        # Assert
+        assert untouched == (PEER, 1234)
+        assert captured["client"] == ("1.2.3.4", 0)
+
+    async def test_unresolvable_peer_caches_nothing(self) -> None:
+        """No address is invented when there is no peer."""
+        # Arrange
+        seen: dict[str, Any] = {}
+
+        async def app(
+            scope: Scope,
+            receive: Receive,  # noqa: ARG001
+            send: Send,  # noqa: ARG001
+        ) -> None:
+            seen.update(scope.get("state", {}))
+
+        middleware = ClientAddressMiddleware(
+            app, trusted=TrustedProxies(TRUSTED)
+        )
+        # Act
+        await middleware(scope(peer=None), _receive, _send)
+        # Assert
+        assert "client_address" not in seen


### PR DESCRIPTION
Closes #609, from #591.

`X-Forwarded-For` is append-only, so its leftmost entry is whatever the original caller wrote. Reading it is the flaw behind a long line of advisories, including [CVE-2025-59152](https://github.com/litestar-org/litestar/security/advisories/GHSA-hm36-ffrh-c77c) in Litestar's rate limiter and go-chi's `RealIP`, which upstream **deprecated entirely** as unfixable without breaking API changes.

## This fixes a live issue in shipped docs

Two examples keyed on `request.client.host`, which behind a proxy is the proxy's own address:

- `docs/snippets/health/show_details.py` gated health-detail visibility on that address being private. Behind a proxy it is the proxy's private address **for every external caller**, so `is_private` was true for all of them and details leaked publicly.
- The README rate limiter example keyed on it, so every caller shared one bucket.

Both now resolve the client. Verified across all three deployment shapes: no proxy with a private caller, proxy with an external caller, proxy with an internal caller.

## The API

The trusted set is **required**, and there is no wildcard. To trust everything, pass `["0.0.0.0/0", "::/0"]`, which a config review will notice.

```python
trusted = TrustedProxies(["10.0.0.0/8"])
client = resolve_client_address(request.scope, trusted)
await limiter.acquire_or_raise(key=client.key)
```

`ClientAddress.ip` is **always** a parsed address the request came from or that a verified trusted proxy vouched for. Never header text, so a rate limiter key can never become attacker-chosen bytes.

## Where it deliberately differs from everyone else

Researched against uvicorn, granian, hypercorn, Werkzeug, Rails, Rack, ASP.NET Core and Express, reading each implementation's source.

**All entries trusted returns the peer, not the leftmost.** uvicorn, granian, Rails, Rack and Express all fall back to the leftmost. That is right for their consumer, a display field where a wrong value is cosmetic. It is wrong for a rate limiter key: in that case no proxy vouched for the leftmost against an untrusted peer, so it is exactly the value MDN says must only be used "where there is no negative impact from using spoofed values". Returned as `CHAIN_EXHAUSTED` so a caller can alert on it.

**A malformed entry stops the walk**, following ASP.NET rather than Rails. Skipping lets an attacker insert padding to shift which entry is chosen.

**Configuration fails loudly.** uvicorn's own comment concedes that it silently downgrades a bad entry to a string literal, so `"10.0.0.1/8"` (host bits set) becomes a dead rule matching nothing. Here it raises.

**IPv4-mapped normalisation on both sides.** Verified that `ip_address("::ffff:10.0.0.1") in ip_network("10.0.0.0/8")` is `False` in Python, so a dual-stack listener would otherwise stop trusting its proxy. Only `proxy-addr` in the whole survey handles this.

**A pure resolver, not a rewriter.** Rewriting `scope["client"]` destroys the verified peer an audit record wants, and is not idempotent under uvicorn's default-on middleware. `overwrite_scope_client=True` is available for code that cannot change.

## Tests

51 tests. The adversarial ones are the point: untrusted peer forging, leftmost losing, all-trusted chains, padding attacks, `<script>` in a header, lenient-parser forms like `1` and `010.1.1.1` that ASP.NET accepts as addresses, a trailing comma that defeats resolution in uvicorn and granian, and dual-stack bucket splitting.

## Scope

`X-Forwarded-For` only. RFC 7239 `Forwarded` is deliberately not included: both implementations that support it pick the header by presence, which hands the client control over which code path runs. Worth doing properly later, as an explicit exclusive choice.

If you only ever run uvicorn, `--forwarded-allow-ips` is a fine answer and the docs say so.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b