### PR TITLE
📝 Name the hazard env_load=False guards against

### DIFF
--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -99,6 +99,30 @@ source that has it:
    `env_load` is unset and `GREL_ENV_LOAD` is truthy).
 3. `Config` class default.
 
+### The hazard in step 2
+
+Step 2 fills every field the caller did not pass, not only the fields that have
+no default anywhere. Passing some fields and leaving others therefore splits the
+config across two sources.
+
+That is the trap for config held in your own `Settings` object. The fields you
+hand over win, and the rest come from the environment. A `Settings` default that
+differs from the environment is dropped, and nothing says so.
+
+```python
+class AppSettings(BaseSettings):
+    lease: float = 30.0  # your default
+
+
+settings = AppSettings()
+lock = Lock("cart", retry_interval=0.5)  # lease_duration not passed
+```
+
+With `GREL_LOCK_CART_LEASE_DURATION=99` in the environment, that lock leases for
+99 seconds. Not 30, and not the library default either. The failure is silent
+and only shows up when the two sources disagree, which is the case nobody
+tests.
+
 ## Recipes
 
 ### Custom env prefix
@@ -112,6 +136,14 @@ lock = Lock("cart", env_prefix="MYAPP_LOCK_CART_")
 ```python
 lock = Lock("cart", env_load=False, lease_duration=10)
 ```
+
+`env_load=False` says the values passed here are the whole truth. Every field
+not passed falls back to the `Config` default, and step 2 is skipped, so the
+environment cannot fill the gaps.
+
+Reach for it whenever the values come from somewhere that is already the source
+of truth. `from_config` says the same thing positively and reads better when the
+config already exists as an object.
 
 ### Wire from `pydantic-settings`
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Docs
+
+* 📝 Name the hazard `env_load=False` guards against. Env reads fill every field the caller did not pass, so a config half taken from a `Settings` object silently gets the rest from the environment. A `Settings` default that differs from the environment is dropped without a word. ([#606](https://github.com/grelinfo/grelmicro/issues/606))
+
 ### Fixed
 
 * 🐛 Report a task fire that never ran. `grelmicro.task.runs` only counted fires that reached the body, so a schedule backend or a lock that stopped answering left no metric at all and looked exactly like a task with nothing due. A fire now always lands on the counter: `coordination_error` when coordination failed, `missed` when no worker ran it, and `skipped` when a peer handled it. The bare total counts more than it did, so read the [migration note](migration.md#0-33-1-task-run-outcomes) if a chart treats it as the run rate. ([#605](https://github.com/grelinfo/grelmicro/issues/605))

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -275,11 +275,6 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
                 Env reads fill every field not passed, so a config
                 half taken from somewhere else silently gets the rest
                 from the environment.
-
-                Pass False when the values here are the whole truth.
-                Env reads fill every field not passed, so a config
-                half taken from somewhere else silently gets the rest
-                from the environment.
                 """,
             ),
         ] = None,

--- a/grelmicro/coordination/leaderelection.py
+++ b/grelmicro/coordination/leaderelection.py
@@ -270,6 +270,16 @@ class LeaderElection(Reconfigurable[LeaderElectionConfig], LockPrimitive, Task):
                 When None (the default), follow the process-wide
                 ``GREL_ENV_LOAD`` flag. Pass True or False to
                 override the flag for this construction.
+
+                Pass False when the values here are the whole truth.
+                Env reads fill every field not passed, so a config
+                half taken from somewhere else silently gets the rest
+                from the environment.
+
+                Pass False when the values here are the whole truth.
+                Env reads fill every field not passed, so a config
+                half taken from somewhere else silently gets the rest
+                from the environment.
                 """,
             ),
         ] = None,

--- a/grelmicro/coordination/lock.py
+++ b/grelmicro/coordination/lock.py
@@ -233,6 +233,11 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
                 When None (the default), follow the process-wide
                 ``GREL_ENV_LOAD`` flag. Pass True or False to
                 override the flag for this construction.
+
+                Pass False when the values here are the whole truth.
+                Env reads fill every field not passed, so a config
+                half taken from somewhere else silently gets the rest
+                from the environment.
                 """,
             ),
         ] = None,

--- a/grelmicro/coordination/tasklock.py
+++ b/grelmicro/coordination/tasklock.py
@@ -198,11 +198,6 @@ class TaskLock(Reconfigurable[TaskLockConfig], LockPrimitive):
                 Env reads fill every field not passed, so a config
                 half taken from somewhere else silently gets the rest
                 from the environment.
-
-                Pass False when the values here are the whole truth.
-                Env reads fill every field not passed, so a config
-                half taken from somewhere else silently gets the rest
-                from the environment.
                 """
             ),
         ] = None,

