### PR TITLE
🔖 Prepare the 0.34.1 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,12 +1,16 @@
 # Changelog
 
-## Unreleased
+## 0.34.1 - 2026-08-02
 
 ### Internal
 
 * ✅ Stop the release matrix failing on tests that were racing their own lease. Two runs of the 0.34.0 release failed on Python 3.14, each on a different test. A leader election test tripped a 5s per-test timeout, and a lock test asserting `extend()` keeps its fencing token got a fresh one instead, because the 10 ms lease had already lapsed and `extend` re-acquired. Neither was a product bug: 3.14 runs the modules about twice as slow as 3.12, on a runner already oversubscribed by `-n auto`. The affected tests now use the generous-lease fixture the file already had for this, and the timeout that only guards against hangs is generous enough to survive the matrix.
 
 ## 0.34.0 - 2026-08-02
+
+Tagged but never published. The release run failed on the Python 3.14 matrix
+before the publish step, so this version does not exist on PyPI. Everything
+below ships in 0.34.1.
 
 ### Breaking
 


### PR DESCRIPTION
0.34.0 was tagged but never published: the release run failed on the Python 3.14 matrix before `publish-pypi`, which was skipped. The tag points at a commit without the test fix from #628, so a retry of that tag fails the same way. This prepares 0.34.1 instead, following the convention that a failed version is burned.

## Changes

- `## Unreleased` becomes `## 0.34.1 - 2026-08-02`, carrying the test-lease fix from #628.
- The 0.34.0 section gains a line saying it was tagged but never published, and that everything under it ships in 0.34.1. Without that, a reader who finds 0.34.0 in the changelog and then cannot install it from PyPI has no explanation.

Everything from 0.34.0 ships here, so an upgrade from 0.33.0 crosses both sections, breaking change and migration note included.

Full pre-commit chain green. `just release-check 0.34.1` runs on `main` after this merges, before the tag.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b