### PR TITLE
🔖 Prepare the 0.33.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.33.0 - 2026-07-31
 
 ### Features
 
@@ -10,13 +10,11 @@
 ### Security
 
 * 🔒 Refuse to show health details when the client address is a fallback. Resolving alone was not enough: a forged chain that could not be believed still returned the proxy's own private address, so the `is_private` check admitted everyone again. `ClientAddress.degraded` marks every such case. ([#609](https://github.com/grelinfo/grelmicro/issues/609))
-
 * 🔒 Stop the health-detail example from showing details to everyone behind a proxy. It gated on `request.client.host` being private, which is the proxy's own address for every external caller, so `is_private` was true for all of them. It now resolves the client. The rate limiter example keyed on the same value, giving every caller one shared bucket. ([#609](https://github.com/grelinfo/grelmicro/issues/609))
 
 ### Internal
 
 * 👷 Enforce the coverage total on the pull request that changes code, not in the next nightly. The slow and integration tiers now run on a code-touching pull request or push, on the primary Python only, so the combined 100% total is measurable there. The Python matrix and the demo tier stay on the nightly, dispatch, and release paths. About two minutes per pull request. ([#602](https://github.com/grelinfo/grelmicro/issues/602))
-
 * 👷 Stop a Codecov upload from failing CI. The test-results action crashed on a transient network error, which fails the step whatever `fail_ci_if_error` says, so a green test run with a passing coverage gate was reported as a failure. Uploads are telemetry and now cannot gate a build. ([#602](https://github.com/grelinfo/grelmicro/issues/602))
 
 ### Docs


### PR DESCRIPTION
Dates the changelog section for 0.33.0.

## Why a minor rather than a patch

Nothing here is breaking, so a patch would be defensible under the rule that `0.x.0` is the breaking position. A **new public module** is the reason to go to `0.33.0` anyway: `grelmicro.clientip` is a new top-level import surface rather than an addition to an existing one, and the release carries security fixes to shipped documentation that adopters should notice rather than skim past.

## What ships

**`grelmicro.clientip`**, resolving the real client address behind a reverse proxy. `X-Forwarded-For` is append-only, so its leftmost entry is attacker-controlled, and reading it naively is the flaw behind a long line of advisories. The trusted set is required, there is no wildcard, and `ClientAddress.ip` is always an address the caller could not choose.

**Two shipped documentation examples were teaching a vulnerable pattern**, which is the part existing adopters care about:

- The health-detail example gated visibility on `request.client.host` being private. Behind a proxy that is the proxy's own private address for every external caller, so `is_private` was true for all of them and details leaked publicly.
- The rate limiter example keyed on the same value, so every caller shared one bucket.

Also the migration page, the written-down pre-1.0 deprecation policy, and the CI change that enforces the coverage total on the pull request that breaks it rather than in the next nightly.

## Verification

Full tier dispatched on main before tagging: Lint, Workflow Lint, Docs, Demo Smoke, and Tests on 3.12, 3.13 and 3.14, all green, with the coverage gate passing across unit, slow and integration.

The client IP module went through two review rounds. The second found four exploitable defects, verified with raw sockets against a live uvicorn, including that uvicorn rewrites `scope["client"]` by default and so defeated the module's central guarantee until the docs said to disable it.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b