--- a/grelmicro/coordination/tasklock.py
+++ b/grelmicro/coordination/tasklock.py
@@ -193,6 +193,16 @@ class TaskLock(Reconfigurable[TaskLockConfig], LockPrimitive):
                 When None (the default), follow the process-wide
                 ``GREL_ENV_LOAD`` flag. Pass True or False to
                 override the flag for this construction.
+
+                Pass False when the values here are the whole truth.
+                Env reads fill every field not passed, so a config
+                half taken from somewhere else silently gets the rest
+                from the environment.
+
+                Pass False when the values here are the whole truth.
+                Env reads fill every field not passed, so a config
+                half taken from somewhere else silently gets the rest
+                from the environment.
                 """
             ),
         ] = None,

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -184,6 +184,11 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
                 When None (the default), follow the process-wide
                 ``GREL_ENV_LOAD`` flag. Pass True or False to
                 override the flag for this construction.
+
+                Pass False when the values here are the whole truth.
+                Env reads fill every field not passed, so a config
+                half taken from somewhere else silently gets the rest
+                from the environment.
                 """
             ),
         ] = None,

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -395,6 +395,11 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
                 When None (the default), follow the process-wide
                 `GREL_ENV_LOAD` flag. Pass True or False to override the
                 flag for this construction.
+
+                Pass False when the values here are the whole truth.
+                Env reads fill every field not passed, so a config
+                half taken from somewhere else silently gets the rest
+                from the environment.
                 """,
             ),
         ] = None,

--- a/grelmicro/log/_dedup.py
+++ b/grelmicro/log/_dedup.py
@@ -217,6 +217,11 @@ class DuplicateFilter(Filter):
                 When None (the default), follow the process-wide
                 ``GREL_ENV_LOAD`` flag. Pass True or False to
                 override the flag for this construction.
+
+                Pass False when the values here are the whole truth.
+                Env reads fill every field not passed, so a config
+                half taken from somewhere else silently gets the rest
+                from the environment.
                 """
             ),
         ] = None,

--- a/grelmicro/log/_ratelimit.py
+++ b/grelmicro/log/_ratelimit.py
@@ -220,6 +220,11 @@ class RateLimitFilter(Filter):
                 When None (the default), follow the process-wide
                 ``GREL_ENV_LOAD`` flag. Pass True or False to
                 override the flag for this construction.
