### PR TITLE
🔖 Prepare the 0.35.1 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.35.1 - 2026-08-05
 
 ### Upgrading
 


### PR DESCRIPTION
Dates the `Unreleased` section as **0.35.1**.

## Why a patch, not a minor

No `### Breaking` section. This repo bumps the minor for breaking changes (`0.35.0`, `0.34.0`, `0.32.0`, `0.31.0` each carried one) and no pre-1.0 patch ever has.

The one judgment call is the uvicorn log format, which changes visible output by default. It is a fix rather than a break: uvicorn's lines carried no timestamp, no level field and no trace context while the app's did, so one process emitted two formats. That was never intended behaviour. No public API changes shape, and `uvicorn_enabled=False` restores the old output. The Upgrading section says so.

## What is in it

Everything reported in two rounds of friction from a real deployment, plus three bugs nobody reported.

| Issue | Change |
|---|---|
| #661 | Sentinel password from the environment, never inferred from the data password |
| #662 | A `GREL_*` variable that is set but not applied now says so |
| #665 | A Provider opens before its Component whatever the list order |
| #666 | Uvicorn's logs match the application format, no log config file |
| #667 | `ProbeFilter` for health probe noise, and why orjson stays opt-in |

Found while building the above, none of them reported:

* A log call could take down logging. `extra={"url": httpx.URL(...)}` raised `TypeError` out of the formatter, destroying the record and every field beside it.
* `record.message` was never set, breaking anything that reads it after formatting, including pytest's `caplog`.
* `override(...)` leaked a broken component into the registry when it failed to open.

## Release notes

The section opens with **Upgrading**, covering the two changes that need action: the uvicorn format, and the new `GrelmicroConfigWarning` that can fail a build running `-W error`. Each carries the escape hatch alongside the fix.

Verified with `uv run python tools/changelog.py check 0.35.1`. `just release-check 0.35.1` runs after this merges, since it requires HEAD to equal `origin/main`.
