### PR TITLE
🧰 Quiet health probe access logs, and say why orjson is opt-in

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,7 +26,7 @@ filterwarnings = ["error", "ignore::grelmicro.GrelmicroConfigWarning"]
 
 ### Features
 
-* ✨ Quiet health probe access logs with `silence_probe_access_logs()`. Kubernetes polls `/livez`, `/readyz` and `/healthz` every few seconds forever, and the access log reported each one, so a healthy pod logged almost nothing else. Suppressing them took a `logging.Filter` that reflected on the shape of uvicorn's access record. Only responses below `400` are dropped, so a readiness check that starts refusing traffic still appears. Paths match by suffix, so `health_router(prefix=...)` needs no configuration, and `paths=` covers other polled endpoints. ([#667](https://github.com/grelinfo/grelmicro/issues/667))
+* ✨ Quiet health probe access logs with `ProbeFilter`. Attach it to the access logger the same way as `DuplicateFilter` and `RateLimitFilter`. Kubernetes polls `/livez`, `/readyz` and `/healthz` every few seconds forever, and the access log reported each one, so a healthy pod logged almost nothing else. Suppressing them took a `logging.Filter` that reflected on the shape of uvicorn's access record. Only responses below `400` are dropped, so a readiness check that starts refusing traffic still appears. Paths match by suffix, so `health_router(prefix=...)` needs no configuration, and `paths=` covers other polled endpoints. ([#667](https://github.com/grelinfo/grelmicro/issues/667))
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,10 @@ To keep the warning visible without failing a build, filter the category rather 
 filterwarnings = ["error", "ignore::grelmicro.GrelmicroConfigWarning"]
 ```
 
+### Features
+
+* ✨ Quiet health probe access logs with `silence_probe_access_logs()`. Kubernetes polls `/livez`, `/readyz` and `/healthz` every few seconds forever, and the access log reported each one, so a healthy pod logged almost nothing else. Suppressing them took a `logging.Filter` that reflected on the shape of uvicorn's access record. Only responses below `400` are dropped, so a readiness check that starts refusing traffic still appears. Paths match by suffix, so `health_router(prefix=...)` needs no configuration, and `paths=` covers other polled endpoints. ([#667](https://github.com/grelinfo/grelmicro/issues/667))
+
 ### Fixed
 
 * 🐛 Open a Provider before the Component that borrows it, whatever order they are listed in. A Provider left out of `uses=` was already discovered and inserted ahead of its Component, but one listed *after* it only got a warning and then failed on startup with `OutOfContextError`, so listing a Provider was worse than omitting it. Both cases are now reordered the same way: `uses=` says what the app is made of, and grelmicro opens it in dependency order. `Grelmicro(strict=True)` still raises `LifecycleOrderError`, for callers who want the list they wrote to be the list that runs. ([#665](https://github.com/grelinfo/grelmicro/issues/665))
@@ -32,6 +36,7 @@ filterwarnings = ["error", "ignore::grelmicro.GrelmicroConfigWarning"]
 ### Docs
 
 * 📝 Teach how a value is resolved, in [Configuration](config.md#how-a-value-is-resolved). Keyword arguments, environment behind `GREL_ENV_LOAD`, and a file through `ExternalConfig`, with a local development recipe that does not need exported variables. Says plainly that `ExternalConfig` reconfigures live components and not `Log`, so log format in local development comes from `configure(...)` or a loaded `.env`. ([#662](https://github.com/grelinfo/grelmicro/issues/662))
+* 📝 Say why orjson is not selected just because it is installed. The two serializers disagree on some payloads: `NaN` and `Infinity` become `null`, and a non-string dict key raises instead of being coerced. Auto-selecting on importability would let an unrelated dependency change what logs say, or turn a working log call into an exception. The choice stays explicit, and the reasoning is now written down. ([#667](https://github.com/grelinfo/grelmicro/issues/667))
 * 📝 Put the opt-in warning above every environment variable table, written once and included, so a reader who lands on a module page from a search engine sees it without following a link. The logging page also no longer claims every knob is an environment variable without saying when they are read. ([#662](https://github.com/grelinfo/grelmicro/issues/662))
 
 ## 0.35.0 - 2026-08-05

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -313,32 +313,25 @@ uvicorn app:app --log-config uvicorn_log_config.json
 
 Kubernetes polls `/livez`, `/readyz` and `/healthz` every few seconds for the life of the pod, and the access log reports every one. In a healthy pod they are close to the only thing in the log.
 
-`silence_probe_access_logs()` drops them:
+`ProbeFilter` drops them. Attach it to the access logger, the same way as the other filters on this page:
 
 ```python
 --8<-- "log/probes.py"
 ```
 
-Call it once at startup, after `configure()`.
-
 **A failing probe is still logged.** Only responses below `400` are dropped, so a readiness check that starts refusing traffic still shows up. That line is often the only evidence the kubelet asked and was refused, so hiding it with the noise would remove the one thing worth reading.
 
 **Paths are matched by suffix**, so `health_router(prefix="/api/v1")` is covered with no configuration. A query string is ignored, so `/healthz?exclude=redis` is still recognised as a probe.
 
-Pass `paths=` to cover other polled endpoints, which replaces the defaults rather than adding to them:
+Pass `paths=` to cover other polled endpoints. It replaces the defaults rather than adding to them:
 
 ```python
