### PR TITLE
💥 Refuse @cached on a method unless it names its key

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -293,6 +293,35 @@ Arguments not named in the template do not affect the key, so calls that differ 
 --8<-- "cache/key.py"
 ```
 
+### On a method
+
+A method must name its key. Decorating one without `key=` or `key_maker=` raises `TypeError` at decoration time:
+
+```python
+class Repo:
+    @cached(cache, key="repo:{user_id}")
+    async def load(self, user_id: int) -> dict:
+        return await self.db.fetch_user(user_id)
+```
+
+The default key is the `repr()` of every argument, and on a method the first one is `self`. That reads two ways, both wrong. Two instances whose `repr()` matches share one entry, so a call on one returns the other's value. An instance using the default `repr()` carries a memory address, so its key changes on every restart and the entry is never found again.
+
+Only you know what identifies the entry, so the decorator asks rather than guesses. Name the fields that matter and leave `self` out. When the result does depend on instance state, fold that state into the key:
+
+```python
+class Repo:
+    @cached(cache, key="repo:{self.region}:{user_id}")
+    async def load(self, user_id: int) -> dict: ...
+```
+
+A `staticmethod` and a `classmethod` are untouched. Neither receives an instance, and a class `repr()` is stable, so their default key is sound.
+
+`refresh()` on a method is reached through the class, because attribute access on an instance returns the helper unbound:
+
+```python
+await Repo.load.refresh(repo, 42)
+```
+
 ### On-demand refresh
 
 `refresh()` recomputes for the given arguments, overwrites the stored entry, and returns the new value. It skips the read, so a live entry is replaced rather than served.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking
+
+* 💥 Refuse `@cached` on a method unless it names its key. The default key is the `repr()` of every argument, and on a method that includes `self`, which was wrong in both directions: two instances whose `repr()` matched shared one entry, so a call on one returned the other's value, and an instance using the default `repr()` carried a memory address, so its key changed on every restart. Neither said anything. Decorating a method without `key=` or `key_maker=` now raises `TypeError` at decoration time. Pass a key naming what identifies the entry, such as `key="repo:{user_id}"`. ([#600](https://github.com/grelinfo/grelmicro/issues/600))
+
 ### Docs
 
 * 📝 Name the hazard `env_load=False` guards against. Env reads fill every field the caller did not pass, so a config half taken from a `Settings` object silently gets the rest from the environment. A `Settings` default that differs from the environment is dropped without a word. ([#606](https://github.com/grelinfo/grelmicro/issues/606))

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -225,6 +225,19 @@ def _resolve_cache(
     )
 
 
+def _takes_self(func: Callable[..., Any]) -> bool:
+    """Return whether `func` receives an instance as its first argument.
+
+    Matches the parameter name rather than the enclosing class, because a
+    `staticmethod` carries no instance and a `classmethod` receives a class,
+    whose `repr()` is stable. Only an instance drags an unstable `repr()`
+    into the key.
+    """
+    parameters = iter(inspect.signature(func).parameters.values())
+    first = next(parameters, None)
+    return first is not None and first.name == "self"
+
+
 def cached(  # noqa: PLR0913, C901
     cache: Annotated[
         TTLCache | None,
@@ -431,6 +444,18 @@ def cached(  # noqa: PLR0913, C901
     def decorator(
         func: Callable[P, R],
     ) -> CachedFunction[P, R]:
+        if key is None and key_maker is None and _takes_self(func):
+            name = getattr(func, "__qualname__", repr(func))
+            msg = (
+                f"@cached on {name} needs an explicit key= or key_maker=, "
+                f"because the default key is built from repr() of every "
+                f"argument, and here that includes self. Two instances "
+                f"whose repr matches then share one entry, and a default "
+                f"repr carries a memory address, so the key changes on "
+                f"every restart. Name what identifies the entry, for "
+                f"example key='user:{{user_id}}'."
+            )
+            raise TypeError(msg)
         is_async_func = inspect.iscoroutinefunction(func)
         if is_private_cache and not is_async_func:
             msg = (

--- a/tests/cache/test_cached_validation.py
+++ b/tests/cache/test_cached_validation.py
@@ -7,6 +7,8 @@ The broader suite checks the common decorator paths. These pin the `early` and
 
 from __future__ import annotations
 
+import pytest
+
 from grelmicro.cache.cached import cached
 
 _TTL = 60
@@ -30,3 +32,77 @@ def test_stale_ttl_of_one_is_accepted() -> None:
         return 1
 
     assert fn is not None
+
+
+def test_method_without_an_explicit_key_is_refused() -> None:
+    """A method needs a key, because the default one embeds `repr(self)`.
+
+    Without this guard two instances whose repr matches silently share one
+    entry, and a default repr carries a memory address, so the key changes
+    on every restart.
+    """
+    with pytest.raises(TypeError, match="needs an explicit key="):
+
+        class Repo:
+            @cached(ttl=_TTL)
+            async def load(self, key: str) -> str:
+                return key
+
+
+def test_method_with_an_explicit_key_is_accepted() -> None:
+    """Naming what identifies the entry is what the guard asks for."""
+
+    class Repo:
+        @cached(ttl=_TTL, key="repo:{key}")
+        async def load(self, key: str) -> str:
+            return key
+
+    assert Repo.load is not None
+
+
+def test_method_with_a_key_maker_is_accepted() -> None:
+    """A `key_maker` names the entry just as explicitly as `key`."""
+
+    class Repo:
+        @cached(ttl=_TTL, key_maker=lambda func, args, kwargs: "repo")  # noqa: ARG005
+        async def load(self, key: str) -> str:
+            return key
+
+    assert Repo.load is not None
+
+
+def test_a_staticmethod_is_accepted() -> None:
+    """A `staticmethod` carries no instance, so nothing unstable reaches the key."""
+
+    class Repo:
+        @staticmethod
+        @cached(ttl=_TTL)
+        async def pure(key: str) -> str:
+            return key
+
+    assert Repo.pure is not None
+
+
+def test_a_classmethod_is_accepted() -> None:
+    """A `classmethod` receives a class, whose `repr()` is stable."""
+
+    class Repo:
+        @classmethod
+        @cached(ttl=_TTL)
+        async def make(cls, key: str) -> str:
+            return key
+
+    assert Repo.make is not None
+
+
+def test_a_function_nested_in_a_function_is_not_a_method() -> None:
+    """`<locals>` in the qualname means a closure, which keys on its own args."""
+
+    def outer() -> object:
+        @cached(ttl=_TTL)
+        async def inner(key: str) -> str:
+            return key
+
+        return inner
+
+    assert outer() is not None


### PR DESCRIPTION
Closes #600.

## What it does today

I ran it before choosing. `@cached` on a method is wrong in both directions, and silently:

```
same-repr instances share a key?
  a.load: b'db:x:1'
  b.load: b'db:x:1'    <- b never ran its own body
