### PR TITLE
🧪 Verify the Patterns across real process boundaries

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -137,6 +137,26 @@ jobs:
           curl -fsS http://localhost:8000/livez
           curl -fsS http://localhost:8000/readyz
           curl -fsS http://localhost:8000/healthz
+      - name: Check the rate limit holds across both workers
+        # The demo runs two uvicorn workers and the limiter is Redis backed,
+        # so the burst capacity of 5 is the whole deployment's budget. A
+        # per-worker limiter would admit about twice as many.
+        run: |
+          allowed=0
+          for _ in $(seq 1 12); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              "http://localhost:8000/quote?client=smoke")
+            if [ "$code" = "200" ]; then allowed=$((allowed + 1)); fi
+          done
+          echo "allowed=$allowed of 12"
+          if [ "$allowed" -gt 8 ]; then
+            echo "::error::rate limit did not hold across workers"
+            exit 1
+          fi
+          if [ "$allowed" -lt 1 ]; then
+            echo "::error::rate limiter rejected everything"
+            exit 1
+          fi
       - name: Dump app logs on failure
         if: failure()
         run: docker compose -f examples/fastapi-demo/compose.yml logs app

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -141,13 +141,16 @@ jobs:
         # The demo runs two uvicorn workers and the limiter is Redis backed,
         # so the burst capacity of 5 is the whole deployment's budget. A
         # per-worker limiter would admit about twice as many.
+        #
+        # The requests go out in parallel. Sent one after another the kernel
+        # can hand every one to the same worker, and a per-worker limiter
+        # would then admit exactly the capacity too, so the check would pass
+        # without ever testing what it claims to.
         run: |
-          allowed=0
-          for _ in $(seq 1 12); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' \
-              "http://localhost:8000/quote?client=smoke")
-            if [ "$code" = "200" ]; then allowed=$((allowed + 1)); fi
-          done
+          allowed=$(seq 1 12 | xargs -P 12 -I{} \
+            curl -s -o /dev/null -w '%{http_code}\n' \
+              "http://localhost:8000/quote?client=smoke" \
+            | grep -c '^200$' || true)
           echo "allowed=$allowed of 12"
           if [ "$allowed" -gt 8 ]; then
             echo "::error::rate limit did not hold across workers"

--- a/docs/architecture/coordination.md
+++ b/docs/architecture/coordination.md
@@ -11,8 +11,15 @@ This provides uniqueness across:
 - **Multiple processes** (e.g., `uvicorn --workers N`): Each worker process imports the application independently, so `token_hex(8)` is called separately per process with independent randomness.
 - **Multiple instances** within the same process: Each `Lock(...)` or `TaskLock(...)` call generates its own `token_hex(8)`, producing a different worker identity.
 
