### PR TITLE
🔒 Refuse an idempotency key that cannot separate callers

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Security
+
+* 🔒 Refuse an idempotency key that cannot separate one caller from another. A `key_maker` reading a value that was not set yet folded `None` into the key, so every caller shared one entry and could replay each other's stored response, while the request still answered `200`. A key that is partly missing does not fail, it merges, and the widening was invisible. `IdempotencyMiddleware` now raises `IdempotencyKeyMakerError` when the key is empty, drops the client's key, or carries an unresolved `None`.
+* 🔒 Stop the multi-tenant `key_maker` example reading an unauthenticated header. It took the tenant from `X-Tenant`, which the client sets, so a caller could name the tenant whose entry they read. It now folds in an authenticated identity, uses a separator an identity cannot contain, and raises rather than building a partial key. The docs also say plainly that a client address is not a tenant identity, because carrier-grade NAT puts many subscribers behind one.
+
 ### Docs
 
 * 📝 Say that a `key_maker` reading the scope needs its source middleware outside `IdempotencyMiddleware`. `ClientAddressMiddleware` added the wrong way round leaves `client_address` unset when the key is built, so the key folds in `None`, every caller shares one entry, and the request still answers `200`. A key that looks like it separates callers and does not is worse than no `key_maker` at all.

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -153,10 +153,17 @@ The stored key combines the method, the path, the query string, and the header v
 !!! warning "Set `key_maker` in a multi-tenant app"
     Without it, any client that learns another client's key replays their response, body included. Fold the caller identity into the key.
 
+    Fold in an **authenticated** identity. Anything the client sends is chosen by the client, so a key built from a raw header lets a caller name the tenant whose entry they read.
+
     ```python
+    SEP = "\x1f"  # not a byte an identity can contain
+
+
     def tenant_key(scope, key):
-        tenant = dict(scope["headers"])[b"x-tenant"].decode()
-        return f"{tenant}|{scope['path']}|{key}"
+        user = scope.get("user")
+        if user is None or not user.is_authenticated:
+            raise PermissionError("idempotency needs an authenticated caller")
+        return SEP.join((str(user.tenant_id), scope["path"], key))
 
 
     app.add_middleware(
@@ -166,17 +173,22 @@ The stored key combines the method, the path, the query string, and the header v
     )
     ```
 
-    Read the identity from wherever your authentication puts it. `scope["user"]` works only when an authentication middleware runs outside this one.
+    Three things carry the isolation here. The identity comes from authentication rather than from the request. The separator is one an identity cannot contain, so `a` plus `b|c` cannot collide with `a|b` plus `c`. And a missing identity raises instead of returning a partial key.
 
-    Anything else the key reads out of the scope has the same requirement, including `ClientAddressMiddleware`. Add it **after** `IdempotencyMiddleware`, so it ends up outside and has resolved the address before the key is built:
+    That last one is the general rule: **a key that is partly missing does not fail, it merges.** Callers whose key lost the same component land in one entry and replay each other, while the request still answers normally.
+
+    `scope["user"]` is set by an authentication middleware, and reading it requires that middleware to run **outside** this one, which means adding it **after**. The same applies to anything else the key reads from the scope, including `ClientAddressMiddleware`:
 
     ```python
     micro.install(app)
-    app.add_middleware(IdempotencyMiddleware, idempotency=idem, key_maker=by_caller)
-    app.add_middleware(ClientAddressMiddleware, trusted=TrustedProxies([...]))
+    app.add_middleware(IdempotencyMiddleware, idempotency=idem, key_maker=tenant_key)
+    app.add_middleware(AuthenticationMiddleware, backend=...)
     ```
 