distinct-address instances:
  o1.load: b'opaque:x:2'
  o2.load: b'opaque:x:3'   <- separate entries, never shared
refresh on a bound method:
  TypeError: Repo.load() missing 1 required positional argument: 'key'
```

Two distinct `Repo("db")` instances returned each other's cached value, because the key is `repr()` of every argument and on a method that starts with `self`. A dataclass whose `repr()` matches is a **correctness** problem, not a hit-rate one. Meanwhile an object with the default `repr()` carries a memory address, so its key changes on every restart and the entry is never found again.

## The decision

Option 3 from the issue, narrowed. The library cannot know whether `self` is part of the cache identity, and guessing is what produces both failures above. So it asks:

```python
class Repo:
    @cached(cache, key="repo:{user_id}")
    async def load(self, user_id: int) -> dict: ...
```

Decorating a method without `key=` or `key_maker=` now raises `TypeError` at decoration time. Same principle as #599 and #605: make the wrong thing unexpressible, and fail at setup rather than silently at runtime.

I did not take option 2 (a bound-proxy `__get__` plus a `noself` flag). It would make `refresh` bind, but it does not answer the question that causes the bug, which is what identifies the entry. An explicit key answers it, and `Class.method.refresh(obj, ...)` was already the documented route.

## Self-review caught a false positive

My first cut keyed on `__qualname__` containing a class, which also refused things that carry no hazard at all:

```
staticmethod in a class body:  REFUSED (false positive)
classmethod:                   REFUSED
```

A `staticmethod` receives no instance, and a `classmethod` receives a class, whose `repr()` is stable. Neither drags an unstable `repr()` into the key. The guard now matches the actual cause, a first parameter named `self`, and both are accepted again. Tests cover both, since they are the cases I got wrong.

## Verified, not assumed

Every shape checked: method without key refused; method with `key=`, method with `key_maker=`, `staticmethod`, `classmethod`, plain function, and a closure nested in a function all accepted.

The docs show folding instance state into the key, and I ran that rather than writing it from memory:

```
eu:        b'eu:42:1'
us:        b'us:42:2'   <- different instances, different entries
eu again:  b'eu:42:1'   <- cached
refresh:   b'eu:42:3'   <- Repo.load.refresh(eu, 42)
```

Breaking, so it is a clean cut with no shim, per the pre-1.0 policy. Full pre-commit chain green.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b