-!!! warning "Pre-fork servers"
-    If the ASGI server uses a pre-fork model (forking after the application is loaded), worker identities generated before the fork will be duplicated across child processes. Uvicorn does **not** pre-fork. It spawns workers via `subprocess.Popen`, so each worker imports the application independently. If using a pre-fork server, pass an explicit `worker` identity to avoid collisions.
+- **Pre-fork servers** (e.g., `gunicorn --preload`): the application is built once and then forked, so every child inherits the same identity. A process whose pid is not the one that minted the identity appends its own random suffix, giving `{worker}.{suffix}`. This covers an explicit `worker` too, because one explicit value is inherited by every child just the same.
+
+The pid is compared on every token build rather than hooked with `os.register_at_fork`. A hook only fires for a fork taken through Python after the module was imported, so comparing also covers a process restored from a checkpoint or duplicated from an image that already carried the identity. The suffix is minted once per process and reused, because two suffixes in one process would leave a holder unable to release its own lock.
+
+!!! note "Uvicorn does not pre-fork"
+    `uvicorn --workers N` starts each worker with the `spawn` start method, so a worker imports the application itself and generates its own identity. No suffix is added there, and the identity is exactly the one that was generated.
+
+!!! warning "Read the identity back, do not assume it"
+    An operator matching on a configured `worker` sees the suffix in `record.holder` under a pre-fork server. Treat `worker` as the readable part of the identity rather than the whole of it.
 
 ## Token Generation
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,9 +5,20 @@
 ### Fixed
 
 * 🐛 Keep the grelmicro request scope outside every other middleware. `IdempotencyMiddleware` had to be added before `micro.install(app)`, and the wrong order raised nothing at setup, so the first failure arrived in production from a client that actually sent `Idempotency-Key`. `install` now places the binding middleware outermost when the stack is built, so either order works, and reads the placement back on startup so a stack that still ends up wrong raises `AmbientBindingError` at boot. ([#599](https://github.com/grelinfo/grelmicro/issues/599))
+* 🐛 Start more than one worker against a fresh Postgres. `CREATE TABLE IF NOT EXISTS` checks and creates in two steps, so two workers starting together both passed the check and one crashed on the row type the table creates. Every Postgres adapter now installs its schema under an advisory lock, as the outbox already did. ([#595](https://github.com/grelinfo/grelmicro/issues/595))
+* 🐛 Give each worker of a pre-fork server its own coordination identity. `gunicorn --preload` builds the application once and forks, so every child inherited the identity generated in the parent. Two workers presented the same lock token, and every child read the leader record holder as itself, so all of them led at once. A child now appends its own random suffix. `uvicorn --workers N` spawns instead of forking and is unaffected. ([#595](https://github.com/grelinfo/grelmicro/issues/595))
 * 🐛 Report a task fire that never ran. `grelmicro.task.runs` only counted fires that reached the body, so a schedule backend or a lock that stopped answering left no metric at all and looked exactly like a task with nothing due. A fire now always lands on the counter: `coordination_error` when coordination failed, `missed` when no worker ran it, and `skipped` when a peer handled it. The bare total counts more than it did, so read the [migration note](migration.md#0-33-1-task-run-outcomes) if a chart treats it as the run rate. ([#605](https://github.com/grelinfo/grelmicro/issues/605))
 * 🐛 Warn when a cron fire is dropped for coming back too late. Past `misfire_grace_seconds` the fire was skipped with no log and no metric, so a task that never replayed said nothing at all. ([#605](https://github.com/grelinfo/grelmicro/issues/605))
 * 🐛 Record a fire that never reached the body on `last_fire`. An introspection endpoint reading it during a coordination outage reported the previous successful fire and looked healthy. ([#605](https://github.com/grelinfo/grelmicro/issues/605))
+
+### Internal
+
+* 🧪 Verify the Patterns across real process boundaries. A new multiprocess tier races worker processes against Redis, so cross-process exclusion, single leadership, and the per-worker memory adapters are asserted rather than read off the code. The demo smoke stack now runs two uvicorn workers and checks the rate limit holds across both. ([#595](https://github.com/grelinfo/grelmicro/issues/595))
+
+### Docs
+
+* 📝 Correct the pre-fork guidance for coordination. It told the reader to pass an explicit `worker` identity, which every child inherits just the same, so the advice turned a likely collision into a certain one. ([#595](https://github.com/grelinfo/grelmicro/issues/595))
+* 📝 Say that `Bulkhead.max_concurrent` and `Shield.max_rate` are per worker process. Both read as a deployment-wide ceiling, so four workers quietly gave the dependency four times the configured number. ([#595](https://github.com/grelinfo/grelmicro/issues/595))
 
 ## 0.33.0 - 2026-07-31
 

--- a/examples/fastapi-demo/Dockerfile
+++ b/examples/fastapi-demo/Dockerfile
@@ -16,4 +16,4 @@ RUN uv pip install --system --no-cache \
 COPY examples/fastapi-demo/app.py ./app.py
 
 EXPOSE 8000
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]

--- a/grelmicro/cache/postgres.py
+++ b/grelmicro/cache/postgres.py
@@ -241,12 +241,28 @@ class PostgresCacheAdapter(CacheBackend):
         if self._owns_provider:
             await self._provider.__aenter__()
         if self._auto_migrate:
-            await self._provider.client.execute(
-                self._SQL_CREATE_TABLE.format(table_name=self._table_name)
-            )
+            await self._migrate()
         if self._cleanup_interval is not None:
             self._janitor_task = asyncio.create_task(self._janitor_loop())
         return self
+
+    async def _migrate(self) -> None:
+        """Install the schema, guarded so replicas do not race.
+
+        `CREATE TABLE IF NOT EXISTS` checks and creates in two steps, so
+        two workers starting together can both pass the check and one then
+        fails on the row type the table creates.
+        """
+        async with (
+            self._provider.client.acquire() as conn,
+            conn.transaction(),
+        ):
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtext($1))", self._table_name
+            )
+            await conn.execute(
+                self._SQL_CREATE_TABLE.format(table_name=self._table_name)
+            )
 
     async def __aexit__(
         self,

--- a/grelmicro/coordination/_base.py
+++ b/grelmicro/coordination/_base.py
@@ -33,6 +33,12 @@ class BaseLockConfig(BaseModel, frozen=True, extra="forbid"):
             The worker identity.
 
             By default, a random 16-character hex token is generated.
+
+            A process that inherited this identity across a fork appends
+            its own suffix, so what reaches the backend is `{worker}.{suffix}`
+            there. Set an identity for readability, and read the effective
+            one back rather than assuming it, because a pre-fork server
+            hands the same configured value to every child.
             """),
         Field(default_factory=generate_worker_id),
     ]

--- a/grelmicro/coordination/_tokens.py
+++ b/grelmicro/coordination/_tokens.py
@@ -1,5 +1,6 @@
 """Coordination Tokens."""
 
+import os
 from asyncio import current_task
 from itertools import count
 from secrets import token_hex
@@ -7,6 +8,43 @@ from threading import get_ident
 from uuid import UUID
 
 _guard_counter = count()
+
+_origin_pid = os.getpid()
+"""The process that imported this module, and so minted the identities."""
+
+_fork_suffixes: dict[int, str] = {}
+"""One suffix per process that inherited an identity, keyed by its pid.
+
+`setdefault` on a dict is atomic, so two threads racing the first token
+build after a fork settle on one suffix. Building two would be worse than
+building none: a token stamped with the first would no longer match the
+ownership check built with the second, and the holder could not release
+its own lock.
+"""
+
+
+def resolve_worker(worker: UUID | str) -> str:
+    """Return the worker identity, diverged when this process was forked.
+
+    A pre-fork server such as `gunicorn --preload` builds the application
+    once and forks, so every child inherits the same identity. Two workers
+    would then present the same lock token and one could release or extend
+    a lease the other holds, and every child would read the leader record
+    holder as itself and lead at the same time.
+
+    The pid is compared on every call rather than hooked with
+    `os.register_at_fork`, because a hook only fires for a fork taken
+    through Python after this module was imported. Comparing covers the
+    rest: a process restored from a checkpoint, or duplicated from an
+    image that already carried the identity.
+    """
+    pid = os.getpid()
+    if pid == _origin_pid:
+        return str(worker)
+    suffix = _fork_suffixes.get(pid)
+    if suffix is None:
+        suffix = _fork_suffixes.setdefault(pid, f".{token_hex(4)}")
+    return f"{worker}{suffix}"
 
 
 def generate_worker_id() -> str:
@@ -20,7 +58,7 @@ def generate_task_token(worker: UUID | str, nonce: str = "") -> str:
     if task is None:  # pragma: no cover
         msg = "generate_task_token must be called from a running asyncio task"
         raise RuntimeError(msg)
-    return f"{worker}:task:{id(task)}{nonce}"
+    return f"{resolve_worker(worker)}:task:{id(task)}{nonce}"
 
 
 def generate_token_nonce() -> str:
@@ -45,4 +83,4 @@ def generate_thread_token(
     """
     if thread_id is None:
         thread_id = get_ident()
-    return f"{worker}:thread:{thread_id}{nonce}"
+    return f"{resolve_worker(worker)}:thread:{thread_id}{nonce}"

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -30,6 +30,7 @@ from grelmicro.coordination._protocol import (
     LockPrimitive,
     Seconds,
 )
+from grelmicro.coordination._tokens import resolve_worker
 from grelmicro.errors import WouldBlockError
 from grelmicro.task._protocol import Task
 
@@ -691,7 +692,7 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
             async with asyncio.timeout(config.backend_timeout):
                 record = await backend.acquire_or_renew(
                     name=self._lock_name,
-                    token=str(config.worker),
+                    token=resolve_worker(config.worker),
                     duration=config.lease_duration,
                     metadata=self._metadata,
                 )
@@ -708,7 +709,7 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
         else:
             self._record = record
             await self._update_state(
-                is_leader=record.holder == str(config.worker),
+                is_leader=record.holder == resolve_worker(config.worker),
                 reason_if_no_more_leader="lock not acquired",
             )
 
@@ -761,7 +762,7 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
         try:
             async with asyncio.timeout(config.backend_timeout):
                 released = await backend.release(
-                    name=self._lock_name, token=str(config.worker)
+                    name=self._lock_name, token=resolve_worker(config.worker)
                 )
             if not released:
                 logger.info(

--- a/grelmicro/coordination/postgres.py
+++ b/grelmicro/coordination/postgres.py
@@ -154,12 +154,28 @@ class PostgresLockAdapter(LockBackend):
         if self._owns_provider:
             await self._provider.__aenter__()
         self._loop = asyncio.get_running_loop()
-        await self._provider.client.execute(
-            self._SQL_CREATE_TABLE_IF_NOT_EXISTS.format(
-                table_name=self._table_name
-            ),
-        )
+        await self._migrate()
         return self
+
+    async def _migrate(self) -> None:
+        """Install the schema, guarded so replicas do not race.
+
+        `CREATE TABLE IF NOT EXISTS` checks and creates in two steps, so
+        two workers starting together can both pass the check and one then
+        fails on the row type the table creates.
+        """
+        async with (
+            self._provider.client.acquire() as conn,
+            conn.transaction(),
+        ):
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtext($1))", self._table_name
+            )
+            await conn.execute(
+                self._SQL_CREATE_TABLE_IF_NOT_EXISTS.format(
+                    table_name=self._table_name
+                ),
+            )
 
     async def __aexit__(
         self,
@@ -296,12 +312,28 @@ class PostgresScheduleAdapter(ScheduleBackend):
         if self._owns_provider:
             await self._provider.__aenter__()
         self._loop = asyncio.get_running_loop()
-        await self._provider.client.execute(
-            self._SQL_CREATE_TABLE_IF_NOT_EXISTS.format(
-                table_name=self._table_name
-            ),
-        )
+        await self._migrate()
         return self
+
+    async def _migrate(self) -> None:
+        """Install the schema, guarded so replicas do not race.
+
+        `CREATE TABLE IF NOT EXISTS` checks and creates in two steps, so
+        two workers starting together can both pass the check and one then
+        fails on the row type the table creates.
+        """
+        async with (
+            self._provider.client.acquire() as conn,
+            conn.transaction(),
+        ):
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtext($1))", self._table_name
+            )
+            await conn.execute(
+                self._SQL_CREATE_TABLE_IF_NOT_EXISTS.format(
+                    table_name=self._table_name
+                ),
+            )
 
     async def __aexit__(
         self,
@@ -560,18 +592,33 @@ class PostgresLeaderElectionAdapter:
         if self._owns_provider:
             await self._provider.__aenter__()
         if self._auto_migrate:  # pragma: no branch
-            pool = self._provider.client
+            await self._migrate()
+        return self
+
+    async def _migrate(self) -> None:
+        """Install the schema, guarded so replicas do not race.
+
+        `CREATE TABLE IF NOT EXISTS` checks and creates in two steps, so
+        two workers starting together can both pass the check and one then
+        fails on the row type the table creates.
+        """
+        async with (
+            self._provider.client.acquire() as conn,
+            conn.transaction(),
+        ):
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtext($1))", self._table_name
+            )
             for sql in (
                 self._SQL_CREATE_TABLE,
                 self._SQL_CREATE_FN_ACQUIRE_OR_RENEW,
             ):
-                await pool.execute(
+                await conn.execute(
                     sql.format(
                         table_name=self._table_name,
                         lock_namespace=_LEADER_ELECTION_ADVISORY_NAMESPACE,
                     )
                 )
-        return self
 
     async def __aexit__(
         self,

--- a/grelmicro/resilience/bulkhead.py
+++ b/grelmicro/resilience/bulkhead.py
@@ -55,8 +55,10 @@ class BulkheadConfig(BaseModel, frozen=True, extra="forbid"):
     max_concurrent: Annotated[
         PositiveInt | None,
         Doc(
-            "Maximum concurrent calls admitted to the bulkhead. `None` "
-            "(the default) leaves concurrency unbounded."
+            "Maximum concurrent calls admitted to the bulkhead, per "
+            "worker process. Four workers each admit this many, so the "
+            "dependency sees four times it. `None` (the default) leaves "
+            "concurrency unbounded."
         ),
     ] = None
 
@@ -116,7 +118,10 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
         *,
         max_concurrent: Annotated[
             PositiveInt | None,
-            Doc("Maximum concurrent calls. `None` leaves it unbounded."),
+            Doc(
+                "Maximum concurrent calls, per worker process. `None` "
+                "leaves it unbounded."
+            ),
         ] = None,
         max_wait: Annotated[
             NonNegativeFloat | None,

--- a/grelmicro/resilience/circuitbreaker/postgres.py
+++ b/grelmicro/resilience/circuitbreaker/postgres.py
@@ -517,7 +517,27 @@ class PostgresCircuitBreakerAdapter(CircuitBreakerBackend):
             await self._provider.__aenter__()
         self._loop = asyncio.get_running_loop()
         if self._auto_migrate:  # pragma: no branch
-            pool = self._provider.client
+            await self._migrate()
+        if self._cleanup_interval is not None:
+            self._janitor_task = asyncio.create_task(self._janitor_loop())
+        return self
+
+    async def _migrate(self) -> None:
+        """Install the schema, guarded so replicas do not race.
+
+        `CREATE TABLE IF NOT EXISTS` checks and creates in two steps, so
+        two workers starting together can both pass the check and one then
+        fails on the row type the table creates. The advisory lock is held
+        to the end of the transaction, so the second worker finds the
+        table already there.
+        """
+        async with (
+            self._provider.client.acquire() as conn,
+            conn.transaction(),
+        ):
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtext($1))", self._table_name
+            )
             for sql in (
                 self._SQL_CREATE_TABLE,
                 self._SQL_CREATE_FN_TRY_ACQUIRE,
@@ -527,7 +547,7 @@ class PostgresCircuitBreakerAdapter(CircuitBreakerBackend):
                 self._SQL_CREATE_FN_CLEANUP,
                 self._SQL_CREATE_FN_GET_STATE,
             ):
-                await pool.execute(
+                await conn.execute(
                     sql.format(
                         table_name=self._table_name,
                         lock_namespace=_CIRCUIT_BREAKER_ADVISORY_NAMESPACE,
@@ -535,9 +555,6 @@ class PostgresCircuitBreakerAdapter(CircuitBreakerBackend):
                         state_ttl_factor=_STATE_TTL_RESET_FACTOR,
                     )
                 )
-        if self._cleanup_interval is not None:
-            self._janitor_task = asyncio.create_task(self._janitor_loop())
-        return self
 
     async def __aexit__(
         self,

--- a/grelmicro/resilience/ratelimiter/postgres.py
+++ b/grelmicro/resilience/ratelimiter/postgres.py
@@ -356,7 +356,23 @@ class PostgresRateLimiterAdapter(RateLimiterBackend):
         if self._owns_provider:
             await self._provider.__aenter__()
         if self._auto_migrate:  # pragma: no branch
-            pool = self._provider.client
+            await self._migrate()
+        return self
+
+    async def _migrate(self) -> None:
+        """Install the schema, guarded so replicas do not race.
+
+        `CREATE TABLE IF NOT EXISTS` checks and creates in two steps, so
+        two workers starting together can both pass the check and one then
+        fails on the row type the table creates.
+        """
+        async with (
+            self._provider.client.acquire() as conn,
+            conn.transaction(),
+        ):
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtext($1))", self._table_name
+            )
             for sql in (
                 self._SQL_CREATE_TABLE,
                 self._SQL_CREATE_FN_TB_ACQUIRE,
@@ -364,13 +380,12 @@ class PostgresRateLimiterAdapter(RateLimiterBackend):
                 self._SQL_CREATE_FN_GCRA_ACQUIRE,
                 self._SQL_CREATE_FN_GCRA_PEEK,
             ):
-                await pool.execute(
+                await conn.execute(
                     sql.format(
                         table_name=self._table_name,
                         lock_namespace=_RATE_LIMITER_ADVISORY_NAMESPACE,
                     )
                 )
-        return self
 
     async def __aexit__(
         self,

--- a/grelmicro/resilience/shield/_profile.py
+++ b/grelmicro/resilience/shield/_profile.py
@@ -104,7 +104,9 @@ class _BaseShieldConfig(
         PositiveFloat | None,
         Doc(
             "Optional hard ceiling on the adaptive bucket's rate in "
-            "tokens per second. `None` disables the cap."
+            "tokens per second, per worker process. Four workers each "
+            "hold this ceiling, so the dependency sees four times it. "
+            "`None` disables the cap."
         ),
     ] = None
 

--- a/tests/_postgres.py
+++ b/tests/_postgres.py
@@ -1,0 +1,59 @@
+"""Shared asyncpg pool fakes for the Postgres adapter tests.
+
+Every Postgres adapter installs its schema inside
+`pool.acquire()` plus `conn.transaction()`, so it can hold an advisory
+lock for the whole migration. A fake pool therefore has to support both,
+and the statements land on the connection rather than the pool.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+
+class _Transaction:
+    """Async context manager standing in for `conn.transaction()`."""
+
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+class _Acquire:
+    """Async context manager standing in for `pool.acquire()`."""
+
+    def __init__(self, conn: MagicMock) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> MagicMock:
+        return self._conn
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+def mock_connection() -> MagicMock:
+    """Return a connection whose `execute` and `transaction` both work."""
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    conn.executemany = AsyncMock()
+    conn.transaction = _Transaction
+    return conn
+
+
+def mock_pool(conn: MagicMock | None = None) -> Any:  # noqa: ANN401
+    """Return a pool that hands out `conn` and records what ran on it."""
+    connection = conn if conn is not None else mock_connection()
+    pool = MagicMock()
+    pool.execute = AsyncMock()
+    pool.acquire = lambda: _Acquire(connection)
+    pool.connection = connection
+    return pool
+
+
+def executed_statements(pool: Any) -> list[str]:  # noqa: ANN401
+    """Return the SQL run on the pool's connection, in order."""
+    return [call.args[0] for call in pool.connection.execute.await_args_list]

--- a/tests/cache/test_postgres.py
+++ b/tests/cache/test_postgres.py
@@ -328,15 +328,18 @@ class TestAsyncMethods:
     async def test_aenter_runs_migration(self) -> None:
         """`__aenter__` runs the create-table SQL when `auto_migrate=True`."""
         backend, pool = _build_with_mock_pool()
-        pool.execute = AsyncMock()
+        conn = _mock_conn()
+        pool.acquire = lambda: _acquire_cm(conn)
 
         async with backend:
             pass
 
-        pool.execute.assert_awaited_once()
-        call = pool.execute.await_args
-        assert call is not None
-        assert "CREATE TABLE IF NOT EXISTS grelmicro_cache" in call.args[0]
+        statements = [call.args[0] for call in conn.execute.await_args_list]
+        assert "pg_advisory_xact_lock" in statements[0]
+        assert any(
+            "CREATE TABLE IF NOT EXISTS grelmicro_cache" in sql
+            for sql in statements
+        )
 
     async def test_aenter_skips_migration_when_disabled(self) -> None:
         """`auto_migrate=False` skips schema installation."""

--- a/tests/coordination/test_schedule_postgres.py
+++ b/tests/coordination/test_schedule_postgres.py
@@ -182,7 +182,7 @@ async def test_aenter_aexit_owned_provider_opens_and_closes_it() -> None:
 
     assert stub.enter_count == 1
     assert stub.exit_count == 1
-    assert stub.client.connection.execute.await_count
+    assert stub.client.connection.execute.await_count > 0
 
 
 @pytest.mark.timeout(1)

--- a/tests/coordination/test_schedule_postgres.py
+++ b/tests/coordination/test_schedule_postgres.py
@@ -3,7 +3,6 @@
 from collections.abc import AsyncGenerator
 from types import TracebackType
 from typing import Self
-from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -15,6 +14,7 @@ from grelmicro.providers.postgres import (
     PostgresProvider,
     PostgresProviderConfigError,
 )
+from tests._postgres import mock_pool
 
 URL = "postgresql://test_user:test_password@test_host:1234/test_db"
 
@@ -153,8 +153,7 @@ class _StubProvider:
     """Minimal `PostgresProvider`-shaped stub tracking enter/exit calls."""
 
     def __init__(self) -> None:
-        self.client = MagicMock()
-        self.client.execute = AsyncMock()
+        self.client = mock_pool()
         self.enter_count = 0
         self.exit_count = 0
 
@@ -183,7 +182,7 @@ async def test_aenter_aexit_owned_provider_opens_and_closes_it() -> None:
 
     assert stub.enter_count == 1
     assert stub.exit_count == 1
-    stub.client.execute.assert_awaited()
+    assert stub.client.connection.execute.await_count
 
 
 @pytest.mark.timeout(1)

--- a/tests/multiprocess/__init__.py
+++ b/tests/multiprocess/__init__.py
@@ -1,0 +1,1 @@
+"""Tests that run grelmicro across real process boundaries."""

--- a/tests/multiprocess/harness.py
+++ b/tests/multiprocess/harness.py
@@ -52,32 +52,36 @@ def run_workers(
     """
     context = multiprocessing.get_context(start_method)
     barrier = context.Barrier(count)
-    results = context.Manager().list()
-    processes = [
-        # Typeshed types `get_context` as the abstract base, which does not
-        # carry `Process`, but every concrete start-method context does.
-        context.Process(target=worker, args=(barrier, results, *args))  # ty: ignore[unresolved-attribute]
-        for _ in range(count)
-    ]
-    for process in processes:
-        process.start()
-    try:
+    # The manager runs in its own process. Hold it for the whole call and
+    # shut it down here, rather than leaving a server process per call for
+    # the collector to reap somewhere later in the session.
+    with context.Manager() as manager:
+        results = manager.list()
+        processes = [
+            # Typeshed types `get_context` as the abstract base, which does
+            # not carry `Process`, but every concrete context does.
+            context.Process(target=worker, args=(barrier, results, *args))  # ty: ignore[unresolved-attribute]
+            for _ in range(count)
+        ]
         for process in processes:
-            process.join(timeout)
-        stragglers = [p for p in processes if p.is_alive()]
-        if stragglers:
-            msg = (
-                f"{len(stragglers)} of {count} workers did not finish "
-                f"within {timeout}s"
-            )
-            raise WorkerFailedError(msg)
-        failed = [p.exitcode for p in processes if p.exitcode]
-        if failed:
-            msg = f"workers exited with {failed}"
-            raise WorkerFailedError(msg)
-    finally:
-        for process in processes:
-            if process.is_alive():  # pragma: no cover
-                process.kill()
+            process.start()
+        try:
+            for process in processes:
                 process.join(timeout)
-    return list(results)
+            stragglers = [p for p in processes if p.is_alive()]
+            if stragglers:
+                msg = (
+                    f"{len(stragglers)} of {count} workers did not finish "
+                    f"within {timeout}s"
+                )
+                raise WorkerFailedError(msg)
+            failed = [p.exitcode for p in processes if p.exitcode]
+            if failed:
+                msg = f"workers exited with {failed}"
+                raise WorkerFailedError(msg)
+        finally:
+            for process in processes:
+                if process.is_alive():  # pragma: no cover
+                    process.kill()
+                    process.join(timeout)
+        return list(results)

--- a/tests/multiprocess/harness.py
+++ b/tests/multiprocess/harness.py
@@ -1,0 +1,83 @@
+"""Run N worker processes against one backend and collect what they did.
+
+A server runs the app in several processes. `uvicorn --workers N` starts
+each one with the `spawn` start method, so a worker imports the
+application itself and shares nothing. `gunicorn --preload` loads the
+application once and forks, so a worker inherits every module-level
+object the parent built. The two models break different things, so both
+start methods are drivable from here.
+
+Every worker is a module-level function, because `spawn` resolves it by
+qualified name in the child. Workers are released together by a barrier
+so they contend, rather than running one after another, and the parent
+joins them all before asserting so a straggler cannot land after the
+check.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from multiprocessing.managers import ListProxy
+
+    Results = ListProxy[Any]
+    """What a worker appends its observation to, shared with the parent."""
+
+DEFAULT_TIMEOUT = 30.0
+"""Seconds the parent waits for a worker before failing the test."""
+
+
+class WorkerFailedError(AssertionError):
+    """Raised when a worker process crashed or did not finish in time."""
+
+
+def run_workers(
+    worker: Callable[..., None],
+    count: int,
+    *args: Any,  # noqa: ANN401
+    start_method: str = "spawn",
+    timeout: float = DEFAULT_TIMEOUT,
+) -> list[Any]:
+    """Run `count` copies of `worker` at once and return what they reported.
+
+    Each worker is called as `worker(barrier, results, *args)`. It should
+    call `barrier.wait()` when it is ready and append what it observed to
+    `results`. Results come back in completion order, not worker order.
+
+    Raises:
+        WorkerFailedError: If a worker exited non-zero or outran `timeout`.
+    """
+    context = multiprocessing.get_context(start_method)
+    barrier = context.Barrier(count)
+    results = context.Manager().list()
+    processes = [
+        # Typeshed types `get_context` as the abstract base, which does not
+        # carry `Process`, but every concrete start-method context does.
+        context.Process(target=worker, args=(barrier, results, *args))  # ty: ignore[unresolved-attribute]
+        for _ in range(count)
+    ]
+    for process in processes:
+        process.start()
+    try:
+        for process in processes:
+            process.join(timeout)
+        stragglers = [p for p in processes if p.is_alive()]
+        if stragglers:
+            msg = (
+                f"{len(stragglers)} of {count} workers did not finish "
+                f"within {timeout}s"
+            )
+            raise WorkerFailedError(msg)
+        failed = [p.exitcode for p in processes if p.exitcode]
+        if failed:
+            msg = f"workers exited with {failed}"
+            raise WorkerFailedError(msg)
+    finally:
+        for process in processes:
+            if process.is_alive():  # pragma: no cover
+                process.kill()
+                process.join(timeout)
+    return list(results)

--- a/tests/multiprocess/test_leader_election_contention.py
+++ b/tests/multiprocess/test_leader_election_contention.py
@@ -1,0 +1,110 @@
+"""Exactly one process may believe it leads.
+
+Leader election reads leadership back as `record.holder == <this worker>`,
+so its token is the worker identity itself rather than a per-task token.
+A pre-fork server hands every child the identity generated in the parent,
+which would make each child match the holder and lead at the same time.
+This drives the fork path on purpose, because it is the one that breaks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from grelmicro.coordination._tokens import generate_worker_id
+
+from .harness import run_workers
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from multiprocessing.synchronize import Barrier
+
+    from .harness import Results
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.timeout(180),
+    pytest.mark.skipif(sys.platform == "win32", reason="fork is POSIX only"),
+    # `os.fork` in a process that already has threads is deprecated, and the
+    # suite turns warnings into errors. Forking is the deployment under test.
+    pytest.mark.filterwarnings("ignore::DeprecationWarning"),
+]
+
+pytest.importorskip("testcontainers.redis")
+
+from testcontainers.redis import RedisContainer  # noqa: E402
+
+WORKERS = 4
+ELECTION_NAME = "multiprocess-election"
+LEASE_DURATION = 5.0
+SETTLE_SECONDS = 1.5
+
+PRELOADED_WORKER = generate_worker_id()
+"""The identity a preloaded app generates once, before it forks.
+
+Every child inherits this exact string, which is the whole hazard. Passing
+it explicitly reproduces `gunicorn --preload` without having to build the
+entire application in the parent.
+"""
+
+
+@pytest.fixture(scope="module")
+def redis_url() -> Iterator[str]:
+    """Yield a host-reachable URL for a module-scoped Redis container."""
+    with RedisContainer() as container:
+        yield f"redis://localhost:{container.get_exposed_port(6379)}/0"
+
+
+def stand_for_election(barrier: Barrier, results: Results, url: str) -> None:
+    """Run for leader and report whether this process won."""
+    asyncio.run(_stand_for_election(barrier, results, url))
+
+
+async def _stand_for_election(
+    barrier: Barrier, results: Results, url: str
+) -> None:
+    from grelmicro.coordination import LeaderElection  # noqa: PLC0415
+    from grelmicro.coordination.redis import (  # noqa: PLC0415
+        RedisLeaderElectionAdapter,
+    )
+
+    os.environ["REDIS_URL"] = url
+    election = LeaderElection(
+        ELECTION_NAME,
+        backend=RedisLeaderElectionAdapter(),
+        worker=PRELOADED_WORKER,
+        lease_duration=LEASE_DURATION,
+        renew_deadline=LEASE_DURATION * 0.66,
+        retry_interval=LEASE_DURATION * 0.2,
+        backend_timeout=LEASE_DURATION * 0.5,
+    )
+    async with election.backend:
+        barrier.wait()
+        async with asyncio.TaskGroup() as group:
+            task = group.create_task(election())
+            # Every worker has raced by now, so whoever holds the lease
+            # holds it. Read leadership once, then stand down.
+            await asyncio.sleep(SETTLE_SECONDS)
+            results.append((os.getpid(), election.is_leader(), time.time()))
+            task.cancel()
+
+
+def test_exactly_one_forked_worker_leads(redis_url: str) -> None:
+    """Four children of a preloaded app elect one leader between them."""
+    # Act
+    outcomes = run_workers(
+        stand_for_election, WORKERS, redis_url, start_method="fork"
+    )
+
+    # Assert
+    assert len(outcomes) == WORKERS
+    assert len({pid for pid, _, _ in outcomes}) == WORKERS
+    leaders = [pid for pid, is_leader, _ in outcomes if is_leader]
+    assert len(leaders) == 1

--- a/tests/multiprocess/test_lock_contention.py
+++ b/tests/multiprocess/test_lock_contention.py
@@ -1,0 +1,88 @@
+"""A distributed lock must exclude across processes, not only across tasks.
+
+The rest of the suite proves exclusion between asyncio tasks in one
+interpreter. A deployment runs several worker processes, so the guarantee
+that matters is the one the backend enforces between them. Each worker
+records when it entered and left the lock, and the parent reconstructs the
+intervals and fails on any overlap.
+
+Intervals are stamped with `time.time()` rather than `time.monotonic()`,
+because only the wall clock is defined to share a reference point across
+processes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from itertools import pairwise
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .harness import run_workers
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from multiprocessing.synchronize import Barrier
+
+    from .harness import Results
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.timeout(180),
+]
+
+pytest.importorskip("testcontainers.redis")
+
+from testcontainers.redis import RedisContainer  # noqa: E402
+
+WORKERS = 4
+LOCK_NAME = "multiprocess-contention"
+HOLD_SECONDS = 0.05
+
+
+@pytest.fixture(scope="module")
+def redis_url() -> Iterator[str]:
+    """Yield a host-reachable URL for a module-scoped Redis container."""
+    with RedisContainer() as container:
+        yield f"redis://localhost:{container.get_exposed_port(6379)}/0"
+
+
+def hold_the_lock(barrier: Barrier, results: Results, url: str) -> None:
+    """Acquire the lock once and report the interval it was held."""
+    asyncio.run(_hold_the_lock(barrier, results, url))
+
+
+async def _hold_the_lock(barrier: Barrier, results: Results, url: str) -> None:
+    from grelmicro import Grelmicro  # noqa: PLC0415
+    from grelmicro.coordination import Coordination  # noqa: PLC0415
+    from grelmicro.coordination.redis import RedisLockAdapter  # noqa: PLC0415
+
+    os.environ["REDIS_URL"] = url
+    micro = Grelmicro(uses=[Coordination(lock=RedisLockAdapter())])
+    async with micro:
+        barrier.wait()
+        async with micro.coordination.lock(LOCK_NAME):
+            entered = time.time()
+            await asyncio.sleep(HOLD_SECONDS)
+            results.append((os.getpid(), entered, time.time()))
+
+
+def test_only_one_process_holds_the_lock_at_a_time(redis_url: str) -> None:
+    """No two workers hold the same lock over overlapping intervals."""
+    # Act
+    held = run_workers(hold_the_lock, WORKERS, redis_url)
+
+    # Assert
+    assert len(held) == WORKERS
+    assert len({pid for pid, _, _ in held}) == WORKERS
+    intervals = sorted((start, end) for _, start, end in held)
+    overlaps = [
+        (earlier, later)
+        for earlier, later in pairwise(intervals)
+        if later[0] < earlier[1]
+    ]
+    assert not overlaps

--- a/tests/multiprocess/test_memory_is_per_worker.py
+++ b/tests/multiprocess/test_memory_is_per_worker.py
@@ -1,0 +1,61 @@
+"""The memory adapters count per worker, and the docs say so.
+
+A memory adapter holds its state in the interpreter that created it, so a
+second worker starts from zero. That is the documented behaviour, not a
+defect, and these tests pin it: a change that quietly made a memory
+adapter shared, or that made a distributed adapter per worker, fails here
+instead of surprising a reader who scaled to four workers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .harness import run_workers
+
+if TYPE_CHECKING:
+    from multiprocessing.synchronize import Barrier
+
+    from .harness import Results
+
+pytestmark = [pytest.mark.timeout(120)]
+
+WORKERS = 3
+LIMIT = 4
+
+
+def spend_the_budget(barrier: Barrier, results: Results) -> None:
+    """Spend one worker's rate-limit budget and report what it got."""
+    asyncio.run(_spend_the_budget(barrier, results))
+
+
+async def _spend_the_budget(barrier: Barrier, results: Results) -> None:
+    from grelmicro.resilience import RateLimiter  # noqa: PLC0415
+    from grelmicro.resilience.ratelimiter.memory import (  # noqa: PLC0415
+        MemoryRateLimiterAdapter,
+    )
+
+    backend = MemoryRateLimiterAdapter()
+    async with backend:
+        limiter = RateLimiter.sliding_window(
+            "per-worker", limit=LIMIT, window=60.0, backend=backend
+        )
+        barrier.wait()
+        allowed = 0
+        for _ in range(LIMIT * 2):
+            outcome = await limiter.acquire(key="shared-caller")
+            allowed += outcome.allowed
+        results.append(allowed)
+
+
+def test_memory_rate_limiter_gives_each_worker_its_own_budget() -> None:
+    """Each worker admits the full limit, so N workers admit N times it."""
+    # Act
+    allowed = run_workers(spend_the_budget, WORKERS)
+
+    # Assert
+    assert allowed == [LIMIT] * WORKERS
+    assert sum(allowed) == LIMIT * WORKERS

--- a/tests/multiprocess/test_worker_identity.py
+++ b/tests/multiprocess/test_worker_identity.py
@@ -1,0 +1,139 @@
+"""The worker identity must differ in every process that presents a token.
+
+`gunicorn --preload` builds the application once and forks, so a worker
+identity generated in the parent is inherited byte for byte by every
+child. Two workers would then present the same lock token, and one could
+release or extend a lease the other holds. Leader election is worse: its
+token is the worker identity itself, so every child would read the record
+holder as itself and believe it leads.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from grelmicro.coordination import _tokens
+from grelmicro.coordination._tokens import (
+    generate_task_token,
+    generate_worker_id,
+    resolve_worker,
+)
+
+from .harness import run_workers
+
+if TYPE_CHECKING:
+    from multiprocessing.synchronize import Barrier
+
+    from .harness import Results
+
+pytestmark = [
+    pytest.mark.timeout(60),
+    pytest.mark.skipif(sys.platform == "win32", reason="fork is POSIX only"),
+    # `os.fork` in a process that already has threads is deprecated, and the
+    # suite turns warnings into errors. Forking is the behaviour under test.
+    pytest.mark.filterwarnings("ignore::DeprecationWarning"),
+]
+
+WORKERS = 4
+
+PRELOADED_WORKER = generate_worker_id()
+"""A worker identity minted at import time, as a preloaded app would."""
+
+
+def report_identity(barrier: Barrier, results: Results, worker: str) -> None:
+    """Report the identity this process resolves for a shared worker id."""
+    barrier.wait()
+    results.append(resolve_worker(worker))
+
+
+def test_forked_workers_resolve_distinct_identities() -> None:
+    """Every child of a pre-fork server presents its own identity."""
+    # Act
+    identities = run_workers(
+        report_identity,
+        WORKERS,
+        PRELOADED_WORKER,
+        start_method="fork",
+    )
+
+    # Assert
+    assert len(identities) == WORKERS
+    assert len(set(identities)) == WORKERS
+    assert resolve_worker(PRELOADED_WORKER) not in identities
+    assert all(identity.startswith(PRELOADED_WORKER) for identity in identities)
+
+
+def test_spawned_workers_resolve_distinct_identities() -> None:
+    """A spawned worker mints its own identity, so nothing is inherited."""
+    # Act
+    identities = run_workers(
+        mint_and_report_identity, WORKERS, start_method="spawn"
+    )
+
+    # Assert
+    assert len(set(identities)) == WORKERS
+
+
+def mint_and_report_identity(barrier: Barrier, results: Results) -> None:
+    """Mint an identity the way an independently imported app would."""
+    worker = generate_worker_id()
+    barrier.wait()
+    results.append(resolve_worker(worker))
+
+
+def test_unforked_process_leaves_the_identity_untouched() -> None:
+    """A deployment that never forks sees the identity it generated."""
+    worker = generate_worker_id()
+
+    assert resolve_worker(worker) == worker
+
+
+async def test_task_token_carries_the_resolved_identity() -> None:
+    """Lock tokens are built from the resolved identity, not the raw one."""
+    worker = generate_worker_id()
+
+    token = generate_task_token(worker)
+
+    assert token.startswith(f"{resolve_worker(worker)}:task:")
+
+
+def test_a_changed_pid_diverges_the_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only a child runs this branch, so drive it in process for coverage."""
+    # Arrange
+    monkeypatch.setattr(_tokens, "_origin_pid", os.getpid() + 1)
+    monkeypatch.setattr(_tokens, "_fork_suffixes", {})
+    worker = generate_worker_id()
+
+    # Act
+    diverged = resolve_worker(worker)
+
+    # Assert
+    assert diverged != worker
+    assert diverged.startswith(f"{worker}.")
+
+
+def test_the_suffix_is_stable_within_one_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second call reuses the suffix, so a token still matches its check.
+
+    Two suffixes in one process would leave a holder unable to release its
+    own lock, because the ownership check would build a different token.
+    """
+    # Arrange
+    monkeypatch.setattr(_tokens, "_origin_pid", os.getpid() + 1)
+    monkeypatch.setattr(_tokens, "_fork_suffixes", {})
+    worker = generate_worker_id()
+
+    # Act
+    first = resolve_worker(worker)
+    second = resolve_worker(worker)
+
+    # Assert
+    assert first == second

--- a/tests/providers/test_postgres_provider.py
+++ b/tests/providers/test_postgres_provider.py
@@ -18,6 +18,7 @@ from grelmicro.resilience.circuitbreaker.postgres import (
     PostgresCircuitBreakerAdapter,
 )
 from grelmicro.resilience.ratelimiter.postgres import PostgresRateLimiterAdapter
+from tests._postgres import mock_pool as make_pool
 
 pytestmark = [pytest.mark.timeout(1)]
 
@@ -472,8 +473,7 @@ class TestBreakerOwnedLifecycle:
         adapter = PostgresCircuitBreakerAdapter()
         assert adapter._owns_provider is True
 
-        pool = MagicMock()
-        pool.execute = AsyncMock()
+        pool = make_pool()
         pool.close = AsyncMock()
         adapter.provider._pool = pool
 
@@ -500,8 +500,7 @@ class TestSharingCache:
             Coordination,
         )
 
-        pool = MagicMock()
-        pool.execute = AsyncMock()
+        pool = make_pool()
         pool.close = AsyncMock()
         for ad in (first, second):
             ad.provider._pool = pool
@@ -534,8 +533,7 @@ class TestSharingCache:
         )
 
         for ad in (write, read):
-            pool = MagicMock()
-            pool.execute = AsyncMock()
+            pool = make_pool()
             pool.close = AsyncMock()
             ad.provider._pool = pool
 

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -15,6 +15,7 @@ from grelmicro.coordination.sqlite import SQLiteLockAdapter
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience.ratelimiter.postgres import PostgresRateLimiterAdapter
 from grelmicro.resilience.ratelimiter.redis import RedisRateLimiterAdapter
+from tests._postgres import mock_pool as make_pool
 
 
 @pytest.fixture
@@ -54,8 +55,7 @@ async def test_sync_postgres_async_with(
 ) -> None:
     """The Postgres sync adapter opens and closes cleanly."""
     monkeypatch.setenv("POSTGRES_URL", "postgresql://localhost/db")
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock()
+    mock_pool = make_pool()
     mock_pool.close = AsyncMock()
     mocker.patch(
         "grelmicro.providers.postgres.create_pool",
@@ -113,8 +113,7 @@ async def test_rate_limiter_postgres_async_with(
 ) -> None:
     """The Postgres rate limiter adapter opens and closes cleanly."""
     monkeypatch.setenv("POSTGRES_URL", "postgresql://localhost/db")
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock()
+    mock_pool = make_pool()
     mock_pool.close = AsyncMock()
     mocker.patch(
         "grelmicro.providers.postgres.create_pool",


### PR DESCRIPTION
Closes #595.

Every Pattern was tested in one process. This adds a tier that races real worker processes, and it found two production bugs on the way.

## Two bugs, not just doc gaps

**Two workers could not start against a fresh Postgres.** Running the demo with `--workers 2` crashed on the first attempt:

```
asyncpg.exceptions.UniqueViolationError: duplicate key value violates
unique constraint "pg_type_typname_nsp_index"
Key (typname, typnamespace)=(grelmicro_circuit_breaker, 2200) already exists
```

`CREATE TABLE IF NOT EXISTS` checks and creates in two steps, so both workers passed the check and one died on the row type the table creates. The outbox adapter already guarded this with `pg_advisory_xact_lock`. The other six now do the same.

**Four forked workers all believed they were the leader.** Leader election reads leadership back as `record.holder == <this worker>`, and its token is the worker identity itself. `gunicorn --preload` builds the app once and forks, so every child inherited the identity minted in the parent and every child matched. Without the fix the test reports `4 == 1`.

`uvicorn --workers N` is unaffected. It starts workers with the `spawn` start method, so each re-imports and mints its own. Verified in `uvicorn/_subprocess.py`, which uses `multiprocessing.get_context("spawn")`.

## The identity fix

A process whose pid is not the one that minted the identity appends its own random suffix, so a token carries `{worker}.{suffix}`. Zero cost when nothing forked, no API change, and it works on all four backends.

The pid is compared per token build rather than hooked with `os.register_at_fork`. A hook only fires for a fork taken through Python after import, so comparing also covers a process restored from a checkpoint or duplicated from an image that already carried the identity. The suffix is memoized per pid through `dict.setdefault`, which is atomic, because two suffixes in one process would leave a holder unable to release its own lock.

Cross-language research shaped this. The systems with the strongest guarantees derive identity from a **server-granted session**: ZooKeeper session ids behind Curator's ephemeral sequential znodes, etcd lease ids, Consul's leader-minted session UUIDs, Hazelcast CP sessions. A fork cannot duplicate those, because the identity is a liveness obligation rather than a copyable string. That is genuinely the better design, and it is not reachable here: it needs a backend with a native session primitive, and grelmicro's are Redis, a Postgres table, SQLite, and the Kubernetes Lease. Every library in that same position ships client-side randomness instead, without exception (Redisson's per-instance UUID plus thread id, the Redlock family's random bytes, DistributedLock.Redis, every Kubernetes client in every language).

The shape adopted here is the one those systems converged on: a stable readable locator plus a per-incarnation discriminator minted as late as possible. That is Erlang's node creation, Orleans' `ip:port@generation`, and `/etc/machine-id`, whose man page says a generic image should ship with the file empty so the OS mints one at first boot. Same failure, same remedy.

**The honest cost**, and the strongest argument against it: an explicitly configured `worker="node-a"` reaches the backend as `node-a.3fa9c21b` under a pre-fork server. Orleans and Erlang make the incarnation visible in the type; this rewrites a user-supplied name at comparison time. It is documented at the `worker` field and in the architecture page, with a warning to read the effective identity back rather than assume it.

## The tier

`tests/multiprocess/` runs workers through a barrier so they contend, then joins them all before asserting so a straggler cannot land after the check. Both start methods are drivable, since `spawn` models uvicorn and `fork` models `gunicorn --preload`.

- Cross-process lock exclusion against real Redis, by reconstructing hold intervals and failing on overlap.
- Exactly one leader among four forked workers.
- Worker identity distinct per child, and untouched when nothing forked.
- Memory adapters pinned as per-worker, so a change that quietly made one shared fails here.

Every test was checked by reverting the fix it covers. That caught a first draft of the leader test which **passed without the fix** and was therefore worthless: each child built its own election object after forking, so each minted a fresh identity anyway. The faithful reproduction needs the identity to exist before the fork.

## Demo smoke

Now runs two uvicorn workers and asserts the Redis-backed rate limit holds across both. Measured 5 of 12 requests allowed, the configured capacity, where a per-worker limiter would give about 10.

## Docs

- The pre-fork guidance told the reader to pass an explicit `worker` identity. Every child inherits one explicit value just the same, so the advice turned a likely collision into a certain one.
- `Bulkhead.max_concurrent` and `Shield.max_rate` now say they are per worker process. Both read as a deployment-wide ceiling, so four workers quietly gave the dependency four times the number.

Full pre-commit chain green, including the integration tier and the 100% coverage gate.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b
