### PR TITLE
✅ Stop the release matrix failing on tests racing their own lease

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+* ✅ Stop the release matrix failing on tests that were racing their own lease. Two runs of the 0.34.0 release failed on Python 3.14, each on a different test. A leader election test tripped a 5s per-test timeout, and a lock test asserting `extend()` keeps its fencing token got a fresh one instead, because the 10 ms lease had already lapsed and `extend` re-acquired. Neither was a product bug: 3.14 runs the modules about twice as slow as 3.12, on a runner already oversubscribed by `-n auto`. The affected tests now use the generous-lease fixture the file already had for this, and the timeout that only guards against hangs is generous enough to survive the matrix.
+
 ## 0.34.0 - 2026-08-02
 
 ### Breaking

--- a/tests/coordination/test_leaderelection.py
+++ b/tests/coordination/test_leaderelection.py
@@ -27,9 +27,13 @@ BACKEND_LOCK_NAME = f"leader:{LEADER_NAME}"
 WORKERS = 4
 WORKER_1 = 0
 WORKER_2 = 1
-# 5s, not 1s: under CPU-oversubscribed parallel CI a correct test can still be
-# starved well past a 1s budget. The timeout only guards against genuine hangs.
-TEST_TIMEOUT = 5
+# 15s, not 1s: under CPU-oversubscribed parallel CI a correct test can still be
+# starved well past a short budget. The timeout only guards against genuine
+# hangs, and a hang never finishes, so a generous budget costs nothing.
+# 5s was still too tight. `test_leader_reconfigure_takes_effect_on_next_iteration`
+# tripped it on Python 3.14 in the release matrix, where the whole module runs
+# about twice as slow as on 3.12 and the runner is oversubscribed by `-n auto`.
+TEST_TIMEOUT = 15
 # Lease and renew deadline are sized for CPU-oversubscribed CI. `is_leader()`
 # lapses once `monotonic() - last_confirmation >= renew_deadline`, and the OS can
 # preempt the whole process (so the renew loop cannot refresh) between a

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -70,19 +70,21 @@ async def lock(locks: list[Lock]) -> Lock:
 
 
 # A lease long enough that it never expires mid-test, even under heavy
-# parallel load. Two shapes need it. A `from_thread` call is a thread<->loop
+# parallel load. Three shapes need it. A `from_thread` call is a thread<->loop
 # round-trip, and the shared session loop can be starved by parallel
 # neighbors. A contention test needs the first worker to still hold the lock
-# when the second one tries. Either way the default 10 ms lease would lapse
-# mid-sequence and flake. The 5 s module timeout still catches a genuine hang.
-# Tests that assert lease *expiry* keep the short-lease `lock`/`locks`
-# fixtures.
+# when the second one tries. A test that asserts a lease was *renewed* needs
+# that lease still held when it renews, or `extend` re-acquires and mints a
+# fresh fencing token. Either way the default 10 ms lease would lapse
+# mid-sequence and flake, which is what tripped the release matrix on Python
+# 3.14. The module timeout still catches a genuine hang. Tests that assert
+# lease *expiry* keep the short-lease `lock`/`locks` fixtures.
 LONG_LEASE_DURATION = 30.0
 
 
 @pytest.fixture