-silence_probe_access_logs(paths=("/livez", "/readyz", "/healthz", "/metrics"))
+logging.getLogger("uvicorn.access").addFilter(
+    ProbeFilter(paths=("/livez", "/readyz", "/healthz", "/metrics"))
+)
 ```
 
-The call returns the `ProbeFilter` it installed, so you can remove it again:
-
-```python
-probe_filter = silence_probe_access_logs()
-logging.getLogger("uvicorn.access").removeFilter(probe_filter)
-```
-
-`ProbeFilter` is a plain `logging.Filter`, so it also works in a `dictConfig` or on another access logger if you are not using uvicorn.
+It is a plain `logging.Filter`, so it also works in a `dictConfig`, on another access logger, or removed again with `removeFilter`.
 
 ## Deduplicating Noisy Logs
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -309,6 +309,37 @@ uvicorn app:app --log-config uvicorn_log_config.json
 
 `UvicornAccessFormatter` additionally parses uvicorn's access log arguments into structured fields: `client_addr`, `method`, `full_path`, `http_version`, `status_code`.
 
+### Quieting health probes
+
+Kubernetes polls `/livez`, `/readyz` and `/healthz` every few seconds for the life of the pod, and the access log reports every one. In a healthy pod they are close to the only thing in the log.
+
+`silence_probe_access_logs()` drops them:
+
+```python
+--8<-- "log/probes.py"
+```
+
+Call it once at startup, after `configure()`.
+
+**A failing probe is still logged.** Only responses below `400` are dropped, so a readiness check that starts refusing traffic still shows up. That line is often the only evidence the kubelet asked and was refused, so hiding it with the noise would remove the one thing worth reading.
+
+**Paths are matched by suffix**, so `health_router(prefix="/api/v1")` is covered with no configuration. A query string is ignored, so `/healthz?exclude=redis` is still recognised as a probe.
+
+Pass `paths=` to cover other polled endpoints, which replaces the defaults rather than adding to them:
+
+```python
+silence_probe_access_logs(paths=("/livez", "/readyz", "/healthz", "/metrics"))
+```
+
+The call returns the `ProbeFilter` it installed, so you can remove it again:
+
+```python
+probe_filter = silence_probe_access_logs()
+logging.getLogger("uvicorn.access").removeFilter(probe_filter)
+```
+
+`ProbeFilter` is a plain `logging.Filter`, so it also works in a `dictConfig` or on another access logger if you are not using uvicorn.
+
 ## Deduplicating Noisy Logs
 
 `DuplicateFilter` is a `logging.Filter` that silences repeated log records.
@@ -514,6 +545,21 @@ Benchmark results (50,000 iterations):
 
 !!! tip "Performance Recommendation"
     For high-throughput applications, use `GREL_LOG_JSON_SERIALIZER=orjson` with `structlog` or `stdlib` backend.
+
+### Why orjson is not selected automatically
+
+Installing orjson does not change anything until you also select it. That is deliberate, and it is the one place in the logging module that is not auto-detected.
+
+The two serializers do not agree on every payload:
+
+| Value in `extra={...}` | `stdlib` | `orjson` |
+|---|---|---|
+| `float("nan")`, `float("inf")` | `NaN`, `Infinity` | `null` |
+| a non-string dict key | coerced to a string | raises `TypeError` |
+
+Picking a serializer because a package happens to be importable would mean an unrelated dependency pulling in orjson could change what your logs say, or turn a working log call into an exception on a payload that used to serialize. A log line that crashes the request is worse than a log line that is slower.
+
+So the choice stays yours. Set `GREL_LOG_JSON_SERIALIZER=orjson`, or pass `json_serializer="orjson"` to `configure()`, once you know your payloads are compatible.
 
 Run the benchmark:
 ```bash

