### PR TITLE
📝 Say which middleware a scope-reading key_maker depends on

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Docs
 
+* 📝 Say that a `key_maker` reading the scope needs its source middleware outside `IdempotencyMiddleware`. `ClientAddressMiddleware` added the wrong way round leaves `client_address` unset when the key is built, so the key folds in `None`, every caller shares one entry, and the request still answers `200`. A key that looks like it separates callers and does not is worse than no `key_maker` at all.
 * 📝 Warn that a mounted sub-application does not fail loudly. A mount is an ordinary call in the same task, so the host's request scope is still bound inside it. A sub-application that forgot `install` therefore resolves against the host's components rather than raising, and two applications that look isolated share one store with nothing reporting it. `check_ambient_binding` catches it, per app.
 
 ### Internal

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -168,6 +168,16 @@ The stored key combines the method, the path, the query string, and the header v
 
     Read the identity from wherever your authentication puts it. `scope["user"]` works only when an authentication middleware runs outside this one.
 
+    Anything else the key reads out of the scope has the same requirement, including `ClientAddressMiddleware`. Add it **after** `IdempotencyMiddleware`, so it ends up outside and has resolved the address before the key is built:
+
+    ```python
+    micro.install(app)
+    app.add_middleware(IdempotencyMiddleware, idempotency=idem, key_maker=by_caller)
+    app.add_middleware(ClientAddressMiddleware, trusted=TrustedProxies([...]))
+    ```
+
+    Get that backwards and `scope["state"]["client_address"]` is not set yet. The key folds in `None` for every caller, they all share one entry, and the request still answers `200`. A key that looks like it separates callers and does not is worse than no `key_maker` at all.
+
 `key_maker` receives the ASGI scope and the client's key, and returns the whole stored key. It mirrors [`key_maker` on `@cached`](cache.md#custom-keys).
 
 ### Duplicates in flight


### PR DESCRIPTION
The last of the ordering findings from #620, and the one with teeth.

#620 made the grelmicro request scope outermost, so a middleware resolving a backend can no longer be ordered wrongly. It said nothing about grelmicro middleware ordering *relative to each other*, and there is one pairing where that matters today.

## The hazard

A multi-tenant `key_maker` folding in the resolved caller depends on `ClientAddressMiddleware` having already run. Added the wrong way round, it has not:

```
stack: ['GrelmicroMiddleware', 'IdempotencyMiddleware', 'ClientAddressMiddleware']
address seen by key_maker: [None]
```

Every caller then keys under `None`, so they all share one entry. The request answers `200`. Nothing logs.

That is precisely the state the existing multi-tenant warning exists to prevent, reached by a `key_maker` that looks like it separates callers. A key that appears to isolate and does not is worse than no `key_maker` at all, because it reads as handled.

Correct order verified in the same way:

```
stack: ['GrelmicroMiddleware', 'ClientAddressMiddleware', 'IdempotencyMiddleware']
```

## What changed

Documentation only. The warning already covered this for `scope["user"]` and authentication middleware. It now generalises to anything the key reads out of the scope, and names `ClientAddressMiddleware` explicitly, since that is the one grelmicro ships and the natural pairing.

## What I did not do

No ordering enforcement. Extending the #620 hoist to a total order over grelmicro middleware would need a declared dependency between them, and this is the only pair that has one today. Worth doing when a second appears, not before.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b