### PR TITLE
🔖 Prepare the 0.34.2 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.34.2 - 2026-08-02
 
 ### Security
 


### PR DESCRIPTION
Security patch. Ships the idempotency key validation from #634, the corrected multi-tenant example, and the two ordering notes from #632 and #633.

An adopter using `key_maker` in a multi-tenant application should take this one. A key that lost a component merged callers into a single entry, and the request answered normally, so the widening was invisible.

`just release-check 0.34.2` runs on `main` after this merges. It now includes the Python matrix, which the 0.34.0 attempt did not.

https://claude.ai/code/session_01WbksbSsVH3wm9HaYeJt64b