### PR TITLE
🐛 Restore the registry when an override component fails to open

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+* 🐛 Restore the component registry when an `override(...)` component fails to open. The registry was mutated one component at a time before the restore was armed, so a mock that raised on `__aenter__` stayed installed for the rest of the `async with micro:` block. The next lookup resolved the broken mock instead of the real component, with nothing reporting it, which in a session-scoped fixture leaked into every later test. ([#651](https://github.com/grelinfo/grelmicro/issues/651))
 * 🐛 Instantiate a bare class passed to `Bulkhead(uses=[...])`. The parameter documented the same shape as `Grelmicro(uses=[...])`, which accepts a class with no parens, but the bulkhead entered the class object itself and failed on startup. ([#646](https://github.com/grelinfo/grelmicro/issues/646))
 * 🐛 Reject `micro.use(None)` with a message naming the fix. It appended `None` to the item list and failed later inside the app lifecycle, pointing at nothing. ([#646](https://github.com/grelinfo/grelmicro/issues/646))
 

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -476,7 +476,8 @@ class Grelmicro:
                 Components to install for the duration of the block. Each one
                 shadows any component already registered under the same
                 `(kind, name)` key. Original registrations are restored on
-                exit, even if the block raises.
+                exit, even if the block raises and even if one of these
+                components fails to open.
                 """,
             ),
         ],
@@ -509,18 +510,21 @@ class Grelmicro:
         snapshot_items = self._items.copy()
         snapshot_by_kind = self._by_kind.copy()
         async with AsyncExitStack() as stack:
-            for component in components:
-                key = (component.kind, component.name)
-                self._by_key[key] = component
-                if component not in self._items:  # pragma: no branch
-                    self._items.append(component)
-                if component.name == "default":  # pragma: no branch
-                    self._by_kind[component.kind] = component
-                # `Component` is an async context manager; ty misreads the
-                # protocol's `Self`-returning `__aenter__` as incompatible
-                # with its own AbstractAsyncContextManager base.
-                await stack.enter_async_context(component)  # ty: ignore[invalid-argument-type]
+            # The registry is mutated one component at a time, so the restore
+            # has to cover the loop as well as the block. A component that
+            # fails to open leaves the ones before it already installed.
             try:
+                for component in components:
+                    key = (component.kind, component.name)
+                    self._by_key[key] = component
+                    if component not in self._items:  # pragma: no branch
+                        self._items.append(component)
+                    if component.name == "default":  # pragma: no branch
+                        self._by_kind[component.kind] = component
+                    # `Component` is an async context manager; ty misreads the
+                    # protocol's `Self`-returning `__aenter__` as incompatible
+                    # with its own AbstractAsyncContextManager base.
+                    await stack.enter_async_context(component)  # ty: ignore[invalid-argument-type]
                 yield
             finally:
                 self._by_key = snapshot_by_key

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -689,15 +689,16 @@ async def test_override_restores_when_a_later_component_fails_to_open() -> None:
 
     real = _RecordingComponent(name="default")
     other = _OtherComponent(name="default")
+    installed = _RecordingComponent(name="default")
     micro = Grelmicro(uses=[real, other])
     async with micro:
         with pytest.raises(RuntimeError, match=_RAISED):
-            async with micro.override(
-                _RecordingComponent(name="default"),
-                _FailingOther(name="default"),
-            ):
+            async with micro.override(installed, _FailingOther(name="default")):
                 pass  # pragma: no cover
 
+        # The component that opened before the failure is closed again.
+        assert installed.entered == 1
+        assert installed.exited == 1
         assert micro.rec is real
         assert micro.oth is other
 

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -663,6 +663,45 @@ async def test_override_restores_on_exception() -> None:
         assert micro.rec is real
 
 
+async def test_override_restores_when_a_component_fails_to_open() -> None:
+    """A component that raises on open leaves no override behind."""
+
+    class _FailingComponent(_RecordingComponent):
+        async def __aenter__(self) -> Self:
+            raise RuntimeError(_RAISED)
+
+    real = _RecordingComponent(name="default")
+    micro = Grelmicro(uses=[real])
+    async with micro:
+        with pytest.raises(RuntimeError, match=_RAISED):
+            async with micro.override(_FailingComponent(name="default")):
+                pass  # pragma: no cover
+
+        assert micro.rec is real
+
+
+async def test_override_restores_when_a_later_component_fails_to_open() -> None:
+    """A partial override unwinds the components installed before the failure."""
+
+    class _FailingOther(_OtherComponent):
+        async def __aenter__(self) -> Self:
+            raise RuntimeError(_RAISED)
+
+    real = _RecordingComponent(name="default")
+    other = _OtherComponent(name="default")
+    micro = Grelmicro(uses=[real, other])
+    async with micro:
+        with pytest.raises(RuntimeError, match=_RAISED):
+            async with micro.override(
+                _RecordingComponent(name="default"),
+                _FailingOther(name="default"),
+            ):
+                pass  # pragma: no cover
+
+        assert micro.rec is real
+        assert micro.oth is other
+
+
 async def test_provider_public_export() -> None:
     """`grelmicro.providers.Provider` is importable as the base class."""
     from grelmicro.providers import Provider  # noqa: PLC0415


### PR DESCRIPTION
Closes #651.

`micro.override(...)` left the override installed when one of its components failed to open, so the app resolved the broken component for the rest of the `async with micro:` block with nothing reporting it.

## The defect

The registry is mutated one component at a time inside the entry loop, but the restore was armed only after the loop finished:

```python
async with AsyncExitStack() as stack:
    for component in components:
        self._by_key[key] = component               # mutated here
        await stack.enter_async_context(component)  # may raise here
    try:
        yield
    finally:
        self._by_key = snapshot_by_key              # armed only here
```

A component whose `__aenter__` raises propagates out of the `async with AsyncExitStack()` block without ever entering the `try`, so the `finally` never runs. `AsyncExitStack` unwinds the components it already entered, but the registry keeps pointing at them.

The docstring promised the opposite: "Original registrations are restored on exit, even if the block raises."

## The fix

The `try` moves above the loop and stays inside the exit stack. That covers the entry path and keeps the current ordering, where the registry is restored before component `__aexit__` runs.

## Why this shape

Wrapping the whole `async with AsyncExitStack()` in an outer `try/finally` also fixes the leak, but it inverts the ordering: the restore would run after `__aexit__` rather than before, so a component consulting the registry during teardown would see something different than it does today. Keeping the `try` inside the stack changes nothing except the bug.

## Verification

Both new tests fail on `main` and pass with the fix:

```
FAILED test_override_restores_when_a_component_fails_to_open
FAILED test_override_restores_when_a_later_component_fails_to_open
2 failed, 3 passed
```

The second covers the partial case, where an earlier component installs successfully and a later one fails.

Existing coverage only exercised a raise *inside* the block, after the `yield`. The entry path had no test.

Full `pre-commit run --all-files` green: ruff, ty, mypy, unit and integration tiers, the 100% coverage gate, and `mkdocs build --strict`.
