### PR TITLE
📝 Keep adapters out of the examples a first-time reader meets

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,12 @@ The smallest grelmicro program: a FastAPI route protected by a process-local rat
 ```python
 from fastapi import FastAPI
 
-from grelmicro.resilience import (
-    MemoryRateLimiterAdapter,
-    RateLimitExceededError,
-    RateLimiter,
-)
+from grelmicro.providers.memory import MemoryProvider
+from grelmicro.resilience import RateLimitExceededError, RateLimiter
 
 app = FastAPI()
 api_limiter = RateLimiter.sliding_window(
-    "api", limit=100, window=60, backend=MemoryRateLimiterAdapter()
+    "api", limit=100, window=60, backend=MemoryProvider().ratelimiter()
 )
 
 
@@ -181,7 +178,6 @@ from grelmicro.resilience import (
     RateLimiter,
     RateLimiterRegistry,
 )
-from grelmicro.resilience.circuitbreaker.memory import MemoryCircuitBreakerAdapter
 from grelmicro.coordination import Coordination, LeaderElection, Lock, TaskLock
 from grelmicro.task import Tasks
 
@@ -191,6 +187,7 @@ logger = logging.getLogger(__name__)
 tasks = Tasks()
 health = HealthChecks()
 
+# One line says where the shared state lives.
 redis = RedisProvider("redis://localhost:6379/0")
 
 leader = LeaderElection("leader-election")
@@ -200,7 +197,7 @@ micro = Grelmicro(uses=[
     Coordination(redis),
     Cache(redis),
     RateLimiterRegistry(redis),
-    CircuitBreakerRegistry(MemoryCircuitBreakerAdapter()),
+    CircuitBreakerRegistry(redis),
     tasks,
     health,
 ])

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -11,10 +11,10 @@ Cache an async function's result with `@cached`. The Memory backend needs no ext
 
 ```python
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
-from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache import JsonSerializer, TTLCache, cached
+from grelmicro.providers.memory import MemoryProvider
 
-micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+micro = Grelmicro(uses=[MemoryProvider()])
 
 cache = TTLCache(ttl=300, serializer=JsonSerializer())
 
@@ -38,10 +38,9 @@ into a `Grelmicro` app via the `Cache` component. For Redis, pass the
 === "Memory"
     ```python
     from grelmicro import Grelmicro
-    from grelmicro.cache import Cache
-    from grelmicro.cache.memory import MemoryCacheAdapter
+    from grelmicro.providers.memory import MemoryProvider
 
-    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    micro = Grelmicro(uses=[MemoryProvider()])
     ```
 
 === "Redis"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Upgrading
