### PR TITLE
🔒 Point client address identity checks at forwarded, not degraded

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+* 🔒 Point client address identity checks at `forwarded` instead of `degraded`. `degraded` is False for `UNTRUSTED_PEER`, so one mistyped CIDR in `TrustedProxies` left every request carrying the proxy's own address, and the guard the docs recommended admitted it. The private network gate in the health docs then showed details to everyone, which is the bypass `degraded` was added to close. `forwarded` is True for `RESOLVED` alone, so it refuses that request. The docstrings and the reason table now say which outcomes mean the peer is the caller and which mean the address is one of your own proxies. ([#636](https://github.com/grelinfo/grelmicro/issues/636))
+
+### Features
+
+* ✨ Log the first untrusted peer that sends `X-Forwarded-For` while `TrustedProxies` is not empty. That combination is either a caller sending the header directly or a proxy of yours missing from the trusted set, and the misconfiguration had no other symptom. One line per `TrustedProxies` object goes to the `grelmicro.clientip` logger, so nothing can flood it. ([#636](https://github.com/grelinfo/grelmicro/issues/636))
+
+### Fixed
+
+* 🐛 Report a truncated forwarded chain as `TOO_MANY_ENTRIES`. The reason existed but was never returned. A header longer than `max_entries` whose read window held only trusted proxies came back as `CHAIN_EXHAUSTED`, which claims every entry was seen. ([#636](https://github.com/grelinfo/grelmicro/issues/636))
+
 ## 0.34.2 - 2026-08-02
 
 ### Security

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,11 +4,11 @@
 
 ### Security
 
-* 🔒 Point client address identity checks at `forwarded` instead of `degraded`. `degraded` is False for `UNTRUSTED_PEER`, so one mistyped CIDR in `TrustedProxies` left every request carrying the proxy's own address, and the guard the docs recommended admitted it. The private network gate in the health docs then showed details to everyone, which is the bypass `degraded` was added to close. `forwarded` is True for `RESOLVED` alone, so it refuses that request. The docstrings and the reason table now say which outcomes mean the peer is the caller and which mean the address is one of your own proxies. ([#636](https://github.com/grelinfo/grelmicro/issues/636))
+* 🔒 Point client address identity checks at `forwarded` instead of `degraded`. `degraded` is False for `UNTRUSTED_PEER`, so one mistyped CIDR in `TrustedProxies` left every request carrying the proxy's own address, and the guard the docs recommended admitted it. The private network gate in the health docs then showed details to everyone, which is the bypass `degraded` was added to close. `forwarded` is True for `RESOLVED` alone, so it refuses that request. The docstrings and the reason table now say which outcomes mean the peer is the caller and which mean the address is one of your own proxies. If nothing fronts your app, `forwarded` is never True and there is nothing to gate on, so read [which check to use](clientip.md#which-check-to-use) before copying the new guard into a direct deployment. ([#636](https://github.com/grelinfo/grelmicro/issues/636))
 
 ### Features
 
-* ✨ Log the first untrusted peer that sends `X-Forwarded-For` while `TrustedProxies` is not empty. That combination is either a caller sending the header directly or a proxy of yours missing from the trusted set, and the misconfiguration had no other symptom. One line per `TrustedProxies` object goes to the `grelmicro.clientip` logger, so nothing can flood it. ([#636](https://github.com/grelinfo/grelmicro/issues/636))
+* ✨ Log an untrusted peer that sends a non-empty `X-Forwarded-For` while `TrustedProxies` is not empty. That combination is either a caller sending the header directly or a proxy of yours missing from the trusted set, and the misconfiguration had no other symptom. The `grelmicro.clientip` logger gets one line per peer, for at most eight peers, so a busy proxy cannot flood it and a caller probing the header cannot take the line your own proxy needs. ([#636](https://github.com/grelinfo/grelmicro/issues/636))
 
 ### Fixed
 

--- a/docs/clientip.md
+++ b/docs/clientip.md
@@ -56,41 +56,73 @@ over a dual-stack socket.
 
 ## Reading the outcome
 
-Every result carries a `reason`. Only `RESOLVED` means a trusted proxy
-vouched for the address, and everything else means the header could not be
-believed, so the verified peer was used instead.
+Every result carries a `reason`. `RESOLVED` is the only one this module
+can vouch for on its own: a trusted proxy wrote that entry. Every other
+value means `ip` is the verified transport peer, and those split in two.
 
-| Reason | What happened |
-|---|---|
-| `RESOLVED` | A trusted proxy vouched for this address. |
-| `NO_FORWARDED_HEADER` | Trusted peer, no header. The peer is the client. |
-| `UNTRUSTED_PEER` | The connecting peer is not a trusted proxy, so the header was ignored. |
-| `CHAIN_EXHAUSTED` | Every entry was a trusted proxy. |
-| `MALFORMED_ENTRY` | An entry was not a valid address. |
-| `HOP_LIMIT`, `TOO_MANY_ENTRIES`, `HEADER_TOO_LARGE` | A bound was hit. |
+| Reason | What happened | Whose address is `ip` |
+|---|---|---|
+| `RESOLVED` | A trusted proxy vouched for this address. | The caller |
+| `UNTRUSTED_PEER` | The peer is not a trusted proxy, so the header was ignored. | The peer, which is the caller only if nothing unlisted fronts the app |
+| `NO_FORWARDED_HEADER` | A trusted peer sent no header. | The peer, which is the caller only if every proxy of yours appends the header |
+| `CHAIN_EXHAUSTED` | Every entry was a trusted proxy. | One of your own proxies |
+| `MALFORMED_ENTRY` | An entry was not a valid address. | One of your own proxies |
+| `HOP_LIMIT`, `TOO_MANY_ENTRIES`, `HEADER_TOO_LARGE` | A bound was hit. | One of your own proxies |
+
+The right-hand column is the part no library can decide for you. Whether
+something sits in front of your app, and whether it appends
+`X-Forwarded-For`, are facts about your deployment.
+
+An audit log should record the reason. A rising `CHAIN_EXHAUSTED`,
+`TOO_MANY_ENTRIES` or `MALFORMED_ENTRY` rate is worth an alert, since all
+three mean something is sending chains your topology does not explain.
+
+### Which check to use
 
 A rate limiter can use `.key` whatever the reason, because every value is
-an address the caller cannot choose. Anything that treats the address as
-the caller's identity must check `degraded` first:
+an address the caller cannot choose.
+
+Anything that treats the address as an identity is different. An
+allowlist, a private network gate, or any check that has to keep callers
+apart needs the address a proxy vouched for:
 
 ```python
-if client is None or client.degraded:
-    return False  # the address is the proxy's, not the caller's
+if client is None or not client.forwarded:
+    return False  # nobody vouched for this address
 ```
 
-`degraded` is True whenever the chain could not be believed, so `ip` holds
-the connecting peer. Behind a proxy that peer is the proxy, whose address
-is private, which is how an allowlist accidentally admits everyone.
+`degraded` is the weaker test. It is True only when `ip` is one of your
+own proxies, so it catches a chain that could not be walked and misses a
+proxy missing from `TrustedProxies`. One mistyped CIDR turns every
+request into `UNTRUSTED_PEER`, where the address is the proxy's and
+`degraded` is False. `forwarded` refuses that request, `degraded` admits
+it, and every caller then looks like the same private client.
 
-An audit log should record the reason. A rising `CHAIN_EXHAUSTED` or
-`MALFORMED_ENTRY` rate is worth an alert, since both mean something is
-sending chains your topology does not explain.
+If nothing fronts your app, `forwarded` is never True and there is
+nothing to gate on. The peer is the caller, verified by the transport,
+and `TrustedProxies([])` says exactly that. One flag cannot serve both
+deployments, so pick the check that matches yours.
 
 !!! warning "A missing trusted set is not a safe default"
     `resolve_client_address(scope)` does not exist. The trusted set is a
     required argument, because the correct value depends on your topology
     and no library can guess it. An empty `TrustedProxies([])` is legal
     and means trust nothing, so the peer is always returned.
+
+## Catching a mistyped trusted set
+
+A proxy left out of the set has no symptom of its own. Every request
+resolves as `UNTRUSTED_PEER` carrying the proxy's own address, which
+looks like a real answer. So the first time an untrusted peer sends
+`X-Forwarded-For`, one line goes to the `grelmicro.clientip` logger:
+
+```text
+Ignored X-Forwarded-For from 192.168.1.10, which is not a trusted proxy.
+```
+
+It fires once per `TrustedProxies` object, so neither a busy proxy nor a
+caller probing the header can flood the log. Nothing is logged when the
+trusted set is empty, since that deployment means trust nothing.
 
 ## One value, read everywhere
 
@@ -138,6 +170,11 @@ which is exactly the value that must not become a rate limiter key.
 
 **A malformed entry stops the walk.** It is not skipped. Skipping lets an
 attacker insert padding to shift which entry gets chosen.
+
+**A capped header says so.** Reading stops at `max_entries`, keeping the
+rightmost entries. If every entry read was a trusted proxy, the reason is
+`TOO_MANY_ENTRIES` rather than `CHAIN_EXHAUSTED`, because the entries
+past the cap were never read.
 
 **A zone id is dropped.** `fe80::1%eth0` keys as `fe80::1`, so two hosts
 reached over different interfaces share one key. Link-local addresses are

--- a/docs/clientip.md
+++ b/docs/clientip.md
@@ -113,16 +113,18 @@ deployments, so pick the check that matches yours.
 
 A proxy left out of the set has no symptom of its own. Every request
 resolves as `UNTRUSTED_PEER` carrying the proxy's own address, which
-looks like a real answer. So the first time an untrusted peer sends
-`X-Forwarded-For`, one line goes to the `grelmicro.clientip` logger:
+looks like a real answer. So an untrusted peer that sends a non-empty
+`X-Forwarded-For` gets a line on the `grelmicro.clientip` logger:
 
 ```text
 Ignored X-Forwarded-For from 192.168.1.10, which is not a trusted proxy.
 ```
 
-It fires once per `TrustedProxies` object, so neither a busy proxy nor a
-caller probing the header can flood the log. Nothing is logged when the
-trusted set is empty, since that deployment means trust nothing.
+One line per peer, for at most eight peers, then silence. A busy proxy
+cannot flood the log, and a caller probing the header cannot take the
+line your own proxy needs. An empty header is not counted, so direct
+health checks stay quiet. Nothing is logged at all when the trusted set
+is empty, since that deployment means trust nothing.
 
 ## One value, read everywhere
 

--- a/docs/snippets/health/show_details.py
+++ b/docs/snippets/health/show_details.py
@@ -12,9 +12,9 @@ def from_private_network(request: Request) -> bool:
     # raw peer is the proxy's own private address, so checking it directly
     # reports every caller as private and shows details to the public.
     client = resolve_client_address(request.scope, trusted)
-    # `degraded` means the chain could not be believed, so the address is
-    # the proxy's again. Refuse, or a forged chain reopens the same hole.
-    if client is None or client.degraded:
+    # `forwarded` means a trusted proxy vouched for this address. Without
+    # it the address is the proxy's own, and every caller looks private.
+    if client is None or not client.forwarded:
         return False
     return client.ip.is_private
 

--- a/docs/snippets/health/show_details.py
+++ b/docs/snippets/health/show_details.py
@@ -13,7 +13,8 @@ def from_private_network(request: Request) -> bool:
     # reports every caller as private and shows details to the public.
     client = resolve_client_address(request.scope, trusted)
     # `forwarded` means a trusted proxy vouched for this address. Without
-    # it the address is the proxy's own, and every caller looks private.
+    # it nobody did, and behind a proxy the address is the proxy's own,
+    # which reads as private and shows details to everyone.
     if client is None or not client.forwarded:
         return False
     return client.ip.is_private

--- a/grelmicro/clientip.py
+++ b/grelmicro/clientip.py
@@ -10,6 +10,7 @@ Read more in the [Client IP](../clientip.md) docs.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from enum import StrEnum
 from ipaddress import (
@@ -50,6 +51,8 @@ __all__ = [
     "resolve_client_address",
 ]
 
+logger = logging.getLogger("grelmicro.clientip")
+
 _FORWARDED_FOR = b"x-forwarded-for"
 
 _MAX_PORT = 65535
@@ -61,19 +64,44 @@ _IPV4_MAPPED_PREFIX = 96
 class ClientAddressReason(StrEnum):
     """Why `ClientAddress.ip` holds the address it holds.
 
-    Only `RESOLVED` means a trusted proxy vouched for the address. Every
-    other value means the header could not be believed and the verified
-    transport peer was used instead, which a caller can log or reject.
+    `RESOLVED` is the one value the library can vouch for on its own: a
+    trusted proxy wrote the entry. Every other value means `ip` is the
+    verified transport peer, and they split in two.
+
+    With `NO_FORWARDED_HEADER` and `UNTRUSTED_PEER` the peer is the
+    caller, as long as nothing sits in front of the app that is missing
+    from the trusted set. That is a claim about your topology, not one
+    this module can check.
+
+    Every remaining value means the peer is itself a trusted proxy whose
+    chain could not be walked to a client, so `ip` is one of your own
+    proxies and never the caller. `ClientAddress.degraded` marks exactly
+    those.
     """
 
     RESOLVED = "resolved"
+    """A trusted proxy vouched for this address."""
+
     NO_FORWARDED_HEADER = "no-forwarded-header"
+    """A trusted peer sent no `X-Forwarded-For`."""
+
     UNTRUSTED_PEER = "untrusted-peer"
+    """The peer is not a trusted proxy, so the header was ignored."""
+
     CHAIN_EXHAUSTED = "chain-exhausted"
+    """Every entry in the chain was a trusted proxy."""
+
     HOP_LIMIT = "hop-limit"
+    """The walk passed more trusted proxies than `max_hops`."""
+
     MALFORMED_ENTRY = "malformed-entry"
+    """An entry was not an address, which stops the walk."""
+
     HEADER_TOO_LARGE = "header-too-large"
+    """The header was longer than `max_header_bytes`."""
+
     TOO_MANY_ENTRIES = "too-many-entries"
+    """More entries than `max_entries`, and every one read was trusted."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,17 +124,28 @@ class ClientAddress:
 
     @property
     def forwarded(self) -> bool:
-        """Whether a trusted proxy vouched for this address."""
+        """Whether a trusted proxy vouched for this address.
+
+        The test to use behind a proxy for anything that treats the
+        address as the caller's identity, such as an allowlist or a
+        private network check. It is True for `RESOLVED` alone.
+        """
         return self.reason is ClientAddressReason.RESOLVED
 
     @property
     def degraded(self) -> bool:
-        """Whether this is a fallback rather than the caller's own address.
+        """Whether `ip` is one of your own proxies rather than a caller.
 
-        True when the forwarded chain could not be believed, so `ip` holds
-        the connecting peer instead. Behind a proxy that peer is the proxy,
-        so any check that treats it as the caller (an allowlist, a private
-        network test) must refuse when this is True.
+        True when the peer was a trusted proxy but its chain could not be
+        walked to a client, so `ip` is that proxy's own address and is
+        never the caller's. Any check that treats it as the caller must
+        refuse.
+
+        False is not the same as vouched for. It also covers the two
+        cases where the peer is the caller only if nothing unlisted sits
+        in front of the app: `UNTRUSTED_PEER` and `NO_FORWARDED_HEADER`.
+        Use `forwarded` when the address has to carry an identity behind
+        a proxy.
         """
         return self.reason not in (
             ClientAddressReason.RESOLVED,
@@ -120,6 +159,11 @@ class ClientAddress:
 
         An IPv4-mapped address folds onto its IPv4 form, so one caller
         never occupies two buckets.
+
+        It is a bucket, not an identity. When `degraded` is True every
+        caller behind the proxy shares one key, so anything that has to
+        keep callers apart, such as an idempotency key or an allowlist,
+        checks `forwarded` first.
         """
         return self.ip.compressed
 
@@ -159,7 +203,13 @@ class TrustedProxies:
     which is visible in a configuration review in a way a `*` is not.
     """
 
-    __slots__ = ("_max_entries", "_max_header_bytes", "_max_hops", "_networks")
+    __slots__ = (
+        "_max_entries",
+        "_max_header_bytes",
+        "_max_hops",
+        "_networks",
+        "_warn_untrusted",
+    )
 
     def __init__(
         self,
@@ -198,6 +248,7 @@ class TrustedProxies:
         self._max_hops = max_hops
         self._max_entries = max_entries
         self._max_header_bytes = max_header_bytes
+        self._warn_untrusted = bool(self._networks)
 
     def __contains__(self, address: IPAddress) -> bool:
         """Whether `address` belongs to a trusted proxy."""
@@ -264,6 +315,24 @@ def _with_port(host: str, port: str) -> tuple[str, int | None] | None:
     return host, int(port)
 
 
+def _warn_untrusted_peer(
+    trusted: TrustedProxies,
+    headers: Sequence[tuple[bytes, bytes]],
+    peer: IPAddress,
+) -> None:
+    """Log the first untrusted peer that sent a forwarded header."""
+    if not any(name.lower() == _FORWARDED_FOR for name, _ in headers):
+        return
+    trusted._warn_untrusted = False  # noqa: SLF001
+    logger.warning(
+        "Ignored X-Forwarded-For from %s, which is not a trusted proxy. "
+        "Add it to TrustedProxies if it is one of yours, otherwise a "
+        "caller is sending the header directly. Logged once per "
+        "TrustedProxies.",
+        peer.compressed,
+    )
+
+
 def _collect_header(
     headers: Sequence[tuple[bytes, bytes]], limit: int
 ) -> bytes | None:
@@ -303,7 +372,14 @@ def resolve_client_address(  # noqa: C901, PLR0911
     When every entry is trusted, the peer is returned with
     `CHAIN_EXHAUSTED` rather than the leftmost entry. No trusted proxy
     vouched for that entry against an untrusted peer, so it is exactly
-    the value that must not become a rate limiter key.
+    the value that must not become a rate limiter key. The same walk
+    ending inside a header the `max_entries` cap truncated returns
+    `TOO_MANY_ENTRIES`, since the entries beyond the cap were never read.
+
+    An untrusted peer that sends `X-Forwarded-For` is logged once per
+    `TrustedProxies`, on the `grelmicro.clientip` logger. Nothing is
+    logged when the trusted set is empty, which is the deployment that
+    means trust nothing.
     """
     client = scope.get("client")
     if not client:
@@ -317,11 +393,14 @@ def resolve_client_address(  # noqa: C901, PLR0911
     def from_peer(reason: ClientAddressReason, hops: int = 0) -> ClientAddress:
         return ClientAddress(ip=peer, port=port, reason=reason, hops=hops)
 
+    headers = scope.get("headers", ())
     if peer not in trusted:
+        if trusted._warn_untrusted:  # noqa: SLF001
+            _warn_untrusted_peer(trusted, headers, peer)
         return from_peer(ClientAddressReason.UNTRUSTED_PEER)
 
     raw = _collect_header(
-        scope.get("headers", ()),
+        headers,
         trusted._max_header_bytes,  # noqa: SLF001
     )
     if raw is None:
@@ -330,11 +409,14 @@ def resolve_client_address(  # noqa: C901, PLR0911
     entries = [part for part in entries if part]
     if not entries:
         return from_peer(ClientAddressReason.NO_FORWARDED_HEADER)
+    exhausted = ClientAddressReason.CHAIN_EXHAUSTED
     if len(entries) > trusted._max_entries:  # noqa: SLF001
         # Keep the rightmost entries, the ones our own proxies wrote.
         # Discarding the header instead would let prepended padding force
-        # every caller onto the proxy's key.
+        # every caller onto the proxy's key. The entries dropped were never
+        # read, so running out of them is not an exhausted chain.
         entries = entries[-trusted._max_entries :]  # noqa: SLF001
+        exhausted = ClientAddressReason.TOO_MANY_ENTRIES
 
     hops = 0
     for entry in reversed(entries):
@@ -357,7 +439,7 @@ def resolve_client_address(  # noqa: C901, PLR0911
         max_hops = trusted._max_hops  # noqa: SLF001
         if max_hops is not None and hops > max_hops:
             return from_peer(ClientAddressReason.HOP_LIMIT, hops)
-    return from_peer(ClientAddressReason.CHAIN_EXHAUSTED, hops)
+    return from_peer(exhausted, hops)
 
 
 class ClientAddressMiddleware:

--- a/grelmicro/clientip.py
+++ b/grelmicro/clientip.py
@@ -60,6 +60,9 @@ _MAX_PORT = 65535
 _IPV4_MAPPED_PREFIX = 96
 """Prefix length at which an IPv6 network is wholly IPv4-mapped space."""
 
+_MAX_WARNED_PEERS = 8
+"""Distinct untrusted peers reported before the warning goes quiet."""
+
 
 class ClientAddressReason(StrEnum):
     """Why `ClientAddress.ip` holds the address it holds.
@@ -208,7 +211,7 @@ class TrustedProxies:
         "_max_header_bytes",
         "_max_hops",
         "_networks",
-        "_warn_untrusted",
+        "_warned_peers",
     )
 
     def __init__(
@@ -248,7 +251,9 @@ class TrustedProxies:
         self._max_hops = max_hops
         self._max_entries = max_entries
         self._max_header_bytes = max_header_bytes
-        self._warn_untrusted = bool(self._networks)
+        self._warned_peers: set[IPAddress] | None = (
+            set() if self._networks else None
+        )
 
     def __contains__(self, address: IPAddress) -> bool:
         """Whether `address` belongs to a trusted proxy."""
@@ -317,18 +322,28 @@ def _with_port(host: str, port: str) -> tuple[str, int | None] | None:
 
 def _warn_untrusted_peer(
     trusted: TrustedProxies,
+    warned: set[IPAddress],
     headers: Sequence[tuple[bytes, bytes]],
     peer: IPAddress,
 ) -> None:
-    """Log the first untrusted peer that sent a forwarded header."""
-    if not any(name.lower() == _FORWARDED_FOR for name, _ in headers):
+    """Report an untrusted peer that sent a forwarded header, once.
+
+    A peer sending nothing in the header is not making a forwarding
+    attempt, and reporting it would spend the report a misconfigured
+    proxy needs.
+    """
+    if not any(
+        name.lower() == _FORWARDED_FOR and value.strip()
+        for name, value in headers
+    ):
         return
-    trusted._warn_untrusted = False  # noqa: SLF001
+    warned.add(peer)
+    if len(warned) >= _MAX_WARNED_PEERS:
+        trusted._warned_peers = None  # noqa: SLF001
     logger.warning(
         "Ignored X-Forwarded-For from %s, which is not a trusted proxy. "
         "Add it to TrustedProxies if it is one of yours, otherwise a "
-        "caller is sending the header directly. Logged once per "
-        "TrustedProxies.",
+        "caller is sending the header directly. Reported once per peer.",
         peer.compressed,
     )
 
@@ -376,10 +391,12 @@ def resolve_client_address(  # noqa: C901, PLR0911
     ending inside a header the `max_entries` cap truncated returns
     `TOO_MANY_ENTRIES`, since the entries beyond the cap were never read.
 
-    An untrusted peer that sends `X-Forwarded-For` is logged once per
-    `TrustedProxies`, on the `grelmicro.clientip` logger. Nothing is
-    logged when the trusted set is empty, which is the deployment that
-    means trust nothing.
+    An untrusted peer that sends a non-empty `X-Forwarded-For` is logged
+    on the `grelmicro.clientip` logger, once per peer and for at most
+    eight peers. A caller probing the header therefore cannot flood the
+    log, nor take the report a misconfigured proxy of yours needs.
+    Nothing is logged when the trusted set is empty, which is the
+    deployment that means trust nothing.
     """
     client = scope.get("client")
     if not client:
@@ -395,8 +412,9 @@ def resolve_client_address(  # noqa: C901, PLR0911
 
     headers = scope.get("headers", ())
     if peer not in trusted:
-        if trusted._warn_untrusted:  # noqa: SLF001
-            _warn_untrusted_peer(trusted, headers, peer)
+        warned = trusted._warned_peers  # noqa: SLF001
+        if warned is not None and peer not in warned:
+            _warn_untrusted_peer(trusted, warned, headers, peer)
         return from_peer(ClientAddressReason.UNTRUSTED_PEER)
 
     raw = _collect_header(

--- a/tests/test_clientip.py
+++ b/tests/test_clientip.py
@@ -6,6 +6,7 @@ spoofing advisory or to a parsing bug found in a widely used server.
 
 from __future__ import annotations
 
+import logging
 from ipaddress import ip_address, ip_network
 from typing import TYPE_CHECKING, Any
 
@@ -294,7 +295,20 @@ class TestLimits:
         # Act
         result = resolve(forwarded=header, max_entries=64)
         # Assert
-        assert result.reason is ClientAddressReason.CHAIN_EXHAUSTED
+        assert result.key == PEER
+        assert result.reason is ClientAddressReason.TOO_MANY_ENTRIES
+
+    def test_truncated_chain_is_not_reported_as_exhausted(self) -> None:
+        """The entries past the cap were never read, so nothing exhausted."""
+        # Arrange
+        untruncated = ", ".join(["10.0.0.1"] * 64)
+        truncated = ", ".join(["10.0.0.1"] * 65)
+        # Act
+        within = resolve(forwarded=untruncated, max_entries=64)
+        beyond = resolve(forwarded=truncated, max_entries=64)
+        # Assert
+        assert within.reason is ClientAddressReason.CHAIN_EXHAUSTED
+        assert beyond.reason is ClientAddressReason.TOO_MANY_ENTRIES
 
     def test_padding_cannot_force_the_proxy_bucket(self) -> None:
         """Prepended padding must not discard the real entry.
@@ -507,6 +521,118 @@ class TestDegraded:
         result = resolve(peer="9.9.9.9")
         # Assert
         assert result.degraded is False
+
+    def test_a_truncated_chain_is_degraded(self) -> None:
+        """A bound leaves the proxy's own address, whichever bound it is."""
+        # Arrange
+        header = ", ".join(["10.0.0.1"] * 65)
+        # Act
+        result = resolve(forwarded=header, max_entries=64)
+        # Assert
+        assert result.reason is ClientAddressReason.TOO_MANY_ENTRIES
+        assert result.degraded is True
+
+
+class TestForwarded:
+    """`forwarded` is the predicate an identity check uses."""
+
+    @pytest.mark.parametrize(
+        ("peer", "forwarded", "expected"),
+        [
+            (PEER, "1.2.3.4", True),
+            (PEER, None, False),
+            (PEER, "10.1.1.1, 10.2.2.2", False),
+            ("9.9.9.9", "1.2.3.4", False),
+        ],
+    )
+    def test_only_a_vouched_address_is_forwarded(
+        self,
+        peer: str,
+        forwarded: str | None,
+        expected: bool,  # noqa: FBT001
+    ) -> None:
+        """Only `RESOLVED` means a trusted proxy wrote the entry."""
+        # Arrange / Act
+        result = resolve(peer=peer, forwarded=forwarded)
+        # Assert
+        assert result.forwarded is expected
+
+    def test_a_mistyped_trusted_set_fails_closed(self) -> None:
+        """The bypass in #636: the guard must refuse, not admit the proxy."""
+        # Arrange / Act
+        result = resolve(
+            peer="10.0.0.5", forwarded="1.2.3.4", trusted=["10.1.0.0/16"]
+        )
+        # Assert
+        assert result.key == "10.0.0.5"
+        assert result.degraded is False
+        assert result.forwarded is False
+
+
+class TestUntrustedPeerWarning:
+    """A proxy missing from the trusted set is otherwise silent."""
+
+    def test_warns_once_for_a_forwarded_header(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One line names the peer, and a flood cannot follow it."""
+        # Arrange
+        trusted = TrustedProxies(TRUSTED)
+        request = scope(peer="9.9.9.9", forwarded="1.2.3.4")
+        # Act
+        with caplog.at_level(logging.WARNING, logger="grelmicro.clientip"):
+            result = resolve_client_address(request, trusted)
+            resolve_client_address(request, trusted)
+        # Assert
+        assert result is not None
+        assert result.reason is ClientAddressReason.UNTRUSTED_PEER
+        assert caplog.text.count("Ignored X-Forwarded-For") == 1
+        assert "9.9.9.9" in caplog.text
+
+    def test_a_headerless_request_keeps_the_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Direct health checks must not spend the one warning."""
+        # Arrange
+        trusted = TrustedProxies(TRUSTED)
+        # Act
+        with caplog.at_level(logging.WARNING, logger="grelmicro.clientip"):
+            resolve_client_address(scope(peer="9.9.9.9"), trusted)
+            silent = caplog.text
+            resolve_client_address(
+                scope(peer="9.9.9.9", forwarded="1.2.3.4"), trusted
+            )
+        # Assert
+        assert silent == ""
+        assert caplog.text.count("Ignored X-Forwarded-For") == 1
+
+    def test_an_empty_trusted_set_stays_silent(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Trusting nothing is a deployment, not a misconfiguration."""
+        # Arrange
+        trusted = TrustedProxies([])
+        # Act
+        with caplog.at_level(logging.WARNING, logger="grelmicro.clientip"):
+            resolve_client_address(
+                scope(peer="9.9.9.9", forwarded="1.2.3.4"), trusted
+            )
+        # Assert
+        assert caplog.text == ""
+
+    def test_a_trusted_peer_stays_silent(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The header was believed, so there is nothing to report."""
+        # Arrange
+        trusted = TrustedProxies(TRUSTED)
+        # Act
+        with caplog.at_level(logging.WARNING, logger="grelmicro.clientip"):
+            resolve_client_address(
+                scope(peer=PEER, forwarded="1.2.3.4"), trusted
+            )
+        # Assert
+        assert caplog.text == ""
 
 
 class TestConfigTypes:

--- a/tests/test_clientip.py
+++ b/tests/test_clientip.py
@@ -29,6 +29,7 @@ from grelmicro.clientip import (
 
 TRUSTED = ["10.0.0.0/8"]
 EXPECTED_HOPS = 2
+EXPECTED_WARNED_PEERS = 8
 PEER = "10.0.0.5"
 
 
@@ -572,7 +573,7 @@ class TestForwarded:
 class TestUntrustedPeerWarning:
     """A proxy missing from the trusted set is otherwise silent."""
 
-    def test_warns_once_for_a_forwarded_header(
+    def test_warns_once_per_peer(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         """One line names the peer, and a flood cannot follow it."""
@@ -589,15 +590,51 @@ class TestUntrustedPeerWarning:
         assert caplog.text.count("Ignored X-Forwarded-For") == 1
         assert "9.9.9.9" in caplog.text
 
-    def test_a_headerless_request_keeps_the_warning(
+    def test_a_prober_cannot_mask_a_mistyped_trusted_set(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Direct health checks must not spend the one warning."""
+        """The report a forgotten proxy needs is not one a caller can take."""
         # Arrange
         trusted = TrustedProxies(TRUSTED)
         # Act
         with caplog.at_level(logging.WARNING, logger="grelmicro.clientip"):
-            resolve_client_address(scope(peer="9.9.9.9"), trusted)
+            for last in range(1, 5):
+                probe = scope(peer=f"203.0.113.{last}", forwarded="1.2.3.4")
+                resolve_client_address(probe, trusted)
+            forgotten = scope(peer="192.168.1.10", forwarded="1.2.3.4")
+            resolve_client_address(forgotten, trusted)
+        # Assert
+        assert "192.168.1.10" in caplog.text
+
+    def test_a_flood_of_peers_goes_quiet(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Remembering every peer that ever probed would be the real leak."""
+        # Arrange
+        trusted = TrustedProxies(TRUSTED)
+        # Act
+        with caplog.at_level(logging.WARNING, logger="grelmicro.clientip"):
+            for last in range(1, 40):
+                probe = scope(peer=f"203.0.113.{last}", forwarded="1.2.3.4")
+                resolve_client_address(probe, trusted)
+        # Assert
+        assert (
+            caplog.text.count("Ignored X-Forwarded-For")
+            == EXPECTED_WARNED_PEERS
+        )
+
+    @pytest.mark.parametrize("forwarded", [None, "", "   "])
+    def test_an_empty_header_is_not_a_forwarding_attempt(
+        self, forwarded: str | None, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Direct health checks must not spend another peer's report."""
+        # Arrange
+        trusted = TrustedProxies(TRUSTED)
+        # Act
+        with caplog.at_level(logging.WARNING, logger="grelmicro.clientip"):
+            resolve_client_address(
+                scope(peer="9.9.9.9", forwarded=forwarded), trusted
+            )
             silent = caplog.text
             resolve_client_address(
                 scope(peer="9.9.9.9", forwarded="1.2.3.4"), trusted


### PR DESCRIPTION
Closes #636.

`ClientAddress.degraded` promised something it did not deliver: it is False for `UNTRUSTED_PEER`, where `ip` is the connecting peer too. One mistyped CIDR in `TrustedProxies` therefore turned every request into `UNTRUSTED_PEER` carrying the proxy's own private address, and the guard the docs recommended (`if client.degraded: refuse`) let it through. The private network gate in the health docs then showed details to everyone, which is the bypass `degraded` was added to close in 0.33.0.

This takes the outcome the issue settled on: fix the words, point identity at `forwarded`, and make the misconfiguration audible. It also closes the two defects found in the same read.

## Identity points at `forwarded`

`forwarded` is `reason is RESOLVED`, the one outcome the library can vouch for on its own. No new API: `trusted_identity` would have been a literal alias, and moving `UNTRUSTED_PEER` into `degraded` would fire on every legitimate direct caller and destroy the one coherent guarantee `degraded` has.

The docs now state the trichotomy instead of hiding it behind a flag:

| Reason | Whose address is `ip` |
|---|---|
| `RESOLVED` | The caller |
| `UNTRUSTED_PEER`, `NO_FORWARDED_HEADER` | The peer, which is the caller only if nothing unlisted fronts the app |
| everything else | One of your own proxies |

That middle row is the honest part. No single boolean can be the universal identity predicate, because soundness there depends on topology the library cannot observe. An empty `TrustedProxies([])` is a legal deployment where every request is `UNTRUSTED_PEER`, the peer genuinely is the caller, and a `forwarded`-only rule would reject all traffic. The page says which check fits which deployment rather than pretending there is one.

Also corrected: `NO_FORWARDED_HEADER` no longer claims "the peer is the client" unconditionally, since an nginx missing `proxy_set_header X-Forwarded-For` forwards all client traffic headerless. And `key` now says it is a bucket, not an identity.

## Reporting a proxy missing from the trusted set

The misconfiguration had no symptom. Resolution now logs a line on the `grelmicro.clientip` logger when an untrusted peer sends a non-empty `X-Forwarded-For`:

```text
Ignored X-Forwarded-For from 192.168.1.10, which is not a trusted proxy.
```

All three conditions are required: the trusted set is non-empty, the peer is untrusted, and the header carries a value. `resolve_client_address` returns `UNTRUSTED_PEER` before reading headers, so dropping the last condition would fire on every headerless health check.

One line per peer, for at most eight peers, then silence. A busy proxy cannot flood the log, the set cannot grow past eight entries, and a caller probing the header cannot take the line your own proxy needs. The first version of this branch was once-per-process and did not check the value, which meant any scanner sending an empty header spent the report and the misconfigured proxy was never named. The security review caught it, and there is now a test for it.

A note on precedent, since the issue cited it: ASP.NET Core does log this, but at **Debug**, not Warning ([`ForwardedHeadersMiddleware.cs`](https://github.com/dotnet/aspnetcore/blob/main/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs)), and per request, which is why people see it flood ([jellyfin#15056](https://github.com/jellyfin/jellyfin/issues/15056)). nginx realip, Traefik and Envoy drop the header silently. Once per peer at warning level is the version that survives both objections: an operator sees it, and it cannot become noise.

## `TOO_MANY_ENTRIES` is reachable

It appeared exactly once in the module, its own definition, while `docs/clientip.md` listed it as an outcome. Rather than delete it, it now names a case `CHAIN_EXHAUSTED` was describing falsely: a header longer than `max_entries` is truncated to its rightmost entries, and when every entry read was a trusted proxy, the entries past the cap were never read, so nothing was exhausted.

No address changes. Both outcomes return the same verified peer and both are `degraded`. Only the reason differs, which matters for the alert the docs already recommend, and 500 padding entries is a stronger signal than an ordinary exhausted chain.

## Tests

`tests/test_clientip.py` covers the mistyped-CIDR bypass failing closed, `forwarded` across all four outcome shapes, the warning firing exactly once, a headerless request not spending it, silence for an empty trusted set and for a trusted peer, and truncated versus exhausted chains at the cap boundary. `grelmicro/clientip.py` stays at 100% line and branch coverage.
