### PR TITLE
✅ Stop the release matrix failing on a lock lease that lapsed mid-test

### DIFF
--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -486,15 +486,15 @@ async def test_lock_from_thread_release(lock: Lock) -> None:
     await asyncio.to_thread(sync)
 
 
-async def test_lock_release_acquired(lock: Lock) -> None:
+async def test_lock_release_acquired(held_lock: Lock) -> None:
     """Test Lock release acquired."""
     # Arrange
-    await lock.acquire()
+    await held_lock.acquire()
 
     # Act
-    locked_before = await lock.locked()
-    await lock.release()
-    locked_after = await lock.locked()
+    locked_before = await held_lock.locked()
+    await held_lock.release()
+    locked_after = await held_lock.locked()
 
     # Assert
     assert locked_before is True
@@ -739,11 +739,13 @@ async def test_from_thread_context_manager_binds_handle(
     assert isinstance(handles[0], LockHandle)
 
 
-async def test_fencing_token_climbs_across_reacquire(lock: Lock) -> None:
+async def test_fencing_token_climbs_across_reacquire(
+    held_lock: Lock,
+) -> None:
     """Releasing and re-acquiring mints a strictly greater fencing token."""
-    first = await lock.acquire()
-    await lock.release()
-    second = await lock.acquire()
+    first = await held_lock.acquire()
+    await held_lock.release()
+    second = await held_lock.acquire()
 
     assert second.fencing_token > first.fencing_token
 
@@ -798,12 +800,12 @@ async def test_lock_reentrant_acquire_nowait_then_acquire(lock: Lock) -> None:
         await lock.acquire()
 
 
-async def test_lock_reacquire_after_release(lock: Lock) -> None:
+async def test_lock_reacquire_after_release(held_lock: Lock) -> None:
     """Test Lock can be acquired again after release."""
-    await lock.acquire()
-    await lock.release()
-    await lock.acquire()
-    assert await lock.locked() is True
+    await held_lock.acquire()
+    await held_lock.release()
+    await held_lock.acquire()
+    assert await held_lock.locked() is True
 
 
 async def test_lock_reacquire_after_context_manager(lock: Lock) -> None:
@@ -985,15 +987,17 @@ async def test_reconfigure_changes_lease_duration_for_next_acquire(
     assert spy.call_args.kwargs["duration"] == 42  # noqa: PLR2004
 
 
-async def test_reconfigure_while_held_keeps_release_working(lock: Lock) -> None:
+async def test_reconfigure_while_held_keeps_release_working(
+    held_lock: Lock,
+) -> None:
     """A swap during a held lease does not break the release path."""
-    new_config = lock.config.model_copy(update={"lease_duration": 5})
+    new_config = held_lock.config.model_copy(update={"lease_duration": 5})
 
-    await lock.acquire()
-    await lock.reconfigure(new_config)
-    await lock.release()
+    await held_lock.acquire()
+    await held_lock.reconfigure(new_config)
+    await held_lock.release()
 
-    assert await lock.locked() is False
+    assert await held_lock.locked() is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The 0.34.3 release failed on the Python 3.14 matrix, in `full-checks`, before `publish-pypi`. The tag exists, nothing was published.

```
FAILED tests/coordination/test_lock.py::test_reconfigure_while_held_keeps_release_working
  grelmicro.coordination.errors.LockNotOwnedError:
  Failed to release lock: name=test_leased_lock, reason=lock not owned
```

Not a product bug. It is the race #628 already fixed for a different set of tests, in one that was missed.

The default `lock` fixture leases for **10 ms**. The test acquires, reconfigures, then releases:

```python
await lock.acquire()
await lock.reconfigure(new_config)
await lock.release()
```

On a 3.14 runner already oversubscribed by `-n auto`, where the modules run about twice as slow as 3.12, the lease lapses between the acquire and the release, so `release()` correctly reports the lock is no longer owned. The assertion never ran.

The file already has the fixture for exactly this: `held_lock`, documented as "Lock whose lease is still held when the test asserts about it", leasing for 30 s. This test simply was not moved to it.

## Also moved

Three neighbours have the same shape, a `release()` on the 10 ms lease after doing work, so they can fail the same way on a loaded runner:

- `test_lock_release_acquired`, which adds a `locked()` round-trip between the acquire and the release
- `test_fencing_token_climbs_across_reacquire`
- `test_lock_reacquire_after_release`

The expiry tests are deliberately left on the short lease. `test_lock_release_expired` and `test_lock_from_thread_release_expired` need the lease to lapse, since that is what they assert.

## Verification

`tests/coordination/` passes, 659 tests, and `test_lock.py` passes again under the randomized default ordering. This does not reproduce locally on demand, since it needs a runner slow enough to lose a 10 ms lease, so the argument is the fixture semantics rather than a red-to-green demo.
