### PR TITLE
🧰 Drop null fields from /healthz and smooth the uses= friction

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased
+
+### Breaking
+
+* 💥 Leave `error` and `details` out of a `/healthz` check that has neither. A passing check sent `"error": null` on every poll, and with details enabled it sent `"details": null` too, so the highest-frequency response in the service spent bytes reporting that nothing happened. A passing check is now `{"status": "ok", "critical": true}`, and a failing one still carries its `error`. The OpenAPI schema types both fields as a plain string and object instead of promising a nullable value that never arrives. Read an absent `error` as a pass. A consumer that required the key needs updating. ([#649](https://github.com/grelinfo/grelmicro/issues/649))
+
+### Features
+
+* ✨ Skip a `None` entry in `Grelmicro(uses=[...])` and `Bulkhead(uses=[...])`. A component registered only for one backend now stays a plain expression, `uses=[Log(), redis if backend == "redis" else None]`, instead of a star-unpacked conditional or a helper function. `micro.use(None)` still raises, because a single call can be guarded with `if`. ([#646](https://github.com/grelinfo/grelmicro/issues/646))
+* ✨ Export `Usable`, the type of everything `uses=` accepts. Building the list in a variable did not type-check, because `Component` was the only exported name and a `Provider` is not a `Component`. Annotate it `list[Usable]` and append either. ([#646](https://github.com/grelinfo/grelmicro/issues/646))
+
+### Fixed
+
+* 🐛 Instantiate a bare class passed to `Bulkhead(uses=[...])`. The parameter documented the same shape as `Grelmicro(uses=[...])`, which accepts a class with no parens, but the bulkhead entered the class object itself and failed on startup. ([#646](https://github.com/grelinfo/grelmicro/issues/646))
+* 🐛 Reject `micro.use(None)` with a message naming the fix. It appended `None` to the item list and failed later inside the app lifecycle, pointing at nothing. ([#646](https://github.com/grelinfo/grelmicro/issues/646))
+
+### Docs
+
+* 📝 Show how to register a component conditionally, in [Wiring an App](wiring.md#register-something-conditionally). Covers the inline `None` entry, the `Usable`-annotated list, and how a Provider registers differently through `use` than inside `uses=`. ([#646](https://github.com/grelinfo/grelmicro/issues/646))
+* 📝 Add a Providers recipe for taking the managed connection and nothing else. Application state that is not a cache, a lock, or a rate limiter is still yours to read and write through `provider.client`, with the lifecycle already handled. ([#646](https://github.com/grelinfo/grelmicro/issues/646))
+* 📝 Document the `/healthz` report body, with a passing and a failing check side by side. ([#649](https://github.com/grelinfo/grelmicro/issues/649))
+
 ## 0.34.3 - 2026-08-05
 
 ### Security

--- a/docs/health.md
+++ b/docs/health.md
@@ -147,6 +147,23 @@ All three also accept `HEAD`. All responses set `Cache-Control: no-store`. Probe
 
 Paths follow the z-pages convention (`/livez`, `/readyz`, `/healthz`). The trailing `z` avoids collisions with application routes like `/health`.
 
+### Report Body
+
+`/healthz` reports the aggregate status and one entry per check. A check that passed carries `status` and `critical` alone:
+
+```json
+{
+  "status": "error",
+  "checks": {
+    "store": {"status": "ok", "critical": true},
+    "analytics": {"status": "ok", "critical": false},
+    "database": {"status": "error", "critical": true, "error": "connection refused"}
+  }
+}
+```
+
+A field that has nothing to report is left out rather than sent as `null`. `error` appears only on a failing check, and `details` only when the check returned some and `show_details` allows them. Read an absent `error` as "this check passed".
+
 ### Using with Docker, Compose, and other Orchestrators
 
 Different orchestrators consume different probes. grelmicro exposes all three endpoints, pick the ones that fit:
@@ -204,7 +221,7 @@ With `show_details=Depends(fn)`, `fn` is wired into FastAPI's dependency-injecti
 --8<-- "health/show_details.py"
 ```
 
-With details enabled, each check entry includes a `details` field:
+With details enabled, a check that returned some includes a `details` field:
 
 ```json
 {
@@ -213,7 +230,6 @@ With details enabled, each check entry includes a `details` field:
     "redis": {
       "status": "ok",
       "critical": true,
-      "error": null,
       "details": {"latency_ms": 1.2, "version": "7.2"}
     }
   }

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -134,6 +134,27 @@ async def redis_provider(redis_container):
         yield provider
 ```
 
+## Recipe 4: the managed connection, nothing else
+
+Not all of your data is a cache, a lock, or a rate limiter. Plain application
+state in a Redis hash is still yours to read and write, and a Provider gives you
+that connection with the lifecycle already handled. Reach for `provider.client`:
+
+```python
+--8<-- "wiring/provider_client.py"
+```
+
+The client is the native one (`redis.asyncio.Redis`, `asyncpg.Pool`,
+`aiosqlite.Connection`), so every command that library offers is available. The
+app opens it on startup and closes it on shutdown, and a `HealthChecks` can probe
+it with `add_provider(redis)`.
+
+Two things to know. The client exists only inside the app scope, so a call made
+before startup raises `OutOfContextError`. And a lone Provider listed with no
+components also registers a default component per kind it serves, which costs
+nothing if you never use them. List the components you do want to be explicit
+about the wiring.
+
 ## Construction forms
 
 ```python

--- a/docs/snippets/wiring/conditional.py
+++ b/docs/snippets/wiring/conditional.py
@@ -1,0 +1,15 @@
+import os
+
+from grelmicro import Grelmicro
+from grelmicro.health import HealthChecks
+from grelmicro.providers.redis import RedisProvider
+
+health = HealthChecks()
+redis = RedisProvider("redis://localhost:6379/0")
+
+micro = Grelmicro(
+    uses=[
+        health,
+        redis if os.getenv("STORE_BACKEND") == "redis" else None,
+    ]
+)

--- a/docs/snippets/wiring/provider_client.py
+++ b/docs/snippets/wiring/provider_client.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from grelmicro import Grelmicro
+from grelmicro.providers.redis import RedisProvider
+
+redis = RedisProvider("redis://localhost:6379/0")
+
+micro = Grelmicro(uses=[redis])
+
+
+async def save_order(order_id: str, total: str) -> None:
+    await redis.client.hset(f"order:{order_id}", mapping={"total": total})
+
+
+async def load_order(order_id: str) -> dict[str, Any]:
+    return await redis.client.hgetall(f"order:{order_id}")

--- a/docs/snippets/wiring/usable.py
+++ b/docs/snippets/wiring/usable.py
@@ -1,0 +1,15 @@
+import os
+
+from grelmicro import Grelmicro, Usable
+from grelmicro.health import HealthChecks
+from grelmicro.providers.redis import RedisProvider
+
+
+def build_components() -> list[Usable]:
+    components: list[Usable] = [HealthChecks()]
+    if os.getenv("STORE_BACKEND") == "redis":
+        components.append(RedisProvider("redis://localhost:6379/0"))
+    return components
+
+
+micro = Grelmicro(uses=build_components())

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -62,6 +62,10 @@ When the list is long enough to deserve its own function, annotate it with
 --8<-- "wiring/usable.py"
 ```
 
+`Usable` names one item, not the list. Keep the conditional in an `if` and the
+annotation stays `list[Usable]`. A prebuilt list that carries its own `None`
+entries is `list[Usable | None]`, which `uses=` accepts just the same.
+
 `micro.use(item)` registers one item after construction and rejects `None`,
 because a single call can be guarded with `if` instead:
 

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -42,6 +42,41 @@ async with micro:
 The lock finds the registered Redis backend through the active app. No `backend=`
 argument needed.
 
+## Register something conditionally
+
+A component that exists only for one backend or one environment stays inline. A
+`None` entry in `uses=` is skipped:
+
+```python
+--8<-- "wiring/conditional.py"
+```
+
+With `STORE_BACKEND` unset, the app registers the health checks alone. Set it to
+`redis` and the provider joins them, with no change to the shape of the list.
+
+When the list is long enough to deserve its own function, annotate it with
+`Usable`. It names everything `uses=` accepts, which `Component` does not: a
+`Provider` is not a `Component`, and neither is a plain async context manager.
+
+```python
+--8<-- "wiring/usable.py"
+```
+
+`micro.use(item)` registers one item after construction and rejects `None`,
+because a single call can be guarded with `if` instead:
+
+```python
+if os.getenv("STORE_BACKEND") == "redis":
+    micro.use(RedisProvider())
+```
+
+!!! note "A Provider registers differently through `use`"
+    Inside `uses=[...]`, a lone Provider on an app with no components registers
+    a default component for every kind it serves. By the time you call
+    `micro.use(provider)` on an app that already holds a component, the Provider
+    is lifecycled only. Pass the components you want explicitly
+    (`micro.use(Cache(redis))`) when you need them.
+
 ## FastAPI
 
 Call `micro.install(app)`. One call wires both pieces:

--- a/grelmicro/__init__.py
+++ b/grelmicro/__init__.py
@@ -9,7 +9,7 @@ from grelmicro._app import (
     LifecycleOrderError,
     NoActiveAppError,
 )
-from grelmicro._component import Component
+from grelmicro._component import Component, Usable
 from grelmicro.config import ExternalConfig
 from grelmicro.errors import (
     AdapterNotRegisteredError,
@@ -40,4 +40,5 @@ __all__ = [
     "OutOfContextError",
     "ProviderNotRegisteredError",
     "SettingsValidationError",
+    "Usable",
 ]

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Protocol, Self, cast
 
 from typing_extensions import Doc
 
-from grelmicro._component import Component, instantiate_if_class
+from grelmicro._component import Component, Usable, instantiate_if_class
 from grelmicro.errors import (
     GrelmicroError,
     MultipleActiveAppsError,
@@ -138,22 +138,23 @@ class Grelmicro:
         self,
         *,
         uses: Annotated[
-            Iterable[
-                AbstractAsyncContextManager[object]
-                | type[AbstractAsyncContextManager[object]]
-            ]
-            | None,
+            Iterable[Usable | None] | None,
             Doc(
                 """
-                Items registered at construction time. Equivalent to a
-                sequence of `.use(item)` calls in the same order. Accepts
-                `Component` instances (registered with `(kind, name)`
+                Items registered at construction time, in the given order.
+                Accepts `Component` instances (registered with `(kind, name)`
                 lookup, exposed on `micro.<kind>`), bare adapter or component
                 classes (instantiated for you), `Provider` instances (a lone
                 Provider registers a default Component per kind it serves), and
                 plain async context managers (lifecycled only, caller holds the
                 reference). Two bare Providers with no Components raise
                 `AmbiguousProviderError`.
+
+                A `None` entry is skipped, so a component registered only for
+                one backend stays a plain expression:
+                `uses=[Log(), redis if backend == "redis" else None]`.
+
+                Annotate a list you build beforehand with `Usable`.
                 """,
             ),
         ] = None,
@@ -196,7 +197,10 @@ class Grelmicro:
         if uses is not None:
             try:
                 for item in uses:
-                    self.use(item)
+                    # A `None` entry is a conditional registration that did
+                    # not apply.
+                    if item is not None:
+                        self.use(item)
             finally:
                 self._deferring_provider_defaults = False
             self._register_provider_defaults()
@@ -228,8 +232,7 @@ class Grelmicro:
     def use(
         self,
         item: Annotated[
-            AbstractAsyncContextManager[object]
-            | type[AbstractAsyncContextManager[object]],
+            Usable,
             Doc(
                 """
                 The item to register and lifecycle with the app. A `Component`
@@ -289,7 +292,16 @@ class Grelmicro:
             ComponentAlreadyRegisteredError: A different component is already
                 registered under the same `(kind, name)` key. Plain async
                 context managers do not raise. They are appended.
+            TypeError: If `item` is `None`. `Grelmicro(uses=[...])` skips a
+                `None` entry, a single call does not.
         """
+        if item is None:
+            msg = (
+                "use(None) registers nothing. Guard the call with `if`, or "
+                "move the conditional into Grelmicro(uses=[...]), which "
+                "skips None entries."
+            )
+            raise TypeError(msg)
         # A bare class (no parens) is instantiated with no arguments, in the
         # spirit of FastAPI's `Depends(dep)`: pass the reference, the framework
         # calls it. Useful for zero-arg adapters like `MemoryLockAdapter`.

--- a/grelmicro/_component.py
+++ b/grelmicro/_component.py
@@ -84,3 +84,28 @@ class Component(
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> bool | None: ...
+
+
+type Usable = (
+    AbstractAsyncContextManager[object]
+    | type[AbstractAsyncContextManager[object]]
+)
+"""Anything `Grelmicro(uses=[...])`, `Bulkhead(uses=[...])`, and `micro.use()` accept.
+
+Covers `Component` instances, `Provider` instances, first-party backends, the
+bare classes of any of those, and plain async context managers. Name it to
+annotate a list you build before passing it in:
+
+```python
+from grelmicro import Grelmicro, Usable
+
+components: list[Usable] = [Log(), health]
+if settings.store_backend == "redis":
+    components.append(RedisProvider())
+
+micro = Grelmicro(uses=components)
+```
+
+`Component` names a narrower set. It excludes `Provider` instances and plain
+async context managers, both of which `uses=` accepts.
+"""

--- a/grelmicro/_component.py
+++ b/grelmicro/_component.py
@@ -90,7 +90,7 @@ type Usable = (
     AbstractAsyncContextManager[object]
     | type[AbstractAsyncContextManager[object]]
 )
-"""Anything `Grelmicro(uses=[...])`, `Bulkhead(uses=[...])`, and `micro.use()` accept.
+"""One item `Grelmicro(uses=[...])`, `Bulkhead(uses=[...])`, or `micro.use()` accepts.
 
 Covers `Component` instances, `Provider` instances, first-party backends, the
 bare classes of any of those, and plain async context managers. Name it to
@@ -108,4 +108,8 @@ micro = Grelmicro(uses=components)
 
 `Component` names a narrower set. It excludes `Provider` instances and plain
 async context managers, both of which `uses=` accepts.
+
+A `uses=` list also takes `None` entries and skips them, which this alias does
+not cover, since `micro.use(None)` is an error. Annotate a prebuilt list that
+carries its own conditionals as `list[Usable | None]`.
 """

--- a/grelmicro/integrations/fastapi.py
+++ b/grelmicro/integrations/fastapi.py
@@ -6,14 +6,15 @@ import re
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Annotated, Any, TypedDict, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import Doc
 
 from grelmicro._app import AmbientBindingError
 from grelmicro._json import json_dumps_bytes
 from grelmicro.errors import OutOfContextError
 from grelmicro.health._checks import HealthChecks
-from grelmicro.health._models import HealthStatus
+from grelmicro.health._models import CheckResult, HealthStatus
 from grelmicro.idempotency.errors import (
     IdempotencyConflictError,
     IdempotencyKeyMakerError,
@@ -1030,13 +1031,30 @@ def _always_false() -> bool:
     return False
 
 
+def _omitted_when_absent(schema: dict[str, Any]) -> None:
+    """Drop the `null` default from a field the response omits when unset."""
+    schema.pop("default", None)
+
+
 class CheckResultResponse(BaseModel):
-    """Health status of a single check."""
+    """Health status of a single check.
+
+    `error` is present only on a failing check, and `details` only when the
+    check returned some and the router is showing them. Both are absent
+    otherwise rather than sent as `null`, so the schema types them as a plain
+    string and object.
+    """
 
     status: HealthStatus
     critical: bool = True
-    error: str | None = None
-    details: dict[str, Any] | None = None
+    error: Annotated[
+        str | SkipJsonSchema[None],
+        Field(default=None, json_schema_extra=_omitted_when_absent),
+    ]
+    details: Annotated[
+        dict[str, Any] | SkipJsonSchema[None],
+        Field(default=None, json_schema_extra=_omitted_when_absent),
+    ]
 
 
 class HealthzResponse(BaseModel):
@@ -1195,21 +1213,13 @@ def health_router(
             critical_only=False,
             exclude=_parse_exclude(exclude),
         )
-        body: Any = (
-            report
-            if include_details
-            else {
-                "status": report["status"],
-                "checks": {
-                    name: {
-                        "status": r["status"],
-                        "critical": r["critical"],
-                        "error": r["error"],
-                    }
-                    for name, r in report["checks"].items()
-                },
-            }
-        )
+        body: Any = {
+            "status": report["status"],
+            "checks": {
+                name: _check_body(result, details=include_details)
+                for name, result in report["checks"].items()
+            },
+        }
         status_code = (
             HTTP_200_OK
             if report["status"] == HealthStatus.OK
@@ -1223,6 +1233,27 @@ def health_router(
         )
 
     return router
+
+
+def _check_body(result: CheckResult, *, details: bool) -> dict[str, Any]:
+    """Build one `/healthz` check entry, leaving out what carries no value.
+
+    A passing check reports `status` and `critical` alone. `error` is added
+    only when the check failed, and `details` only when the check returned
+    some and the router is showing them.
+    """
+    body: dict[str, Any] = {
+        "status": result["status"],
+        "critical": result["critical"],
+    }
+    error = result["error"]
+    if error is not None:
+        body["error"] = error
+    if details:
+        check_details = result["details"]
+        if check_details is not None:
+            body["details"] = check_details
+    return body
 
 
 def _resolve_show_details_dep(show_details: Any) -> "Callable[..., Any]":  # noqa: ANN401

--- a/grelmicro/resilience/bulkhead.py
+++ b/grelmicro/resilience/bulkhead.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, NonNegativeFloat, PositiveInt
 from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro, _active_bulkhead
-from grelmicro._component import Component
+from grelmicro._component import Component, Usable, instantiate_if_class
 from grelmicro._config import (
     Reconfigurable,
     default_env_prefix,
@@ -24,7 +24,6 @@ from grelmicro.resilience.errors import BulkheadFullError
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable
-    from contextlib import AbstractAsyncContextManager
     from contextvars import Token
     from types import TracebackType
 
@@ -135,7 +134,7 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
             Doc("Private thread-pool size for `to_thread`."),
         ] = None,
         uses: Annotated[
-            Iterable[AbstractAsyncContextManager[object]],
+            Iterable[Usable | None],
             Doc(
                 """
                 Providers and Components, in the same shape as
@@ -146,6 +145,7 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
                 with an explicit `backend=` is unaffected. The bulkhead
                 opens these on first entry and closes them when the app
                 shuts down, so an active `Grelmicro` app is required.
+                A `None` entry is skipped, as in `Grelmicro(uses=[...])`.
                 """
             ),
         ] = (),
@@ -186,7 +186,9 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
         )
         self._reconfigure_lock = asyncio.Lock()
         self._executor: ThreadPoolExecutor | None = None
-        self._uses = tuple(uses)
+        self._uses = tuple(
+            instantiate_if_class(item) for item in uses if item is not None
+        )
         self._overrides: dict[tuple[str, str], Component] = {
             (item.kind, item.name): item
             for item in self._uses

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -35,7 +35,8 @@
     },
     "SettingsValidationError": {
       "()": "(error)"
-    }
+    },
+    "Usable": null
   },
   "grelmicro.cache": {
     "Cache": {

--- a/tests/resilience/test_bulkhead.py
+++ b/tests/resilience/test_bulkhead.py
@@ -298,6 +298,17 @@ async def test_uses_overrides_default_backend_in_scope() -> None:
         assert micro.get("coordination", "default").lock_backend is default
 
 
+async def test_uses_skips_none_entries() -> None:
+    """A `None` entry is skipped, matching `Grelmicro(uses=[...])`."""
+    default = MemoryLockAdapter()
+    dedicated = MemoryLockAdapter()
+    micro = Grelmicro(uses=[Coordination(lock=default)])
+    bulkhead = Bulkhead("checkout", uses=[None, Coordination(lock=dedicated)])
+
+    async with micro, bulkhead:
+        assert micro.get("coordination", "default").lock_backend is dedicated
+
+
 async def test_uses_override_only_covers_registered_keys() -> None:
     """A key the bulkhead does not override falls through to the registry."""
     default = MemoryLockAdapter()

--- a/tests/test_health_router.py
+++ b/tests/test_health_router.py
@@ -205,6 +205,54 @@ def test_healthz_503_on_critical_failure(
     assert response.json()["status"] == "error"
 
 
+def test_healthz_omits_error_on_passing_check(
+    registry: HealthChecks, client: TestClient
+) -> None:
+    """A passing check reports status and critical alone, with no null error."""
+    registry.add("db", healthy())
+
+    response = client.get("/healthz")
+
+    assert response.json()["checks"]["db"] == {"status": "ok", "critical": True}
+
+
+def test_healthz_keeps_error_on_failing_check(
+    registry: HealthChecks, client: TestClient
+) -> None:
+    """A failing check still carries its error string."""
+    registry.add("db", unhealthy())
+
+    response = client.get("/healthz")
+
+    assert response.json()["checks"]["db"]["error"]
+
+
+def test_healthz_omits_details_when_check_returned_none() -> None:
+    """A check with no details omits the field even when details are shown."""
+    registry = HealthChecks(cache_ttl=0)
+    registry.add("db", healthy())
+    app = FastAPI()
+    app.include_router(health_router(registry=registry, show_details=True))
+    client = TestClient(app)
+
+    response = client.get("/healthz")
+
+    assert response.json()["checks"]["db"] == {"status": "ok", "critical": True}
+
+
+def test_healthz_schema_types_optional_fields_as_absent() -> None:
+    """OpenAPI types the omitted fields as plain values, never as null."""
+    app = FastAPI()
+    app.include_router(health_router(registry=HealthChecks()))
+
+    schema = app.openapi()["components"]["schemas"]["CheckResultResponse"]
+
+    assert schema["properties"]["error"] == {"type": "string", "title": "Error"}
+    assert "null" not in str(schema["properties"]["details"])
+    assert "error" not in schema["required"]
+    assert "details" not in schema["required"]
+
+
 def test_healthz_details_hidden_by_default(
     registry: HealthChecks, client: TestClient
 ) -> None:

--- a/tests/test_uses_coercion.py
+++ b/tests/test_uses_coercion.py
@@ -305,3 +305,44 @@ def test_use_provider_after_component_is_lifecycle_only() -> None:
 
     kinds = {component.kind for component in micro.components}
     assert kinds == {"cache"}
+
+
+# --- conditional registration ---
+
+
+def test_uses_skips_none_entries() -> None:
+    """A `None` entry in `uses=` registers nothing and does not raise."""
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter()), None])
+
+    assert {component.kind for component in micro.components} == {"cache"}
+
+
+def test_uses_all_none_registers_nothing() -> None:
+    """A list of only `None` leaves an empty app rather than failing."""
+    micro = Grelmicro(uses=[None, None])
+
+    assert micro.components == ()
+
+
+def test_uses_none_does_not_block_provider_defaults() -> None:
+    """A skipped entry still leaves a lone Provider auto-registering its kinds."""
+    micro = Grelmicro(uses=[None, _MemoryProvider()])
+
+    assert isinstance(micro.get("cache"), Cache)
+    assert isinstance(micro.get("coordination"), Coordination)
+
+
+async def test_uses_none_is_not_lifecycled() -> None:
+    """A skipped entry never reaches the exit stack."""
+    micro = Grelmicro(uses=[None, Cache(MemoryCacheAdapter())])
+
+    async with micro:
+        assert isinstance(micro.get("cache"), Cache)
+
+
+def test_use_none_raises_pointing_at_the_alternative() -> None:
+    """`micro.use(None)` is a mistake and says what to write instead."""
+    micro = Grelmicro()
+
+    with pytest.raises(TypeError, match=r"use\(None\) registers nothing"):
+        micro.use(None)  # ty: ignore[invalid-argument-type]

--- a/tests/typechecking/app.py
+++ b/tests/typechecking/app.py
@@ -2,8 +2,9 @@
 
 from typing import assert_type
 
-from grelmicro import Grelmicro
+from grelmicro import Grelmicro, Usable
 from grelmicro.health import HealthChecks
+from grelmicro.providers.memory import MemoryProvider
 
 
 def build() -> None:
@@ -11,6 +12,19 @@ def build() -> None:
     assert_type(Grelmicro(), Grelmicro)
     assert_type(Grelmicro(uses=[HealthChecks()]), Grelmicro)
     assert_type(Grelmicro(uses=[HealthChecks]), Grelmicro)
+
+
+def usable_list() -> None:
+    """`Usable` annotates a list mixing Components and Providers."""
+    components: list[Usable] = [HealthChecks()]
+    components.append(MemoryProvider())
+    assert_type(Grelmicro(uses=components), Grelmicro)
+
+
+def conditional() -> None:
+    """Accept a `None` entry in `uses=` for a conditional registration."""
+    provider: MemoryProvider | None = MemoryProvider()
+    assert_type(Grelmicro(uses=[HealthChecks(), provider]), Grelmicro)
 
 
 def current() -> None:

--- a/tests/typechecking/app.py
+++ b/tests/typechecking/app.py
@@ -27,6 +27,12 @@ def conditional() -> None:
     assert_type(Grelmicro(uses=[HealthChecks(), provider]), Grelmicro)
 
 
+def usable_list_with_conditionals() -> None:
+    """Annotate a prebuilt list carrying `None` entries as `list[Usable | None]`."""
+    components: list[Usable | None] = [HealthChecks(), None]
+    assert_type(Grelmicro(uses=components), Grelmicro)
+
+
 def current() -> None:
     """`Grelmicro.current()` returns the app, not `Any`."""
     assert_type(Grelmicro.current(), Grelmicro)


### PR DESCRIPTION
Closes #649. Closes #646.

Two issues that both come from the same place: a shape the library sends or accepts that reads as noise to whoever is on the other side of it.

## `/healthz` stops sending nulls (#649)

A passing check spent bytes on every poll saying nothing went wrong. It is now:

```json
{
  "status": "error",
  "checks": {
    "store": {"status": "ok", "critical": true},
    "database": {"status": "error", "critical": true, "error": "connection refused"}
  }
}
```

`error` appears only on a failure, `details` only when the check returned some and `show_details` allows them. `critical` stays on every check, so a dashboard reading it never has to infer the default.

`response_model_exclude_none` could not fix this, since the handler returns a `Response` directly and never serializes through the model. Both branches build through one `_check_body` helper now, which also fixes the `show_details=True` path that was returning the raw report with `"details": null` on every check.

The OpenAPI schema is honest about it. `error: str | SkipJsonSchema[None]` plus a helper that pops the null default gives `{"type": "string"}`, not required, no null branch. The model still validates `None`, so anything parsing the old shape keeps working.

**Breaking.** A consumer that required the `error` key needs updating. Read an absent `error` as a pass.

## The `uses=` friction (#646)

**A type for the list.** `Usable` is exported from `grelmicro` and names everything `uses=` accepts. `list[Usable]` takes Components and Providers together, which is the mypy error the issue opened with. `Component` could not cover it, since it requires `kind` and `name` and a `Provider` has neither.

**Conditional registration.** A `None` entry in `Grelmicro(uses=[...])` and `Bulkhead(uses=[...])` is skipped:

```python
micro = Grelmicro(uses=[Log(), health, redis if backend == "redis" else None])
```

`micro.use(None)` stays an error, because a single call can be guarded with `if`. It was not actually an error before: it appended `None` and failed later inside the app lifecycle pointing at nothing. It now raises a `TypeError` naming both alternatives.

**A Provider on its own.** Recipe 4 in the Providers page covers taking the managed connection and nothing else, through `provider.client`, for application state that is not a cache, a lock, or a rate limiter.

## Found while wiring it up

* `Bulkhead(uses=[...])` documented "the same shape as `Grelmicro(uses=[...])`" but entered a bare class object directly instead of instantiating it, so passing one would have failed on startup. Sharing the type surfaced it.
* The `uses=` docstring claimed equivalence to "a sequence of `.use(item)` calls", which no longer holds for `None`.

## Docs

`docs/wiring.md` gains **Register something conditionally**, covering the inline `None`, the `Usable`-annotated helper, and `micro.use()` after construction, with a note that a lone Provider registers default components inside `uses=` but is lifecycle-only through `use()`. `docs/health.md` gains a **Report Body** section showing a passing and a failing check together.

All three new snippets live under `docs/snippets/wiring/`, so the test suite imports and executes them.

## Verification

Full `pre-commit run --all-files` green: ruff, ty, mypy, unit and integration tiers, the 100% coverage gate, and `mkdocs build --strict`. 4005 tests pass.
