### PR TITLE
📝 Put the env opt-in warning above every variable table

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,18 @@
 
 ### Upgrading
 
+**Uvicorn's own log lines change format.** `configure()` now applies your format to uvicorn's loggers, so lines that used to look like this:
+
+```
+INFO:     127.0.0.1:54321 - "POST /orders HTTP/1.1" 200 OK
+```
+
+now match everything else your app emits, with a timestamp, a level field, and structured request fields. That is the point, but a pipeline parsing uvicorn's plain format needs updating, or the old behaviour back:
+
+```python
+configure(uvicorn_enabled=False)
+```
+
 **A misconfigured `GREL_*` variable now warns.** Setting one without `GREL_ENV_LOAD` used to pass silently and now raises `GrelmicroConfigWarning`. A suite running `-W error`, or pytest with `filterwarnings = error`, will fail on it.
 
 Fix the configuration, which is the point of the warning:

--- a/docs/coordination.md
+++ b/docs/coordination.md
@@ -170,6 +170,8 @@ Tune any field in deployment without code changes.
 
 Prefix: `GREL_LOCK_{NAME_UPPER}_`. The default instance drops the name segment and reads `GREL_LOCK_*`.
 
+--8<-- "env_gate.md"
+
 | Env var                                      | Config field     | Type            | Default          |
 |----------------------------------------------|------------------|-----------------|------------------|
 | `GREL_LOCK_{NAME_UPPER}_WORKER`              | `worker`         | `str \| UUID`   | generated UUID   |

--- a/docs/resilience/bulkhead.md
+++ b/docs/resilience/bulkhead.md
@@ -44,6 +44,8 @@ The bulkhead opens its `uses=` on first entry and closes them when the app shuts
 
 Prefix: `GREL_BULKHEAD_{NAME_UPPER}_`. The default instance drops the name segment and reads `GREL_BULKHEAD_*`.
 
+--8<-- "env_gate.md"
+
 | Env var | Field | Type | Default |
 |---|---|---|---|
 | `GREL_BULKHEAD_{NAME_UPPER}_MAX_CONCURRENT` | `max_concurrent` | `PositiveInt` | unbounded |

--- a/docs/resilience/fallback.md
+++ b/docs/resilience/fallback.md
@@ -63,6 +63,8 @@ Build the policy with keyword arguments. Set `when` to choose which exceptions f
 
 Prefix: `GREL_FALLBACK_{NAME_UPPER}_`. The default instance drops the name segment and reads `GREL_FALLBACK_*`.
 
+--8<-- "env_gate.md"
+
 | Env var | Field | Type | Default |
 |---|---|---|---|
 | `GREL_FALLBACK_{NAME_UPPER}_WHEN` | `when` | CSV or JSON list of FQN strings (e.g. `httpx.HTTPError`). Coerced to `Match.exception(...)`. Predicate forms cannot come from env. | required |

--- a/docs/resilience/retry.md
+++ b/docs/resilience/retry.md
@@ -163,6 +163,8 @@ Build the policy with keyword arguments. Set `when` to choose which outcomes ret
 
 Prefix: `GREL_RETRY_{NAME_UPPER}_`. The default instance drops the name segment and reads `GREL_RETRY_*`.
 
+--8<-- "env_gate.md"
+
 | Env var | Field | Type | Default |
 |---|---|---|---|
 | `GREL_RETRY_{NAME_UPPER}_ATTEMPTS` | `attempts` | `int` (>= 1) | `3` |

--- a/docs/resilience/shield.md
+++ b/docs/resilience/shield.md
@@ -178,6 +178,8 @@ Pass the profile and knobs as keyword arguments.
 
 Prefix: `GREL_SHIELD_{NAME_UPPER}_`. The default instance drops the name segment and reads `GREL_SHIELD_*`.
 
+--8<-- "env_gate.md"
+
 | Env var | Field | Type | Default |
 |---|---|---|---|
 | `GREL_SHIELD_{NAME_UPPER}_PROFILE` | profile | `internal` / `api` / `slow` | `api` |

--- a/docs/resilience/timeout.md
+++ b/docs/resilience/timeout.md
@@ -34,6 +34,8 @@ Build the policy with keyword arguments. Set `seconds` to the deadline for the w
 
 Prefix: `GREL_TIMEOUT_{NAME_UPPER}_`. The default instance drops the name segment and reads `GREL_TIMEOUT_*`.
 
+--8<-- "env_gate.md"
+
 | Env var | Field | Type | Default |
 |---|---|---|---|
 | `GREL_TIMEOUT_{NAME_UPPER}_SECONDS` | `seconds` | `PositiveFloat` | required |


### PR DESCRIPTION
Review-pass finding: the changelog claimed the opt-in warning sits "above every environment variable table", and it did not.

#663 added the snippet to `config.md` and `logging.md` only. Six user-facing pages document `GREL_*` variables in a table and never mentioned `GREL_ENV_LOAD`:

* `coordination.md` (4 rows, plus a concrete `GREL_LOCK_CART_*` bash block)
* `resilience/retry.md`, `shield.md`, `bulkhead.md` (3 rows each)
* `resilience/fallback.md` (2 rows)
* `resilience/timeout.md` (1 row)

A reader following any of those exactly hits the same silent no-op that started this whole cycle. My earlier grep missed them because those tables use a `{NAME_UPPER}` placeholder, so the rows did not match a `GREL_[A-Z_]` pattern.

`advanced/config.md` and `architecture/config.md` are left alone deliberately: they are the pages that *explain* the flag rather than assume it.

The snippet is included, not copied, so there is one source of truth. Verified it renders on nested pages as well as flat ones by grepping the built HTML, since `pymdownx.snippets` resolves against `base_path` rather than the page.

Also adds an Upgrading note for the uvicorn format change, which alters visible log output by default and had no migration guidance.

`mkdocs build --strict` and the full `pre-commit run --all-files` are green.