### PR TITLE
✨ Back off per kind instead of disabling every provider default

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,19 +166,17 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request
 
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
+from grelmicro.cache import JsonSerializer, TTLCache, cached
 from grelmicro.clientip import TrustedProxies, resolve_client_address
 from grelmicro.health import HealthChecks
 from grelmicro.log import configure as configure_logging
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience import (
     CircuitBreaker,
-    CircuitBreakerRegistry,
     RateLimitExceededError,
     RateLimiter,
-    RateLimiterRegistry,
 )
-from grelmicro.coordination import Coordination, LeaderElection, Lock, TaskLock
+from grelmicro.coordination import LeaderElection, Lock, TaskLock
 from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
@@ -193,14 +191,7 @@ redis = RedisProvider("redis://localhost:6379/0")
 leader = LeaderElection("leader-election")
 tasks.add_task(leader)
 
-micro = Grelmicro(uses=[
-    Coordination(redis),
-    Cache(redis),
-    RateLimiterRegistry(redis),
-    CircuitBreakerRegistry(redis),
-    tasks,
-    health,
-])
+micro = Grelmicro(uses=[redis, tasks, health])
 
 # === Patterns declared once at module load, no backend wiring ===
 ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer())

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -85,17 +85,22 @@ Grelmicro(uses=[redis])
 
 A Provider serves a kind when its factory for that kind is implemented. `RedisProvider` and `PostgresProvider` serve all four kinds. `SQLiteProvider` skips leader election. An unserved kind (the factory raises `NotImplementedError`) is skipped. Any other factory error propagates, a misconfigured Provider fails loudly instead of registering a partial app.
 
-This auto-registration is all-or-nothing. The moment you list **any** explicit Component, every Provider in the list becomes lifecycle-only and registers nothing. The list then reads the way it runs: a lone Provider is a full default app, a Provider beside Components is just a shared connection the Components wire themselves.
+Back-off is per kind: **explicit wins, the Provider fills the rest.** A Component you list keeps its own kind, and every other kind the Provider serves still gets a default.
 
 ```python
-# auto-registered: one default Component per served kind
+# one default Component per served kind
 Grelmicro(uses=[redis])
 
-# explicit: redis is lifecycle-only, only Cache is registered
+# Cache is yours, coordination / ratelimiter / circuitbreaker come from redis
+Grelmicro(uses=[redis, Cache(other)])
+
+# only Cache is registered, redis is never listed to fill anything else
 Grelmicro(uses=[Cache(redis)])
 ```
 
-Two bare Providers with no Components raise `AmbiguousProviderError`: the default Component for a shared kind could come from either Provider. Wrap each Provider in the Components it should serve to resolve it.
+A Component of a kind no Provider serves (`HealthChecks`, `Log`, `Trace`) claims nothing, so it never suppresses a default. Adding health checks to an app does not remove its cache.
+
+Two bare Providers with no Components raise `AmbiguousProviderError`: the default Component for a shared kind could come from either Provider. Neither fills defaults, so listing any Component alongside them makes both lifecycle-only, which is how `HealthChecks(auto_health=True)` probes several Providers at once. Wrap each Provider in the Components it should serve to resolve the ambiguity.
 
 ```python
 # raises AmbiguousProviderError

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,18 @@ if error is not None:
 
 A failing check still carries `error`, and `status` and `critical` are still on every entry, so a dashboard reading those needs no change.
 
+**A `HealthChecks` no longer removes your backends.** Listing any Component used to switch provider auto-registration off entirely, so an app that added health checks lost its cache and locks with no warning. If you listed components explicitly only to work around that, the short form works now:
+
+```diff
+-micro = Grelmicro(uses=[
+-    Coordination(redis), Cache(redis), RateLimiterRegistry(redis),
+-    CircuitBreakerRegistry(redis), tasks, health,
+-])
++micro = Grelmicro(uses=[redis, tasks, health])
+```
+
+Explicit components still win for their own kind, so mixed wiring keeps working untouched. Two or more providers still fill no defaults, so `HealthChecks(auto_health=True)` across several providers is unchanged.
+
 **Redis credentials split across two variables now work.** `REDIS_PASSWORD` next to a `REDIS_URL` was read and then dropped, so the client connected unauthenticated. If you worked around that by building the provider from explicit settings, the plain form is enough again:
 
 ```diff
