### PR TITLE
🐛 Report a task fire that never ran

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* 🐛 Report a task fire that never ran. `grelmicro.task.runs` only counted fires that reached the body, so a schedule backend or a lock that stopped answering left no metric at all and looked exactly like a task with nothing due. A fire now always lands on the counter: `coordination_error` when coordination failed, `missed` when no worker ran it, and `skipped` when a peer handled it. The bare total counts more than it did, so read the [migration note](migration.md#0-33-1-task-run-outcomes) if a chart treats it as the run rate. ([#605](https://github.com/grelinfo/grelmicro/issues/605))
+* 🐛 Warn when a cron fire is dropped for coming back too late. Past `misfire_grace_seconds` the fire was skipped with no log and no metric, so a task that never replayed said nothing at all. ([#605](https://github.com/grelinfo/grelmicro/issues/605))
+* 🐛 Record a fire that never reached the body on `last_fire`. An introspection endpoint reading it during a coordination outage reported the previous successful fire and looked healthy. ([#605](https://github.com/grelinfo/grelmicro/issues/605))
+
 ## 0.33.0 - 2026-07-31
 
 ### Features

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -130,6 +130,35 @@ When a `Metrics` component is active, grelmicro emits these metrics from its own
 
 The `grelmicro.circuit_breaker.state` gauge maps states to codes: `CLOSED` is 0, `OPEN` is 1, `HALF_OPEN` is 2, `FORCED_OPEN` is 3, `FORCED_CLOSED` is 4.
 
+### Every fire lands on `grelmicro.task.runs`
+
+Every fire a worker evaluates is counted once, whatever happens to it.
+The `outcome` attribute says what:
+
+| `outcome` | What happened |
+|---|---|
+| `success` | the body ran and returned |
+| `error` | the body raised, `error.type` names the exception |
+| `skipped` | another worker handled this fire, so this one stood down |
+| `missed` | the fire was dropped and no worker ran it, either because it came back too late to replay or because the worker that claimed it could not admit the body |
+| `coordination_error` | the fire never reached the body because coordination failed, `error.type` names the exception |
+
+`coordination_error` is the one to alert on. It means the schedule backend
+or the lock is unreachable, so the task is not running anywhere and its
+own error rate stays at zero because the body never ran.
+
+Watch `missed` too. A fire dropped past its grace budget ran on no worker
+at all, which a `skipped` series cannot tell you.
+
+Filter on `outcome="success"` for "how often does my task actually run".
+The bare total counts every fire each worker saw, so on a fleet of N
+workers sharing a lock it is roughly N times the number of fires.
+
+The startup catch-up tick is silent when it finds nothing to replay, and
+so is the first sight of a schedule, which records a baseline once so
+that later fires can be told apart from fires that never happened.
+Neither is a fire the worker had to act on.
+
 ## Background work always reports its failure
 
 Work that runs outside your call stack has nowhere to raise. A cache
@@ -153,6 +182,12 @@ Both counters carry `outcome` and, on a failure, `error.type`, so an
 error **rate** is derivable rather than only an absolute count. That
 follows the same shape as `grelmicro.task.runs`, and it is why success and
 failure share one counter instead of having their own.
+
+A task fire that never reaches the body follows the same rule. A
+coordination failure counts as `coordination_error` and a dropped fire as
+`missed`, both on `grelmicro.task.runs`, so a task that stopped running
+because its backend is down is never mistaken for a task with nothing to
+do.
 
 Watch the `outcome="error"` series on `grelmicro.cache.early_refreshes` and
 `grelmicro.shield.cache_writes`. Neither failure shows up in your latency

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,9 +9,10 @@ sections in the [changelog](changelog.md), newest first.
 
 In `0.x` the minor is the breaking position: a `0.x.0` release may change the
 public API, and a `0.x.y` release is a safe patch. So an upgrade within one
-minor rarely needs this page. The one exception so far is
-[0.32.2](#0-32-2-circuit-breaker-state), which changes no API but does change
-what an already-open circuit does once.
+minor rarely needs this page. Two patches are exceptions, and neither changes
+an API: [0.32.2](#0-32-2-circuit-breaker-state) changes what an already-open
+circuit does once, and [0.33.1](#0-33-1-task-run-outcomes) changes what a task
+metric counts.
 
 ## Find your symptom
 
@@ -23,6 +24,7 @@ what an already-open circuit does once.
 | `TypeError` on a SQLite adapter, either `unexpected keyword argument 'path'` or `takes 1 positional argument` | 0.32 | [Pass `provider=`](#0-32-sqlite-provider) |
 | `SettingsValidationError` where you caught `CoordinationSettingsValidationError` | 0.32 | [Catch the base error](#0-32-sqlite-provider) |
 | An open circuit closed once, just after upgrading | 0.32.2 | [Expected, happens once](#0-32-2-circuit-breaker-state) |
+| Task run totals jumped after upgrading, with no new failures | 0.33.1 | [Filter on `outcome`](#0-33-1-task-run-outcomes) |
 
 ## 0.32
 
@@ -117,6 +119,32 @@ async with idem(key) as op:
 
 It is valid **only** on a replay. Calling it on a first execution raises
 `IdempotencyStateError`, so keep it behind `if op.replayed:`.
+
+## 0.33.1, not breaking but worth knowing {#0-33-1-task-run-outcomes}
+
+`grelmicro.task.runs` now counts every fire, not only the fires that ran
+the body. A fire a peer took counts as `skipped`, a fire dropped past its
+grace budget as `missed`, and a fire that never got there because
+coordination failed as `coordination_error`.
+
+That makes the bare total larger. On a fleet of N workers sharing a lock
+it is now roughly N times the number of fires, because the N-1 workers
+that stand down each count their fire.
+
+If a chart or an alert reads the total as "how often does my task run",
+filter it:
+
+```promql
+# Before
+rate(grelmicro_task_runs_total[5m])
+
+# After
+rate(grelmicro_task_runs_total{outcome="success"}[5m])
+```
+
+Nothing else changes. `outcome="success"` and `outcome="error"` keep the
+meanings they had, so an alert already filtering on either is correct as
+it stands.
 
 ## 0.32.2, not breaking but worth knowing {#0-32-2-circuit-breaker-state}
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -236,9 +236,16 @@ Each task exposes two read-only properties for observability:
   computed from the last loop instant. For cron tasks, it comes from the
   parsed expression.
 - **`last_fire`**: a `FireInfo` with the `started_at` timestamp, outcome (a
-  `FireOutcome` enum: `SUCCESS`, `ERROR`, or `SKIPPED`), and duration in
-  seconds. `None` before the first fire. `FireOutcome` is a `StrEnum`, so each
-  member compares equal to its string value (`outcome == "success"`).
+  `FireOutcome` enum: `SUCCESS`, `ERROR`, `SKIPPED`, `MISSED`, or
+  `COORDINATION_ERROR`), and duration in seconds. `None` before the first
+  fire. `FireOutcome` is a `StrEnum`, so each member compares equal to its
+  string value (`outcome == "success"`).
+
+  A fire that never reached the body sets `last_fire` too, with a duration
+  of `0.0`. So a task whose schedule backend went down reads as
+  `COORDINATION_ERROR` rather than keeping yesterday's success on display.
+  The same outcomes are counted on
+  [`grelmicro.task.runs`](metrics.md#every-fire-lands-on-grelmicrotaskruns).
 
 Access the task object via `tasks.tasks`:
 

--- a/grelmicro/task/_cron.py
+++ b/grelmicro/task/_cron.py
@@ -35,13 +35,21 @@ class FireOutcome(StrEnum):
 
     - ``SUCCESS``: the body ran and returned without raising.
     - ``ERROR``: the body raised an exception.
-    - ``SKIPPED``: the fire was skipped because acquiring a lock would
-      block (a ``WouldBlockError``).
+    - ``SKIPPED``: another worker handled the fire, so this one stood
+      down. The peer either ran it or recorded it as missed.
+    - ``MISSED``: the fire was dropped and no worker ran it. Either it
+      came back too late to replay, past ``misfire_grace_seconds``, or
+      this worker claimed it and then could not admit the body.
+    - ``COORDINATION_ERROR``: the fire never reached the body because
+      coordination itself failed, such as an unreachable schedule backend
+      or a lock acquire that raised.
     """
 
     SUCCESS = "success"
     ERROR = "error"
     SKIPPED = "skipped"
+    MISSED = "missed"
+    COORDINATION_ERROR = "coordination_error"
 
 
 @dataclass(frozen=True)
@@ -57,6 +65,26 @@ class FireInfo:
 # cron matching is deterministic and never straddles a real minute boundary.
 # Mirrors the `_now` seam in the cache.
 _now = datetime.now
+
+
+def _report_unrun_fire(
+    name: str,
+    started_at: datetime,
+    outcome: FireOutcome,
+    error: Exception | None = None,
+) -> FireInfo:
+    """Record a fire that never reached the body and return its `FireInfo`.
+
+    Emits one `grelmicro.task.runs` point and builds the matching
+    `FireInfo` together, so the counter and `last_fire` cannot disagree
+    about a fire. The caller assigns the return value to `_last_fire`.
+    """
+    attributes: dict[str, Any] = {"task.name": name, "outcome": outcome}
+    if error is not None:
+        attributes["error.type"] = type(error).__name__
+    _emit.incr("grelmicro.task.runs", **attributes)
+    return FireInfo(started_at=started_at, outcome=outcome, duration=0.0)
+
 
 # Maximum number of years to search for the next matching datetime before
 # giving up. Covers Feb-29 schedules (every 4 years) with margin so an
@@ -348,6 +376,9 @@ class CronTask(Task):
 
         self._next_fire_time: datetime | None = None
         self._last_fire: FireInfo | None = None
+        # Whether the body started on the current tick. A failure raised
+        # after it started is already counted by `_run_body`.
+        self._body_started = False
 
     @property
     def name(self) -> str:
@@ -439,23 +470,32 @@ class CronTask(Task):
 
     async def _tick_guarded(self, *, catchup: bool) -> None:
         """Run one tick, catching the errors a single fire may raise."""
+        self._body_started = False
         try:
             await self._tick(catchup=catchup)
         except asyncio.CancelledError:
             raise
         except WouldBlockError as exc:
-            self._last_fire = FireInfo(
-                started_at=_now(self._tz),
-                outcome=FireOutcome.SKIPPED,
-                duration=0.0,
+            self._last_fire = _report_unrun_fire(
+                self.name, _now(self._tz), FireOutcome.SKIPPED
             )
             logger.debug("Task skipped: %s (%s)", self.name, exc)
         except LockNotOwnedError:
+            # The lock expired on release, so the body already ran and
+            # already reported its own outcome. Counting it again would
+            # double the fire.
             logger.warning(
                 "Task took too long and lock expired: %s.", self.name
             )
-        except Exception:
+        except Exception as exc:
             logger.exception("Task synchronization error: %s", self.name)
+            if not self._body_started:
+                self._last_fire = _report_unrun_fire(
+                    self.name,
+                    _now(self._tz),
+                    FireOutcome.COORDINATION_ERROR,
+                    exc,
+                )
         # Re-raise pending cancellation that an inner cleanup may have
         # shadowed with a regular Exception.
         task = asyncio.current_task()
@@ -489,22 +529,68 @@ class CronTask(Task):
         last = await backend.last_fired(self.name)
         if last is None:
             # First sight of this schedule: establish the baseline without
-            # running, so only later fires count as missed and replay.
+            # running, so only later fires count as missed and replay. No
+            # fire was ever due here, so nothing is reported.
             await backend.claim(self.name, due)
             return
         if due <= last:
             # Already handled (coalesce: only the most recent fire matters).
+            # On a scheduled tick that means a peer claimed this fire while
+            # this worker was reading, which is where most losers land.
+            if not catchup:
+                self._last_fire = _report_unrun_fire(
+                    self.name, now, FireOutcome.SKIPPED
+                )
             return
         if (
             self._misfire_grace_seconds is not None
             and (now.timestamp() - due) > self._misfire_grace_seconds
         ):
-            # Too late to replay this missed fire: skip but advance the
-            # baseline so it is not retried forever.
-            await backend.claim(self.name, due)
+            await self._drop_late_fire(backend, due, now)
             return
+        await self._claim_and_run(backend, due, now)
+
+    async def _drop_late_fire(
+        self, backend: ScheduleBackend, due: float, now: datetime
+    ) -> None:
+        """Drop a fire that came back too late to replay.
+
+        Advances the baseline so the fire is not retried forever. Only the
+        worker that wins the claim reports the drop, so one dropped fire
+        counts once however many workers saw it.
+        """
         if await backend.claim(self.name, due):
+            logger.warning(
+                "Task fire missed, too late to replay: %s (%.0fs late)",
+                self.name,
+                now.timestamp() - due,
+            )
+            outcome = FireOutcome.MISSED
+        else:
+            outcome = FireOutcome.SKIPPED
+        self._last_fire = _report_unrun_fire(self.name, now, outcome)
+
+    async def _claim_and_run(
+        self, backend: ScheduleBackend, due: float, now: datetime
+    ) -> None:
+        """Run the body when this worker wins the claim for `due`."""
+        if not await backend.claim(self.name, due):
+            self._last_fire = _report_unrun_fire(
+                self.name, now, FireOutcome.SKIPPED
+            )
+            return
+        try:
             await self._run()
+        except WouldBlockError:
+            # The claim advanced the baseline, so no peer replays this
+            # fire. A `sync` primitive that refuses to admit the body
+            # loses it outright, which is a miss and not a skip.
+            logger.warning(
+                "Task fire missed, claimed but not admitted: %s", self.name
+            )
+            self._last_fire = _report_unrun_fire(
+                self.name, now, FireOutcome.MISSED
+            )
 
     async def _run(self) -> None:
         """Run the body, optionally under the resource sync lock, with metrics."""
@@ -516,6 +602,7 @@ class CronTask(Task):
 
     async def _run_body(self) -> None:
         """Run the task body and emit metrics."""
+        self._body_started = True
         _emit.add_up_down(
             "grelmicro.task.active", 1, **{"task.name": self.name}
         )

--- a/grelmicro/task/_interval.py
+++ b/grelmicro/task/_interval.py
@@ -17,7 +17,7 @@ from grelmicro.coordination.leaderelection import LeaderElection
 from grelmicro.coordination.tasklock import TaskLock
 from grelmicro.errors import WouldBlockError
 from grelmicro.metrics import _emit
-from grelmicro.task._cron import FireInfo, FireOutcome
+from grelmicro.task._cron import FireInfo, FireOutcome, _report_unrun_fire
 from grelmicro.task._protocol import Task
 from grelmicro.task._utils import validate_and_generate_reference
 
@@ -83,6 +83,9 @@ class IntervalTask(Task):
 
         self._last_fire: FireInfo | None = None
         self._last_loop_start: float | None = None
+        # Whether the body started on the current iteration. A failure
+        # raised after it started is already counted by `_run_with_sync`.
+        self._body_started = False
 
     def _resolve_task_lock(
         self, lock: TaskLock | None, seconds: float
@@ -146,27 +149,36 @@ class IntervalTask(Task):
             ready.set_result(None)
         try:
             while True:
+                self._body_started = False
                 try:
                     await self._run_with_sync(self._sync_primitives)
                 except asyncio.CancelledError:
                     raise
                 except WouldBlockError as exc:
-                    self._last_fire = FireInfo(
-                        started_at=datetime.now(UTC),
-                        outcome=FireOutcome.SKIPPED,
-                        duration=0.0,
+                    self._last_fire = _report_unrun_fire(
+                        self.name, datetime.now(UTC), FireOutcome.SKIPPED
                     )
                     logger.debug("Task skipped: %s (%s)", self.name, exc)
                 except LockNotOwnedError:
+                    # The lock expired on release, so the body already ran
+                    # and already reported its own outcome. Counting it
+                    # again would double the fire.
                     logger.warning(
                         "Task took too long and lock expired: %s."
                         " Consider increasing lease_duration.",
                         self.name,
                     )
-                except Exception:
+                except Exception as exc:
                     logger.exception(
                         "Task synchronization error: %s", self.name
                     )
+                    if not self._body_started:
+                        self._last_fire = _report_unrun_fire(
+                            self.name,
+                            datetime.now(UTC),
+                            FireOutcome.COORDINATION_ERROR,
+                            exc,
+                        )
                 # Re-raise pending cancellation that an inner cleanup
                 # may have shadowed with a regular Exception.
                 task = asyncio.current_task()
@@ -191,6 +203,7 @@ class IntervalTask(Task):
         overhead on every iteration.
         """
         if index >= len(primitives):
+            self._body_started = True
             _emit.add_up_down(
                 "grelmicro.task.active", 1, **{"task.name": self.name}
             )

--- a/tests/metrics/test_auto_task.py
+++ b/tests/metrics/test_auto_task.py
@@ -1,13 +1,41 @@
-"""Auto-instrumentation tests for the task component."""
+"""Auto-instrumentation tests for the task component.
+
+The tests below the success and error cases cover the fires that never
+reach the body. Each one proves the failure is observable on
+`grelmicro.task.runs`, so a refactor cannot silently reintroduce the
+suppression that issue #605 removed.
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+from asyncio import sleep
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Self
 
+from grelmicro.coordination._protocol import LockPrimitive
+from grelmicro.coordination.errors import LockNotOwnedError
+from grelmicro.coordination.memory import MemoryScheduleAdapter
+from grelmicro.task._cron import CronTask
 from grelmicro.task._interval import IntervalTask
+from tests.task._helpers import cancel_group, start_task
+from tests.task.samples import BadLock, WouldBlockLock
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
+    import pytest
+    from pytest_mock import MockFixture
+
     from tests.metrics.conftest import MetricsHarness
+
+EVERY_MINUTE = "* * * * *"
+SLEEP = 0.01
+WORKERS = 3
+# A fixed instant 30 seconds past a whole minute, so the most recent fire
+# is always 30 seconds old and a grace budget below that always expires.
+PINNED = datetime(2026, 7, 31, 12, 0, 30, tzinfo=UTC)
+PINNED_DUE = PINNED.replace(second=0).timestamp()
 
 _ran = False
 
@@ -21,6 +49,71 @@ async def _work() -> None:
 async def _boom() -> None:
     """Module-level failing task body."""
     raise ValueError
+
+
+class _LockExpiredOnRelease(LockPrimitive):
+    """Lock that enters cleanly, then fails on release like an expired lease."""
+
+    async def __aenter__(self) -> Self:
+        """Enter the synchronization primitive."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Fail on release, after the body already ran and reported."""
+        raise LockNotOwnedError(name="expired")
+
+
+class _FailsOnRelease(LockPrimitive):
+    """Lock that enters cleanly, then raises on release."""
+
+    async def __aenter__(self) -> Self:
+        """Enter the synchronization primitive."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Fail on release, after the body already ran and reported."""
+        msg = "release failed"
+        raise RuntimeError(msg)
+
+
+class _UnreachableSchedule(MemoryScheduleAdapter):
+    """Schedule backend that cannot be reached."""
+
+    async def last_fired(self, name: str) -> float | None:  # noqa: ARG002
+        """Fail like an unreachable backend."""
+        msg = "backend unreachable"
+        raise ConnectionError(msg)
+
+
+class _LosingSchedule(MemoryScheduleAdapter):
+    """Schedule backend where every claim is won by a peer."""
+
+    async def claim(self, name: str, due: float) -> bool:  # noqa: ARG002
+        """Lose every claim."""
+        return False
+
+
+def _outcomes(harness: MetricsHarness) -> dict[str, dict[str, Any]]:
+    """Return the `grelmicro.task.runs` attributes keyed by outcome."""
+    return {
+        attributes["outcome"]: attributes
+        for _, attributes in harness.points("grelmicro.task.runs")
+    }
+
+
+def _pin_clock(mocker: MockFixture) -> None:
+    """Pin the cron wall clock to `PINNED`."""
+    mocker.patch("grelmicro.task._cron._now", PINNED.astimezone)
 
 
 async def test_task_emits_success(metrics_reader: MetricsHarness) -> None:
@@ -57,3 +150,341 @@ async def test_task_metrics_noop_when_off() -> None:
     task = IntervalTask(seconds=1, function=_work, name="svc")
     await task._run_with_sync([])
     assert _ran
+
+
+# --- Fires that never reach the body ---
+
+
+async def test_interval_task_emits_coordination_error(
+    metrics_reader: MetricsHarness,
+) -> None:
+    """A lock that fails to acquire emits runs(outcome=coordination_error)."""
+    task = IntervalTask(seconds=1, function=_work, name="sync", sync=BadLock())
+
+    async with asyncio.TaskGroup() as tg:
+        await start_task(tg, task)
+        await sleep(SLEEP)
+        cancel_group(tg)
+
+    assert _outcomes(metrics_reader)["coordination_error"] == {
+        "task.name": "sync",
+        "outcome": "coordination_error",
+        "error.type": "ValueError",
+    }
+    assert task.last_fire is not None
+    assert task.last_fire.outcome == "coordination_error"
+
+
+async def test_interval_task_emits_skipped(
+    metrics_reader: MetricsHarness,
+) -> None:
+    """A fire a peer already holds emits runs(outcome=skipped)."""
+    task = IntervalTask(
+        seconds=1, function=_work, name="peer", sync=WouldBlockLock()
+    )
+
+    async with asyncio.TaskGroup() as tg:
+        await start_task(tg, task)
+        await sleep(SLEEP)
+        cancel_group(tg)
+
+    assert _outcomes(metrics_reader)["skipped"] == {
+        "task.name": "peer",
+        "outcome": "skipped",
+    }
+
+
+async def test_interval_task_counts_expired_lock_fire_once(
+    metrics_reader: MetricsHarness,
+) -> None:
+    """A lock expiring on release does not count the fire a second time.
+
+    The body already ran and already reported, so a second point would
+    inflate the total the counter exists to give.
+    """
+    task = IntervalTask(
+        seconds=1,
+        function=_work,
+        name="expired",
+        sync=_LockExpiredOnRelease(),
+    )
+
+    async with asyncio.TaskGroup() as tg:
+        await start_task(tg, task)
+        await sleep(SLEEP)
+        cancel_group(tg)
+
+    assert set(_outcomes(metrics_reader)) == {"success"}
+
+
+async def test_interval_task_counts_fire_once_when_release_fails(
+    metrics_reader: MetricsHarness,
+) -> None:
+    """A sync lock failing on release does not count the fire twice."""
+    task = IntervalTask(
+        seconds=1, function=_work, name="release", sync=_FailsOnRelease()
+    )
+
+    async with asyncio.TaskGroup() as tg:
+        await start_task(tg, task)
+        await sleep(SLEEP)
+        cancel_group(tg)
+
+    assert set(_outcomes(metrics_reader)) == {"success"}
+
+
+async def test_cron_task_emits_coordination_error(
+    metrics_reader: MetricsHarness,
+) -> None:
+    """An unreachable schedule backend emits runs(outcome=coordination_error)."""
+    backend = _UnreachableSchedule()
+    await backend.__aenter__()
+    task = CronTask(
+        expr=EVERY_MINUTE, function=_work, name="down", backend=backend
+    )
+
+    await task._tick_guarded(catchup=False)
+
+    assert _outcomes(metrics_reader)["coordination_error"] == {
+        "task.name": "down",
+        "outcome": "coordination_error",
+        "error.type": "ConnectionError",
+    }
+    assert task.last_fire is not None
+    assert task.last_fire.outcome == "coordination_error"
+
+
+async def test_cron_task_emits_skipped_when_peer_claimed_first(
+    metrics_reader: MetricsHarness, mocker: MockFixture
+) -> None:
+    """A fire a peer claimed while this worker was reading emits skipped.
+
+    This is where most losing workers land: the peer's claim commits
+    before this worker reads `last_fired`, so the fire reads as handled.
+    """
+    _pin_clock(mocker)
+    backend = MemoryScheduleAdapter()
+    await backend.__aenter__()
+    task = CronTask(
+        expr=EVERY_MINUTE, function=_work, name="late-read", backend=backend
+    )
+    await backend.claim("late-read", PINNED_DUE)
+
+    await task._tick_guarded(catchup=False)
+
+    assert _outcomes(metrics_reader)["skipped"] == {
+        "task.name": "late-read",
+        "outcome": "skipped",
+    }
+    assert task.last_fire is not None
+    assert task.last_fire.outcome == "skipped"
+
+
+async def test_cron_task_emits_skipped_when_peer_holds_the_lock(
+    metrics_reader: MetricsHarness, mocker: MockFixture
+) -> None:
+    """A fire a peer holds emits runs(outcome=skipped).
+
+    With no schedule backend every worker fires, so a lock refusing to
+    admit the body means a peer is running it. Nothing is lost.
+    """
+    _pin_clock(mocker)
+    task = CronTask(
+        expr=EVERY_MINUTE,
+        function=_work,
+        name="held",
+        sync=WouldBlockLock(),
+    )
+
+    await task._tick_guarded(catchup=False)
+
+    assert _outcomes(metrics_reader)["skipped"] == {
+        "task.name": "held",
+        "outcome": "skipped",
+    }
+    assert task.last_fire is not None
+    assert task.last_fire.outcome == "skipped"
+
+
+async def test_cron_task_emits_missed_when_claimed_but_not_admitted(
+    metrics_reader: MetricsHarness,
+    mocker: MockFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A claimed fire the body cannot be admitted to is missed, not skipped.
+
+    The claim advanced the baseline, so no peer replays the fire. Calling
+    that a skip would label a lost fire as healthy sharing.
+    """
+    _pin_clock(mocker)
+    backend = MemoryScheduleAdapter()
+    await backend.__aenter__()
+    backend._last_fired["unadmitted"] = PINNED_DUE - 120
+    task = CronTask(
+        expr=EVERY_MINUTE,
+        function=_work,
+        name="unadmitted",
+        backend=backend,
+        sync=WouldBlockLock(),
+    )
+
+    await task._tick_guarded(catchup=False)
+
+    assert _outcomes(metrics_reader)["missed"] == {
+        "task.name": "unadmitted",
+        "outcome": "missed",
+    }
+    assert any(
+        "claimed but not admitted" in record.message
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )
+
+
+async def test_cron_task_emits_skipped_when_claim_lost(
+    metrics_reader: MetricsHarness,
+) -> None:
+    """A claim a peer wins emits runs(outcome=skipped)."""
+    backend = _LosingSchedule()
+    await backend.__aenter__()
+    backend._last_fired["lost"] = datetime.now(UTC).timestamp() - 120
+    task = CronTask(
+        expr=EVERY_MINUTE, function=_work, name="lost", backend=backend
+    )
+
+    await task._tick_guarded(catchup=False)
+
+    assert _outcomes(metrics_reader)["skipped"] == {
+        "task.name": "lost",
+        "outcome": "skipped",
+    }
+
+
+async def test_cron_task_catchup_tick_reports_nothing(
+    metrics_reader: MetricsHarness, mocker: MockFixture
+) -> None:
+    """A startup catch-up with nothing missed is not a skipped fire."""
+    _pin_clock(mocker)
+    backend = MemoryScheduleAdapter()
+    await backend.__aenter__()
+    task = CronTask(
+        expr=EVERY_MINUTE, function=_work, name="catchup", backend=backend
+    )
+    await backend.claim("catchup", PINNED_DUE)
+
+    await task._tick_guarded(catchup=True)
+
+    assert _outcomes(metrics_reader) == {}
+    assert task.last_fire is None
+
+
+async def test_cron_task_emits_missed_when_too_late_to_replay(
+    metrics_reader: MetricsHarness,
+    mocker: MockFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A fire dropped past the grace budget emits runs(outcome=missed).
+
+    No worker runs it, so it is not a skip. Before this it had no log
+    and no metric at all.
+    """
+    _pin_clock(mocker)
+    backend = MemoryScheduleAdapter()
+    await backend.__aenter__()
+    backend._last_fired["dropped"] = PINNED_DUE - 120
+    task = CronTask(
+        expr=EVERY_MINUTE,
+        function=_work,
+        name="dropped",
+        backend=backend,
+        misfire_grace_seconds=1,
+    )
+
+    await task._tick_guarded(catchup=False)
+
+    assert _outcomes(metrics_reader)["missed"] == {
+        "task.name": "dropped",
+        "outcome": "missed",
+    }
+    assert task.last_fire is not None
+    assert task.last_fire.outcome == "missed"
+    assert any(
+        "Task fire missed" in record.message
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )
+
+
+async def test_cron_task_emits_skipped_when_peer_took_the_dropped_fire(
+    metrics_reader: MetricsHarness, mocker: MockFixture
+) -> None:
+    """A peer that records a dropped fire leaves this worker skipped.
+
+    The peer handled the fire even though nobody ran it, so this worker
+    stands down rather than reporting the same drop twice.
+    """
+    _pin_clock(mocker)
+    backend = _LosingSchedule()
+    await backend.__aenter__()
+    backend._last_fired["taken"] = PINNED_DUE - 120
+    task = CronTask(
+        expr=EVERY_MINUTE,
+        function=_work,
+        name="taken",
+        backend=backend,
+        misfire_grace_seconds=1,
+    )
+
+    await task._tick_guarded(catchup=False)
+
+    assert set(_outcomes(metrics_reader)) == {"skipped"}
+
+
+async def test_cron_task_counts_fire_once_when_release_fails(
+    metrics_reader: MetricsHarness,
+) -> None:
+    """A sync lock failing on release does not count the fire twice."""
+    backend = MemoryScheduleAdapter()
+    await backend.__aenter__()
+    backend._last_fired["release"] = datetime.now(UTC).timestamp() - 120
+    task = CronTask(
+        expr=EVERY_MINUTE,
+        function=_work,
+        name="release",
+        backend=backend,
+        sync=_FailsOnRelease(),
+    )
+
+    await task._tick_guarded(catchup=False)
+
+    assert set(_outcomes(metrics_reader)) == {"success"}
+
+
+async def test_cron_task_missed_fire_counted_once_across_workers(
+    metrics_reader: MetricsHarness, mocker: MockFixture
+) -> None:
+    """Only the worker that advances the baseline reports a dropped fire."""
+    _pin_clock(mocker)
+    backend = MemoryScheduleAdapter()
+    await backend.__aenter__()
+    backend._last_fired["shared"] = PINNED_DUE - 120
+    workers = [
+        CronTask(
+            expr=EVERY_MINUTE,
+            function=_work,
+            name="shared",
+            backend=backend,
+            misfire_grace_seconds=1,
+        )
+        for _ in range(WORKERS)
+    ]
+
+    for worker in workers:
+        await worker._tick_guarded(catchup=False)
+
+    points = {
+        attributes["outcome"]: value
+        for value, attributes in metrics_reader.points("grelmicro.task.runs")
+    }
+    assert points["missed"] == 1
+    assert points["skipped"] == WORKERS - 1


### PR DESCRIPTION
Closes the tail of #605: `grelmicro.task.runs` never fired when the claiming step failed, so on a metrics-only dashboard a broken claim looked identical to "not due".

## What was invisible

A point was only ever emitted from inside the body wrapper. Everything that stopped a fire before the body ran was missing from the metric:

| Path | Before |
|---|---|
| Schedule backend `claim()` or `last_fired()` raises | `ERROR` log, no metric |
| Lock or leader-election acquire raises | same |
| A peer holds the lock, or won the claim | `DEBUG` log at best, often nothing |
| A fire dropped past `misfire_grace_seconds` | **nothing at all**, no log and no metric |

The last row is a live violation of the contract in `docs/metrics.md`, not just a metrics gap. A cron task that stopped replaying said nothing anywhere.

With N workers sharing a lock, the N-1 that correctly stood down emitted nothing, and a worker whose backend was down also emitted nothing. "Working perfectly" and "completely broken" drew the same picture.

## What lands now

Every fire a worker evaluates is counted once, on the existing counter:

| `outcome` | Meaning |
|---|---|
| `success` / `error` | unchanged, the body ran |
| `skipped` | another worker handled this fire |
| `missed` | the fire was dropped and no worker ran it |
| `coordination_error` | coordination failed, the fire never reached the body |

`coordination_error` is the one to alert on: the task is running nowhere and its own error rate stays at zero because the body never ran.

The same outcomes now land on `FireInfo.last_fire`, which previously kept the last successful fire on display right through an outage, so an introspection endpoint reading it looked healthy while the task was dead.

## Not breaking, but it changes a number

No API changes, and `outcome="success"` and `outcome="error"` keep their meanings, so an alert already filtering on either is correct as it stands. The bare total grows, roughly N times on a fleet of N workers, because the workers that stand down now count their fires. `docs/migration.md` carries the entry with the promql fix, keyed on the symptom "task run totals jumped after upgrading".

## Design notes

**Why extend the counter instead of adding one.** grelmicro's own convention, set in #611: one counter carrying `outcome` so an error rate is derivable, not a failure-only counter. OpenTelemetry supports both shapes, and its closest analog ([`cicd.system.errors`](https://opentelemetry.io/docs/specs/semconv/cicd/cicd-metrics/)) is actually the separate-counter shape, so the internal convention is the reason here, not the spec.

**Why not rename `error` to OTel's `failure`.** [OTel's CI/CD result vocabulary](https://opentelemetry.io/docs/specs/semconv/cicd/cicd-metrics/) draws the distinction this change needs (`failure` is the workload's fault, `error` is the system's). Aligning fully would mean reusing the shipped `error` with an inverted meaning, which would leave adopters with a body-failure alert that quietly measures something else. More to the point, `success`/`error` is grelmicro's library-wide vocabulary, shared with `retry.attempts`, `cache.early_refreshes` and `shield.cache_writes`. Renaming one metric breaks that consistency and renaming all of them is a large break for alignment with a CI/CD vocabulary that does not govern task metrics.

**One point per fire.** A `LockNotOwnedError`, or anything else raised after the body already reported, is not counted a second time. That is what the `_body_started` flag guards.

**A claimed fire that cannot start is `missed`, not `skipped`.** The claim already advanced the baseline, so no peer replays it. Calling it a skip would label a lost fire as healthy sharing.

## Review

Three adversarial rounds, each asked to refute rather than approve. They caught, in order: that most losing cron workers exit at the `due <= last` branch rather than the claim-False branch, so the first design missed the common case entirely; that 0.33.0 was already published, so the changelog belonged under `Unreleased`; that two tests raced the real minute boundary; and the lost-fire hole above. The last round mutation-tested the suite, reverting seven production lines one at a time, and each mutation killed a test.

Full pre-commit passes clean, including the 100% coverage gate.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b