-async def thread_locks(backend: LockBackend) -> list[Lock]:
-    """Locks whose lease outlives thread<->loop round-trip jitter."""
+async def long_lease_locks(backend: LockBackend) -> list[Lock]:
+    """Locks whose lease never lapses mid-test, whatever the load."""
     return [
         Lock(
             backend=backend,
@@ -96,9 +98,15 @@ async def thread_locks(backend: LockBackend) -> list[Lock]:
 
 
 @pytest.fixture
-async def thread_lock(thread_locks: list[Lock]) -> Lock:
+async def held_lock(long_lease_locks: list[Lock]) -> Lock:
+    """Lock whose lease is still held when the test asserts about it."""
+    return long_lease_locks[WORKER_1]
+
+
+@pytest.fixture
+async def thread_lock(long_lease_locks: list[Lock]) -> Lock:
     """Single generous-lease lock for from-thread tests."""
-    return thread_locks[WORKER_1]
+    return long_lease_locks[WORKER_1]
 
 
 @pytest.fixture
@@ -146,8 +154,10 @@ async def test_lock_key_prefix(backend: LockBackend, lock: Lock) -> None:
     assert await backend.locked(name=LOCK_NAME) is False
 
 
-async def test_lock_owned(locks: list[Lock]) -> None:
+async def test_lock_owned(long_lease_locks: list[Lock]) -> None:
     """Test Lock owned."""
+    # Arrange
+    locks = long_lease_locks
     # Act
     worker_1_owned_before = await locks[WORKER_1].owned()
     worker_2_owned_before = await locks[WORKER_2].owned()
@@ -162,9 +172,9 @@ async def test_lock_owned(locks: list[Lock]) -> None:
     assert worker_2_owned_after is False
 
 
-async def test_lock_from_thread_owned(thread_locks: list[Lock]) -> None:
+async def test_lock_from_thread_owned(long_lease_locks: list[Lock]) -> None:
     """Test Lock from thread owned."""
-    locks = thread_locks
+    locks = long_lease_locks
     # Arrange
     worker_1_owned_before = None
     worker_2_owned_before = None
@@ -443,10 +453,10 @@ async def test_lock_acquire_nowait_would_block(
 
 
 async def test_lock_from_thread_acquire_nowait_would_block(
-    thread_locks: list[Lock],
+    long_lease_locks: list[Lock],
 ) -> None:
     """Test Lock from thread wait acquire would block."""
-    locks = thread_locks
+    locks = long_lease_locks
     # Arrange
     await locks[WORKER_1].acquire()
 
@@ -1079,11 +1089,13 @@ async def test_lock_acquire_timeout_none_waits_forever(
 # --- extend ---
 
 
-async def test_lock_extend_renews_same_fencing_token(lock: Lock) -> None:
+async def test_lock_extend_renews_same_fencing_token(
+    held_lock: Lock,
+) -> None:
     """`extend()` renews the lease and returns the same fencing token."""
-    first = await lock.acquire()
+    first = await held_lock.acquire()
 
-    extended = await lock.extend()
+    extended = await held_lock.extend()
 
     assert extended.name == LOCK_NAME
     assert extended.fencing_token == first.fencing_token


### PR DESCRIPTION
The 0.34.0 release failed twice on the Python 3.14 matrix, each time on a different test. Neither is a product bug. Both are tests racing their own lease.

## What failed

**Run 1** — `test_leader_reconfigure_takes_effect_on_next_iteration`, `Timeout (>5.0s)`.

**Run 2** — `test_lock_extend_renews_same_fencing_token`, `assert 2 == 1`. That one looked alarming, since a fencing token changing on `extend()` would be a real coordination bug. It is not. The default `locks` fixture uses `lease_duration=0.01`, so when the runner starves the process for more than 10 ms between `acquire()` and `extend()`, the lease has already lapsed and `extend` re-acquires, minting a fresh token. The test was asserting a renewal that never happened.

Both passed locally on 3.14, repeatedly. What CI adds is oversubscription: `-n auto` spawns a worker per core on a runner that has few, and 3.14 runs these modules about twice as slow as 3.12 (measured: the leader election module takes 1.7s on 3.12 and 3.6s on 3.14).

## The fix

`test_lock.py` already had `LONG_LEASE_DURATION = 30.0` and a comment naming the two shapes that need it. This adds the third, which is the one that just bit: a test asserting a lease was *renewed* needs that lease still held when it renews.

- The list fixture is renamed `thread_locks` to `long_lease_locks`, because it is no longer only for from-thread tests. `thread_lock` keeps its name, since those tests genuinely are about threads.
- `test_lock_extend_renews_same_fencing_token` moves to a `held_lock` fixture.
- `test_lock_owned` moves too. It has the same shape, acquire then assert still owned, and its from-thread sibling was already on the generous lease. It had not failed yet, but it would.
- The leader election module timeout goes from 5s to 15s. That timeout exists only to catch a genuine hang, and a hang never finishes, so a generous budget costs nothing while a tight one fails correct tests.

Tests that assert lease *expiry* keep the short-lease fixtures, which is the distinction the file already drew.

## Verified

Both modules green on 3.12 and on 3.14, and the full unit suite green on 3.14 twice over (3704 passed). Full pre-commit chain green.

## Release status

Nothing was published. `publish-pypi` was skipped both times, so 0.34.0 never reached PyPI. The tag exists and points at a commit without this fix, so the next release will be 0.34.1 rather than a retry of 0.34.0.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b