@@ -41,6 +53,7 @@ One combination newly raises instead of passing silently: a URL that already car
 
 ### Breaking
 
+* 💥 Back off per kind instead of disabling every provider default. Listing any Component used to turn provider auto-registration off entirely, so adding a `HealthChecks` silently removed the cache and the locks and the first `Lock("cart")` raised, naming the lock rather than the health registry that caused it. A Component now claims its own kind and the Provider fills the rest, which reads as one sentence: explicit wins, the Provider fills the rest. A Component of a kind no Provider serves (`HealthChecks`, `Log`, `Trace`) claims nothing and suppresses nothing. Two or more Providers still fill no defaults, since neither can be the default for a kind they both serve, so `HealthChecks(auto_health=True)` across several Providers is unchanged. ([#655](https://github.com/grelinfo/grelmicro/issues/655))
 * 💥 Leave `error` and `details` out of a `/healthz` check that has neither. A passing check sent `"error": null` on every poll, and with details enabled it sent `"details": null` too, so the highest-frequency response in the service spent bytes reporting that nothing happened. A passing check is now `{"status": "ok", "critical": true}`, and a failing one still carries its `error`. The OpenAPI schema types both fields as a plain string and object instead of promising a nullable value that never arrives. Read an absent `error` as a pass. A consumer that required the key needs updating. ([#649](https://github.com/grelinfo/grelmicro/issues/649))
 
 ### Features

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,19 +166,17 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request
 
 from grelmicro import Grelmicro
-from grelmicro.cache import Cache, JsonSerializer, TTLCache, cached
+from grelmicro.cache import JsonSerializer, TTLCache, cached
 from grelmicro.clientip import TrustedProxies, resolve_client_address
 from grelmicro.health import HealthChecks
 from grelmicro.log import configure as configure_logging
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience import (
     CircuitBreaker,
-    CircuitBreakerRegistry,
     RateLimitExceededError,
     RateLimiter,
-    RateLimiterRegistry,
 )
-from grelmicro.coordination import Coordination, LeaderElection, Lock, TaskLock
+from grelmicro.coordination import LeaderElection, Lock, TaskLock
 from grelmicro.task import Tasks
 
 logger = logging.getLogger(__name__)
@@ -193,14 +191,7 @@ redis = RedisProvider("redis://localhost:6379/0")
 leader = LeaderElection("leader-election")
 tasks.add_task(leader)
 
-micro = Grelmicro(uses=[
-    Coordination(redis),
-    Cache(redis),
-    RateLimiterRegistry(redis),
-    CircuitBreakerRegistry(redis),
-    tasks,
-    health,
-])
+micro = Grelmicro(uses=[redis, tasks, health])
 
 # === Patterns declared once at module load, no backend wiring ===
 ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer())

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -76,9 +76,15 @@ if os.getenv("STORE_BACKEND") == "redis":
 
 !!! note "A Provider fills the kinds nothing else claims"
     A Provider registers a default component for every kind it serves that no
-    component of yours already claims, whether you list it in `uses=` or pass it
-    to `micro.use(provider)`. Both forms behave the same way: explicit wins, the
-    provider fills the rest.
+    component already claims, whether you list it in `uses=` or pass it to
+    `micro.use(provider)`. Explicit wins, the provider fills the rest.
+
+    Two providers are the one case where the forms differ. `uses=[p1, p2]` sees
+    both at once and raises `AmbiguousProviderError`, because neither can be the
+    default for a kind they share. `micro.use(p1)` then `micro.use(p2)` is
+    ordered, so `p1` fills its kinds first and `p2` finds them claimed and fills
+    only what is left. Register the components explicitly when you want two
+    providers to serve different kinds.
 
 ## FastAPI
 

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -74,12 +74,11 @@ if os.getenv("STORE_BACKEND") == "redis":
     micro.use(RedisProvider())
 ```
 
-!!! note "A Provider registers differently through `use`"
-    Inside `uses=[...]`, a lone Provider on an app with no components registers
-    a default component for every kind it serves. By the time you call
-    `micro.use(provider)` on an app that already holds a component, the Provider
-    is lifecycled only. Pass the components you want explicitly
-    (`micro.use(Cache(redis))`) when you need them.
+!!! note "A Provider fills the kinds nothing else claims"
+    A Provider registers a default component for every kind it serves that no
+    component of yours already claims, whether you list it in `uses=` or pass it
+    to `micro.use(provider)`. Both forms behave the same way: explicit wins, the
+    provider fills the rest.
 
 ## FastAPI
 

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -325,17 +325,17 @@ class Grelmicro:
     def _use_provider(self, provider: Provider) -> None:
         """Lifecycle a bare Provider and queue its default-Component registration.
 
-        The Provider is always lifecycled here. When the app holds no explicit
-        Component, it also auto-registers one default Component per kind it
-        serves. Inside `Grelmicro(uses=[...])` that registration is deferred to
-        `_register_provider_defaults` so an explicit Component listed anywhere in
-        the list wins. A standalone `use(provider)` call registers right away,
-        against whatever is registered so far.
+        The Provider is always lifecycled here. It also auto-registers one
+        default Component for every kind it serves that no explicit Component
+        already claims. Inside `Grelmicro(uses=[...])` that registration is
+        deferred to `_register_provider_defaults` so a Component listed anywhere
+        in the list wins, whatever the order. A standalone `use(provider)` call
+        registers right away, against whatever is claimed so far.
         """
         self._items.append(provider)
         if self._deferring_provider_defaults:
             self._pending_providers.append(provider)
-        elif not self._by_key:
+        else:
             self._register_one_provider(provider)
 
     def _register_component(self, component: Component) -> None:
@@ -378,24 +378,34 @@ class Grelmicro:
     def _register_provider_defaults(self) -> None:
         """Auto-register default Components from Providers passed bare to `uses=`.
 
-        Runs once after every item in `uses=` is processed. When the app holds
-        no explicit Component, each kind a listed Provider serves (`coordination`,
-        `cache`, `ratelimiter`, `circuitbreaker`) gets one default-named
-        Component wired to that Provider. Listing any explicit Component turns
-        this off entirely, so the `uses=` list reads the same way it runs: a
-        lone Provider is a full default app, a Provider mixed with Components is
-        lifecycle-only and the Components own the wiring.
+        Runs once after every item in `uses=` is processed. Each kind a listed
+        Provider serves (`coordination`, `cache`, `ratelimiter`,
+        `circuitbreaker`) gets one default-named Component wired to that
+        Provider, unless an explicit Component already claims that kind.
+        Explicit wins, the Provider fills the rest.
+
+        Back-off is per kind, so a Component of an unrelated kind
+        (`HealthChecks`, `Log`, `Trace`) leaves the provider defaults alone.
+
+        Two or more Providers never fill defaults, because neither can be the
+        default for a kind they both serve.
 
         Raises:
-            AmbiguousProviderError: Two or more bare Providers are listed with no
-                explicit Component, so the default for a shared kind is
+            AmbiguousProviderError: Two or more bare Providers are listed with
+                no explicit Component, so the default for each kind is
                 ambiguous.
         """
         pending = self._pending_providers
         self._pending_providers = []
-        if not pending or self._by_key:
+        if not pending:
             return
         if len(pending) > 1:
+            # Two Providers cannot both be the default for a shared kind, so
+            # neither fills anything. With Components present the app is
+            # wiring explicitly and they are lifecycle-only, without them
+            # there is no way to guess and it is worth saying so early.
+            if self._by_key:
+                return
             names = ", ".join(type(p).__name__ for p in pending)
             msg = (
                 f"Grelmicro(uses=[...]) lists multiple providers ({names}) "
@@ -408,13 +418,18 @@ class Grelmicro:
         self._register_one_provider(pending[0])
 
     def _register_one_provider(self, provider: Provider) -> None:
-        """Register one default Component per kind `provider` serves.
+        """Register a default Component for every unclaimed kind `provider` serves.
 
         A kind is served when the matching Component builds without the provider
-        raising `NotImplementedError`. The provider stays lifecycled where it was
-        listed, the Components borrow its client and are not lifecycled again.
+        raising `NotImplementedError`. A kind an explicit Component already holds
+        is skipped, so an explicit choice is never overwritten. The provider
+        stays lifecycled where it was listed, the Components borrow its client
+        and are not lifecycled again.
         """
+        claimed = {component.kind for component in self._by_key.values()}
         for component in _default_components_for_provider(provider):
+            if component.kind in claimed:
+                continue
             self._register_component(component)
 
     def get(

--- a/tests/test_uses_coercion.py
+++ b/tests/test_uses_coercion.py
@@ -324,6 +324,19 @@ def test_use_lone_provider_auto_registers() -> None:
     assert isinstance(micro.get("coordination"), Coordination)
 
 
+def test_use_two_providers_in_order_lets_the_first_win() -> None:
+    """Sequential `use` is ordered, so it fills rather than raising."""
+    first = _MemoryProvider()
+    micro = Grelmicro()
+    micro.use(first)
+    micro.use(_CacheOnlyProvider())
+
+    # `uses=[first, second]` would raise, the ordered form cannot be ambiguous.
+    assert micro.get("cache").backend is not None
+    kinds = {component.kind for component in micro.components}
+    assert kinds == {"cache", "coordination", "ratelimiter", "circuitbreaker"}
+
+
 def test_use_provider_after_component_fills_the_other_kinds() -> None:
     """`use(component)` then `use(provider)` matches the `uses=` list form."""
     backend = MemoryCacheAdapter()

--- a/tests/test_uses_coercion.py
+++ b/tests/test_uses_coercion.py
@@ -34,6 +34,19 @@ from grelmicro.resilience.circuitbreaker.memory import (
 from grelmicro.resilience.ratelimiter.memory import MemoryRateLimiterAdapter
 
 
+class _HealthLikeComponent:
+    """A Component of a kind no Provider serves, as `HealthChecks` is."""
+
+    kind: ClassVar[str] = "health"
+    name: str = "default"
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
 class _MemoryProvider(Provider):
     """A Provider serving every kind from in-memory adapters.
 
@@ -231,20 +244,34 @@ async def test_provider_auto_registered_components_lifecycle() -> None:
 # --- Explicit wins ---
 
 
-def test_explicit_component_disables_provider_auto_registration() -> None:
-    """Any explicit Component turns provider auto-registration off entirely."""
-    provider = _MemoryProvider()
-    micro = Grelmicro(uses=[provider, Cache(MemoryCacheAdapter())])
+def test_explicit_component_wins_for_its_own_kind() -> None:
+    """An explicit Component keeps its kind, the Provider fills the rest."""
+    backend = MemoryCacheAdapter()
+    micro = Grelmicro(uses=[_MemoryProvider(), Cache(backend)])
 
-    assert isinstance(micro.get("cache"), Cache)
+    assert micro.get("cache").backend is backend
     kinds = {component.kind for component in micro.components}
-    assert kinds == {"cache"}
+    assert kinds == {"cache", "coordination", "ratelimiter", "circuitbreaker"}
+
+
+def test_unrelated_component_does_not_suppress_defaults() -> None:
+    """A Component of a kind no Provider serves leaves the defaults alone."""
+    micro = Grelmicro(uses=[_MemoryProvider(), _HealthLikeComponent()])
+
+    kinds = {component.kind for component in micro.components}
+    assert kinds == {
+        "cache",
+        "coordination",
+        "ratelimiter",
+        "circuitbreaker",
+        "health",
+    }
 
 
 async def test_explicit_provider_listed_with_component_lifecycled_once() -> (
     None
 ):
-    """A Provider listed beside an explicit Component is lifecycle-only."""
+    """A Provider beside an explicit Component still fills the other kinds."""
     provider = _MemoryProvider()
     micro = Grelmicro(uses=[provider, Coordination(lock=MemoryLockAdapter())])
 
@@ -252,7 +279,7 @@ async def test_explicit_provider_listed_with_component_lifecycled_once() -> (
         pass
 
     kinds = {component.kind for component in micro.components}
-    assert kinds == {"coordination"}
+    assert kinds == {"coordination", "cache", "ratelimiter", "circuitbreaker"}
 
 
 # --- Two-provider ambiguity ---
@@ -297,14 +324,16 @@ def test_use_lone_provider_auto_registers() -> None:
     assert isinstance(micro.get("coordination"), Coordination)
 
 
-def test_use_provider_after_component_is_lifecycle_only() -> None:
-    """`use(component)` then `use(provider)` leaves the provider lifecycle-only."""
+def test_use_provider_after_component_fills_the_other_kinds() -> None:
+    """`use(component)` then `use(provider)` matches the `uses=` list form."""
+    backend = MemoryCacheAdapter()
     micro = Grelmicro()
-    micro.use(Cache(MemoryCacheAdapter()))
+    micro.use(Cache(backend))
     micro.use(_MemoryProvider())
 
+    assert micro.get("cache").backend is backend
     kinds = {component.kind for component in micro.components}
-    assert kinds == {"cache"}
+    assert kinds == {"cache", "coordination", "ratelimiter", "circuitbreaker"}
 
 
 # --- conditional registration ---


### PR DESCRIPTION
Closes #655.

Adding a `HealthChecks` to `uses=` silently removed every backend a Provider would have registered.

```
uses=[redis, tasks]                  -> coordination, cache, ratelimiter, circuitbreaker
uses=[redis, tasks, HealthChecks()]  -> health only
```

Nothing warned. The first `Lock("cart")` then raised `ComponentNotRegisteredError`, naming the lock rather than the health registry that caused it. I hit this writing the README block in #656 and had to keep that example verbose to avoid it.

## The rule

Back-off is now per kind. One sentence describes it:

> **Explicit wins, the Provider fills the rest.**

```python
uses=[redis, health]        # coordination, cache, ratelimiter, circuitbreaker, health
uses=[redis, Cache(other)]  # Cache(other), plus the other three from redis
```

A Component of a kind no Provider serves (`HealthChecks`, `Log`, `Trace`) claims nothing, so it suppresses nothing.

`micro.use(provider)` now behaves identically to listing the provider in `uses=`. The two forms used to diverge, which #656 had to document as a caveat. That caveat is deleted here rather than explained.

## What I did not change, and why

The first version of this raised `AmbiguousProviderError` for `uses=[redis, postgres, HealthChecks(auto_health=True)]`, because neither provider could claim the unclaimed kinds. That is a **documented pattern**, and `docs/snippets/health/auto_health.py` broke on it. The test suite caught it, not review.

So multi-provider behaviour is deliberately untouched: two or more Providers still fill no defaults, since neither can be the default for a kind they both serve. Only the single-provider case gained per-kind back-off. That fixes the reported trap with no collateral change, and keeps `AmbiguousProviderError` firing exactly where it did before.

## Precedent

This is how Spring Boot's `@ConditionalOnMissingBean` scopes back-off: to the individual bean, not the whole auto-configuration class. Whole-class back-off exists there too as `@EnableWebMvc`, but it is opt-in through an explicit marker rather than inferred from declaring one bean, and it is one of Spring's best known surprises. The rule being replaced here was the inferred variant of that.

## Breaking

`uses=[redis, Cache(redis)]` used to register `cache` alone and now also registers coordination, ratelimiter and circuitbreaker. They are lazy and borrow a client that is already lifecycled, so the cost is near zero, but it is a behaviour change and it is in the changelog under `### Breaking` with an upgrade note.

Three tests encoded the old rule and were rewritten to the new one. A fourth was added for the case that caused this, a Component whose kind no Provider serves.

## Verification

4008 tests pass. Full `pre-commit run --all-files` green. The README example is simplified to `uses=[redis, tasks, health]` in this PR, which is the shape #656 could not use.
