### PR TITLE
👷 Add just recipes for release preflight and supply-chain verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -452,7 +452,45 @@ uv run pytest -m integration
 uv run pytest -m "not integration" --cov
 uv run pytest -m integration --cov --cov-append
 uv run coverage report --fail-under=100
+
+# The tier the Release workflow runs, which adds the slow marker
+just test-full
 ```
+
+### Before cutting a release
+
+A release tag is immutable, so a failure found after tagging burns the
+version and forces a patch bump. Run the preflight first, which runs what
+the Release workflow will run:
+
+```bash
+just release-check 0.33.1
+```
+
+It refuses unless the working tree is clean and `HEAD` is `origin/main`,
+because anything else is not what would be tagged. It then checks that
+`docs/changelog.md` has a section for the version dated today, runs the
+full test tier, builds the docs with `--strict`, and smoke-tests the demo
+stack. Use `just release-check-fast` to skip the demo tier while
+iterating.
+
+`just release-notes 0.33.1` prints that version's changelog section, which
+is what the GitHub Release body should hold.
+
+### Verifying a published release
+
+The README advertises SLSA Build Level 2. That claim holds only while
+provenance keeps being produced and keeps verifying, so it is checkable
+in one command:
+
+```bash
+just verify-release 0.33.0
+```
+
+It downloads the wheel and the sdist from PyPI, verifies build provenance
+for each with `gh attestation verify`, then resolves and imports the
+published version and checks its `Documentation` URL. Verification is
+bound to the file digest, so a tampered artifact finds no attestation.
 
 ## Documentation
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 * 📝 Name the hazard `env_load=False` guards against. Env reads fill every field the caller did not pass, so a config half taken from a `Settings` object silently gets the rest from the environment. A `Settings` default that differs from the environment is dropped without a word. ([#606](https://github.com/grelinfo/grelmicro/issues/606))
 * 📝 Treat outbox retention as a decision the caller makes. A payload sits in the database until its row is deleted, so a single-use secret is at rest for as long as the row lives. The default deletes a delivered row, which is the safe end, but a default is not a guarantee. Pin `keep_delivered` rather than inherit it, and note that dead rows are never purged automatically. ([#607](https://github.com/grelinfo/grelmicro/issues/607))
 * 📝 Say that a stored idempotent response sits at rest for `ttl`. The same audit: the middleware stores the whole response, so `ttl` is a retention window and not only a replay window. ([#607](https://github.com/grelinfo/grelmicro/issues/607))
+
 ### Internal
 
 * 👷 Add `just` recipes for the release path. `just release-check <version>` runs what the Release workflow runs, before the tag exists, so a failure costs nothing rather than burning an immutable tag. `just verify-release <version>` downloads a published wheel and sdist and verifies build provenance for each, which turns the SLSA Build Level 2 badge into something anyone can check. `just release-notes <version>` prints the changelog section the GitHub Release body should hold. ([#584](https://github.com/grelinfo/grelmicro/issues/584))
@@ -603,7 +604,6 @@ Re-cut of 0.32.0, which never reached PyPI. A flaky test failed the release run,
 ### Internal
 
 * ⚡ Defer the `opentelemetry` import in `grelmicro.trace`. `import grelmicro.trace` no longer loads `opentelemetry` (was 16 modules). The package is resolved lazily on first call to `instrument`, `span`, or `add_context` and cached. Issue [#189](https://github.com/grelinfo/grelmicro/issues/189).
-
 
 ## 0.21.0 - 2026-05-06
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@
 * 📝 Name the hazard `env_load=False` guards against. Env reads fill every field the caller did not pass, so a config half taken from a `Settings` object silently gets the rest from the environment. A `Settings` default that differs from the environment is dropped without a word. ([#606](https://github.com/grelinfo/grelmicro/issues/606))
 * 📝 Treat outbox retention as a decision the caller makes. A payload sits in the database until its row is deleted, so a single-use secret is at rest for as long as the row lives. The default deletes a delivered row, which is the safe end, but a default is not a guarantee. Pin `keep_delivered` rather than inherit it, and note that dead rows are never purged automatically. ([#607](https://github.com/grelinfo/grelmicro/issues/607))
 * 📝 Say that a stored idempotent response sits at rest for `ttl`. The same audit: the middleware stores the whole response, so `ttl` is a retention window and not only a replay window. ([#607](https://github.com/grelinfo/grelmicro/issues/607))
+### Internal
+
+* 👷 Add `just` recipes for the release path. `just release-check <version>` runs what the Release workflow runs, before the tag exists, so a failure costs nothing rather than burning an immutable tag. `just verify-release <version>` downloads a published wheel and sdist and verifies build provenance for each, which turns the SLSA Build Level 2 badge into something anyone can check. `just release-notes <version>` prints the changelog section the GitHub Release body should hold. ([#584](https://github.com/grelinfo/grelmicro/issues/584))
 
 ### Fixed
 

--- a/justfile
+++ b/justfile
@@ -19,6 +19,7 @@ demo-down:
 # Uses tools/run_mutmut.py, which disables string-literal mutations (almost all
 # log and exception message text here) and runs as `python -m mutmut` so the
 # mutants/ copy shadows the editable install.
+[doc("Mutation-test the files listed in [tool.mutmut] only_mutate")]
 mutation:
     uv run python tools/run_mutmut.py run
     uv run python -m mutmut results
@@ -26,3 +27,84 @@ mutation:
 # List surviving mutants from the last mutation run.
 mutation-results:
     uv run python -m mutmut results
+
+# Run the full test tier the Release workflow runs, the way it runs it.
+# The PR tier skips the slow marker, so this is the first place it runs
+# locally. Coverage is appended across the three tiers because the 100%
+# total is a claim about all of them together.
+[doc("Run the full test tier the Release workflow runs")]
+test-full:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    uv run pytest -x -m "not integration and not slow" --cov
+    # Exit 5 is "no tests collected", which is fine while the tier is empty.
+    uv run pytest -x -m "slow and not integration" --cov --cov-append || [ $? -eq 5 ]
+    uv run pytest -x -m integration --cov --cov-append
+    uv run coverage report --fail-under=100
+
+# Bring the demo stack up, probe it the way CI does, and tear it down.
+[doc("Bring the demo stack up, probe it the way CI does, tear it down")]
+demo-smoke:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    compose="examples/fastapi-demo/compose.yml"
+    trap 'docker compose -f "$compose" down -v >/dev/null 2>&1 || true' EXIT
+    docker compose -f "$compose" up --build --wait --wait-timeout 240
+    curl -fsS http://localhost:8000/livez > /dev/null
+    curl -fsS http://localhost:8000/readyz > /dev/null
+    curl -fsS http://localhost:8000/healthz > /dev/null
+    echo "demo smoke passed"
+
+# Everything the Release workflow will run, before the tag exists.
+# A release tag is immutable, so a failure found here costs nothing and the
+# same failure found after tagging burns the version.
+[doc("Run everything the Release workflow will run, before the tag exists")]
+release-check version: (release-check-fast version) demo-smoke
+    @echo "release-check passed for {{version}}"
+
+# `release-check` without the demo tier, for iterating.
+[doc("release-check without the demo tier, for iterating")]
+release-check-fast version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "working tree is not clean" >&2
+        exit 1
+    fi
+    git fetch --quiet origin main
+    if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+        echo "HEAD is not origin/main, so this is not what would be tagged" >&2
+        exit 1
+    fi
+    uv run python tools/changelog.py check "{{version}}"
+    just test-full
+    uv run mkdocs build --strict
+    echo "release-check-fast passed for {{version}}"
+
+# Print a version's changelog section, which is the GitHub Release body.
+release-notes version:
+    @uv run python tools/changelog.py notes "{{version}}"
+
+# Check a published version against the supply-chain claims in the README.
+# The SLSA Build L2 badge is only true while provenance keeps being produced
+# and keeps verifying, so this turns the badge into something anyone can
+# check rather than something the project asserts.
+[doc("Check a published version against the supply-chain claims")]
+verify-release version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    dir="$(mktemp -d)"
+    trap 'rm -rf "$dir"' EXIT
+    echo "== downloading grelmicro=={{version}} from PyPI"
+    uv run --no-project -- python tools/download_release.py "{{version}}" "$dir"
+    echo "== verifying build provenance"
+    for artifact in "$dir"/*; do
+        # `gh` is silent on success, so say what passed. Verification is
+        # bound to the file digest: a tampered artifact finds no attestation.
+        gh attestation verify "$artifact" --repo grelinfo/grelmicro
+        echo "  verified $(basename "$artifact")"
+    done
+    echo "== verifying the version resolves, imports, and points at its docs"
+    uv run --refresh --no-project --with "grelmicro=={{version}}" --with httpx \
+        -- python tools/verify_release.py "{{version}}"
+    echo "verify-release passed for {{version}}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,6 +272,7 @@ ignore = [
 [tool.ruff.lint.extend-per-file-ignores]
 "tools/*" = [
     "INP001",  # standalone dev scripts, not an importable package
+    "T201",    # these are command-line tools, so stdout is the interface
 ]
 "tests/typechecking/*" = [
     "INP001",  # static type assertions, never imported or collected

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -48,7 +48,7 @@ def sections(text: str) -> dict[str, tuple[str | None, str]]:
 
 def check(version: str, today: str) -> int:
     """Report whether `version` is ready to tag. Returns an exit code."""
-    found = sections(CHANGELOG.read_text())
+    found = sections(CHANGELOG.read_text(encoding="utf-8"))
     if version not in found:
         print(f"changelog has no section for {version}", file=sys.stderr)
         released = [v for v, (d, _) in found.items() if d]
@@ -79,7 +79,7 @@ def check(version: str, today: str) -> int:
 
 def notes(version: str) -> int:
     """Print the body of `version`'s section. Returns an exit code."""
-    found = sections(CHANGELOG.read_text())
+    found = sections(CHANGELOG.read_text(encoding="utf-8"))
     if version not in found:
         print(f"changelog has no section for {version}", file=sys.stderr)
         return 1

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -1,0 +1,105 @@
+"""Read a version's section out of `docs/changelog.md`.
+
+Two release steps need the same parsing. `check` gates a release on the
+section existing and carrying today's date, so a tag is never cut against a
+changelog that still says `Unreleased` or carries yesterday's date. `notes`
+prints the section body, which is what the GitHub Release description
+should hold.
+
+Run via `just release-check` and `just release-notes`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import sys
+from pathlib import Path
+
+CHANGELOG = Path(__file__).resolve().parent.parent / "docs" / "changelog.md"
+
+HEADING = re.compile(
+    r"^## (?P<version>\S+)(?: - (?P<date>\d{4}-\d{2}-\d{2}))?\s*$"
+)
+
+
+def sections(text: str) -> dict[str, tuple[str | None, str]]:
+    """Return `{version: (date, body)}` for every section in the changelog."""
+    found: dict[str, tuple[str | None, str]] = {}
+    version: str | None = None
+    date: str | None = None
+    body: list[str] = []
+    for line in text.splitlines():
+        match = HEADING.match(line)
+        if match:
+            if version is not None:
+                found[version] = (date, "\n".join(body).strip())
+            version = match["version"]
+            date = match["date"]
+            body = []
+            continue
+        if version is not None:
+            body.append(line)
+    if version is not None:
+        found[version] = (date, "\n".join(body).strip())
+    return found
+
+
+def check(version: str, today: str) -> int:
+    """Report whether `version` is ready to tag. Returns an exit code."""
+    found = sections(CHANGELOG.read_text())
+    if version not in found:
+        print(f"changelog has no section for {version}", file=sys.stderr)
+        released = [v for v, (d, _) in found.items() if d]
+        if released:
+            print(f"latest released section: {released[0]}", file=sys.stderr)
+        if "Unreleased" in found:
+            print(
+                f"rename the 'Unreleased' heading to '## {version} - {today}'",
+                file=sys.stderr,
+            )
+        return 1
+    date, body = found[version]
+    if date is None:
+        print(f"section for {version} carries no date", file=sys.stderr)
+        return 1
+    if date != today:
+        print(
+            f"section for {version} is dated {date}, not today ({today})",
+            file=sys.stderr,
+        )
+        return 1
+    if not body:
+        print(f"section for {version} is empty", file=sys.stderr)
+        return 1
+    print(f"changelog ready: {version} dated {date}")
+    return 0
+
+
+def notes(version: str) -> int:
+    """Print the body of `version`'s section. Returns an exit code."""
+    found = sections(CHANGELOG.read_text())
+    if version not in found:
+        print(f"changelog has no section for {version}", file=sys.stderr)
+        return 1
+    print(found[version][1])
+    return 0
+
+
+def main() -> int:
+    """Parse arguments and dispatch."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("check", "notes"):
+        item = sub.add_parser(name)
+        item.add_argument("version")
+    args = parser.parse_args()
+    if args.command == "check":
+        today = datetime.datetime.now(tz=datetime.UTC).date().isoformat()
+        return check(args.version, today)
+    return notes(args.version)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/download_release.py
+++ b/tools/download_release.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import sys
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -17,11 +18,26 @@ PYPI_JSON = "https://pypi.org/pypi/grelmicro/{version}/json"
 WANTED = ("bdist_wheel", "sdist")
 
 
+def fetch(url: str, timeout: int) -> bytes | None:
+    """Return the body at `url`, or None after reporting why it failed."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+            return bytes(response.read())
+    except urllib.error.HTTPError as error:
+        print(f"{url} returned HTTP {error.code}", file=sys.stderr)
+    except urllib.error.URLError as error:
+        print(f"could not reach {url}: {error.reason}", file=sys.stderr)
+    return None
+
+
 def download(version: str, target: Path) -> int:
     """Download the wheel and the sdist for `version` into `target`."""
-    url = PYPI_JSON.format(version=version)
-    with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
-        payload = json.load(response)
+    target.mkdir(parents=True, exist_ok=True)
+    body = fetch(PYPI_JSON.format(version=version), timeout=30)
+    if body is None:
+        print(f"no published release for grelmicro=={version}", file=sys.stderr)
+        return 1
+    payload = json.loads(body)
 
     files = [f for f in payload["urls"] if f["packagetype"] in WANTED]
     if not files:
@@ -38,9 +54,11 @@ def download(version: str, target: Path) -> int:
         return 1
 
     for entry in files:
-        destination = target / entry["filename"]
-        with urllib.request.urlopen(entry["url"], timeout=60) as response:  # noqa: S310
-            destination.write_bytes(response.read())
+        content = fetch(entry["url"], timeout=60)
+        if content is None:
+            print(f"could not download {entry['filename']}", file=sys.stderr)
+            return 1
+        (target / entry["filename"]).write_bytes(content)
         print(f"downloaded {entry['filename']}")
     return 0
 

--- a/tools/download_release.py
+++ b/tools/download_release.py
@@ -1,0 +1,59 @@
+"""Download the published artifacts for a grelmicro version from PyPI.
+
+`gh attestation verify` needs the files themselves, so they have to be on
+disk before anything is installed. Run through `just verify-release`.
+
+Uses only the standard library, so it runs before any environment is built.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+PYPI_JSON = "https://pypi.org/pypi/grelmicro/{version}/json"
+WANTED = ("bdist_wheel", "sdist")
+
+
+def download(version: str, target: Path) -> int:
+    """Download the wheel and the sdist for `version` into `target`."""
+    url = PYPI_JSON.format(version=version)
+    with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
+        payload = json.load(response)
+
+    files = [f for f in payload["urls"] if f["packagetype"] in WANTED]
+    if not files:
+        print(f"no wheel or sdist published for {version}", file=sys.stderr)
+        return 1
+
+    kinds = {f["packagetype"] for f in files}
+    missing = set(WANTED) - kinds
+    if missing:
+        print(
+            f"{version} is missing: {', '.join(sorted(missing))}",
+            file=sys.stderr,
+        )
+        return 1
+
+    for entry in files:
+        destination = target / entry["filename"]
+        with urllib.request.urlopen(entry["url"], timeout=60) as response:  # noqa: S310
+            destination.write_bytes(response.read())
+        print(f"downloaded {entry['filename']}")
+    return 0
+
+
+def main() -> int:
+    """Parse arguments and download."""
+    if len(sys.argv) != 3:  # noqa: PLR2004
+        print(
+            "usage: download_release.py <version> <directory>", file=sys.stderr
+        )
+        return 2
+    return download(sys.argv[1], Path(sys.argv[2]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_release.py
+++ b/tools/verify_release.py
@@ -11,6 +11,7 @@ runs against the downloaded files with `gh` before anything is installed.
 from __future__ import annotations
 
 import sys
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as installed_version
 
 DOCUMENTATION_URL = "https://grelmicro.grel.info"
@@ -20,7 +21,10 @@ PYPI_JSON = "https://pypi.org/pypi/grelmicro/{version}/json"
 def check_installed(expected: str) -> list[str]:
     """Return failures from resolving and importing the published version."""
     failures: list[str] = []
-    found = installed_version("grelmicro")
+    try:
+        found = installed_version("grelmicro")
+    except PackageNotFoundError:
+        return [f"grelmicro=={expected} is not installed in this environment"]
     if found != expected:
         failures.append(f"resolved grelmicro=={found}, expected {expected}")
     try:
@@ -34,10 +38,17 @@ def check_metadata(expected: str) -> list[str]:
     """Return failures from the project URLs PyPI serves for the version."""
     import httpx  # noqa: PLC0415
 
-    response = httpx.get(PYPI_JSON.format(version=expected), timeout=30)
+    try:
+        response = httpx.get(PYPI_JSON.format(version=expected), timeout=30)
+    except httpx.HTTPError as error:
+        return [f"could not reach PyPI: {error!r}"]
     if response.status_code != httpx.codes.OK:
         return [f"PyPI returned {response.status_code} for {expected}"]
-    urls = response.json()["info"].get("project_urls") or {}
+    try:
+        info = response.json()["info"]
+    except (ValueError, KeyError) as error:
+        return [f"PyPI returned unreadable metadata: {error!r}"]
+    urls = info.get("project_urls") or {}
     found = urls.get("Documentation")
     if found != DOCUMENTATION_URL:
         return [

--- a/tools/verify_release.py
+++ b/tools/verify_release.py
@@ -1,0 +1,65 @@
+"""Check a published grelmicro version against the claims the README makes.
+
+Run through `just verify-release <version>`, which installs the published
+package into a throwaway environment first. Importing here therefore reaches
+the artifact on PyPI, not the working tree.
+
+The build-provenance check lives in the recipe rather than here, because it
+runs against the downloaded files with `gh` before anything is installed.
+"""
+
+from __future__ import annotations
+
+import sys
+from importlib.metadata import version as installed_version
+
+DOCUMENTATION_URL = "https://grelmicro.grel.info"
+PYPI_JSON = "https://pypi.org/pypi/grelmicro/{version}/json"
+
+
+def check_installed(expected: str) -> list[str]:
+    """Return failures from resolving and importing the published version."""
+    failures: list[str] = []
+    found = installed_version("grelmicro")
+    if found != expected:
+        failures.append(f"resolved grelmicro=={found}, expected {expected}")
+    try:
+        import grelmicro  # noqa: F401, PLC0415
+    except Exception as error:  # noqa: BLE001
+        failures.append(f"importing grelmicro raised {error!r}")
+    return failures
+
+
+def check_metadata(expected: str) -> list[str]:
+    """Return failures from the project URLs PyPI serves for the version."""
+    import httpx  # noqa: PLC0415
+
+    response = httpx.get(PYPI_JSON.format(version=expected), timeout=30)
+    if response.status_code != httpx.codes.OK:
+        return [f"PyPI returned {response.status_code} for {expected}"]
+    urls = response.json()["info"].get("project_urls") or {}
+    found = urls.get("Documentation")
+    if found != DOCUMENTATION_URL:
+        return [
+            f"Documentation URL is {found!r}, expected {DOCUMENTATION_URL!r}"
+        ]
+    return []
+
+
+def main() -> int:
+    """Run every check and report all failures rather than the first."""
+    if len(sys.argv) != 2:  # noqa: PLR2004
+        print("usage: verify_release.py <version>", file=sys.stderr)
+        return 2
+    expected = sys.argv[1]
+    failures = check_installed(expected) + check_metadata(expected)
+    for failure in failures:
+        print(f"FAIL: {failure}", file=sys.stderr)
+    if failures:
+        return 1
+    print(f"grelmicro=={expected} resolves, imports, and points at its docs")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #584.

Six recipes, all exercised against the real thing rather than written and hoped for.

## Preflight, before the tag exists

```
just release-check 0.33.1
```

Refuses unless the working tree is clean and `HEAD` is `origin/main`, because anything else is not what would be tagged. Then it checks the changelog has a section for that version dated today, runs the full test tier, builds the docs with `--strict`, and smoke-tests the demo stack.

`just release-check-fast` skips the demo tier for iterating. `just test-full` is the tier on its own, which matters because the PR tier skips the `slow` marker, so this is the first place it runs locally.

Verified it refuses for the right reason:

```
$ just release-check-fast 0.33.1
working tree is not clean
error: Recipe `release-check-fast` failed with exit code 1
```

## Supply-chain verification, any published version

```
just verify-release 0.33.0
```

Run against the real 0.33.0 on PyPI:

```
== downloading grelmicro==0.33.0 from PyPI
downloaded grelmicro-0.33.0-py3-none-any.whl
downloaded grelmicro-0.33.0.tar.gz
== verifying build provenance
  verified grelmicro-0.33.0-py3-none-any.whl
  verified grelmicro-0.33.0.tar.gz
