### PR TITLE
🔖 Prepare the 0.34.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,37 +1,31 @@
 # Changelog
 
-## Unreleased
+## 0.34.0 - 2026-08-02
 
 ### Breaking
 
 * 💥 Refuse `@cached` on a method unless it names its key. The default key is the `repr()` of every argument, and on a method that includes `self`, which was wrong in both directions: two instances whose `repr()` matched shared one entry, so a call on one returned the other's value, and an instance using the default `repr()` carried a memory address, so its key changed on every restart. Neither said anything. Decorating a method without `key=` or `key_maker=` now raises `TypeError` at decoration time. Pass a key naming what identifies the entry, such as `key="repo:{user_id}"`. ([#600](https://github.com/grelinfo/grelmicro/issues/600))
-
-### Docs
-
-* 📝 Name the hazard `env_load=False` guards against. Env reads fill every field the caller did not pass, so a config half taken from a `Settings` object silently gets the rest from the environment. A `Settings` default that differs from the environment is dropped without a word. ([#606](https://github.com/grelinfo/grelmicro/issues/606))
-* 📝 Treat outbox retention as a decision the caller makes. A payload sits in the database until its row is deleted, so a single-use secret is at rest for as long as the row lives. The default deletes a delivered row, which is the safe end, but a default is not a guarantee. Pin `keep_delivered` rather than inherit it, and note that dead rows are never purged automatically. ([#607](https://github.com/grelinfo/grelmicro/issues/607))
-* 📝 Say that a stored idempotent response sits at rest for `ttl`. The same audit: the middleware stores the whole response, so `ttl` is a retention window and not only a replay window. ([#607](https://github.com/grelinfo/grelmicro/issues/607))
-
-### Internal
-
-* 👷 Add `just` recipes for the release path. `just release-check <version>` runs what the Release workflow runs, before the tag exists, so a failure costs nothing rather than burning an immutable tag. `just verify-release <version>` downloads a published wheel and sdist and verifies build provenance for each, which turns the SLSA Build Level 2 badge into something anyone can check. `just release-notes <version>` prints the changelog section the GitHub Release body should hold. ([#584](https://github.com/grelinfo/grelmicro/issues/584))
-* ✅ Pin both sides of the span exception check, so the coverage gate stops failing at random. Only one side had a test of its own. The other was covered whenever some unrelated test happened to raise inside a non-recording span, which depends on the order `pytest-randomly` picks, so a run could report `_span.py` at 96% and fail `--fail-under=100` on a pull request that changed nothing near it.
 
 ### Fixed
 
 * 🐛 Keep the grelmicro request scope outside every other middleware. `IdempotencyMiddleware` had to be added before `micro.install(app)`, and the wrong order raised nothing at setup, so the first failure arrived in production from a client that actually sent `Idempotency-Key`. `install` now places the binding middleware outermost when the stack is built, so either order works, and reads the placement back on startup so a stack that still ends up wrong raises `AmbientBindingError` at boot. ([#599](https://github.com/grelinfo/grelmicro/issues/599))
 * 🐛 Start more than one worker against a fresh Postgres. `CREATE TABLE IF NOT EXISTS` checks and creates in two steps, so two workers starting together both passed the check and one crashed on the row type the table creates. Every Postgres adapter now installs its schema under an advisory lock, as the outbox already did. ([#595](https://github.com/grelinfo/grelmicro/issues/595))
 * 🐛 Give each worker of a pre-fork server its own coordination identity. `gunicorn --preload` builds the application once and forks, so every child inherited the identity generated in the parent. Two workers presented the same lock token, and every child read the leader record holder as itself, so all of them led at once. A child now appends its own random suffix. `uvicorn --workers N` spawns instead of forking and is unaffected. ([#595](https://github.com/grelinfo/grelmicro/issues/595))
-* 🐛 Report a task fire that never ran. `grelmicro.task.runs` only counted fires that reached the body, so a schedule backend or a lock that stopped answering left no metric at all and looked exactly like a task with nothing due. A fire now always lands on the counter: `coordination_error` when coordination failed, `missed` when no worker ran it, and `skipped` when a peer handled it. The bare total counts more than it did, so read the [migration note](migration.md#0-33-1-task-run-outcomes) if a chart treats it as the run rate. ([#605](https://github.com/grelinfo/grelmicro/issues/605))
+* 🐛 Report a task fire that never ran. `grelmicro.task.runs` only counted fires that reached the body, so a schedule backend or a lock that stopped answering left no metric at all and looked exactly like a task with nothing due. A fire now always lands on the counter: `coordination_error` when coordination failed, `missed` when no worker ran it, and `skipped` when a peer handled it. The bare total counts more than it did, so read the [migration note](migration.md#0-34-task-run-outcomes) if a chart treats it as the run rate. ([#605](https://github.com/grelinfo/grelmicro/issues/605))
 * 🐛 Warn when a cron fire is dropped for coming back too late. Past `misfire_grace_seconds` the fire was skipped with no log and no metric, so a task that never replayed said nothing at all. ([#605](https://github.com/grelinfo/grelmicro/issues/605))
 * 🐛 Record a fire that never reached the body on `last_fire`. An introspection endpoint reading it during a coordination outage reported the previous successful fire and looked healthy. ([#605](https://github.com/grelinfo/grelmicro/issues/605))
 
 ### Internal
 
+* 👷 Add `just` recipes for the release path. `just release-check <version>` runs what the Release workflow runs, before the tag exists, so a failure costs nothing rather than burning an immutable tag. `just verify-release <version>` downloads a published wheel and sdist and verifies build provenance for each, which turns the SLSA Build Level 2 badge into something anyone can check. `just release-notes <version>` prints the changelog section the GitHub Release body should hold. ([#584](https://github.com/grelinfo/grelmicro/issues/584))
+* ✅ Pin both sides of the span exception check, so the coverage gate stops failing at random. Only one side had a test of its own. The other was covered whenever some unrelated test happened to raise inside a non-recording span, which depends on the order `pytest-randomly` picks, so a run could report `_span.py` at 96% and fail `--fail-under=100` on a pull request that changed nothing near it.
 * 🧪 Verify the Patterns across real process boundaries. A new multiprocess tier races worker processes against Redis, so cross-process exclusion, single leadership, and the per-worker memory adapters are asserted rather than read off the code. The demo smoke stack now runs two uvicorn workers and checks the rate limit holds across both. ([#595](https://github.com/grelinfo/grelmicro/issues/595))
 
 ### Docs
 
+* 📝 Name the hazard `env_load=False` guards against. Env reads fill every field the caller did not pass, so a config half taken from a `Settings` object silently gets the rest from the environment. A `Settings` default that differs from the environment is dropped without a word. ([#606](https://github.com/grelinfo/grelmicro/issues/606))
+* 📝 Treat outbox retention as a decision the caller makes. A payload sits in the database until its row is deleted, so a single-use secret is at rest for as long as the row lives. The default deletes a delivered row, which is the safe end, but a default is not a guarantee. Pin `keep_delivered` rather than inherit it, and note that dead rows are never purged automatically. ([#607](https://github.com/grelinfo/grelmicro/issues/607))
+* 📝 Say that a stored idempotent response sits at rest for `ttl`. The same audit: the middleware stores the whole response, so `ttl` is a retention window and not only a replay window. ([#607](https://github.com/grelinfo/grelmicro/issues/607))
 * 📝 Correct the pre-fork guidance for coordination. It told the reader to pass an explicit `worker` identity, which every child inherits just the same, so the advice turned a likely collision into a certain one. ([#595](https://github.com/grelinfo/grelmicro/issues/595))
 * 📝 Say that `Bulkhead.max_concurrent` and `Shield.max_rate` are per worker process. Both read as a deployment-wide ceiling, so four workers quietly gave the dependency four times the configured number. ([#595](https://github.com/grelinfo/grelmicro/issues/595))
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,10 +9,9 @@ sections in the [changelog](changelog.md), newest first.
 
 In `0.x` the minor is the breaking position: a `0.x.0` release may change the
 public API, and a `0.x.y` release is a safe patch. So an upgrade within one
-minor rarely needs this page. Two patches are exceptions, and neither changes
-an API: [0.32.2](#0-32-2-circuit-breaker-state) changes what an already-open
-circuit does once, and [0.33.1](#0-33-1-task-run-outcomes) changes what a task
-metric counts.
+minor rarely needs this page. One patch is an exception, and it changes no
+API: [0.32.2](#0-32-2-circuit-breaker-state) changes what an already-open
+circuit does once.
 
 ## Find your symptom
 
@@ -24,7 +23,49 @@ metric counts.
 | `TypeError` on a SQLite adapter, either `unexpected keyword argument 'path'` or `takes 1 positional argument` | 0.32 | [Pass `provider=`](#0-32-sqlite-provider) |
 | `SettingsValidationError` where you caught `CoordinationSettingsValidationError` | 0.32 | [Catch the base error](#0-32-sqlite-provider) |
 | An open circuit closed once, just after upgrading | 0.32.2 | [Expected, happens once](#0-32-2-circuit-breaker-state) |
-| Task run totals jumped after upgrading, with no new failures | 0.33.1 | [Filter on `outcome`](#0-33-1-task-run-outcomes) |
+| `TypeError: @cached on ... needs an explicit key=` | 0.34 | [Name the key](#0-34-cached-method-key) |
+| Task run totals jumped after upgrading, with no new failures | 0.34 | [Filter on `outcome`](#0-34-task-run-outcomes) |
+
+## 0.34
+
+### `@cached` on a method needs an explicit key {#0-34-cached-method-key}
+
+Decorating a method without `key=` or `key_maker=` now raises `TypeError` at
+decoration time, so the failure lands at import rather than on a request.
+
+The default key is the `repr()` of every argument, and on a method the first
+one is `self`. That read two ways, both wrong. Two instances whose `repr()`
+matched shared one entry, so a call on one returned the other's value. An
+instance using the default `repr()` carried a memory address, so its key
+changed on every restart and the entry was never found again.
+
+Name what identifies the entry and leave `self` out:
+
+```python
+# Before
+class Repo:
+    @cached(cache)
+    async def load(self, user_id: int) -> dict: ...
+
+
+# After
+class Repo:
+    @cached(cache, key="repo:{user_id}")
+    async def load(self, user_id: int) -> dict: ...
+```
+
+When the result does depend on instance state, fold that state into the key:
+
+```python
+@cached(cache, key="repo:{self.region}:{user_id}")
+async def load(self, user_id: int) -> dict: ...
+```
+
+A `staticmethod` and a `classmethod` are untouched. Neither receives an
+instance, so their default key was already sound.
+
+Entries written before the upgrade are not reachable under the new key, so
+expect one cold period for the functions you change.
 
 ## 0.32
 
@@ -120,7 +161,7 @@ async with idem(key) as op:
 It is valid **only** on a replay. Calling it on a first execution raises
 `IdempotencyStateError`, so keep it behind `if op.replayed:`.
 
-## 0.33.1, not breaking but worth knowing {#0-33-1-task-run-outcomes}
+## 0.34, not breaking but worth knowing {#0-34-task-run-outcomes}
 
 `grelmicro.task.runs` now counts every fire, not only the fires that ran
 the body. A fire a peer took counts as `skipped`, a fire dropped past its


### PR DESCRIPTION
Prepares **0.34.0**, covering everything merged since `0.33.0` (eight pull requests, #619 through #626).

## Why a minor, not a patch

`0.x.0` is the breaking position, and this release has a breaking change: `@cached` now refuses a method that does not name its key. A patch would misreport that.

The public API snapshot is unchanged, because the break is behavioural rather than a signature change. That is exactly the case the snapshot test cannot catch, so the `Breaking` entry and the migration note carry it instead.

## What changed in this PR

**The changelog heading**, `## Unreleased` to `## 0.34.0 - 2026-08-02`.

**Consolidated duplicate sections.** The merges had left two `### Internal` blocks and two `### Docs` blocks, because each pull request appended its own. Now one of each, in the order the previous releases use. All 15 bullets are accounted for, checked by count rather than by eye.

**Renumbered the migration note that never shipped.** The task-run-outcomes note was written for a `0.33.1` that was never released, and the changelog linked `#0-33-1-task-run-outcomes`. Both now say `0.34`, along with the symptom-table row and the intro sentence that called it one of "two patches" that are exceptions. Only `0.32.2` is still such an exception.

**Added the migration note for the break**, which the contributing guide requires for every entry under `Breaking`. It names the symptom, shows before and after, covers the instance-state case, and says that `staticmethod` and `classmethod` are untouched. It also warns that existing entries are unreachable under the new key, so expect one cold period.

## The release itself

| | |
|---|---|
| Breaking | 1 |
| Fixed | 6 |
| Internal | 3 |
| Docs | 5 |

Three of the fixes were defects nobody had reported. Two workers could not start against a fresh Postgres, four forked workers all believed they were the leader, and the coverage gate could fail any pull request at random. The first two were found by the multiprocess tier added in #621, which is the thing that tier exists to do.

## Before tagging

`just release-check 0.34.0` refuses unless `HEAD` is `origin/main`, so it belongs after this merges rather than on this branch. Run it on `main` before cutting the tag. It runs the full tier including the `slow` marker, builds the docs strict, smoke-tests the two-worker demo, and re-checks that the changelog section carries today's date.

Not tagging anything here. Stopping at prepared, as usual.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b
