### PR TITLE
📝 Warn that a mounted sub-application does not fail loudly

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Docs
+
+* 📝 Warn that a mounted sub-application does not fail loudly. A mount is an ordinary call in the same task, so the host's request scope is still bound inside it. A sub-application that forgot `install` therefore resolves against the host's components rather than raising, and two applications that look isolated share one store with nothing reporting it. `check_ambient_binding` catches it, per app.
+
 ### Internal
 
 * 👷 Run the Python matrix in the release preflight. `just release-check` tested only the primary Python, so 0.34.0 passed every check it ran and still failed its release on 3.14, which burned the version. The new `just test-matrix` runs the unit and integration tiers on every other Python in the matrix, and reads that list out of the workflow so the preflight cannot drift away from what CI runs.

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -78,6 +78,36 @@ micro.install(app, ambient=False)
         assert micro.check_ambient_binding(app)
     ```
 
+!!! danger "A mounted sub-application does not fail loudly"
+    Install every app that owns components, mounted ones included. A mount is
+    an ordinary call in the same task, so the host's request scope is still
+    bound inside the sub-application. A sub-application that forgot `install`
+    therefore resolves against the **host's** components instead of raising:
+
+    ```python
+    host_micro = Grelmicro(uses=[Cache(host_backend)])
+    sub_micro = Grelmicro(uses=[Cache(sub_backend)])
+
+    host = FastAPI()
+    host_micro.install(host)
+
+    sub = FastAPI()  # install(sub) forgotten
+    host.mount("/sub", sub)
+    ```
+
+    A write from `sub` lands in `host_backend`. `sub_backend` stays empty, and
+    nothing reports it. Two applications that look isolated share one store.
+
+    This is the one case where a forgotten `install` does not raise
+    `OutOfContextError`, because a binding is present, just the wrong one.
+    Assert each app separately:
+
+    ```python
+    def test_every_app_is_wired() -> None:
+        assert host_micro.check_ambient_binding(host)
+        assert sub_micro.check_ambient_binding(sub)  # False when install is missing
+    ```
+
 ## FastStream
 
 The same call wires a FastStream app:

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -288,6 +288,29 @@ def test_check_ambient_binding_false_without_middleware() -> None:
     assert micro.check_ambient_binding(app) is False
 
 
+def test_check_ambient_binding_catches_an_uninstalled_mounted_app() -> None:
+    """A mounted sub-app that forgot `install` is caught by the check.
+
+    The mount is the one place a forgotten `install` does not raise on the
+    first request. The host's request scope is still bound inside the
+    sub-application, so it resolves against the host's components instead of
+    its own, silently. The check is what turns that back into a signal.
+    """
+    host_micro = Grelmicro(
+        uses=[RateLimiterRegistry(MemoryRateLimiterAdapter())]
+    )
+    sub_micro = Grelmicro(
+        uses=[RateLimiterRegistry(MemoryRateLimiterAdapter())]
+    )
+    host = FastAPI()
+    host_micro.install(host)
+    sub = FastAPI()  # install(sub) deliberately forgotten
+    host.mount("/sub", sub)
+
+    assert host_micro.check_ambient_binding(host) is True
+    assert sub_micro.check_ambient_binding(sub) is False
+
+
 def test_check_ambient_binding_true_without_ambient_components() -> None:
     """Nothing needs binding, so the check passes regardless of middleware."""
     micro = Grelmicro()


### PR DESCRIPTION
Found while verifying #595 and never written down. This is the one place a forgotten `install` does not raise.

## The behaviour

A mount is an ordinary awaited call in the same task, so the host's request scope is still bound inside the sub-application. A sub-application that forgot `install` therefore resolves against the **host's** components rather than raising `OutOfContextError`.

Measured, not reasoned about. Host and sub each own a `Grelmicro` with its own cache backend, `install(sub)` omitted, then a write through the sub-app:

```
sub /write   : {'ok': True}
host /read   : {'value': "b'written-by-sub'"}

Where did the sub-app's write actually land?
  sub backend  : None
```

The sub-app's write is in the host's cache. Its own backend is empty. Two applications that look isolated share one store, and nothing says so.

Everywhere else a missing `install` fails on the first ambient call. Here a binding is present, just the wrong one, so the usual signal never fires.

## What changed

Documentation only, plus a test.

`docs/wiring.md` gains a danger callout next to the existing "always call install" warning, with the worked example and the remedy. `check_ambient_binding` already catches this, it just was not pointed at mounted apps:

```python
assert host_micro.check_ambient_binding(host)   # True
assert sub_micro.check_ambient_binding(sub)     # False when install is missing
```

The test pins that, so the remedy the docs recommend is verified rather than asserted.

## What I did not do

No behaviour change. Making a mount reset the binding, or scoping ambient resolution to the nearest enclosing app, is a real change to `Grelmicro.current()` semantics and wants deciding on its own merits rather than being folded into a docs fix.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b