+
+                Pass False when the values here are the whole truth.
+                Env reads fill every field not passed, so a config
+                half taken from somewhere else silently gets the rest
+                from the environment.
                 """
             ),
         ] = None,

--- a/grelmicro/resilience/bulkhead.py
+++ b/grelmicro/resilience/bulkhead.py
@@ -156,6 +156,8 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
             Doc(
                 "Whether to read environment variables. Defaults to the "
                 "process-wide `GREL_ENV_LOAD` flag."
+                "Pass False when the values here are the whole "
+                "truth, because env reads fill every field not passed."
             ),
         ] = None,
     ) -> None:

--- a/grelmicro/resilience/bulkhead.py
+++ b/grelmicro/resilience/bulkhead.py
@@ -155,7 +155,7 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
             bool | None,
             Doc(
                 "Whether to read environment variables. Defaults to the "
-                "process-wide `GREL_ENV_LOAD` flag."
+                "process-wide `GREL_ENV_LOAD` flag. "
                 "Pass False when the values here are the whole "
                 "truth, because env reads fill every field not passed."
             ),

--- a/grelmicro/resilience/fallback.py
+++ b/grelmicro/resilience/fallback.py
@@ -399,7 +399,7 @@ class Fallback(Reconfigurable[FallbackConfig]):
             bool | None,
             Doc(
                 "Whether to read environment variables. Defaults to "
-                "the process-wide ``GREL_ENV_LOAD`` flag."
+                "the process-wide ``GREL_ENV_LOAD`` flag. "
                 "Pass False when the values here are the whole "
                 "truth, because env reads fill every field not passed."
             ),

--- a/grelmicro/resilience/fallback.py
+++ b/grelmicro/resilience/fallback.py
@@ -400,6 +400,8 @@ class Fallback(Reconfigurable[FallbackConfig]):
             Doc(
                 "Whether to read environment variables. Defaults to "
                 "the process-wide ``GREL_ENV_LOAD`` flag."
+                "Pass False when the values here are the whole "
+                "truth, because env reads fill every field not passed."
             ),
         ] = None,
     ) -> None:

--- a/grelmicro/resilience/retry.py
+++ b/grelmicro/resilience/retry.py
@@ -611,6 +611,8 @@ class Retry(Reconfigurable[RetryConfig]):
             Doc(
                 "Whether to read environment variables. Defaults "
                 "to the process-wide ``GREL_ENV_LOAD`` flag."
+                "Pass False when the values here are the whole "
+                "truth, because env reads fill every field not passed."
             ),
         ] = None,
     ) -> None:

--- a/grelmicro/resilience/retry.py
+++ b/grelmicro/resilience/retry.py
@@ -610,7 +610,7 @@ class Retry(Reconfigurable[RetryConfig]):
             bool | None,
             Doc(
                 "Whether to read environment variables. Defaults "
-                "to the process-wide ``GREL_ENV_LOAD`` flag."
+                "to the process-wide ``GREL_ENV_LOAD`` flag. "
                 "Pass False when the values here are the whole "
                 "truth, because env reads fill every field not passed."
             ),

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -305,6 +305,8 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
             Doc(
                 "Whether to read environment variables. Defaults to the "
                 "process-wide `GREL_ENV_LOAD` flag."
+                "Pass False when the values here are the whole "
+                "truth, because env reads fill every field not passed."
             ),
         ] = None,
         time_source: Annotated[

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -304,7 +304,7 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
             bool | None,
             Doc(
                 "Whether to read environment variables. Defaults to the "
-                "process-wide `GREL_ENV_LOAD` flag."
+                "process-wide `GREL_ENV_LOAD` flag. "
                 "Pass False when the values here are the whole "
                 "truth, because env reads fill every field not passed."
             ),

--- a/grelmicro/resilience/timeout.py
+++ b/grelmicro/resilience/timeout.py
@@ -100,7 +100,7 @@ class Timeout(Reconfigurable[TimeoutConfig]):
             bool | None,
             Doc(
                 "Whether to read environment variables. Defaults to "
-                "the process-wide ``GREL_ENV_LOAD`` flag."
+                "the process-wide ``GREL_ENV_LOAD`` flag. "
                 "Pass False when the values here are the whole "
                 "truth, because env reads fill every field not passed."
             ),

--- a/grelmicro/resilience/timeout.py
+++ b/grelmicro/resilience/timeout.py
@@ -101,6 +101,8 @@ class Timeout(Reconfigurable[TimeoutConfig]):
             Doc(
                 "Whether to read environment variables. Defaults to "
                 "the process-wide ``GREL_ENV_LOAD`` flag."
+                "Pass False when the values here are the whole "
+                "truth, because env reads fill every field not passed."
             ),
         ] = None,
     ) -> None:


### PR DESCRIPTION
Closes #606.

Documentation only. The flag keeps its name and its behaviour.

## What the reader was missing

`env_load` was documented as what it toggles ("whether to read environment variables") and never as what it guards against. The hazard lives in step 2 of the resolution order: **env reads fill every field the caller did not pass**, not only the fields with no default anywhere.

That splits a config across two sources without saying so. Confirmed against the code:

```python
# GREL_ENV_LOAD=1, GREL_LOCK_CART_LEASE_DURATION=99
Lock("cart")                          # lease_duration -> 99.0
Lock("cart", retry_interval=0.5)      # lease_duration -> 99.0, still
Lock.from_config("cart", cfg)         # lease_duration -> 30.0, env ignored
```

The second line is the trap. A caller handing over some fields from their own `Settings` object gets the rest from the environment, so a `Settings` default that differs from the environment is dropped and nothing reports it. It only surfaces when the two sources disagree, which is the case nobody tests.

## What changed

- `docs/advanced/config.md` gains a "The hazard in step 2" section that names it with the worked example above, and the "Disable env reads" recipe now says what `env_load=False` asserts rather than what it switches off.
- The `env_load` parameter says the same thing on all twelve components that take it.
- Points at `from_config`, which already skips the env layer entirely and expresses the same intent positively.

## Scope

Kept to documentation deliberately. Env loading is opt-in and off unless `GREL_ENV_LOAD` is truthy, so the exposure is bounded to deployments that asked for it, and the positive construction path the issue asks about already exists as `from_config`. The gap was that nothing named the hazard.

Full pre-commit chain green.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b
