### PR TITLE
🔒 Declare code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Every change is owned and reviewed by the maintainer.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @grelinfo

--- a/examples/fastapi-demo/Dockerfile
+++ b/examples/fastapi-demo/Dockerfile
@@ -4,11 +4,7 @@
 FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /srv
-
-# uv comes from its own image rather than pip, so it is pinned by digest like
-# the base image is. Dependabot bumps both. A version-pinned `pip install` still
-# resolves whatever the index serves for that version.
-COPY --from=ghcr.io/astral-sh/uv:0.11.29@sha256:eb2843a1e56fd9e30c7276ce1a52cba86e64c7b385f5e3279a0e08e02dd058fc /uv /usr/local/bin/uv
+RUN pip install --no-cache-dir uv==0.11.29
 
 # Install grelmicro (current source) plus the demo's runtime deps.
 COPY pyproject.toml README.md ./

--- a/examples/fastapi-demo/Dockerfile
+++ b/examples/fastapi-demo/Dockerfile
@@ -4,7 +4,11 @@
 FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /srv
-RUN pip install --no-cache-dir uv==0.11.29
+
+# uv comes from its own image rather than pip, so it is pinned by digest like
+# the base image is. Dependabot bumps both. A version-pinned `pip install` still
+# resolves whatever the index serves for that version.
+COPY --from=ghcr.io/astral-sh/uv:0.11.29@sha256:eb2843a1e56fd9e30c7276ce1a52cba86e64c7b385f5e3279a0e08e02dd058fc /uv /usr/local/bin/uv
 
 # Install grelmicro (current source) plus the demo's runtime deps.
 COPY pyproject.toml README.md ./


### PR DESCRIPTION
Adds `.github/CODEOWNERS`, closing the one genuinely fixable sub-warning in the OpenSSF Scorecard `BranchProtectionID` finding:

> Warn: codeowners review is required - but no codeowners file found in repo

## Scope, after review feedback

This PR originally also swapped the demo's `pip install uv==0.11.29` for a digest-pinned `COPY --from=ghcr.io/astral-sh/uv:...@sha256:...`, to close `PinnedDependenciesID`.

That is reverted. The demo exists to be read by someone meeting the project for the first time, and a 71-character digest on the second instruction costs more in clarity than the finding is worth. `PinnedDependenciesID` already scores 9/10 with the base image digest-pinned, and it is dismissed with that reasoning rather than fixed.

The demo Dockerfile is byte-identical to `main`.

## What stays open, deliberately

Three `BranchProtectionID` sub-warnings remain, all consequences of one maintainer rather than of a wrong setting:

* **`enforce_admins` disabled**, because enabling it blocks the maintainer's own `--admin` merge, which is how every PR lands.
* **Required approving reviews is 1**, where Scorecard wants 2.
* **Last push approval disabled**, which would need a second person to approve the final push.

`CodeReviewID` and `FuzzingID` are dismissed separately with reasons. Neither is a vulnerability: this repository has zero open Dependabot alerts and zero secret-scanning alerts.