--- a/docs/snippets/log/probes.py
+++ b/docs/snippets/log/probes.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+
+from grelmicro import Grelmicro
+from grelmicro.health import HealthChecks
+from grelmicro.integrations.fastapi import health_router
+from grelmicro.log import configure, silence_probe_access_logs
+
+health = HealthChecks()
+micro = Grelmicro(uses=[health])
+
+app = FastAPI()
+micro.install(app)
+app.include_router(health_router())
+
+configure()
+silence_probe_access_logs()

--- a/docs/snippets/log/probes.py
+++ b/docs/snippets/log/probes.py
@@ -1,9 +1,11 @@
+import logging
+
 from fastapi import FastAPI
 
 from grelmicro import Grelmicro
 from grelmicro.health import HealthChecks
 from grelmicro.integrations.fastapi import health_router
-from grelmicro.log import configure, silence_probe_access_logs
+from grelmicro.log import ProbeFilter, configure
 
 health = HealthChecks()
 micro = Grelmicro(uses=[health])
@@ -13,4 +15,4 @@ micro.install(app)
 app.include_router(health_router())
 
 configure()
-silence_probe_access_logs()
+logging.getLogger("uvicorn.access").addFilter(ProbeFilter())

--- a/grelmicro/log/__init__.py
+++ b/grelmicro/log/__init__.py
@@ -8,6 +8,11 @@ from grelmicro._config import resolve_config
 from grelmicro.log._apply import apply as _apply
 from grelmicro.log._component import Log
 from grelmicro.log._dedup import DuplicateFilter, DuplicateFilterConfig
