### PR TITLE
✨ Cache an async generator producer, streamed or whole

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -359,6 +359,37 @@ Refreshing a key that was never cached simply computes and stores it. A refresh 
 !!! tip "Refreshing one key, not the whole cache"
     `cache_clear()` is bound to the whole `TTLCache`, so on a cache shared between functions it removes every function's entries. `refresh()` touches one key.
 
+### Streaming producers
+
+Decorate an async generator and `@cached` caches what it yields. Iterating the result streams the items, and the assembled list is stored once the producer finishes.
+
+```python title="stream.py"
+--8<-- "cache/stream.py"
+```
+
+This is the shape where one result is served two ways: a streaming endpoint that yields items as they are produced, and a buffered endpoint that returns the whole thing. Both read one entry, so whichever runs first pays for the work:
+
+```python
+@app.get("/answer/{question_id}/stream")
+async def stream(question_id: int) -> EventSourceResponse:
+    return EventSourceResponse(answer(question_id))
+
+
+@app.get("/answer/{question_id}")
+async def whole(question_id: int) -> str:
+    return "".join(await answer.collect(question_id))
+```
+
+**Only a completed sequence is stored.** A reader that stops early, and a producer that raises part way, both leave the key untouched. A truncated sequence is never published, so the next reader gets the whole thing rather than the part the first one happened to read.
+
+**A second reader waits, then replays.** Under the default `lock`, a concurrent miss folds like any other: the second caller waits for the first to finish and then replays the stored entry, rather than running the producer again. It trades incremental output for not paying twice. Use `lock=False` to let both stream live at the cost of two executions.
+
+**The stored form is a plain list**, so `await cache.get(key)` returns the items and anything else reading that key sees an ordinary cached value.
+
+`skip` receives the assembled list, so `skip=lambda items: not items` declines to store an empty sequence. `tags`, `early` and `refresh()` work as they do anywhere else, and `stale_ttl` serves the reserve when the producer fails before its first item. Past that the caller already holds part of the live sequence, so the error propagates rather than replaying items it just read.
+
+A sync generator is not supported and raises at decoration time. It yields its items once, so a cached one would replay as empty.
+
 ### Stampede Protection
 
 A cache stampede (or "dog-pile") happens when many callers miss the same key at once and all recompute it together. By default `@cached` folds those misses in-process (`lock="local"`). Raise it to `lock=True` to fold across replicas, drop it to `lock=False` to opt out, and add `early=` to refresh hot keys before they expire:
@@ -435,6 +466,7 @@ A flaky upstream then degrades to slightly stale data instead of an error storm.
 | Helper | Returns | Description |
 |---|---|---|
 | `refresh(*args, **kwargs)` | the new value | Recompute for these arguments and overwrite the stored entry. On a method, call it as `Class.method.refresh(obj, ...)`. |
