### PR TITLE
🔖 Prepare the 0.35.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.35.0 - 2026-08-05
 
 ### Upgrading
 


### PR DESCRIPTION
Dates the `Unreleased` section as **0.35.0**.

## Why a minor bump

Two breaking changes ship here, and this repo bumps the minor for breaking changes: `0.34.0`, `0.32.0` and `0.31.0` each carried a `### Breaking` section. Pre-1.0 patch releases have never carried one.

## What is in it

Seven issues, all reported or found in this cycle:

| Issue | Change |
|---|---|
| #653 | `REDIS_PASSWORD` next to `REDIS_URL` was silently dropped, so the client connected unauthenticated |
| #654 | `redis+sentinel://` and `redis+cluster://` were rejected from the environment and `RedisConfig` |
| #655 | Any Component disabled every provider default, so adding `HealthChecks` removed the cache and locks |
| #651 | `override(...)` leaked a broken component into the registry when it failed to open |
| #649 | `/healthz` sent `"error": null` on every passing check |
| #646 | No exported type for `uses=`, no shape for conditional registration, no provider-only recipe |
| #644 | Adapters appeared in the first examples a reader meets |

## Release notes

The section opens with **Upgrading**, covering the three changes that need action: the `/healthz` shape, the `HealthChecks` fix that lets `uses=` shrink again, and the Redis credential split. Each carries a before/after diff rather than only a description.

Verified with `uv run python tools/changelog.py check 0.35.0`. `just release-check 0.35.0` runs after this merges, since it requires HEAD to equal `origin/main`.
