### PR TITLE
✅ Pin both sides of the span exception check

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@
 ### Internal
 
 * 👷 Add `just` recipes for the release path. `just release-check <version>` runs what the Release workflow runs, before the tag exists, so a failure costs nothing rather than burning an immutable tag. `just verify-release <version>` downloads a published wheel and sdist and verifies build provenance for each, which turns the SLSA Build Level 2 badge into something anyone can check. `just release-notes <version>` prints the changelog section the GitHub Release body should hold. ([#584](https://github.com/grelinfo/grelmicro/issues/584))
+* ✅ Pin both sides of the span exception check, so the coverage gate stops failing at random. Only one side had a test of its own. The other was covered whenever some unrelated test happened to raise inside a non-recording span, which depends on the order `pytest-randomly` picks, so a run could report `_span.py` at 96% and fail `--fail-under=100` on a pull request that changed nothing near it.
 
 ### Fixed
 

--- a/tests/tracing/test_context.py
+++ b/tests/tracing/test_context.py
@@ -289,6 +289,67 @@ class TestSpanExceptionRecording:
         mock_span.set_status.assert_called_once()
         mock_span.record_exception.assert_called_once()
 
+    def test_span_exception_is_not_recorded_when_not_recording(
+        self,
+        mocker: pytest_mock.MockerFixture,
+    ) -> None:
+        """A span that is not recording gets no status and no exception.
+
+        Pins the other side of the recording check. Without this the branch
+        is covered only when some unrelated test happens to raise inside a
+        non-recording span, which depends on test order and on whichever
+        tracer provider is installed at the time.
+        """
+        # Arrange
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = False
+
+        mock_tracer = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(
+            return_value=mock_span
+        )
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(
+            return_value=False
+        )
+
+        mock_trace = MagicMock()
+        mock_trace.get_tracer.return_value = mock_tracer
+        mocker.patch(
+            "grelmicro.trace._span._get_otel",
+            return_value=OTel(mock_trace, MagicMock()),
+        )
+
+        def _raise_in_span() -> None:
+            with tracing_span("test", key="val"):
+                msg = "not recorded"
+                raise ValueError(msg)
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="not recorded"):
+            _raise_in_span()
+
+        mock_span.set_status.assert_not_called()
+        mock_span.record_exception.assert_not_called()
+
+    def test_span_exception_propagates_without_otel(
+        self,
+        mocker: pytest_mock.MockerFixture,
+    ) -> None:
+        """Without opentelemetry the span is a no-op and the error still raises."""
+        # Arrange
+        mocker.patch("grelmicro.trace._span._get_otel", return_value=None)
+
+        def _raise_in_span() -> None:
+            with tracing_span("test", key="val"):
+                msg = "no otel"
+                raise ValueError(msg)
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="no otel"):
+            _raise_in_span()
+
+        assert get_context() == {}
+
 
 class TestInstrumentNoOtel:
     """Test @instrument when OTel tracer is None."""


### PR DESCRIPTION
The 100% coverage gate could fail any pull request at random. This pins the branch that caused it.

## Proof it was a flake

The same commit on #624 failed and then passed on re-run, with no code change between them:

```
run 1:  TOTAL  11275  0  2496  1   99%   <- gate fails
run 2:  TOTAL  11275  0  2496  0  100%   <- gate passes
```

## Root cause

Running the one existing test in `TestSpanExceptionRecording` on its own reproduces the CI failure exactly:

```
grelmicro/trace/_span.py   23   0   4   1   96%   52->62
```

Those are the same numbers CI reported. The missing arc `52->62` is the recording check in `span()` falling through to `raise`:

```python
except BaseException:
    if (
        otel is not None
        and otel_span is not None
        and hasattr(otel_span, "is_recording")
        and otel_span.is_recording()
    ):
        ...
    raise          # <- line 62, reached only when the check is false
```

Only the **taken** side had a test of its own. The not-taken side was covered whenever some unrelated test happened to raise inside a span that was not recording, and whether that happens depends on the order `pytest-randomly` picks and on which tracer provider is installed at the time. It also only showed in the combined unit + slow + integration run, which is why local pre-commit kept passing.

## The fix

Two tests that pin the other side deterministically, both driven by mocks so nothing depends on global state:

- an exception inside a span that is not recording, asserting no status and no exception are recorded
- an exception inside a span with opentelemetry absent, asserting it still propagates

## Verification

The three tests in that class now cover the file on their own, independent of anything else in the suite:

```
$ pytest tests/tracing/test_context.py::TestSpanExceptionRecording --cov=grelmicro.trace._span
TOTAL   23   0   4   0   100%
```

Before this change the same command over just the pre-existing test gave `23 0 4 1 96%`, so the new tests are load-bearing rather than decorative. Five consecutive randomized runs of `tests/tracing/` hold at 100% with zero partial branches.

Tests only, no production change. Full pre-commit chain green.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b