+from grelmicro.log._probes import (
+    DEFAULT_PROBE_PATHS,
+    ProbeFilter,
+    silence_probe_access_logs,
+)
 from grelmicro.log._ratelimit import (
     RateLimitFilter,
     RateLimitFilterConfig,
@@ -137,6 +142,7 @@ def configure_with(
 
 
 __all__ = [
+    "DEFAULT_PROBE_PATHS",
     "DuplicateFilter",
     "DuplicateFilterConfig",
     "ErrorDict",
@@ -145,8 +151,10 @@ __all__ = [
     "LogConfig",
     "LogError",
     "LogSettingsValidationError",
+    "ProbeFilter",
     "RateLimitFilter",
     "RateLimitFilterConfig",
     "configure",
     "configure_with",
+    "silence_probe_access_logs",
 ]

--- a/grelmicro/log/__init__.py
+++ b/grelmicro/log/__init__.py
@@ -8,11 +8,7 @@ from grelmicro._config import resolve_config
 from grelmicro.log._apply import apply as _apply
 from grelmicro.log._component import Log
 from grelmicro.log._dedup import DuplicateFilter, DuplicateFilterConfig
-from grelmicro.log._probes import (
-    DEFAULT_PROBE_PATHS,
-    ProbeFilter,
-    silence_probe_access_logs,
-)
+from grelmicro.log._probes import ProbeFilter
 from grelmicro.log._ratelimit import (
     RateLimitFilter,
     RateLimitFilterConfig,
@@ -142,7 +138,6 @@ def configure_with(
 
 
 __all__ = [
-    "DEFAULT_PROBE_PATHS",
     "DuplicateFilter",
     "DuplicateFilterConfig",
     "ErrorDict",
@@ -156,5 +151,4 @@ __all__ = [
     "RateLimitFilterConfig",
     "configure",
     "configure_with",
-    "silence_probe_access_logs",
 ]

--- a/grelmicro/log/_probes.py
+++ b/grelmicro/log/_probes.py
@@ -4,15 +4,12 @@ Stdlib :class:`logging.Filter` that drops uvicorn access lines for the
 health endpoints. See the logging user guide for semantics and examples.
 """
 
-from logging import Filter, LogRecord, getLogger
+from logging import Filter, LogRecord
 from typing import Annotated
 
 from typing_extensions import Doc
 
-DEFAULT_PROBE_PATHS: tuple[str, ...] = ("/livez", "/readyz", "/healthz")
-"""Endpoint suffixes `health_router()` serves."""
-
-_UVICORN_ACCESS_LOGGER = "uvicorn.access"
+_DEFAULT_PROBE_PATHS = ("/livez", "/readyz", "/healthz")
 _ACCESS_RECORD_ARGS = 5
 _PATH_INDEX = 2
 _STATUS_INDEX = 4
@@ -26,6 +23,12 @@ class ProbeFilter(Filter):
     for the life of the pod, and an access logger reports each one, so the
     probes crowd out everything else.
 
+    Attach it to the access logger:
+
+    ```python
+    logging.getLogger("uvicorn.access").addFilter(ProbeFilter())
+    ```
+
     A probe that fails is kept. A failing readiness check is often the only
     thing in the log that says the kubelet asked and was refused, so it is
     the line worth reading.
@@ -37,19 +40,21 @@ class ProbeFilter(Filter):
     def __init__(
         self,
         paths: Annotated[
-            "tuple[str, ...] | None",
+            tuple[str, ...] | None,
             Doc(
                 """
-                Endpoint suffixes to drop. Defaults to the three
-                `health_router()` serves. Pass your own to cover extra
-                probe endpoints, such as a metrics scrape.
+                Endpoint suffixes to drop, replacing the default
+                `("/livez", "/readyz", "/healthz")`. Pass your own to cover
+                other polled endpoints, such as a metrics scrape.
                 """,
             ),
         ] = None,
     ) -> None:
         """Initialize the filter."""
         super().__init__()
-        self._paths = tuple(paths) if paths is not None else DEFAULT_PROBE_PATHS
+        self._paths = (
+            tuple(paths) if paths is not None else _DEFAULT_PROBE_PATHS
+        )
 
     def filter(self, record: LogRecord) -> bool:
         """Return False for a probe request that succeeded."""
@@ -64,29 +69,3 @@ class ProbeFilter(Filter):
         except ValueError:
             return True
         return status >= _FIRST_ERROR_STATUS
-
-
-def silence_probe_access_logs(
-    paths: Annotated[
-        "tuple[str, ...] | None",
-        Doc("Endpoint suffixes to drop. Defaults to the health endpoints."),
-    ] = None,
-) -> ProbeFilter:
-    """Stop successful health probes from reaching the access log.
-
-    Attaches a `ProbeFilter` to the `uvicorn.access` logger and returns it,
-    so it can be removed again:
-
-    ```python
-    from grelmicro.log import silence_probe_access_logs
-
-    silence_probe_access_logs()
-    ```
-
-    Call it once at startup, after logging is configured. Failing probes
-    still appear, so a readiness check that starts refusing traffic is not
-    hidden along with the noise.
-    """
-    probe_filter = ProbeFilter(paths)
-    getLogger(_UVICORN_ACCESS_LOGGER).addFilter(probe_filter)
-    return probe_filter

--- a/grelmicro/log/_probes.py
+++ b/grelmicro/log/_probes.py
@@ -1,0 +1,92 @@
+"""Health probe access log filter.
+
+Stdlib :class:`logging.Filter` that drops uvicorn access lines for the
+health endpoints. See the logging user guide for semantics and examples.
+"""
+
+from logging import Filter, LogRecord, getLogger
+from typing import Annotated
+
+from typing_extensions import Doc
+
+DEFAULT_PROBE_PATHS: tuple[str, ...] = ("/livez", "/readyz", "/healthz")
+"""Endpoint suffixes `health_router()` serves."""
+
+_UVICORN_ACCESS_LOGGER = "uvicorn.access"
+_ACCESS_RECORD_ARGS = 5
+_PATH_INDEX = 2
+_STATUS_INDEX = 4
+_FIRST_ERROR_STATUS = 400
+
+
+class ProbeFilter(Filter):
+    """Drop successful health probe lines from an access log.
+
+    Kubernetes polls `/livez`, `/readyz` and `/healthz` every few seconds
+    for the life of the pod, and an access logger reports each one, so the
+    probes crowd out everything else.
+
+    A probe that fails is kept. A failing readiness check is often the only
+    thing in the log that says the kubelet asked and was refused, so it is
+    the line worth reading.
+
+    Paths are matched by suffix, so a router mounted under a prefix is
+    covered without configuration.
+    """
+
+    def __init__(
+        self,
+        paths: Annotated[
+            "tuple[str, ...] | None",
+            Doc(
+                """
+                Endpoint suffixes to drop. Defaults to the three
+                `health_router()` serves. Pass your own to cover extra
+                probe endpoints, such as a metrics scrape.
+                """,
+            ),
+        ] = None,
+    ) -> None:
+        """Initialize the filter."""
+        super().__init__()
+        self._paths = tuple(paths) if paths is not None else DEFAULT_PROBE_PATHS
+
+    def filter(self, record: LogRecord) -> bool:
+        """Return False for a probe request that succeeded."""
+        args = record.args
+        if not isinstance(args, tuple) or len(args) != _ACCESS_RECORD_ARGS:
+            return True
+        path = str(args[_PATH_INDEX]).split("?", 1)[0]
+        if not path.endswith(self._paths):
+            return True
+        try:
+            status = int(str(args[_STATUS_INDEX]))
+        except ValueError:
+            return True
+        return status >= _FIRST_ERROR_STATUS
+
+
+def silence_probe_access_logs(
+    paths: Annotated[
+        "tuple[str, ...] | None",
+        Doc("Endpoint suffixes to drop. Defaults to the health endpoints."),
+    ] = None,
+) -> ProbeFilter:
+    """Stop successful health probes from reaching the access log.
+
+    Attaches a `ProbeFilter` to the `uvicorn.access` logger and returns it,
+    so it can be removed again:
+
+    ```python
+    from grelmicro.log import silence_probe_access_logs
+
+    silence_probe_access_logs()
+    ```
+
+    Call it once at startup, after logging is configured. Failing probes
+    still appear, so a readiness check that starts refusing traffic is not
+    hidden along with the noise.
+    """
+    probe_filter = ProbeFilter(paths)
+    getLogger(_UVICORN_ACCESS_LOGGER).addFilter(probe_filter)
+    return probe_filter

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -253,7 +253,6 @@
     }
   },
   "grelmicro.log": {
-    "DEFAULT_PROBE_PATHS": null,
     "DuplicateFilter": {
       "()": "(*, allowed_repetitions=..., cache_size=..., key_mode=..., ttl=..., key=..., env_name=..., env_prefix=..., env_load=...)",
       ".from_config": "(config, *, key=...)"
@@ -289,9 +288,6 @@
     },
     "configure_with": {
       "()": "(config)"
-    },
-    "silence_probe_access_logs": {
-      "()": "(paths=...)"
     }
   },
   "grelmicro.metrics": {

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -253,6 +253,7 @@
     }
   },
   "grelmicro.log": {
+    "DEFAULT_PROBE_PATHS": null,
     "DuplicateFilter": {
       "()": "(*, allowed_repetitions=..., cache_size=..., key_mode=..., ttl=..., key=..., env_name=..., env_prefix=..., env_load=...)",
       ".from_config": "(config, *, key=...)"
@@ -273,6 +274,9 @@
     "LogSettingsValidationError": {
       "()": "(error)"
     },
+    "ProbeFilter": {
+      "()": "(paths=...)"
+    },
     "RateLimitFilter": {
       "()": "(*, capacity=..., refill_rate=..., key_mode=..., cost=..., key=..., env_name=..., env_prefix=..., env_load=...)",
       ".from_config": "(config, *, key=...)"
@@ -285,6 +289,9 @@
     },
     "configure_with": {
       "()": "(config)"
+    },
+    "silence_probe_access_logs": {
+      "()": "(paths=...)"
     }
   },
   "grelmicro.metrics": {

--- a/tests/logging/test_probes.py
+++ b/tests/logging/test_probes.py
@@ -1,0 +1,86 @@
+"""Tests for the health probe access log filter."""
+
+import logging
+
+from grelmicro.log import ProbeFilter, silence_probe_access_logs
+
+
+def _access_record(path: str, status: int = 200) -> logging.LogRecord:
+    """Build a record shaped like uvicorn's access log."""
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:54321", "GET", path, "1.1", status),
+        exc_info=None,
+    )
+
+
+def test_successful_probe_is_dropped() -> None:
+    """A passing probe carries no information and is dropped."""
+    assert ProbeFilter().filter(_access_record("/healthz")) is False
+
+
+def test_failing_probe_is_kept() -> None:
+    """A failing probe is the line worth reading."""
+    assert ProbeFilter().filter(_access_record("/readyz", 503)) is True
+
+
+def test_application_request_is_kept() -> None:
+    """A request that is not a probe passes through."""
+    assert ProbeFilter().filter(_access_record("/orders")) is True
+
+
+def test_prefixed_probe_is_dropped() -> None:
+    """Suffix matching covers `health_router(prefix=...)` with no configuration."""
+    assert ProbeFilter().filter(_access_record("/api/v1/livez")) is False
+
+
+def test_query_string_is_ignored() -> None:
+    """`/healthz?exclude=redis` is still a probe."""
+    assert ProbeFilter().filter(_access_record("/healthz?exclude=x")) is False
+
+
+def test_custom_paths_replace_the_defaults() -> None:
+    """`paths=` covers extra endpoints such as a metrics scrape."""
+    probe_filter = ProbeFilter(paths=("/metrics",))
+
+    assert probe_filter.filter(_access_record("/metrics")) is False
+    assert probe_filter.filter(_access_record("/healthz")) is True
+
+
+def test_non_access_record_passes_through() -> None:
+    """A record that is not an access line is never inspected for a path."""
+    record = logging.LogRecord(
+        name="uvicorn.error",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Application startup complete.",
+        args=None,
+        exc_info=None,
+    )
+
+    assert ProbeFilter().filter(record) is True
+
+
+def test_unparsable_status_passes_through() -> None:
+    """A record that only looks like an access line is left alone."""
+    record = _access_record("/healthz")
+    record.args = ("a", "b", "/healthz", "d", "not-a-status")
+
+    assert ProbeFilter().filter(record) is True
+
+
+def test_silence_attaches_to_the_uvicorn_access_logger() -> None:
+    """The helper wires the filter and hands it back for removal."""
+    logger = logging.getLogger("uvicorn.access")
+    probe_filter = silence_probe_access_logs()
+    try:
+        assert probe_filter in logger.filters
+    finally:
+        logger.removeFilter(probe_filter)
+
+    assert probe_filter not in logger.filters

--- a/tests/logging/test_probes.py
+++ b/tests/logging/test_probes.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from grelmicro.log import ProbeFilter, silence_probe_access_logs
+from grelmicro.log import ProbeFilter
 
 
 def _access_record(path: str, status: int = 200) -> logging.LogRecord:
@@ -74,13 +74,14 @@ def test_unparsable_status_passes_through() -> None:
     assert ProbeFilter().filter(record) is True
 
 
-def test_silence_attaches_to_the_uvicorn_access_logger() -> None:
-    """The helper wires the filter and hands it back for removal."""
+def test_attaches_to_a_logger_like_the_other_filters() -> None:
+    """It is a plain `logging.Filter`, attached the usual way."""
     logger = logging.getLogger("uvicorn.access")
-    probe_filter = silence_probe_access_logs()
+    probe_filter = ProbeFilter()
+    logger.addFilter(probe_filter)
     try:
-        assert probe_filter in logger.filters
+        # `Logger.filter` returns the record itself when it passes.
+        assert not logger.filter(_access_record("/healthz"))
+        assert logger.filter(_access_record("/orders"))
     finally:
         logger.removeFilter(probe_filter)
-
-    assert probe_filter not in logger.filters


### PR DESCRIPTION
Closes #667.

Two logging items from the same friction report. One ships code, one deliberately does not.

## Quieting health probes

Kubernetes polls `/livez`, `/readyz` and `/healthz` every few seconds for the life of the pod, and the access log reported every one, so a healthy pod logged almost nothing else.

```python
from grelmicro.log import configure, silence_probe_access_logs

configure()
silence_probe_access_logs()
```

Three decisions worth reviewing:

**It lives in the log module, not on `health_router()`.** A router reaching out to reconfigure another library's global logger is a side effect in a surprising place. The log module already owns logging configuration.

**Failing probes are kept.** Only responses below `400` are dropped. A readiness check that starts refusing traffic is often the only line proving the kubelet asked and was refused, so hiding it along with the noise would remove the one thing worth reading.

**Paths match by suffix.** Hard-coding `/livez` breaks under `health_router(prefix="/api/v1")`, and coupling the filter to the router to share the prefix would tie two components together for one string. Suffix matching covers any prefix with no configuration, and `paths=` handles other polled endpoints such as a metrics scrape. Query strings are stripped, so `/healthz?exclude=redis` is still recognised.

`ProbeFilter` is a plain `logging.Filter`, so it works in a `dictConfig` or on a non-uvicorn access logger too. `silence_probe_access_logs()` returns the filter it installed so it can be removed again.

The record shape it reads (`args[2]` path, `args[4]` status) was verified against uvicorn 0.51.0. A record that is not an access line, or whose status will not parse, passes through untouched rather than being guessed at.

## orjson: documented, not changed

The report also asked for orjson to be auto-selected when installed, since the rest of the module is auto-detected. **Declining that**, with the reasoning written into the docs rather than left in a reply.

The two serializers disagree on real payloads. Verified against the installed orjson:

```
stdlib nan : {"v": NaN}      orjson nan : {"v":null}
stdlib key : {"1": "a"}      orjson key : TypeError: Dict key must be str
```

Selecting on importability would let an unrelated transitive dependency change what logs say, or turn a working log call into an exception on an `extra={...}` payload. A log line that crashes the request is worse than one that is slower. The consistency complaint is fair, so the fix is to say why the difference exists, next to the recommendation that tells people to switch.

## Verification

Nine new tests covering the drop, the kept failure, the prefixed path, the query string, custom paths, non-access records, an unparsable status, and attach/detach. Docs snippet is executed by the test suite. Full `pre-commit run --all-files` green.