-    Get that backwards and `scope["state"]["client_address"]` is not set yet. The key folds in `None` for every caller, they all share one entry, and the request still answers `200`. A key that looks like it separates callers and does not is worse than no `key_maker` at all.
+    Get that backwards and the value is not set yet. `IdempotencyMiddleware` refuses a key carrying an unresolved `None` rather than storing under it, so the mistake surfaces on the first request instead of quietly merging callers.
+
+!!! warning "A client address is not a tenant identity"
+    `ClientAddressMiddleware` resolves who connected, not who they are. Carrier-grade NAT puts many subscribers behind one address, so they would share an idempotency entry, and a caller moving between networks changes address mid-retry and loses the replay. Use it to rate limit, not to separate tenants.
 
 `key_maker` receives the ASGI scope and the client's key, and returns the whole stored key. It mirrors [`key_maker` on `@cached`](cache.md#custom-keys).
 

--- a/grelmicro/idempotency/__init__.py
+++ b/grelmicro/idempotency/__init__.py
@@ -17,6 +17,7 @@ from grelmicro.idempotency.config import IdempotencyConfig
 from grelmicro.idempotency.errors import (
     IdempotencyConflictError,
     IdempotencyError,
+    IdempotencyKeyMakerError,
     IdempotencySettingsValidationError,
     IdempotencyStateError,
     IdempotencyWaitTimeoutError,
@@ -27,6 +28,7 @@ __all__ = [
     "IdempotencyConfig",
     "IdempotencyConflictError",
     "IdempotencyError",
+    "IdempotencyKeyMakerError",
     "IdempotencySettingsValidationError",
     "IdempotencyStateError",
     "IdempotencyWaitTimeoutError",

--- a/grelmicro/idempotency/errors.py
+++ b/grelmicro/idempotency/errors.py
@@ -13,6 +13,16 @@ class IdempotencySettingsValidationError(
     """Idempotency Settings Validation Error."""
 
 
+class IdempotencyKeyMakerError(IdempotencyError, ValueError):
+    """Raised when a `key_maker` returns a key that cannot separate callers.
+
+    A key that is partly missing does not fail, it merges. Callers whose key
+    lost the same component share one entry and can replay each other's
+    response, while the request still answers normally. The middleware
+    refuses the key instead of widening the boundary silently.
+    """
+
+
 class IdempotencyStateError(IdempotencyError, RuntimeError):
     """Raised when an `Operation` value is read in the wrong state.
 

--- a/grelmicro/integrations/fastapi.py
+++ b/grelmicro/integrations/fastapi.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import logging
+import re
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Annotated, Any, TypedDict, cast
 
@@ -15,6 +16,7 @@ from grelmicro.health._checks import HealthChecks
 from grelmicro.health._models import HealthStatus
 from grelmicro.idempotency.errors import (
     IdempotencyConflictError,
+    IdempotencyKeyMakerError,
     IdempotencyWaitTimeoutError,
 )
 
@@ -585,7 +587,7 @@ class IdempotencyMiddleware:
     def _storage_key(self, scope: "Scope", key: str) -> str:
         """Build the stored key, scoped by route unless `key_maker` says otherwise."""
         if self._key_maker is not None:
-            return self._key_maker(scope, key)
+            return _checked_key(self._key_maker(scope, key), key)
         parts = [scope["method"], scope["path"]]
         query = scope.get("query_string", b"")
         if query:
@@ -774,6 +776,44 @@ def _merge_response(
     current = existing.get("description", "")
     if description not in current:
         existing["description"] = f"{current}\n\n{description}".strip()
+
+
+_UNRESOLVED_TOKEN = re.compile(r"(?:^|[^0-9A-Za-z_])None(?:$|[^0-9A-Za-z_])")
+"""A formatted `None` sitting on its own between separators in a key."""
+
+
+def _checked_key(built: object, client_key: str) -> str:
+    """Return `built`, or raise when it cannot separate one caller from another.
+
+    A key that is partly missing does not fail, it merges. Every caller whose
+    key lost the same component lands in one entry, and the request still
+    answers normally, so the widening is invisible. That is a confidentiality
+    boundary quietly removed, which is worth refusing over.
+
+    Raises:
+        IdempotencyKeyMakerError: If the key is not a non-empty string, drops
+            the client's key, or carries an unresolved `None`.
+    """
+    if not isinstance(built, str) or not built:
+        msg = f"key_maker returned {built!r}, expected a non-empty string."
+        raise IdempotencyKeyMakerError(msg)
+    if client_key not in built:
+        msg = (
+            f"key_maker returned {built!r}, which drops the client's "
+            f"idempotency key. Every request to this route would then share "
+            f"one entry. Include the key it was given."
+        )
+        raise IdempotencyKeyMakerError(msg)
+    if _UNRESOLVED_TOKEN.search(built):
+        msg = (
+            f"key_maker returned {built!r}, which carries an unresolved None. "
+            f"Something the key reads was not set yet, so that component is "
+            f"the same for every caller and they share one entry. A middleware "
+            f"the key depends on must run outside IdempotencyMiddleware, which "
+            f"means adding it after."
+        )
+        raise IdempotencyKeyMakerError(msg)
+    return built
 
 
 _OUT_OF_CONTEXT_HINT = (

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -202,6 +202,7 @@
       "()": "(*, name, key)"
     },
     "IdempotencyError": null,
+    "IdempotencyKeyMakerError": null,
     "IdempotencySettingsValidationError": {
       "()": "(error)"
     },

--- a/tests/test_fastapi_idempotency.py
+++ b/tests/test_fastapi_idempotency.py
@@ -36,6 +36,7 @@ from grelmicro.cache import Cache
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.errors import DependencyNotFoundError, OutOfContextError
 from grelmicro.idempotency import Idempotency
+from grelmicro.idempotency.errors import IdempotencyKeyMakerError
 from grelmicro.integrations.fastapi import (
     IdempotencyMiddleware,
     document_idempotency,
@@ -606,6 +607,85 @@ def test_middleware_resolves_the_cache_under_a_forking_middleware() -> None:
     assert second.json() == {"call": 1}
     assert second.headers["idempotent-replayed"] == "true"
     assert calls == {"count": 1}
+
+
+def _app_with_key_maker(key_maker: Any) -> FastAPI:  # noqa: ANN401
+    """Build an installed app whose middleware uses `key_maker`."""
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    app = FastAPI()
+    micro.install(app)
+    app.add_middleware(
+        IdempotencyMiddleware,
+        idempotency=Idempotency("http", ttl=60),
+        key_maker=key_maker,
+    )
+
+    @app.post("/charge")
+    async def charge() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app
+
+
+def test_key_maker_carrying_an_unresolved_none_is_refused() -> None:
+    """A key built from a value that was not set yet merges every caller.
+
+    This is the shape a scope-reading `key_maker` takes when the middleware
+    it depends on runs inside this one. The key still looks per-caller and
+    separates nobody, so it is refused rather than stored under.
+    """
+    # Arrange
+    app = _app_with_key_maker(
+        lambda scope, key: f"{scope.get('state', {}).get('missing')}|{key}"
+    )
+
+    # Act / Assert
+    with (
+        TestClient(app) as client,
+        pytest.raises(IdempotencyKeyMakerError, match="unresolved None"),
+    ):
+        client.post("/charge", headers=KEY)
+
+
+def test_key_maker_dropping_the_client_key_is_refused() -> None:
+    """Without the client's key every request to the route shares one entry."""
+    # Arrange
+    app = _app_with_key_maker(lambda scope, _key: scope["path"])
+
+    # Act / Assert
+    with (
+        TestClient(app) as client,
+        pytest.raises(IdempotencyKeyMakerError, match="drops the client"),
+    ):
+        client.post("/charge", headers=KEY)
+
+
+def test_key_maker_returning_an_empty_key_is_refused() -> None:
+    """An empty key is one bucket for the whole application."""
+    # Arrange
+    app = _app_with_key_maker(lambda _scope, _key: "")
+
+    # Act / Assert
+    with (
+        TestClient(app) as client,
+        pytest.raises(IdempotencyKeyMakerError, match="non-empty string"),
+    ):
+        client.post("/charge", headers=KEY)
+
+
+def test_key_maker_keeping_a_none_lookalike_is_accepted() -> None:
+    """A tenant whose name merely contains None is not a partial key."""
+    # Arrange
+    app = _app_with_key_maker(lambda _scope, key: f"NoneSuchCorp\x1f{key}")
+
+    # Act
+    with TestClient(app) as client:
+        first = client.post("/charge", headers=KEY)
+        second = client.post("/charge", headers=KEY)
+
+    # Assert
+    assert first.status_code == HTTP_200_OK
+    assert second.headers["idempotent-replayed"] == "true"
 
 
 def test_middleware_without_grelmicro_scope_names_the_fix() -> None:


### PR DESCRIPTION
An adversarial review of the docs-only fix in #633 concluded I under-fixed it, and it was right on both counts. This replaces the note with a control, and fixes a worse problem the review found in the docs themselves.

## The docs shipped a worse example than the bug I fixed

The canonical `key_maker` example, sitting directly under the warning about cross-tenant replay, read the tenant from an **unauthenticated client-supplied header**:

```python
tenant = dict(scope["headers"])[b"x-tenant"].decode()
```

Any caller sets `X-Tenant`. That is not weak isolation, it is none, and it is worse than omitting `key_maker` entirely: the attacker **chooses** the victim's bucket instead of having to guess a key. Two lesser faults in the same three lines, a `KeyError` on a missing header and a `|` separator an identity can contain.

The example now folds in an authenticated identity, uses `\x1f` (which the default key path already uses for this reason), and raises rather than building a partial key.

## Documentation was the wrong control

#633 documented the ordering hazard. The review's decisive point is that the failure is invisible at every stage a developer would catch it, **including their own tests**: under Starlette's `TestClient` the peer is `("testclient", 50000)`, which does not parse as an address, so `client_address` is never set. A test asserting "tenant A does not replay tenant B" passes identically whether the ordering is right or wrong. A unix-domain-socket deployment has no `scope["client"]` at all and fails the same way with correct ordering.

So the ordering note guarded one of several paths to the same collapse, and the paths it missed survive doing everything the docs say.

Django, express-rate-limit and ASP.NET Core all treat this class (configuration that silently disables a security control) with a runtime signal rather than prose. `express-rate-limit` ships error codes for precisely this failure, a key that silently stops discriminating between callers.

## The fix

`IdempotencyMiddleware` now checks what `key_maker` returns and raises `IdempotencyKeyMakerError` when the key cannot separate callers: empty, missing the client's key, or carrying an unresolved `None`.

This catches the cause rather than one trigger, so it covers the ordering bug, the `TestClient` case, and the unix-socket case alike:

```
IdempotencyKeyMakerError: key_maker returned 'None|/charge|k1', which carries
an unresolved None. Something the key reads was not set yet, so that component
is the same for every caller and they share one entry. A middleware the key
depends on must run outside IdempotencyMiddleware, which means adding it after.
```

No false positives: a correct `key_maker` replays normally, and a tenant literally named `NoneSuchCorp` is accepted. The `None` match is token-delimited, not a substring.

The general rule is now written down where it belongs: **a key that is partly missing does not fail, it merges.** Cache keys widen rather than error, so a missing component silently enlarges the sharing scope.

## Also

A warning that a client address is not a tenant identity. Carrier-grade NAT puts many subscribers behind one address, so they would share an entry, and a caller changing network loses the replay mid-retry. Rate limiting, not tenancy.

## Deliberately not changed

`ClientAddress.degraded` excludes `UNTRUSTED_PEER`, so the guard the clientip docs recommend does not refuse when a mistyped trusted CIDR makes every caller resolve to the proxy's address. Whether that is a bug depends on whether an untrusted peer should be read as "the caller, correctly ignoring a spoofed header" or "a proxy we failed to list", and the library cannot tell them apart. That is a judgement call on a security primitive with an existing changelog entry and tests, so it wants deciding on its own merits rather than being folded in here.

`IdempotencyKeyMakerError` is additive, and the public API snapshot is updated deliberately.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b