== verifying the version resolves, imports, and points at its docs
grelmicro==0.33.0 resolves, imports, and points at its docs
verify-release passed for 0.33.0
```

**I checked that this verifies rather than silently passing**, because a supply-chain check that no-ops is worse than none. `gh attestation verify` prints nothing on success, so two negative controls:

- Wrong repo: `HTTP 404` against `grelinfo/nonexistent-repo`.
- Tampered artifact: appending one byte to the wheel changes the digest and finds no attestation, also `404`.

Verification is bound to the file digest, so the recipe now echoes each filename it verified rather than leaving success silent.

## Release notes

`just release-notes 0.33.0` prints that version's changelog section, which is what the GitHub Release body should hold. Both releases mentioned in the issue had that pasted by hand.

## Notes

- Three small stdlib-only helpers under `tools/`: changelog parsing (shared by `release-check` and `release-notes`), artifact download, and the published-version checks. `uv pip download` does not exist, so the download reads the PyPI JSON API directly.
- The `[doc(...)]` attribute now supplies the `just --list` descriptions. Without it `just` shows the *last* comment line, which turned the longer rationale comments into nonsense entries. Fixed the pre-existing `mutation` recipe the same way, which had the same wart.
- `T201` is ignored for `tools/*`: these are command-line scripts, so stdout is the interface.

Full pre-commit chain green.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b
