### PR TITLE
📝 Record the launch release as published and verified

### DIFF
--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -6,7 +6,7 @@ Maintainer planning doc (not published to the docs site). Tracks the launch task
 
 The launch ships on the current `0.x` line. It is not gated on a 1.0 bump.
 
-- [ ] Tag and publish the launch release on PyPI. Confirm `pip install grelmicro` resolves it.
+- [x] Tag and publish the launch release on PyPI. Confirm `pip install grelmicro` resolves it. Verified 2026-08-02: 0.34.1 is published, `pip install grelmicro` resolves it in a clean environment, and `just verify-release 0.34.1` confirms build provenance on both the wheel and the sdist. 0.34.0 was tagged the same day but never reached PyPI, because its release run failed on the Python 3.14 matrix before the publish step.
 - [ ] `docs/benchmarks.md` numbers re-run on a clean machine and dated. Most rows date from 2026-06-14 and the circuit breaker rows from 2026-07-29 (Apple Silicon, macOS, CPython 3.12). Both runs shared the machine with other work, so neither meets the clean-machine bar.
 - [x] The [FastAPI demo](examples/fastapi-demo) starts from a fresh clone in three commands. Verified 2026-07-28: `cd examples/fastapi-demo`, `docker compose up --wait`, `open http://localhost:8000/docs`.
 - [x] Record the demo asset (see below) and embed it in the README. `docs/img/demo.gif`, 840K, embedded at the top of `README.md`.


### PR DESCRIPTION
Ticks the first pre-launch item in `LAUNCH_CHECKLIST.md`.

The item asks for two things, and both are done rather than assumed:

- **Published.** 0.34.1 is on PyPI. `just verify-release 0.34.1` downloads the wheel and the sdist and confirms build provenance on each.
- **`pip install grelmicro` resolves it.** Checked literally, with pip in a clean virtualenv rather than with uv's resolver, since that is what the line says. It resolves 0.34.1.

The note also records that 0.34.0 was tagged the same day but never reached PyPI, because its release run failed on the Python 3.14 matrix before the publish step. Anyone reading the tag list later will wonder, and the answer belongs next to the claim.

No changelog entry: the checklist is internal launch tracking, not part of the documentation site, and an entry would tell a user nothing.

## Still open on this checklist

The benchmark re-run is the last unchecked pre-launch item, and **I did not do it**. The line asks for a clean machine, and this one is not: two Docker containers running and a load average of 3.71 across 12 cores, much of it from this session's test tiers. Numbers measured here would fail the same bar the line already records the previous two runs failing, and dated figures that look authoritative but are not are worse than leaving the box unticked.

It wants an otherwise idle machine, the four scripts under `benchmarks/`, and the results table in `docs/benchmarks.md` updated with the new date and hardware.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b