### PR TITLE
📝 Treat outbox retention as a decision the caller makes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,8 @@
 ### Docs
 
 * 📝 Name the hazard `env_load=False` guards against. Env reads fill every field the caller did not pass, so a config half taken from a `Settings` object silently gets the rest from the environment. A `Settings` default that differs from the environment is dropped without a word. ([#606](https://github.com/grelinfo/grelmicro/issues/606))
+* 📝 Treat outbox retention as a decision the caller makes. A payload sits in the database until its row is deleted, so a single-use secret is at rest for as long as the row lives. The default deletes a delivered row, which is the safe end, but a default is not a guarantee. Pin `keep_delivered` rather than inherit it, and note that dead rows are never purged automatically. ([#607](https://github.com/grelinfo/grelmicro/issues/607))
+* 📝 Say that a stored idempotent response sits at rest for `ttl`. The same audit: the middleware stores the whole response, so `ttl` is a retention window and not only a replay window. ([#607](https://github.com/grelinfo/grelmicro/issues/607))
 
 ### Fixed
 

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -118,6 +118,20 @@ Everything else is stored whatever its content type, so a `201 Created` with an 
 
 The response streams to the client as the handler produces it. The copy is buffered alongside and written to the cache after the last chunk is sent.
 
+### Stored responses sit at rest
+
+A stored response is the whole response, headers and body, held in the cache
+backend for `ttl`. A body carrying a token, a signed URL, or personal data is at
+rest there for that long, on whatever backend the `Cache` component points at.
+
+`ttl` is therefore a retention decision, not only a replay window. Set it to the
+shortest window that still catches the retries you care about, rather than the
+longest one the cache will tolerate. Use `skip` to keep a response out of the
+cache entirely when its body should never be written down.
+
+Responses carrying `Set-Cookie` are already never stored, because replaying one
+hands a caller another caller's session.
+
 ### Custom rules with `skip`
 
 `skip` receives the finished response and returns `True` to leave it unstored. It mirrors [`skip` on `@cached`](cache.md#decorator-parameters).

--- a/docs/outbox.md
+++ b/docs/outbox.md
@@ -339,6 +339,33 @@ await outbox.purge()                              # all delivered and dead rows
 await outbox.purge(older_than=timedelta(days=7))  # only those older than 7 days
 ```
 
+### Retention is your decision, not a default
+
+A message payload sits in your database until the row is deleted. Whatever you
+publish is stored, so a payload carrying a password reset token, a signed URL, or
+a one-time code is at rest in the outbox table for as long as the row lives.
+
+The default deletes a delivered row immediately, which is the safe end of the
+range. Do not rely on that. Pin the value you want:
+
+```python
+micro = Grelmicro(uses=[Outbox(postgres, keep_delivered=False)])
+```
+
+Pinning it says the choice was made, and a later release cannot move it under
+you. Two things are worth separating when you choose:
+
+- **Delivered rows** follow `keep_delivered`. A window keeps them for
+  replay and audit, and the relay purges them once they age out.
+- **Dead rows are never purged automatically**, whatever `keep_delivered`
+  says, because a dead-letter exists to be inspected. A payload that failed
+  to deliver therefore stays until you call `purge`. That is the case people
+  miss.
+
+Keep single-use secrets out of the payload where you can. Publish a reference
+and let the consumer fetch the secret, so the outbox holds an identifier rather
+than the credential itself.
+
 Pending and in-flight messages are never touched. Run `purge` from a scheduled [task](task.md) when you keep delivered rows for good and still want dead rows trimmed.
 
 ## Observability


### PR DESCRIPTION
Closes #607.

Documentation only. `keep_delivered` keeps its default of `False`.

## The gap

The reporter in #591 pinned `keep_delivered=False` explicitly, reasoning that the guarantee must not hinge on a library default. That instinct was right, and it points at something the docs never said: **a default that is currently safe is not the same as a guarantee.** Nothing told an adopter the decision mattered.

A message payload sits in the database until its row is deleted, so a payload carrying a password reset token, a signed URL, or a one-time code is at rest for as long as the row lives.

`docs/outbox.md` now frames retention as the caller's decision, recommends pinning the value rather than inheriting it, and separates the two cases:

- Delivered rows follow `keep_delivered` and the relay purges them.
- **Dead rows are never purged automatically**, whatever `keep_delivered` says, because a dead-letter exists to be inspected. A payload that failed to deliver stays until someone calls `purge`. That is the case people miss, and it is the one where a secret lingers longest.

It also suggests publishing a reference rather than the credential, so the outbox holds an identifier instead of the secret.

## The audit

The issue asked to check for other defaults carrying a compliance implication rather than only a behavioural one. The clear match is `IdempotencyMiddleware`, which stores the **whole response**, headers and body, in the cache backend for `ttl`. A body carrying a token or personal data is at rest there for that long, and the docs presented `ttl` purely as a replay window.

`docs/idempotency.md` now says `ttl` is a retention decision too, and points at `skip` for a response whose body should never be written down. The existing rule that `Set-Cookie` responses are never stored is noted there as the precedent it is.

Nothing else in the sweep changed hands: the cache stores what the caller puts in it, and `clientip` resolves an address without persisting one.

## Scope

Option 1 from the issue. Option 2, requiring the choice explicitly, is a breaking change to a component where the default is already the safe end of the range, so it is better weighed as a deliberate 1.0 decision than folded into a docs fix.

Full pre-commit chain green.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b