+
+**`/healthz` stopped sending null fields.** A check that passed no longer carries `error`, and a check with no details no longer carries `details`.
+
+```diff
+-{"status": "ok", "critical": true, "error": null}
++{"status": "ok", "critical": true}
+```
+
+A consumer that reads `error` unconditionally needs to treat it as absent:
+
+```python
+error = check.get("error")  # None when the check passed
+if error is not None:
+    alert(name, error)
+```
+
+A failing check still carries `error`, and `status` and `critical` are still on every entry, so a dashboard reading those needs no change.
+
 ### Breaking
 
 * 💥 Leave `error` and `details` out of a `/healthz` check that has neither. A passing check sent `"error": null` on every poll, and with details enabled it sent `"details": null` too, so the highest-frequency response in the service spent bytes reporting that nothing happened. A passing check is now `{"status": "ok", "critical": true}`, and a failing one still carries its `error`. The OpenAPI schema types both fields as a plain string and object instead of promising a nullable value that never arrives. Read an absent `error` as a pass. A consumer that required the key needs updating. ([#649](https://github.com/grelinfo/grelmicro/issues/649))
@@ -22,6 +41,7 @@
 * 📝 Show how to register a component conditionally, in [Wiring an App](wiring.md#register-something-conditionally). Covers the inline `None` entry, the `Usable`-annotated list, and how a Provider registers differently through `use` than inside `uses=`. ([#646](https://github.com/grelinfo/grelmicro/issues/646))
 * 📝 Add a Providers recipe for taking the managed connection and nothing else. Application state that is not a cache, a lock, or a rate limiter is still yours to read and write through `provider.client`, with the lifecycle already handled. ([#646](https://github.com/grelinfo/grelmicro/issues/646))
 * 📝 Document the `/healthz` report body, with a passing and a failing check side by side. ([#649](https://github.com/grelinfo/grelmicro/issues/649))
+* 📝 Keep adapter classes out of the examples a first-time reader meets. The guide opened with `MemoryLeaderElectionAdapter()` and `Cache(MemoryCacheAdapter())` before the reader had any reason to know what an adapter is. Every quick start now names a provider once, `uses=[MemoryProvider()]` or `uses=[redis]`, and the pattern follows with no wiring in sight. Adapter references in the snippets went from 56 to 8, and the 8 that remain are Kubernetes and the outbox memory backend, where choosing a backend is the subject. Nothing about the API changed, so no code needs updating. ([#644](https://github.com/grelinfo/grelmicro/issues/644))
 
 ## 0.34.3 - 2026-08-05
 

--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -32,8 +32,8 @@ lock state in the process, so this runs with nothing else installed.
 Three things happen here:
 
 1. `Lock("cart")` builds a lock named `cart` with default settings.
-2. `Coordination(lock=MemoryLockAdapter())` gives the lock a backend.
-3. `Grelmicro(uses=[...])` wires the component into the app.
+2. `MemoryProvider()` says where the shared state lives.
+3. `Grelmicro(uses=[...])` wires it into the app, and the lock finds it.
 
 One caller holds `cart` at a time. The next caller waits for the release.
 

--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -33,7 +33,12 @@ Three things happen here:
 
 1. `Lock("cart")` builds a lock named `cart` with default settings.
 2. `MemoryProvider()` says where the shared state lives.
-3. `Grelmicro(uses=[...])` wires it into the app, and the lock finds it.
+3. `Grelmicro(uses=[...])` wires it into the app.
+
+The lock carries no backend reference. It finds one when it is used, inside
+`async with micro:`, which is why `checkout()` is called from there. In a web
+app `micro.install(app)` extends that scope to your request handlers, so
+handlers need no `async with`.
 
 One caller holds `cart` at a time. The next caller waits for the release.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,15 +100,12 @@ The smallest grelmicro program: a FastAPI route protected by a process-local rat
 ```python
 from fastapi import FastAPI
 
-from grelmicro.resilience import (
-    MemoryRateLimiterAdapter,
-    RateLimitExceededError,
-    RateLimiter,
-)
+from grelmicro.providers.memory import MemoryProvider
+from grelmicro.resilience import RateLimitExceededError, RateLimiter
 
 app = FastAPI()
 api_limiter = RateLimiter.sliding_window(
-    "api", limit=100, window=60, backend=MemoryRateLimiterAdapter()
+    "api", limit=100, window=60, backend=MemoryProvider().ratelimiter()
 )
 
 
@@ -181,7 +178,6 @@ from grelmicro.resilience import (
     RateLimiter,
     RateLimiterRegistry,
 )
-from grelmicro.resilience.circuitbreaker.memory import MemoryCircuitBreakerAdapter
 from grelmicro.coordination import Coordination, LeaderElection, Lock, TaskLock
 from grelmicro.task import Tasks
 
@@ -191,6 +187,7 @@ logger = logging.getLogger(__name__)
 tasks = Tasks()
 health = HealthChecks()
 
+# One line says where the shared state lives.
 redis = RedisProvider("redis://localhost:6379/0")
 
 leader = LeaderElection("leader-election")
@@ -200,7 +197,7 @@ micro = Grelmicro(uses=[
     Coordination(redis),
     Cache(redis),
     RateLimiterRegistry(redis),
-    CircuitBreakerRegistry(MemoryCircuitBreakerAdapter()),
+    CircuitBreakerRegistry(redis),
     tasks,
     health,
 ])

--- a/docs/snippets/cache/batch.py
+++ b/docs/snippets/cache/batch.py
@@ -1,11 +1,10 @@
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache, JsonSerializer
-from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache import JsonSerializer
+from grelmicro.providers.memory import MemoryProvider
 
-cache = Cache(MemoryCacheAdapter())
-micro = Grelmicro(uses=[cache])
+micro = Grelmicro(uses=[MemoryProvider()])
 
-ttl_cache = cache.ttl(ttl=300, serializer=JsonSerializer())
+ttl_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
 
 
 async def main() -> None:

--- a/docs/snippets/cache/get_or_set.py
+++ b/docs/snippets/cache/get_or_set.py
@@ -1,11 +1,10 @@
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache, JsonSerializer
-from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache import JsonSerializer
+from grelmicro.providers.memory import MemoryProvider
 
-cache = Cache(MemoryCacheAdapter())
-micro = Grelmicro(uses=[cache])
+micro = Grelmicro(uses=[MemoryProvider()])
 
-ttl_cache = cache.ttl(ttl=300, serializer=JsonSerializer())
+ttl_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
 
 
 async def main() -> None:

--- a/docs/snippets/cache/key.py
+++ b/docs/snippets/cache/key.py
@@ -1,11 +1,10 @@
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache, JsonSerializer, cached
-from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache import JsonSerializer, cached
+from grelmicro.providers.memory import MemoryProvider
 
-cache = Cache(MemoryCacheAdapter())
-micro = Grelmicro(uses=[cache])
+micro = Grelmicro(uses=[MemoryProvider()])
 
-ttl_cache = cache.ttl(ttl=300, serializer=JsonSerializer())
+ttl_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
 
 
 @cached(ttl_cache, key="user:{user_id}")

--- a/docs/snippets/cache/refresh.py
+++ b/docs/snippets/cache/refresh.py
@@ -1,8 +1,8 @@
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
-from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache import JsonSerializer, TTLCache, cached
+from grelmicro.providers.memory import MemoryProvider
 
-micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+micro = Grelmicro(uses=[MemoryProvider()])
 
 cache = TTLCache(ttl=300, serializer=JsonSerializer())
 

--- a/docs/snippets/cache/stream.py
+++ b/docs/snippets/cache/stream.py
@@ -1,10 +1,10 @@
 from collections.abc import AsyncIterator
 
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
-from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache import JsonSerializer, TTLCache, cached
+from grelmicro.providers.memory import MemoryProvider
 
-micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+micro = Grelmicro(uses=[MemoryProvider()])
 
 cache = TTLCache(ttl=300, serializer=JsonSerializer())
 

--- a/docs/snippets/cache/tags.py
+++ b/docs/snippets/cache/tags.py
@@ -1,11 +1,10 @@
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache, JsonSerializer, cached
-from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.cache import JsonSerializer, cached
+from grelmicro.providers.memory import MemoryProvider
 
-cache = Cache(MemoryCacheAdapter())
-micro = Grelmicro(uses=[cache])
+micro = Grelmicro(uses=[MemoryProvider()])
 
-ttl_cache = cache.ttl(ttl=300, serializer=JsonSerializer())
+ttl_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
 
 
 @cached(ttl_cache, tags=["users", "user:{user_id}"])

--- a/docs/snippets/coordination/fencing.py
+++ b/docs/snippets/coordination/fencing.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from grelmicro.coordination import Lock
-from grelmicro.coordination.memory import MemoryLockAdapter
+from grelmicro.providers.memory import MemoryProvider
 
 
 class Resource:
@@ -21,8 +21,8 @@ class Resource:
 async def main() -> None:
     resource = Resource()
 
-    async with MemoryLockAdapter() as backend:
-        lock = Lock("cart", backend=backend)
+    async with MemoryProvider() as provider:
+        lock = Lock("cart", backend=provider.lock())
 
         # A stale holder writes with an old token.
         stale = await lock.acquire()

--- a/docs/snippets/coordination/lead.py
+++ b/docs/snippets/coordination/lead.py
@@ -1,14 +1,11 @@
 import asyncio
 
 from grelmicro import Grelmicro
-from grelmicro.coordination import Coordination
-from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
+from grelmicro.providers.memory import MemoryProvider
 from grelmicro.task import Tasks
 
 tasks = Tasks()
-micro = Grelmicro(
-    uses=[Coordination(election=MemoryLeaderElectionAdapter()), tasks]
-)
+micro = Grelmicro(uses=[MemoryProvider(), tasks])
 
 leader = micro.coordination.leaderelection("worker")
 tasks.add_task(leader)

--- a/docs/snippets/coordination/leaderelection_asyncio.py
+++ b/docs/snippets/coordination/leaderelection_asyncio.py
@@ -1,9 +1,11 @@
 import asyncio
 
 from grelmicro.coordination import LeaderElection
-from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
+from grelmicro.providers.memory import MemoryProvider
 
-leader = LeaderElection("cluster_group", backend=MemoryLeaderElectionAdapter())
+leader = LeaderElection(
+    "cluster_group", backend=MemoryProvider().leaderelection()
+)
 
 
 async def main():

--- a/docs/snippets/coordination/leaderelection_task.py
+++ b/docs/snippets/coordination/leaderelection_task.py
@@ -1,8 +1,9 @@
-from grelmicro.coordination import Coordination, LeaderElection
-from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
+from grelmicro import Grelmicro
+from grelmicro.providers.memory import MemoryProvider
 from grelmicro.task import Tasks
 
-leader = LeaderElection("cluster_group", backend=MemoryLeaderElectionAdapter())
-coordination = Coordination(election=leader.backend)
 task = Tasks()
+micro = Grelmicro(uses=[MemoryProvider(), task])
+
+leader = micro.coordination.leaderelection("cluster_group")
 task.add_task(leader)

--- a/docs/snippets/coordination/memory.py
+++ b/docs/snippets/coordination/memory.py
@@ -1,15 +1,4 @@
 from grelmicro import Grelmicro
-from grelmicro.coordination import Coordination
-from grelmicro.coordination.memory import (
-    MemoryLeaderElectionAdapter,
-    MemoryLockAdapter,
-)
+from grelmicro.providers.memory import MemoryProvider
 
-micro = Grelmicro(
-    uses=[
-        Coordination(
-            lock=MemoryLockAdapter(),
-            election=MemoryLeaderElectionAdapter(),
-        )
-    ]
-)
+micro = Grelmicro(uses=[MemoryProvider()])

--- a/docs/snippets/coordination/quickstart.py
+++ b/docs/snippets/coordination/quickstart.py
@@ -1,12 +1,9 @@
 from grelmicro import Grelmicro
-from grelmicro.coordination import Coordination
-from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
+from grelmicro.providers.memory import MemoryProvider
 from grelmicro.task import Tasks
 
 tasks = Tasks()
-micro = Grelmicro(
-    uses=[Coordination(election=MemoryLeaderElectionAdapter()), tasks]
-)
+micro = Grelmicro(uses=[MemoryProvider(), tasks])
 
 leader = micro.coordination.leaderelection("worker")
 tasks.add_task(leader)

--- a/docs/snippets/coordination/quickstart_lock.py
+++ b/docs/snippets/coordination/quickstart_lock.py
@@ -10,3 +10,9 @@ lock = Lock("cart")
 async def checkout() -> None:
     async with lock:
         ...
+
+
+async def main() -> None:
+    # The lock resolves its backend inside the app scope.
+    async with micro:
+        await checkout()

--- a/docs/snippets/coordination/quickstart_lock.py
+++ b/docs/snippets/coordination/quickstart_lock.py
@@ -1,8 +1,8 @@
 from grelmicro import Grelmicro
-from grelmicro.coordination import Coordination, Lock
-from grelmicro.coordination.memory import MemoryLockAdapter
+from grelmicro.coordination import Lock
+from grelmicro.providers.memory import MemoryProvider
 
-micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+micro = Grelmicro(uses=[MemoryProvider()])
 
 lock = Lock("cart")
 

--- a/docs/snippets/idempotency/middleware.py
+++ b/docs/snippets/idempotency/middleware.py
@@ -1,12 +1,11 @@
 from fastapi import FastAPI
 
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache
-from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.idempotency import Idempotency
 from grelmicro.integrations.fastapi import IdempotencyMiddleware
+from grelmicro.providers.memory import MemoryProvider
 
-micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+micro = Grelmicro(uses=[MemoryProvider()])
 app = FastAPI()
 
 micro.install(app)

--- a/docs/snippets/idempotency/run.py
+++ b/docs/snippets/idempotency/run.py
@@ -1,9 +1,8 @@
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache
-from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.idempotency import Idempotency
+from grelmicro.providers.memory import MemoryProvider
 
-micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+micro = Grelmicro(uses=[MemoryProvider()])
 
 idem = Idempotency("charge", ttl=3600)
 

--- a/docs/snippets/json/cache_integration.py
+++ b/docs/snippets/json/cache_integration.py
@@ -1,7 +1,8 @@
 from pydantic import BaseModel
 
+from grelmicro import Grelmicro
 from grelmicro.cache import PydanticSerializer, TTLCache
-from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.providers.memory import MemoryProvider
 
 
 class User(BaseModel):
@@ -9,13 +10,13 @@ class User(BaseModel):
     name: str
 
 
-backend = MemoryCacheAdapter()
+micro = Grelmicro(uses=[MemoryProvider()])
 
 cache = TTLCache[User](ttl=300, serializer=PydanticSerializer(User))
 
 
 async def main() -> None:
-    async with backend:
+    async with micro:
         await cache.set("user:1", User(id=1, name="Alice"))
         user = await cache.get("user:1")
         print(user)

--- a/docs/snippets/resilience/ratelimiter_memory.py
+++ b/docs/snippets/resilience/ratelimiter_memory.py
@@ -1,3 +1,3 @@
-from grelmicro.resilience.ratelimiter.memory import MemoryRateLimiterAdapter
+from grelmicro.providers.memory import MemoryProvider
 
-backend = MemoryRateLimiterAdapter()
+backend = MemoryProvider().ratelimiter()

--- a/docs/snippets/simple_fastapi_app.py
+++ b/docs/snippets/simple_fastapi_app.py
@@ -4,19 +4,10 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from grelmicro import Grelmicro
-from grelmicro.coordination import (
-    Coordination,
-    LeaderElection,
-    Lock,
-    TaskLock,
-)
-from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
+from grelmicro.coordination import LeaderElection, Lock, TaskLock
 from grelmicro.log import configure
 from grelmicro.providers.redis import RedisProvider
-from grelmicro.resilience import CircuitBreaker, CircuitBreakerRegistry
-from grelmicro.resilience.circuitbreaker.memory import (
-    MemoryCircuitBreakerAdapter,
-)
+from grelmicro.resilience import CircuitBreaker
 from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
@@ -26,15 +17,10 @@ tasks = Tasks()
 leader_election = LeaderElection("leader-election")
 tasks.add_task(leader_election)
 
+# One line says where the shared state lives.
 redis = RedisProvider("redis://localhost:6379/0")
 
-micro = Grelmicro(
-    uses=[
-        Coordination(lock=redis.lock(), election=MemoryLeaderElectionAdapter()),
-        CircuitBreakerRegistry(MemoryCircuitBreakerAdapter()),
-        tasks,
-    ]
-)
+micro = Grelmicro(uses=[redis, tasks])
 
 
 # === FastAPI ===

--- a/docs/snippets/single_file_app.py
+++ b/docs/snippets/single_file_app.py
@@ -8,14 +8,12 @@ from fast_depends import Depends
 from fastapi import FastAPI
 
 from grelmicro.coordination import LeaderElection, Lock
-from grelmicro.coordination.memory import (
-    MemoryLeaderElectionAdapter,
-    MemoryLockAdapter,
-)
+from grelmicro.providers.memory import MemoryProvider
 from grelmicro.task import Tasks
 
-backend = MemoryLockAdapter()
-coordination_backend = MemoryLeaderElectionAdapter()
+provider = MemoryProvider()
+backend = provider.lock()
+coordination_backend = provider.leaderelection()
 task = Tasks()
 
 

--- a/docs/snippets/task/interval_leader.py
+++ b/docs/snippets/task/interval_leader.py
@@ -1,8 +1,8 @@
 from grelmicro.coordination import LeaderElection
-from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
+from grelmicro.providers.memory import MemoryProvider
 from grelmicro.task import Tasks
 
-leader = LeaderElection("my-service", backend=MemoryLeaderElectionAdapter())
+leader = LeaderElection("my-service", backend=MemoryProvider().leaderelection())
 task = Tasks()
 task.add_task(leader)
 

--- a/docs/snippets/task/leaderelection.py
+++ b/docs/snippets/task/leaderelection.py
@@ -1,8 +1,8 @@
 from grelmicro.coordination import LeaderElection
-from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
+from grelmicro.providers.memory import MemoryProvider
 from grelmicro.task import Tasks
 
-leader = LeaderElection("my-service", backend=MemoryLeaderElectionAdapter())
+leader = LeaderElection("my-service", backend=MemoryProvider().leaderelection())
 task = Tasks()
 task.add_task(leader)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,18 +32,12 @@ from collections.abc import AsyncIterator
 import pytest
 
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache
-from grelmicro.cache.memory import MemoryCacheAdapter
-from grelmicro.coordination import Coordination
-from grelmicro.coordination.memory import MemoryLockAdapter
+from grelmicro.providers.memory import MemoryProvider
 
 
 @pytest.fixture
 async def micro() -> AsyncIterator[Grelmicro]:
-    app = Grelmicro(uses=[
-        Coordination(lock=MemoryLockAdapter()),
-        Cache(MemoryCacheAdapter()),
-    ])
+    app = Grelmicro(uses=[MemoryProvider()])
     async with app:
         yield app
 ```
@@ -75,12 +69,12 @@ backend keeps its real behavior while the log captures every call for assertions
 ```python
 from grelmicro import Grelmicro
 from grelmicro.coordination import Coordination
-from grelmicro.coordination.memory import MemoryLockAdapter
+from grelmicro.providers.memory import MemoryProvider
 from grelmicro.testing import record
 
 
 async def test_login_takes_the_lock() -> None:
-    backend = MemoryLockAdapter()
+    backend = MemoryProvider().lock()
     log = record(backend)
     micro = Grelmicro(uses=[Coordination(lock=backend)])
 


### PR DESCRIPTION
Closes #644.

The guide reached for adapters before the reader had any reason to know what an adapter is. Every quick start now names a provider once and the pattern follows with no wiring in sight.

## Before and after

```diff
-from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
-from grelmicro.resilience.circuitbreaker.memory import MemoryCircuitBreakerAdapter
-
-micro = Grelmicro(uses=[
-    Coordination(lock=redis.lock(), election=MemoryLeaderElectionAdapter()),
-    CircuitBreakerRegistry(MemoryCircuitBreakerAdapter()),
-    tasks,
-])
+# One line says where the shared state lives.
+redis = RedisProvider("redis://localhost:6379/0")
+
+micro = Grelmicro(uses=[redis, tasks])
```

## No API change

This is documentation only. `uses=[provider]` already auto-registers a default component per kind the provider serves, so the target shape works on `main` today. Verified before writing any of it:

```
uses=[MemoryProvider()]  ->  Lock("cart"), @cached, CircuitBreaker("svc") all resolve
```

That is why this PR adds no defaults and changes no constructor. Nothing in a user's code needs updating.

## Numbers

Adapter references in `docs/snippets/` went from **56 to 8**. The 8 that remain are where choosing a backend is the actual subject:

* `coordination/kubernetes.py` and `coordination/independent_backends.py`, because Kubernetes has no Provider.
* `outbox/testing.py`, because `MemoryProvider.outbox()` genuinely raises `NotImplementedError`. Verified, not assumed.

Adapters stay documented centrally in [Backends and Adapters](docs/architecture/backends.md), which already existed. No per-pattern duplication was added, since one adapter serves several patterns.

## Prose swept too

`README.md` (and `docs/index.md` through the sync hook), `first-steps.md`, `cache.md` and `testing.md` had adapters in their own code blocks, not just in the included snippets.

## One trap found and avoided

The obvious rewrite of the README block is `uses=[redis, tasks, health]`. That is silently wrong:

```
uses=[redis, tasks]                  -> coordination, cache, ratelimiter, circuitbreaker
uses=[redis, tasks, HealthChecks()]  -> health only
```

`HealthChecks` is a Component, and any Component disables provider auto-registration, so the locks and cache vanish with no warning. The README block therefore keeps explicit components, adapter-free. Filed separately as #655, which is the fix rather than the workaround.

## Verification

`tests/test_snippets.py` executes all 149 snippets and `tests/test_readme.py` executes the README blocks, so every example here is run, not just parsed. Full `pre-commit run --all-files` green: ruff, ty, mypy, unit and integration tiers, the 100% coverage gate, and `mkdocs build --strict`.

## Scope note

The changelog also gains an `### Upgrading` section for the `/healthz` shape change from #649. That change merged in #650, so no open PR carries it, and it has to reach the same release as the change it describes.