+| `collect(*args, **kwargs)` | awaitable list | Read the whole sequence of a streaming producer. Only on an async generator. |
 | `cache_info()` | `CacheInfo` | Statistics for the whole cache backing this function. |
 | `cache_clear()` | awaitable | Remove every entry from that cache. Always a coroutine, even for a sync function. |
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* ✨ Cache an async generator with `@cached`. Iterating the decorated producer streams its items and stores the assembled list once it finishes, and `collect()` reads that same entry whole, so a streaming endpoint and a buffered one share one producer, one key and one execution. Only a completed sequence is stored, so a reader that stops early and a producer that raises part way both leave the key untouched rather than publishing a truncated result. ([#501](https://github.com/grelinfo/grelmicro/issues/501))
+
+### Fixed
+
+* 🐛 Stop `@cached` hanging on a generator function. An async generator is not a coroutine function, so it took the sync wrapper, which blocks its own thread waiting on the cache loop. Decorating one wedged the event loop on the first call, with no error. Async generators are now supported, and a sync generator raises at decoration time, since it yields its items once and a cached one would replay as empty. ([#501](https://github.com/grelinfo/grelmicro/issues/501))
+
 ## 0.34.2 - 2026-08-02
 
 ### Security

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -14,6 +14,7 @@
         - CacheSerializer
         - CacheSettingsValidationError
         - CachedFunction
+        - CachedStream
         - JsonSerializer
         - PickleSerializer
         - PydanticSerializer

--- a/docs/snippets/cache/stream.py
+++ b/docs/snippets/cache/stream.py
@@ -1,0 +1,28 @@
+from collections.abc import AsyncIterator
+
+from grelmicro import Grelmicro
+from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
+from grelmicro.cache.memory import MemoryCacheAdapter
+
+micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+
+cache = TTLCache(ttl=300, serializer=JsonSerializer())
+
+
+@cached(cache, key="answer:{question_id}")
+async def answer(question_id: int) -> AsyncIterator[str]:
+    for token in ("The", " answer", " is", " 42."):
+        yield token
+
+
+async def main() -> None:
+    async with micro:
+        # Streams live from the producer, stores the tokens at the end.
+        async for token in answer(1):
+            print(token)
+        # Replays the stored tokens, the producer does not run again.
+        async for token in answer(1):
+            print(token)
+        # The same entry, read whole.
+        tokens = await answer.collect(1)
+        print("".join(tokens))

--- a/grelmicro/cache/__init__.py
+++ b/grelmicro/cache/__init__.py
@@ -2,7 +2,7 @@
 
 from grelmicro.cache._component import Cache
 from grelmicro.cache._protocol import CacheBackend
-from grelmicro.cache.cached import CachedFunction, cached
+from grelmicro.cache.cached import CachedFunction, CachedStream, cached
 from grelmicro.cache.errors import CacheError, CacheSettingsValidationError
 from grelmicro.cache.serializers import (
     CacheSerializer,
@@ -20,6 +20,7 @@ __all__ = [
     "CacheSerializer",
     "CacheSettingsValidationError",
     "CachedFunction",
+    "CachedStream",
     "JsonSerializer",
     "PickleSerializer",
     "PydanticSerializer",

--- a/grelmicro/cache/_stampede.py
+++ b/grelmicro/cache/_stampede.py
@@ -19,7 +19,7 @@ from grelmicro._app import Grelmicro
 from grelmicro.coordination.lock import Lock
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable
 
     from grelmicro.cache.ttl import TTLCache
 
@@ -127,3 +127,46 @@ async def compute_with_stampede(
                     return result
                 return await compute()
         return await compute()
+
+
+async def stream_with_stampede(
+    cache: TTLCache,
+    key: str,
+    produce: Callable[[], AsyncIterator[Any]],
+    guard: AsyncStampedeGuard,
+    *,
+    per_key: bool,
+    auto_distributed: bool,
+) -> AsyncIterator[Any]:
+    """Stream ``produce`` once for ``key`` under stampede protection.
+
+    The streaming twin of `compute_with_stampede`, holding the same locks
+    for the whole stream. A second caller therefore waits, then replays
+    the stored entry from the double-check rather than producing it a
+    second time. A caller that stops reading closes ``produce`` without
+    storing anything, and releases the locks on its way out.
+    """
+    if not per_key:
+        async for item in produce():
+            yield item
+        return
+
+    the_lock = await guard.get_lock(key)
+    async with the_lock:
+        result: Any = await cache._peek(key, _SENTINEL)  # noqa: SLF001
+        if result is not _SENTINEL:
+            for item in result:
+                yield item
+            return
+        if auto_distributed and _has_lock_backend():
+            async with Lock(_stampede_lock_name(key)):
+                shared: Any = await cache._peek(key, _SENTINEL)  # noqa: SLF001
+                if shared is not _SENTINEL:
+                    for item in shared:
+                        yield item
+                    return
+                async for item in produce():
+                    yield item
+                return
+        async for item in produce():
+            yield item

--- a/grelmicro/cache/cached.py
+++ b/grelmicro/cache/cached.py
@@ -10,7 +10,14 @@ import random
 import threading
 import time
 from collections import OrderedDict
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Sequence,
+)
 from typing import (
     Annotated,
     Any,
@@ -19,7 +26,7 @@ from typing import (
     ParamSpec,
     Protocol,
     TypeVar,
-    cast,
+    overload,
 )
 
 from typing_extensions import Doc
@@ -31,6 +38,7 @@ from grelmicro.cache._stampede import (
     _has_lock_backend,
     _stampede_lock_name,
     compute_with_stampede,
+    stream_with_stampede,
 )
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.serializers import PickleSerializer
@@ -49,6 +57,7 @@ from grelmicro.metrics import _emit
 # ``ParamSpec``/``TypeVar`` is the working pattern.
 P = ParamSpec("P")
 R = TypeVar("R")
+T = TypeVar("T")
 
 
 class CachedFunction(Protocol[P, R]):
@@ -117,6 +126,92 @@ class CachedFunction(Protocol[P, R]):
         Typed as `Any` because a signature carrying `ParamSpec` cannot
         also express descriptor binding.
         """
+        ...
+
+
+class CachedStream(Protocol[P, T]):
+    """An async generator producer wrapped by `@cached`.
+
+    Iterating it streams the items. On a miss they arrive live from the
+    producer and the assembled list is stored once the producer runs to
+    completion. On a hit the stored list is replayed. A caller that stops
+    reading early stores nothing, so a truncated stream never becomes the
+    entry every later caller reads.
+
+    `collect` reads the same entry as a whole, so a streaming endpoint
+    and a buffered one share one producer, one key, and one execution.
+    """
+
+    __wrapped__: Callable[P, AsyncIterator[T]]
+    """The undecorated producer."""
+
+    __name__: str
+    """The undecorated producer's name."""
+
+    def __call__(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncGenerator[T, None]:
+        """Stream the items, producing them on a miss."""
+        ...
+
+    def collect(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> Coroutine[Any, Any, list[T]]:
+        """Return the whole sequence, producing it on a miss.
+
+        The buffered read of the entry `__call__` streams. Both share the
+        key, so whichever runs first populates it and the other serves it.
+        """
+        ...
+
+    def refresh(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> Coroutine[Any, Any, list[T]]:
+        """Produce the sequence again, store it, and return it whole.
+
+        Skips the read, so a live entry is replaced rather than served.
+        """
+        ...
+
+    def cache_info(self) -> CacheInfo:
+        """Return statistics for the whole cache backing this producer."""
+        ...
+
+    def cache_clear(self) -> Awaitable[None]:
+        """Remove every entry from the cache backing this producer."""
+        ...
+
+    def __get__(
+        self,
+        instance: Any,  # noqa: ANN401
+        owner: Any = None,  # noqa: ANN401
+        /,
+    ) -> Any:  # noqa: ANN401
+        """Bind as a method.
+
+        Typed as `Any` because a signature carrying `ParamSpec` cannot
+        also express descriptor binding.
+        """
+        ...
+
+
+class _CachedDecorator(Protocol):
+    """The decorator `cached()` returns.
+
+    An async generator producer becomes a `CachedStream`, and anything
+    else a `CachedFunction`.
+    """
+
+    @overload
+    def __call__(  # type: ignore[overload-overlap]
+        self, func: Callable[P, AsyncIterator[T]], /
+    ) -> CachedStream[P, T]: ...
+
+    @overload
+    def __call__(self, func: Callable[P, R], /) -> CachedFunction[P, R]: ...
+
+    def __call__(self, func: Any, /) -> Any:
+        """Wrap the decorated function."""
         ...
 
 
@@ -393,11 +488,17 @@ def cached(  # noqa: PLR0913, C901
             """,
         ),
     ] = (),
-) -> Callable[[Callable[P, R]], CachedFunction[P, R]]:
+) -> _CachedDecorator:
     """Cache decorator for sync and async functions.
 
     Automatically detects whether the decorated function is sync or
     async and wraps it accordingly.
+
+    An async generator producer is wrapped as a
+    [`CachedStream`][grelmicro.cache.CachedStream]: iterating it streams
+    the items and stores the assembled list once the producer completes,
+    and `collect()` reads that same entry whole. A sync generator is not
+    supported and raises.
 
     The decorated function exposes ``refresh()``, which recomputes for
     the given arguments and overwrites the stored entry, plus
@@ -414,7 +515,8 @@ def cached(  # noqa: PLR0913, C901
 
     Raises:
         TypeError: If both ``cache`` and ``ttl`` are given, if neither is
-            given, or if both ``key`` and ``key_maker`` are given.
+            given, if both ``key`` and ``key_maker`` are given, or if the
+            decorated function is a sync generator.
         ValueError: If ``lock`` is not ``True``, ``False``, or ``"local"``,
             if ``early`` is outside ``[0, 1)``, or if ``stale_ttl`` is not
             positive.
@@ -443,7 +545,16 @@ def cached(  # noqa: PLR0913, C901
 
     def decorator(
         func: Callable[P, R],
-    ) -> CachedFunction[P, R]:
+    ) -> Any:  # noqa: ANN401
+        if inspect.isgeneratorfunction(func):
+            name = getattr(func, "__qualname__", repr(func))
+            msg = (
+                f"@cached does not support the sync generator {name}. A "
+                f"generator yields its items once, so a cached one would "
+                f"replay as empty. Make it an async generator to stream "
+                f"from the cache, or return a list to cache it whole."
+            )
+            raise TypeError(msg)
         if key is None and key_maker is None and _takes_self(func):
             name = getattr(func, "__qualname__", repr(func))
             msg = (
@@ -456,7 +567,8 @@ def cached(  # noqa: PLR0913, C901
                 f"example key='user:{{user_id}}'."
             )
             raise TypeError(msg)
-        is_async_func = inspect.iscoroutinefunction(func)
+        is_async_gen_func = inspect.isasyncgenfunction(func)
+        is_async_func = inspect.iscoroutinefunction(func) or is_async_gen_func
         if is_private_cache and not is_async_func:
             msg = (
                 "@cached(ttl=...) supports async functions only: the "
@@ -487,7 +599,20 @@ def cached(  # noqa: PLR0913, C901
             ) -> str:
                 return key
 
-        if is_async_func:
+        if is_async_gen_func:
+            wrapper = _build_async_gen_wrapper(
+                func,
+                cache,
+                resolved_key_maker,
+                skip,
+                typed=typed,
+                per_key=per_key,
+                auto_distributed=auto_distributed,
+                early=early,
+                stale_ttl=stale_ttl,
+                tag_spec=tag_spec,
+            )
+        elif is_async_func:
             wrapper = _build_async_wrapper(
                 func,
                 cache,
@@ -515,7 +640,7 @@ def cached(  # noqa: PLR0913, C901
             )
         wrapper.cache_info = cache.cache_info
         wrapper.cache_clear = cache.clear
-        return cast("CachedFunction[P, R]", wrapper)
+        return wrapper
 
     return decorator
 
@@ -602,7 +727,7 @@ def _serve_stale_sync(cache: TTLCache, key: str, loop: Any) -> tuple[bool, Any]:
 # --- Async function ---
 
 
-def _build_async_wrapper(  # noqa: C901
+def _build_async_wrapper(  # noqa: C901, PLR0913
     func: Any,  # noqa: ANN401
     cache: TTLCache,
     key_maker: Any,  # noqa: ANN401
@@ -614,9 +739,15 @@ def _build_async_wrapper(  # noqa: C901
     early: float | None,
     stale_ttl: float | None,
     tag_spec: _TagSpec,
+    guard: AsyncStampedeGuard | None = None,
 ) -> Any:  # noqa: ANN401
-    """Build async wrapper for cached decorator."""
-    guard = AsyncStampedeGuard()
+    """Build async wrapper for cached decorator.
+
+    ``guard`` is shared when a streaming producer builds its buffered
+    twin, so both fold onto the same per-key lock instead of running the
+    producer once each.
+    """
+    guard = guard if guard is not None else AsyncStampedeGuard()
     # Strong references to in-flight background refreshes. The event loop
     # holds only weak references, so a task with no other referent can be
     # collected before it finishes and would then report nothing at all.
@@ -812,6 +943,164 @@ async def _compute_and_cache(
         if early is not None:
             await _write_meta(cache, key, _now(), delta)
     return result
+
+
+# --- Async generator producer ---
+
+
+def _build_async_gen_wrapper(
+    func: Any,  # noqa: ANN401
+    cache: TTLCache,
+    key_maker: Any,  # noqa: ANN401
+    skip: Any,  # noqa: ANN401
+    *,
+    typed: bool,
+    per_key: bool,
+    auto_distributed: bool,
+    early: float | None,
+    stale_ttl: float | None,
+    tag_spec: _TagSpec,
+) -> Any:  # noqa: ANN401
+    """Build the wrapper for an async generator producer."""
+    guard = AsyncStampedeGuard()
+    refresh_tasks: set[asyncio.Task[None]] = set()
+
+    @functools.wraps(func)
+    async def collector(*args: Any, **kwargs: Any) -> list[Any]:  # noqa: ANN401
+        return [item async for item in func(*args, **kwargs)]
+
+    # The buffered twin drains the producer into the list the stream
+    # stores, so `collect()` and `refresh()` inherit the stampede
+    # folding, early refresh and stale reserve already built there.
+    buffered = _build_async_wrapper(
+        collector,
+        cache,
+        key_maker,
+        skip,
+        typed=typed,
+        per_key=per_key,
+        auto_distributed=auto_distributed,
+        early=early,
+        stale_ttl=stale_ttl,
+        tag_spec=tag_spec,
+        guard=guard,
+    )
+
+    @functools.wraps(func)
+    async def stream_wrapper(*args: Any, **kwargs: Any) -> AsyncIterator[Any]:  # noqa: ANN401
+        key = _make_key(func, args, kwargs, key_maker, typed=typed)
+        result: Any = await cache.get(key, _SENTINEL)
+        if result is not _SENTINEL:
+            if early is not None:
+                await _maybe_refresh_async(
+                    collector,
+                    args,
+                    kwargs,
+                    cache,
+                    key,
+                    skip,
+                    early,
+                    stale_ttl,
+                    guard,
+                    tag_spec,
+                    refresh_tasks,
+                )
+            for item in result:
+                yield item
+            return
+
+        def produce() -> AsyncIterator[Any]:
+            return _stream_and_store(
+                func,
+                args,
+                kwargs,
+                cache,
+                key,
+                skip,
+                early=early,
+                stale_ttl=stale_ttl,
+                tag_spec=tag_spec,
+            )
+
+        stream = stream_with_stampede(
+            cache,
+            key,
+            produce,
+            guard,
+            per_key=per_key,
+            auto_distributed=auto_distributed,
+        )
+        if stale_ttl is not None:
+            stream = _stream_stale_on_error(stream, cache, key)
+        async for item in stream:
+            yield item
+
+    wrapper: Any = stream_wrapper
+    wrapper.collect = buffered
+    wrapper.refresh = buffered.refresh
+    return wrapper
+
+
+async def _stream_stale_on_error(
+    stream: AsyncIterator[Any],
+    cache: TTLCache,
+    key: str,
+) -> AsyncIterator[Any]:
+    """Replay the stale reserve for a stream that failed at the start.
+
+    A reserve can only stand in for a producer that failed before its
+    first item. Past that the caller already holds part of the live
+    sequence, and replaying a stored one would repeat what it just read,
+    so the error propagates instead.
+    """
+    started = False
+    try:
+        async for item in stream:
+            started = True
+            yield item
+    except Exception:
+        if started:
+            raise
+        found, value = await _serve_stale_async(cache, key)
+        if not found:
+            raise
+        for item in value:
+            yield item
+
+
+async def _stream_and_store(
+    func: Callable[..., AsyncIterator[Any]],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    cache: TTLCache,
+    key: str,
+    skip: Callable[[Any], bool] | None,
+    *,
+    early: float | None,
+    stale_ttl: float | None,
+    tag_spec: _TagSpec,
+) -> AsyncIterator[Any]:
+    """Stream a producer live, storing the assembled list at the end.
+
+    Nothing is stored until the producer is exhausted, so a caller that
+    stops reading, and a producer that raises part way, both leave the
+    key untouched rather than publishing a truncated sequence.
+    """
+    started = time.perf_counter()
+    items: list[Any] = []
+    async for item in func(*args, **kwargs):
+        items.append(item)
+        yield item
+    delta = time.perf_counter() - started
+    if skip is None or not skip(items):
+        await cache.set(
+            key,
+            items,
+            tags=tag_spec.render(args, kwargs),
+            stale_ttl=stale_ttl,
+        )
+        if early is not None:
+            await _write_meta(cache, key, _now(), delta)
 
 
 # --- Sync function (delegates to async cache via from_thread) ---

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -58,6 +58,9 @@
     "CachedFunction": {
       "()": "(*args, **kwargs)"
     },
+    "CachedStream": {
+      "()": "(*args, **kwargs)"
+    },
     "JsonSerializer": {
       "()": "()"
     },

--- a/tests/cache/test_cached_stream.py
+++ b/tests/cache/test_cached_stream.py
@@ -1,0 +1,582 @@
+"""Test @cached on an async generator producer.
+
+The point of the shape is that one producer backs two reads: a stream
+that yields items as they arrive and a buffered read of the same entry.
+Anything that lets a truncated sequence become that entry is a
+correctness bug, so the abandonment cases carry as much weight as the
+happy path.
+"""
+
+import asyncio
+import sys
+from collections.abc import AsyncIterator
+from contextlib import suppress
+
+import pytest
+
+from grelmicro import Grelmicro
+from grelmicro.cache.cached import cached
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache.serializers import JsonSerializer, PickleSerializer
+from grelmicro.cache.ttl import TTLCache
+from grelmicro.coordination import Coordination
+from grelmicro.coordination.memory import MemoryLockAdapter
+
+pytestmark = [pytest.mark.timeout(10)]
+
+EXPECTED_ITEMS = [0, 1, 2]
+EXPECTED_CALLS_1 = 1
+EXPECTED_CALLS_2 = 2
+EXPECTED_PARTIAL = 2
+
+
+def _make_cache(ttl: float = 60) -> TTLCache:
+    """Create a TTLCache on the in-memory backend."""
+    backend = MemoryCacheAdapter()
+    with suppress(RuntimeError):
+        backend._loop = asyncio.get_running_loop()
+    return TTLCache(ttl=ttl, backend=backend, serializer=PickleSerializer())
+
+
+class TestStreamAndReplay:
+    """A producer runs once, then its items are replayed."""
+
+    async def test_streams_live_then_replays(self) -> None:
+        """The miss streams from the producer, the hit from the entry."""
+        # Arrange
+        cache = _make_cache()
+        calls = 0
+
+        @cached(cache, key="s:{n}")
+        async def produce(n: int) -> AsyncIterator[int]:
+            nonlocal calls
+            calls += 1
+            for item in range(n):
+                yield item
+
+        # Act
+        miss = [item async for item in produce(3)]
+        hit = [item async for item in produce(3)]
+        # Assert
+        assert miss == EXPECTED_ITEMS
+        assert hit == EXPECTED_ITEMS
+        assert calls == EXPECTED_CALLS_1
+
+    async def test_items_arrive_before_the_producer_finishes(self) -> None:
+        """A miss must stream, not buffer and hand over at the end."""
+        # Arrange
+        cache = _make_cache()
+        released = asyncio.Event()
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            yield 0
+            await released.wait()
+            yield 1
+
+        # Act
+        stream = produce()
+        first = await anext(stream)
+        # Assert
+        assert first == 0
+        # Cleanup
+        released.set()
+        assert [item async for item in stream] == [1]
+
+    async def test_the_key_holds_a_plain_list(self) -> None:
+        """The stored form is the sequence, so anything can read it."""
+        # Arrange
+        cache = _make_cache()
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            for item in range(3):
+                yield item
+
+        # Act
+        [item async for item in produce()]
+        # Assert
+        assert await cache.get("s") == EXPECTED_ITEMS
+
+
+class TestCollect:
+    """The buffered read and the stream share one entry."""
+
+    async def test_collect_serves_what_the_stream_stored(self) -> None:
+        """Streaming first, collecting second, one execution."""
+        # Arrange
+        cache = _make_cache()
+        calls = 0
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            nonlocal calls
+            calls += 1
+            for item in range(3):
+                yield item
+
+        # Act
+        streamed = [item async for item in produce()]
+        collected = await produce.collect()
+        # Assert
+        assert streamed == collected == EXPECTED_ITEMS
+        assert calls == EXPECTED_CALLS_1
+
+    async def test_the_stream_serves_what_collect_stored(self) -> None:
+        """Collecting first, streaming second, still one execution."""
+        # Arrange
+        cache = _make_cache()
+        calls = 0
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            nonlocal calls
+            calls += 1
+            for item in range(3):
+                yield item
+
+        # Act
+        collected = await produce.collect()
+        streamed = [item async for item in produce()]
+        # Assert
+        assert collected == streamed == EXPECTED_ITEMS
+        assert calls == EXPECTED_CALLS_1
+
+    async def test_refresh_replaces_a_live_entry(self) -> None:
+        """A caller asking for fresh items gets the producer, not the entry."""
+        # Arrange
+        cache = _make_cache()
+        calls = 0
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            nonlocal calls
+            calls += 1
+            for item in range(3):
+                yield item
+
+        # Act
+        await produce.collect()
+        refreshed = await produce.refresh()
+        # Assert
+        assert refreshed == EXPECTED_ITEMS
+        assert calls == EXPECTED_CALLS_2
+
+    async def test_cache_helpers_are_attached(self) -> None:
+        """The producer carries the same helpers as any cached function."""
+        # Arrange
+        cache = _make_cache()
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            yield 0
+
+        # Act
+        [item async for item in produce()]
+        info = produce.cache_info()
+        await produce.cache_clear()
+        # Assert
+        assert info.misses == EXPECTED_CALLS_1
+        assert await cache.get("s") is None
+
+
+class TestPartialStreams:
+    """A truncated sequence must never become the entry."""
+
+    async def test_an_abandoned_stream_stores_nothing(self) -> None:
+        """A reader that stops early leaves the key untouched."""
+        # Arrange
+        cache = _make_cache()
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            for item in range(5):
+                yield item
+
+        # Act
+        stream = produce()
+        partial = [await anext(stream), await anext(stream)]
+        await stream.aclose()
+        # Assert
+        assert partial == [0, 1]
+        assert await cache.get("s") is None
+
+    async def test_the_next_reader_gets_the_whole_sequence(self) -> None:
+        """An abandoned stream must not truncate what anyone reads later."""
+        # Arrange
+        cache = _make_cache()
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            for item in range(5):
+                yield item
+
+        # Act
+        stream = produce()
+        await anext(stream)
+        await stream.aclose()
+        # Assert
+        assert [item async for item in produce()] == [0, 1, 2, 3, 4]
+
+    async def test_a_producer_failing_part_way_stores_nothing(self) -> None:
+        """The error propagates and the partial sequence is discarded."""
+        # Arrange
+        cache = _make_cache()
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            yield 0
+            yield 1
+            msg = "upstream died"
+            raise RuntimeError(msg)
+
+        # Act
+        stream = produce()
+        seen = [await anext(stream), await anext(stream)]
+        # Assert
+        with pytest.raises(RuntimeError, match="upstream died"):
+            await anext(stream)
+        assert seen == [0, 1]
+        assert await cache.get("s") is None
+
+    async def test_an_abandoned_collect_stores_nothing(self) -> None:
+        """Cancelling the buffered read leaves the key untouched too."""
+        # Arrange
+        cache = _make_cache()
+        started = asyncio.Event()
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            started.set()
+            yield 0
+            await asyncio.sleep(10)
+            yield 1
+
+        # Act
+        task = asyncio.create_task(produce.collect())
+        await started.wait()
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        # Assert
+        assert await cache.get("s") is None
+
+
+class TestStampede:
+    """Concurrent misses fold onto one producer."""
+
+    async def test_concurrent_streams_run_the_producer_once(self) -> None:
+        """The second reader waits, then replays the stored entry."""
+        # Arrange
+        cache = _make_cache()
+        calls = 0
+        released = asyncio.Event()
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            nonlocal calls
+            calls += 1
+            await released.wait()
+            for item in range(3):
+                yield item
+
+        async def read() -> list[int]:
+            return [item async for item in produce()]
+
+        # Act
+        first = asyncio.create_task(read())
+        second = asyncio.create_task(read())
+        await asyncio.sleep(0.02)
+        released.set()
+        # Assert
+        assert await first == EXPECTED_ITEMS
+        assert await second == EXPECTED_ITEMS
+        assert calls == EXPECTED_CALLS_1
+
+    async def test_a_stream_and_a_collect_fold_together(self) -> None:
+        """The two reads share the lock, not only the key."""
+        # Arrange
+        cache = _make_cache()
+        calls = 0
+        released = asyncio.Event()
+
+        @cached(cache, key="s")
+        async def produce() -> AsyncIterator[int]:
+            nonlocal calls
+            calls += 1
+            await released.wait()
+            for item in range(3):
+                yield item
+
+        async def read() -> list[int]:
+            return [item async for item in produce()]
+
+        # Act
+        streaming = asyncio.create_task(read())
+        buffered = asyncio.create_task(produce.collect())
+        await asyncio.sleep(0.02)
+        released.set()
+        # Assert
+        assert await streaming == EXPECTED_ITEMS
+        assert await buffered == EXPECTED_ITEMS
+        assert calls == EXPECTED_CALLS_1
+
+    async def test_lock_false_lets_both_run(self) -> None:
+        """Opting out of folding is still available to a streaming producer."""
+        # Arrange
+        cache = _make_cache()
+        calls = 0
+        released = asyncio.Event()
+
+        @cached(cache, key="s", lock=False)
+        async def produce() -> AsyncIterator[int]:
+            nonlocal calls
+            calls += 1
+            await released.wait()
+            for item in range(3):
+                yield item
+
+        async def read() -> list[int]:
+            return [item async for item in produce()]
+
+        # Act
+        first = asyncio.create_task(read())
+        second = asyncio.create_task(read())
+        await asyncio.sleep(0.02)
+        released.set()
+        await first
+        await second
+        # Assert
+        assert calls == EXPECTED_CALLS_2
+
+    async def test_two_replicas_fold_through_the_lock_backend(self) -> None:
+        """lock=True serializes streaming misses across replicas."""
+        # Arrange
+        loop = asyncio.get_running_loop()
+        backend = MemoryCacheAdapter()
+        backend._loop = loop
+        cache = TTLCache(backend=backend, serializer=PickleSerializer())
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+        calls = 0
+        released = asyncio.Event()
+
+        async def impl() -> AsyncIterator[int]:
+            nonlocal calls
+            calls += 1
+            await released.wait()
+            for item in range(3):
+                yield item
+
+        replica_a = cached(cache, key="s", lock=True)(impl)
+        replica_b = cached(cache, key="s", lock=True)(impl)
+
+        # Act
+        async with micro:
+
+            async def read(replica) -> list[int]:  # noqa: ANN001
+                return [item async for item in replica()]
+
+            first = asyncio.create_task(read(replica_a))
+            await asyncio.sleep(0.02)
+            second = asyncio.create_task(read(replica_b))
+            await asyncio.sleep(0.02)
+            released.set()
+            items_a = await first
+            items_b = await second
+        # Assert
+        assert items_a == EXPECTED_ITEMS
+        assert items_b == EXPECTED_ITEMS
+        assert calls == EXPECTED_CALLS_1
+
+    async def test_a_replica_arriving_after_the_store_replays(self) -> None:
+        """The double-check inside the distributed lock serves the entry."""
+        # Arrange
+        loop = asyncio.get_running_loop()
+        backend = MemoryCacheAdapter()
+        backend._loop = loop
+        cache = TTLCache(backend=backend, serializer=PickleSerializer())
+        micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+        calls = 0
+
+        async def impl() -> AsyncIterator[int]:
+            nonlocal calls
+            calls += 1
+            for item in range(3):
+                yield item
+
+        replica_a = cached(cache, key="s", lock=True)(impl)
+        replica_b = cached(cache, key="s", lock=True)(impl)
+
+        # Act
+        async with micro:
+            first = [item async for item in replica_a()]
+            second = [item async for item in replica_b()]
+        # Assert
+        assert first == second == EXPECTED_ITEMS
+        assert calls == EXPECTED_CALLS_1
+
+
+class TestSkipAndTags:
+    """The predicate and the tags see the assembled sequence."""
+
+    async def test_skip_receives_the_whole_sequence(self) -> None:
+        """A producer that yielded nothing worth keeping is not stored."""
+        # Arrange
+        cache = _make_cache()
+
+        @cached(cache, key="s", skip=lambda items: not items)
+        async def produce() -> AsyncIterator[int]:
+            for item in ():
+                yield item
+
+        # Act
+        streamed = [item async for item in produce()]
+        # Assert
+        assert streamed == []
+        assert await cache.get("s") is None
+
+    async def test_tags_invalidate_a_stored_sequence(self) -> None:
+        """Tag invalidation reaches a streamed entry like any other."""
+        # Arrange
+        cache = _make_cache()
+
+        @cached(cache, key="s:{n}", tags=["seq", "seq:{n}"])
+        async def produce(n: int) -> AsyncIterator[int]:
+            for item in range(n):
+                yield item
+
+        # Act
+        [item async for item in produce(3)]
+        await cache.delete_tags("seq:3")
+        # Assert
+        assert await cache.get("s:3") is None
+
+
+class TestStaleOnError:
+    """A reserve stands in only where it can stand in cleanly."""
+
+    async def test_serves_stale_when_the_producer_fails_at_the_start(
+        self,
+    ) -> None:
+        """Nothing was yielded, so the reserve replays without a seam."""
+        # Arrange
+        cache = _make_cache(ttl=0.05)
+        fail = False
+
+        @cached(cache, key="s", stale_ttl=60)
+        async def produce() -> AsyncIterator[int]:
+            if fail:
+                msg = "upstream down"
+                raise RuntimeError(msg)
+            for item in range(3):
+                yield item
+
+        # Act
+        [item async for item in produce()]
+        await asyncio.sleep(0.1)
+        fail = True
+        # Assert
+        assert [item async for item in produce()] == EXPECTED_ITEMS
+
+    async def test_propagates_when_the_producer_fails_part_way(self) -> None:
+        """The caller already holds live items, so a replay would repeat."""
+        # Arrange
+        cache = _make_cache(ttl=0.05)
+        fail = False
+
+        @cached(cache, key="s", stale_ttl=60)
+        async def produce() -> AsyncIterator[int]:
+            yield 0
+            yield 1
+            if fail:
+                msg = "upstream died"
+                raise RuntimeError(msg)
+            yield 2
+
+        # Act
+        [item async for item in produce()]
+        await asyncio.sleep(0.1)
+        fail = True
+        stream = produce()
+        seen = [await anext(stream), await anext(stream)]
+        # Assert
+        with pytest.raises(RuntimeError, match="upstream died"):
+            await anext(stream)
+        assert seen == [0, 1]
+
+    async def test_propagates_when_there_is_no_reserve(self) -> None:
+        """A first call that fails has nothing to fall back to."""
+        # Arrange
+        cache = _make_cache()
+
+        @cached(cache, key="s", stale_ttl=60)
+        async def produce() -> AsyncIterator[int]:
+            msg = "upstream down"
+            raise RuntimeError(msg)
+            yield 0
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="upstream down"):
+            [item async for item in produce()]
+
+
+class _Clock:
+    """Mutable wall clock standing in for ``cached._now``."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+
+class TestEarlyRefresh:
+    """The background recompute drains the producer with no reader."""
+
+    async def test_a_hit_in_the_early_window_refreshes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The refresh stores a new sequence without anyone streaming it."""
+        # Arrange
+        cached_mod = sys.modules["grelmicro.cache.cached"]
+        clock = _Clock()
+        monkeypatch.setattr(cached_mod, "_now", clock)
+        monkeypatch.setattr(
+            cached_mod, "_xfetch_should_refresh", lambda *_: True
+        )
+        cache = _make_cache(ttl=60)
+        calls = 0
+
+        @cached(cache, key="s", early=0.9)
+        async def produce() -> AsyncIterator[int]:
+            nonlocal calls
+            calls += 1
+            for item in range(3):
+                yield item
+
+        # Act
+        [item async for item in produce()]
+        clock.t = 1055  # remaining 5s, inside the 54s early window
+        [item async for item in produce()]
+        await asyncio.sleep(0.05)
+        # Assert
+        assert calls == EXPECTED_CALLS_2
+        assert await cache.get("s") == EXPECTED_ITEMS
+
+
+class TestSyncGeneratorIsRefused:
+    """A sync generator would replay as empty, so it raises."""
+
+    def test_decorating_a_sync_generator_raises(self) -> None:
+        """The error names the two ways out."""
+        # Arrange
+        cache = TTLCache(
+            backend=MemoryCacheAdapter(), serializer=JsonSerializer()
+        )
+
+        # Act / Assert
+        with pytest.raises(TypeError, match="does not support the sync"):
+
+            @cached(cache, key="s")
+            def produce():  # noqa: ANN202
+                yield 0

--- a/tests/cache/test_cached_stream.py
+++ b/tests/cache/test_cached_stream.py
@@ -519,6 +519,38 @@ class TestStaleOnError:
         with pytest.raises(RuntimeError, match="upstream down"):
             [item async for item in produce()]
 
+    async def test_cancellation_is_not_an_upstream_failure(self) -> None:
+        """A cancelled reader must not be answered with the reserve.
+
+        `CancelledError` derives from `BaseException`, so the stale
+        handler cannot catch it. Widening that clause would turn
+        cancellation into a stale serve and swallow the cancel.
+        """
+        # Arrange
+        cache = _make_cache(ttl=0.05)
+        hang = False
+
+        @cached(cache, key="s", stale_ttl=60)
+        async def produce() -> AsyncIterator[int]:
+            if hang:
+                await asyncio.sleep(10)
+            for item in range(3):
+                yield item
+
+        async def read() -> list[int]:
+            return [item async for item in produce()]
+
+        # Act
+        [item async for item in produce()]
+        await asyncio.sleep(0.1)
+        hang = True
+        task = asyncio.create_task(read())
+        await asyncio.sleep(0.02)
+        task.cancel()
+        # Assert
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
 
 class _Clock:
     """Mutable wall clock standing in for ``cached._now``."""


### PR DESCRIPTION
Closes #501.

`@cached` memoizes a return value, so it could not cache a producer that yields, and a streaming endpoint and a buffered one could not share an entry without hand-rolling the key. This adds that, and fixes a hang found on the way in.

## `@cached` on an async generator hung the event loop

`inspect.iscoroutinefunction` is False for an async generator function, so decorating one routed it to the **sync** wrapper, which calls `asyncio.run_coroutine_threadsafe(...).result()`. Called from inside the running loop, that blocks the loop's own thread waiting for a coroutine only that thread can service. The sketch in the issue did not fail, it wedged. Reproduced before the fix, and my probe had to be killed.

## The shape

One producer, one key, one execution, read two ways:

```python
@cached(cache, key="answer:{question_id}")
async def answer(question_id: int) -> AsyncIterator[str]:
    async for token in llm.stream(question_id):
        yield token


@app.get("/answer/{question_id}/stream")
async def stream(question_id: int) -> EventSourceResponse:
    return EventSourceResponse(answer(question_id))


@app.get("/answer/{question_id}")
async def whole(question_id: int) -> str:
    return "".join(await answer.collect(question_id))
```

Whichever endpoint runs first pays for the work. A miss streams live from the producer and stores the assembled list when it finishes. A hit replays that list.

The three open questions in the issue:

- **Partial streams are never stored.** A reader that stops early, and a producer that raises part way, both leave the key untouched. Storing a truncated sequence would publish it to every later reader, which is the kind of bug that never announces itself. Abandonment falls out of the generator protocol: closing the wrapper closes the producer, so the store is simply never reached.
- **`skip=` receives the assembled list**, so `skip=lambda items: not items` declines to store an empty sequence. `early=`, `stale_ttl`, `tags`, `lock` and `refresh()` all compose. `stale_ttl` serves the reserve only when the producer fails **before its first item**: past that the caller already holds part of the live sequence and a replay would repeat what it just read, so the error propagates.
- **The stored form is a plain list**, so `await cache.get(key)` returns the items and a buffered `@cached` function on the same key interoperates.

Concurrent misses fold the way `lock=` already means: the second caller waits, then replays the finished entry rather than running the producer twice. The stampede helper gained a streaming twin that holds the same in-process and cross-replica locks, with the same double-check, so a caller arriving after the work is done replays instead of producing.

A sync generator raises at decoration time. It yields once, so a cached one would replay as empty.

## API

`cached()` now returns an overloaded decorator protocol: an async generator becomes a `CachedStream`, everything else stays a `CachedFunction`. `CachedStream.__call__` is typed as `AsyncGenerator[T, None]`, so `aclose()` is available, and `collect`/`refresh` as coroutines, so `asyncio.create_task(produce.collect(...))` type-checks.

`collect()` is the buffered twin drained through the existing async wrapper, sharing the stream's stampede guard. That is why the two fold onto one execution rather than merely sharing a key.

## Prior art

No library ships this primitive. [LiteLLM](https://docs.litellm.ai/docs/completion/stream) is the closest real implementation and uses the same accumulate-then-replay shape, wrapping the stored chunk list in an iterator that is drop-in interchangeable with a live stream. aiocache and cachetools have nothing here, and cachetools is synchronous besides. The one thing LiteLLM does that this does not is tee to live subscribers mid-stream, which only works within a single worker and would make the guarantee differ local vs cross-replica.

## Tests

23 tests in `tests/cache/test_cached_stream.py`: replay, both directions of the shared entry, items arriving before the producer finishes, abandoned stream and abandoned `collect()`, a producer failing part way, in-process and cross-replica folding, the double-check replay, `lock=False`, `skip`, tags, both `stale_ttl` cases plus no-reserve, early refresh with no reader, and the sync-generator guard. `cached.py` and `_stampede.py` stay at 100% line and branch coverage.
