### PR TITLE
🐛 Report an ignored GREL_ variable in the log stream, and add a deployment guide

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* 🐛 Log the ignored-variable report, so it survives a JSON log stream. A `GREL_*` variable set without `GREL_ENV_LOAD` was reported through `warnings` only, which writes plain text to stderr, so in a pod the one line explaining why `GREL_LOG_LEVEL=DEBUG` did nothing was the one line the log collector could not parse. The report now also goes to the `grelmicro` logger, which the default backend renders like every other record, with the name in a `variable` field an alert can match. A component resolves its config before logging exists, so a report made then waits and goes out as soon as logging is configured. `Log` restores the reporting state on exit along with the handlers it replaced, so a second lifecycle formats its own reports. The `GrelmicroConfigWarning` channel is unchanged. ([#676](https://github.com/grelinfo/grelmicro/issues/676))
+
+### Docs
+
+* 📝 Add a [Deployment](deployment.md) guide, which says `GREL_ENV_LOAD=1` out loud and puts it in the image rather than the manifest, where one copy always forgets it. Covers the log format and the probe noise, the probe endpoints, the shutdown window against `Tasks(shutdown_timeout=...)`, and a Deployment manifest that applies as it stands. ([#676](https://github.com/grelinfo/grelmicro/issues/676))
+* 📝 Scope the resolution order to the `GREL_*` namespace, in [Configuration](config.md#how-a-value-is-resolved). Step 2 read as though `GREL_ENV_LOAD` gated every environment variable, which no Provider has ever obeyed: `RedisProvider()` reads `REDIS_URL` with no flag, since that name belongs to the deployment rather than to grelmicro, and a missing one fails at construction naming the variable it wanted instead of falling back to a default. [Providers](providers.md) says the same where a reader of the env-driven recipe will see it. ([#676](https://github.com/grelinfo/grelmicro/issues/676))
+
 ## 0.35.1 - 2026-08-06
 
 ### Upgrading

--- a/docs/config.md
+++ b/docs/config.md
@@ -8,22 +8,36 @@ environment variables. No code change between the two.
 A field takes the first of these that supplies it:
 
 1. **A keyword argument.** Always wins, always available, needs nothing enabled.
-2. **An environment variable**, when `GREL_ENV_LOAD` is truthy. Off by default.
+2. **A `GREL_*` environment variable**, when `GREL_ENV_LOAD` is truthy. Off by
+   default.
 3. **A file**, through
    [`ExternalConfig`](configuration/reconfigure-from-configmap.md), which also
    reconfigures a running component when the file changes.
 4. The field's default.
 
+The flag gates the `GREL_*` namespace, which is grelmicro's own. It does not
+gate a [Provider](providers.md), and it never did. `RedisProvider()` reads
+`REDIS_URL`, `PostgresProvider()` reads `POSTGRES_URL`, with no flag, because
+those names belong to your environment rather than to grelmicro. A provider
+variable that is missing fails at construction and names the variable it
+wanted, so there is no silent default to protect you from. Pass
+`env_load=False` to a provider to turn its env reads off.
+
 Step 2 is the one that surprises people. `GREL_ENV_LOAD` is a single
 process-wide switch, so a variable set without it is ignored and the default
-applies. Since 0.35.1 that situation warns at startup instead of passing
-silently, naming the variable:
+applies. That situation reports at startup instead of passing silently, naming
+the variable:
 
 ```
 UserWarning: GREL_LOG_FORMAT is set but was not applied: environment-driven
 configuration is opt-in. Set GREL_ENV_LOAD=1 to enable it, or pass the value
 directly.
 ```
+
+The same report is logged on the `grelmicro` logger once logging is configured,
+so on the default backend it also lands in the JSON log stream, where a warning
+on stderr would be lost. [Deployment](deployment.md) covers where to set the
+switch in a container.
 
 The switch exists because step 2 fills *every* field you did not pass, not only
 the ones with no default. An app that passes some settings from its own config

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,209 @@
+# Deployment
+
+What a container image and a Kubernetes manifest need before they run a
+grelmicro application in production.
+
+## Turn on environment configuration
+
+Set `GREL_ENV_LOAD=1` in the image:
+
+```dockerfile
+ENV GREL_ENV_LOAD=1
+```
+
+Every `GREL_*` variable is read only when this flag is truthy (`1`, `true`,
+`yes`, `on`). Without it, a pod that sets `GREL_LOG_LEVEL=DEBUG` logs at
+`INFO`, and a pod that sets `GREL_LOCK_CART_LEASE_DURATION=120` keeps the
+60 second default.
+
+Provider variables are not gated. `REDIS_URL`, `VALKEY_URL`, `POSTGRES_URL`
+and `SQLITE_PATH` are read out of the box, because those names belong to your
+environment rather than to grelmicro, and a missing one fails at startup
+naming the variable it wanted. So a pod without the flag still connects to its
+backend and still ignores every `GREL_*` knob, which is what makes the flag
+easy to forget.
+
+Set it in the image, not in the manifest. A manifest gets copied from one
+environment to the next, and one copy will leave it out.
+
+### When the flag is missing
+
+grelmicro names the ignored variable on two channels. It raises a
+`GrelmicroConfigWarning`, which fails a test suite running `-W error`. It
+also logs a `WARNING` on the `grelmicro` logger, so on the default backend
+the report is a normal record in the log stream:
+
+```json
+{"variable":"GREL_LOG_LEVEL","time":"2026-08-06T13:44:04.156560+00:00","level":"WARNING","msg":"GREL_LOG_LEVEL is set but was not applied: environment-driven configuration is opt-in. Set GREL_ENV_LOAD=1 to enable it, or pass the value directly.","logger":"grelmicro"}
+```
+
+The variable name is in the `variable` field, so an alert can match on the
+field instead of the message text. Each name is reported once per process,
+at startup, and only for variables a component actually declares.
+
+Passing `env_load=False` to a component is a decision, so it stays quiet.
+
+## Logs
+
+A container needs no log configuration. The default `AUTO` format writes
+`TEXT` to a terminal and `JSON` everywhere else, so the same image gives a
+readable stream in development and a parseable one in a pod. Uvicorn's own
+lines take the same format.
+
+Set the level per environment, once the flag above is on:
+
+```bash
+GREL_LOG_LEVEL=INFO
+```
+
+Kubernetes polls the probe endpoints every few seconds for the life of the
+pod, and the access log reports each one. Attach `ProbeFilter` to drop them:
+
+```python
+--8<-- "log/probes.py"
+```
+
+[Logging](logging.md) covers the formats, the backends and the other filters.
+
+## Health probes
+
+`health_router()` serves `/livez`, `/readyz` and `/healthz`. Point the
+liveness probe at `/livez`, which stays `200` while the process is alive, and
+the readiness probe at `/readyz`, which turns `503` as soon as a critical
+check fails and takes the pod out of the Service.
+
+Keep the readiness period short and the liveness period long. Readiness
+reacts to a lost backend, liveness only to a process that is gone. Use a
+`startupProbe` on `/livez` instead of a long `initialDelaySeconds`, so a slow
+first connection never counts as a liveness failure.
+[Health checks](health.md) covers the registry and the endpoint behavior.
+
+## Shutdown
+
+Kubernetes sends `SIGTERM` and waits `terminationGracePeriodSeconds` before
+`SIGKILL`. Keep `Tasks(shutdown_timeout=...)` at or below that window. Both
+default to 30 seconds, so the defaults already line up.
+
+Removing the pod from the Service and sending `SIGTERM` happen in parallel, so
+a request in flight can arrive after the server has started to stop. A short
+`preStop` sleep holds the signal back until the endpoint change has spread.
+
+Draining matters for the locks. A task that finishes its iteration releases
+its lock through `async with`, and `LeaderElection` releases the leadership
+lock so a standby takes over at once. A task force-cancelled at the end of
+the window leaves its lease to expire on the backend instead.
+[Graceful shutdown](architecture/graceful-shutdown.md) has the full contract.
+
+## Replicas
+
+`Lock`, `TaskLock` and `LeaderElection` coordinate through the backend, so
+every replica has to point at the same one. Give them a provider and let the
+environment carry the connection:
+
+```bash
+REDIS_URL=redis+sentinel://sentinel-0:26379,sentinel-1:26379/mymaster/0
+REDIS_PASSWORD=...
+REDIS_SENTINEL_PASSWORD=...
+```
+
+The composition root then holds no connection code at all:
+
+```python
+--8<-- "deployment/composition_root.py"
+```
+
+Pods sharing a namespace with another grelmicro application need a `prefix`
+so the two do not collide on key or lease names. [Providers](providers.md)
+covers the URL forms and the backend options.
+
+## Reconfigure without a restart
+
+Mount a ConfigMap or a Secret and grelmicro re-resolves the live components
+when the file changes, with no rollout. See
+[Live reconfiguration](configuration/reconfigure-from-configmap.md).
+
+## A complete manifest
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cart
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cart
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cart
+    spec:
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cart
+          image: registry.example.com/cart:1.4.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          ports:
+            - containerPort: 8000
+          env:
+            - name: GREL_LOG_LEVEL
+              value: INFO
+            - name: GREL_LOCK_CART_LEASE_DURATION
+              value: "120"
+            - name: REDIS_URL
+              value: redis://redis:6379/0
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cart-redis
+                  key: password
+          startupProbe:
+            httpGet:
+              path: /livez
+              port: 8000
+            periodSeconds: 2
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8000
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: 5
+```
+
+`GREL_ENV_LOAD=1` is missing here on purpose: the image sets it, so no
+manifest can forget it. Put it in the `env` block only when you cannot
+change the image, and then put it in every copy of the manifest.
+
+## Checklist
+
+- [ ] `GREL_ENV_LOAD=1` is in the image.
+- [ ] The startup logs carry no `variable` field.
+- [ ] `GREL_LOG_LEVEL` is set per environment, and the format is left to `AUTO`.
+- [ ] `ProbeFilter` is attached to `uvicorn.access`.
+- [ ] `/livez` and `/readyz` are wired, with readiness the faster of the two.
+- [ ] `terminationGracePeriodSeconds` is at or above `Tasks(shutdown_timeout=...)`.
+- [ ] Every replica points at the same backend, through a provider.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,6 +24,7 @@ Each primitive is a protocol, so you can swap Redis for PostgreSQL, SQLite, Kube
 - [Tracing](https://grelmicro.grel.info/tracing/): OpenTelemetry spans and structured log context through `@instrument`.
 - [Metrics](https://grelmicro.grel.info/metrics/): OpenTelemetry metrics with a `@measure` decorator and a Prometheus router.
 - [Configuration](https://grelmicro.grel.info/config/): reconfigure live components from a ConfigMap, Secret, or file.
+- [Deployment](https://grelmicro.grel.info/deployment/): run a grelmicro app in a container, starting with the `GREL_ENV_LOAD` opt-in.
 - [Testing](https://grelmicro.grel.info/testing/): test grelmicro apps with the in-memory backends.
 
 ## API reference

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -84,6 +84,10 @@ micro = Grelmicro(uses=[
 Set `REDIS_URL` (or `REDIS_HOST` + `REDIS_PORT` + `REDIS_DB` +
 `REDIS_PASSWORD`) in the environment.
 
+These reads need no flag. `GREL_ENV_LOAD` gates the `GREL_*` variables that
+tune components, not a Provider's own connection variables. Pass
+`env_load=False` to build a Provider from keyword arguments alone.
+
 ## Recipe 2: split pools by env prefix
 
 Two Redis instances (or two databases) live behind different prefixes.

--- a/docs/snippets/deployment/__init__.py
+++ b/docs/snippets/deployment/__init__.py
@@ -1,0 +1,1 @@
+"""Deployment snippets."""

--- a/docs/snippets/deployment/composition_root.py
+++ b/docs/snippets/deployment/composition_root.py
@@ -1,0 +1,5 @@
+from grelmicro import Grelmicro
+from grelmicro.providers.redis import RedisProvider
+
+redis = RedisProvider()
+micro = Grelmicro(uses=[redis])

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -24,6 +24,7 @@ import logging
 import os
 import re
 import warnings
+from collections import deque
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 from weakref import WeakSet
@@ -212,7 +213,7 @@ A component is often constructed many times, and the same misconfiguration
 would otherwise be reported on every construction.
 """
 
-_pending_ignored_env: list[str] = []
+_pending_ignored_env: deque[str] = deque()
 """Reported variable names still waiting for a log record.
 
 A component resolves its config before logging is configured, so the names
@@ -289,7 +290,7 @@ def flush_ignored_env_reports() -> None:
     global _logging_configured  # noqa: PLW0603
     _logging_configured = True
     while _pending_ignored_env:
-        _log_ignored_env(_pending_ignored_env.pop(0))
+        _log_ignored_env(_pending_ignored_env.popleft())
 
 
 def hold_ignored_env_reports() -> None:

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -212,13 +212,29 @@ A component is often constructed many times, and the same misconfiguration
 would otherwise be reported on every construction.
 """
 
+_pending_ignored_env: list[str] = []
+"""Reported variable names still waiting for a log record.
+
+A component resolves its config before logging is configured, so the names
+queue here until `flush_ignored_env_reports` drains them.
+"""
+
+_logging_configured = False
+"""True while `grelmicro.log` has its handlers installed."""
+
+_IGNORED_ENV_MESSAGE = (
+    "%s is set but was not applied: environment-driven configuration is "
+    "opt-in. Set %s=1 to enable it, or pass the value directly."
+)
+"""Report text, shared by the `warnings` and the `logging` channel."""
+
 
 def _warn_ignored_env(
     config_cls: type[BaseModel],
     env_prefix: str,
     provided: Mapping[str, object],
 ) -> None:
-    """Warn when a variable this config declares is set but will not be read.
+    """Report a variable this config declares that is set but will not be read.
 
     Only the exact names `config_cls` declares are looked up. A prefix scan
     would match unrelated variables, and Kubernetes injects
@@ -229,8 +245,11 @@ def _warn_ignored_env(
     environment, so that variable would not have applied either way and the
     caller has already done what the message would ask of them.
 
-    Reported through `warnings` rather than `logging`, because the logging
-    component resolves its own config before logging is configured.
+    Each name is reported on both channels. `warnings` carries it under
+    `GrelmicroConfigWarning`, which a test suite can filter or turn into an
+    error. `logging` carries it on the `grelmicro` logger with the name in a
+    `variable` field, so a pipeline can match the field instead of the
+    message text. The log record waits until logging is configured.
     """
     for field in config_cls.model_fields:
         if field in provided:
@@ -239,12 +258,54 @@ def _warn_ignored_env(
         if name not in os.environ or name in _warned_ignored_env:
             continue
         _warned_ignored_env.add(name)
-        msg = (
-            f"{name} is set but was not applied: environment-driven "
-            f"configuration is opt-in. Set {_ENV_LOAD_VAR}=1 to enable it, "
-            f"or pass the value directly."
+        warnings.warn(
+            _IGNORED_ENV_MESSAGE % (name, _ENV_LOAD_VAR),
+            GrelmicroConfigWarning,
+            stacklevel=4,
         )
-        warnings.warn(msg, GrelmicroConfigWarning, stacklevel=4)
+        if _logging_configured:
+            _log_ignored_env(name)
+        else:
+            _pending_ignored_env.append(name)
+
+
+def _log_ignored_env(name: str) -> None:
+    """Emit one ignored-variable report on the `grelmicro` logger."""
+    logger.warning(
+        _IGNORED_ENV_MESSAGE,
+        name,
+        _ENV_LOAD_VAR,
+        extra={"variable": name},
+    )
+
+
+def flush_ignored_env_reports() -> None:
+    """Emit the queued ignored-variable reports as log records.
+
+    Called by `grelmicro.log` once the backend has installed its handlers, so
+    a queued report is emitted with logging in place. Later reports go
+    straight to the logger.
+    """
+    global _logging_configured  # noqa: PLW0603
+    _logging_configured = True
+    while _pending_ignored_env:
+        _log_ignored_env(_pending_ignored_env.pop(0))
+
+
+def hold_ignored_env_reports() -> None:
+    """Queue the reports again, until logging is configured once more.
+
+    Called by `grelmicro.log` when the `Log` component restores a root logger
+    that had no logging on it. A report made between two lifecycles then waits
+    for the next one instead of reaching a root logger with nothing installed.
+    """
+    global _logging_configured  # noqa: PLW0603
+    _logging_configured = False
+
+
+def ignored_env_reports_enabled() -> bool:
+    """Return True while a report goes straight to the logger."""
+    return _logging_configured
 
 
 @lru_cache(maxsize=256)

--- a/grelmicro/log/_apply.py
+++ b/grelmicro/log/_apply.py
@@ -1,10 +1,16 @@
 """Backend dispatcher for logging configuration."""
 
+from grelmicro._config import flush_ignored_env_reports
 from grelmicro.log.config import LogBackendType, LogConfig
 
 
 def apply(config: LogConfig) -> None:
-    """Dispatch to the selected backend with the resolved config."""
+    """Dispatch to the selected backend with the resolved config.
+
+    Flushes the queued ignored-variable reports last, so a `GREL_*`
+    variable set without `GREL_ENV_LOAD` is named on the `grelmicro`
+    logger once the handlers are installed.
+    """
     if config.backend == LogBackendType.STRUCTLOG:
         from grelmicro.log._structlog import (  # noqa: PLC0415
             configure as _configure,
@@ -26,3 +32,5 @@ def apply(config: LogConfig) -> None:
         )
 
         _apply_uvicorn(config)
+
+    flush_ignored_env_reports()

--- a/grelmicro/log/_component.py
+++ b/grelmicro/log/_component.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Annotated, ClassVar, Self
 
 from typing_extensions import Doc
 
-from grelmicro._config import resolve_config
+from grelmicro._config import (
+    hold_ignored_env_reports,
+    ignored_env_reports_enabled,
+    resolve_config,
+)
 from grelmicro.log._apply import apply as _apply
 from grelmicro.log.config import (
     LogBackendType,
@@ -129,6 +133,7 @@ class Log:
         self._resolved: LogConfig | None = None
         self._snapshot_handlers: list[logging.Handler] | None = None
         self._snapshot_level: int | None = None
+        self._snapshot_reports = False
 
     @classmethod
     def from_config(
@@ -178,6 +183,7 @@ class Log:
             root = logging.getLogger()
             self._snapshot_handlers = list(root.handlers)
             self._snapshot_level = root.level
+            self._snapshot_reports = ignored_env_reports_enabled()
             self._resolved = resolve_config(
                 LogConfig,
                 explicit=self._explicit_config,
@@ -195,7 +201,14 @@ class Log:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> bool | None:
-        """Restore the snapshotted stdlib root handlers and level."""
+        """Restore the snapshotted stdlib root handlers and level.
+
+        The ignored-variable reports are restored the same way. They queue
+        again when nothing was configured before this lifecycle, so a report
+        made after the restore waits for the next one instead of reaching a
+        root logger with nothing installed. When an earlier `configure()`
+        left logging in place, its handlers come back and reporting with them.
+        """
         with self._lifecycle_lock:
             root = logging.getLogger()
             for handler in list(root.handlers):
@@ -205,6 +218,8 @@ class Log:
                     root.addHandler(handler)
             if self._snapshot_level is not None:  # pragma: no branch
                 root.setLevel(self._snapshot_level)
+            if not self._snapshot_reports:
+                hold_ignored_env_reports()
             self._snapshot_handlers = None
             self._snapshot_level = None
         return None

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - tracing.md
     - metrics.md
     - config.md
+    - deployment.md
     - testing.md
 - Advanced User Guide:
     - advanced/config.md

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 
 import pytest
 
+from grelmicro import _config
 from grelmicro.clock import VirtualClock
 
 
@@ -32,3 +33,16 @@ def _opt_in_env_config(monkeypatch: pytest.MonkeyPatch) -> None:
     ``monkeypatch.delenv("GREL_ENV_LOAD", raising=False)``.
     """
     monkeypatch.setenv("GREL_ENV_LOAD", "true")
+
+
+@pytest.fixture(autouse=True)
+def _reset_ignored_env_reports(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset the process-wide ignored-variable report state.
+
+    A report is deduplicated for the life of the process and queued until
+    logging is configured. Without a reset, a report made in one test would
+    be missing from, or surface in, another.
+    """
+    _config._warned_ignored_env.clear()
+    _config._pending_ignored_env.clear()
+    monkeypatch.setattr(_config, "_logging_configured", False)

--- a/tests/logging/test_component.py
+++ b/tests/logging/test_component.py
@@ -7,8 +7,11 @@ import logging
 import pytest
 
 from grelmicro import Component, ComponentAlreadyRegisteredError, Grelmicro
-from grelmicro.log import Log, LogConfig
-from grelmicro.log.config import LogLevelType
+from grelmicro._config import resolve_config
+from grelmicro.errors import GrelmicroConfigWarning
+from grelmicro.log import Log, LogConfig, configure
+from grelmicro.log.config import LogFormatType, LogLevelType
+from tests.logging.conftest import parse_json_log
 
 
 def test_log_satisfies_component_protocol() -> None:
@@ -90,6 +93,66 @@ async def test_log_restores_root_handlers_on_exit(
         assert sentinel not in root.handlers
     assert root.handlers == before
     assert root.level == logging.WARNING
+
+
+async def test_log_reports_ignored_env_in_a_second_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    reset_stdlib: None,  # noqa: ARG001
+) -> None:
+    """Exiting queues the reports again, so the next lifecycle formats them.
+
+    Exiting restores the handlers `Log` replaced, which usually means none at
+    all. A report made in between would otherwise reach the root logger with
+    nothing installed and come out as unformatted text.
+    """
+    monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
+    monkeypatch.setenv("GREL_LOG_LEVEL", "DEBUG")
+
+    with pytest.warns(GrelmicroConfigWarning):
+        async with Log(format=LogFormatType.JSON):
+            pass
+    capsys.readouterr()
+
+    monkeypatch.setenv("GREL_LOG_TIMEZONE", "Europe/Zurich")
+    with pytest.warns(GrelmicroConfigWarning):
+        async with Log(format=LogFormatType.JSON):
+            pass
+
+    record = parse_json_log(capsys.readouterr().out)
+    assert record["variable"] == "GREL_LOG_TIMEZONE"
+
+
+async def test_log_keeps_reporting_when_exit_restores_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    reset_stdlib: None,  # noqa: ARG001
+) -> None:
+    """A restore that carries handlers keeps the reports going to them.
+
+    `configure()` before the lifecycle leaves its handler in the snapshot, so
+    exiting puts a working logger back. A report after that has somewhere to
+    go and must not wait for a lifecycle that may never come.
+    """
+    monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
+    configure(format=LogFormatType.JSON)
+
+    async with Log(format=LogFormatType.JSON):
+        pass
+    capsys.readouterr()
+
+    monkeypatch.setenv("GREL_LOG_TIMEZONE", "Europe/Zurich")
+    with pytest.warns(GrelmicroConfigWarning):
+        resolve_config(
+            LogConfig,
+            explicit=None,
+            kwargs={},
+            env_prefix="GREL_LOG_",
+            env_load=None,
+        )
+
+    record = parse_json_log(capsys.readouterr().out)
+    assert record["variable"] == "GREL_LOG_TIMEZONE"
 
 
 async def test_log_use_via_micro_attribute(reset_stdlib: None) -> None:  # noqa: ARG001

--- a/tests/logging/test_log_config.py
+++ b/tests/logging/test_log_config.py
@@ -2,14 +2,15 @@
 
 import pytest
 
-from grelmicro.errors import SettingsValidationError
+from grelmicro.errors import GrelmicroConfigWarning, SettingsValidationError
 from grelmicro.log import (
     LogConfig,
     LogSettingsValidationError,
     configure,
     configure_with,
 )
-from grelmicro.log.config import LogBackendType, LogLevelType
+from grelmicro.log.config import LogBackendType, LogFormatType, LogLevelType
+from tests.logging.conftest import parse_json_log
 
 
 def test_configure_returns_resolved_config(
@@ -53,6 +54,24 @@ def test_configure_env_load_false_ignores_env(
     monkeypatch.setenv("GREL_LOG_LEVEL", "ERROR")
     cfg = configure(env_load=False)
     assert cfg.level == LogLevelType.INFO  # default
+
+
+def test_configure_reports_ignored_env_in_the_log_stream(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    reset_backend: None,  # noqa: ARG001
+) -> None:
+    """A variable set without the opt-in is named in the application's format."""
+    monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
+    monkeypatch.setenv("GREL_LOG_LEVEL", "DEBUG")
+
+    with pytest.warns(GrelmicroConfigWarning):
+        configure(format=LogFormatType.JSON)
+
+    record = parse_json_log(capsys.readouterr().out)
+    assert record["level"] == "WARNING"
+    assert record["variable"] == "GREL_LOG_LEVEL"
+    assert "GREL_ENV_LOAD=1" in record["msg"]
 
 
 def test_configure_invalid_level_raises_settings_error(

--- a/tests/test_env_load.py
+++ b/tests/test_env_load.py
@@ -1,13 +1,14 @@
 """Tests for the GREL_ENV_LOAD opt-in flag."""
 
+import logging
 import warnings
 
 import pytest
 
 from grelmicro import GrelmicroConfigWarning
 from grelmicro._config import (
-    _warned_ignored_env,
     env_load_default,
+    flush_ignored_env_reports,
     resolve_config,
 )
 from grelmicro.coordination.lock import Lock, LockConfig
@@ -28,12 +29,6 @@ def backend() -> MemoryLockAdapter:
 def _no_env_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
     """Override the autouse fixture and turn the global flag off."""
     monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
-
-
-@pytest.fixture(autouse=True)
-def _reset_ignored_env_warnings() -> None:
-    """Clear the process-wide dedup set so warnings do not depend on test order."""
-    _warned_ignored_env.clear()
 
 
 @pytest.mark.parametrize("value", ["1", "true", "True", "TRUE", "yes", "on"])
@@ -89,6 +84,76 @@ def test_ignored_env_is_reported_once(
         Lock("cart", backend=backend)
 
     assert [w for w in caught if w.category is GrelmicroConfigWarning] == []
+
+
+@pytest.mark.usefixtures("_no_env_opt_in")
+def test_ignored_env_waits_for_logging_then_logs(
+    backend: MemoryLockAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The report reaches the `grelmicro` logger once logging is configured."""
+    monkeypatch.setenv(
+        "GREL_LOCK_CART_LEASE_DURATION", str(int(LEASE_OVERRIDE))
+    )
+
+    with caplog.at_level(logging.WARNING, logger="grelmicro"):
+        with pytest.warns(GrelmicroConfigWarning):
+            Lock("cart", backend=backend)
+
+        assert caplog.records == []  # queued, logging is not configured yet
+        flush_ignored_env_reports()
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.__dict__["variable"] == "GREL_LOCK_CART_LEASE_DURATION"
+    assert "GREL_ENV_LOAD=1" in record.getMessage()
+
+
+@pytest.mark.usefixtures("_no_env_opt_in")
+def test_ignored_env_is_logged_once(
+    backend: MemoryLockAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Configuring logging twice does not repeat the report."""
+    monkeypatch.setenv(
+        "GREL_LOCK_CART_LEASE_DURATION", str(int(LEASE_OVERRIDE))
+    )
+
+    with caplog.at_level(logging.WARNING, logger="grelmicro"):
+        with pytest.warns(GrelmicroConfigWarning):
+            Lock("cart", backend=backend)
+
+        flush_ignored_env_reports()
+        flush_ignored_env_reports()
+
+    assert len(caplog.records) == 1
+
+
+@pytest.mark.usefixtures("_no_env_opt_in")
+def test_ignored_env_after_logging_is_logged_straight_away(
+    backend: MemoryLockAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A component built after logging is configured reports without waiting."""
+    flush_ignored_env_reports()
+    monkeypatch.setenv(
+        "GREL_LOCK_CART_LEASE_DURATION", str(int(LEASE_OVERRIDE))
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="grelmicro"),
+        pytest.warns(GrelmicroConfigWarning),
+    ):
+        Lock("cart", backend=backend)
+
+    assert len(caplog.records) == 1
+    assert (
+        caplog.records[0].__dict__["variable"]
+        == "GREL_LOCK_CART_LEASE_DURATION"
+    )
 
 
 @pytest.mark.usefixtures("_no_env_opt_in")

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -44,6 +44,9 @@ _ENV = {
     "coordination/postgres.py": {
         "POSTGRES_URL": "postgresql://user:password@localhost:5432/db",
     },
+    "deployment/composition_root.py": {
+        "REDIS_URL": "redis://localhost:6379/0",
+    },
 }
 
 _ALL = sorted(


### PR DESCRIPTION
From a friction report against 0.35.1, running on OpenShift.

A `GREL_*` variable set while `GREL_ENV_LOAD` is off was reported through `warnings` only, which writes plain text to stderr. In a container that is the one line the log collector cannot parse, so the single explanation of why `GREL_LOG_LEVEL=DEBUG` did nothing is the one that gets lost.

```
<string>:4: GrelmicroConfigWarning: GREL_LOG_LEVEL is set but was not applied: ...
{"time":"...","level":"INFO","msg":"hello","logger":"app"}
```

## Report on the logger too

The same report now goes to the `grelmicro` logger, with the name in a `variable` field so an alert matches the field instead of the message text.

```json
{"variable":"GREL_LOG_LEVEL","time":"...","level":"WARNING","msg":"GREL_LOG_LEVEL is set but was not applied: environment-driven configuration is opt-in. Set GREL_ENV_LOAD=1 to enable it, or pass the value directly.","logger":"grelmicro"}
```

A component resolves its config before logging exists, so a report made then queues and goes out as soon as logging is configured. `grelmicro/log/_apply.py` is the single point where all three backends and both `configure()` and the `Log` component finish installing, so one hook covers every path. `Log` snapshots the reporting state on enter and restores it on exit, the same way it already snapshots the root handlers and level, so a second lifecycle formats its own reports and a lifecycle that ran after `configure()` keeps reporting through the handlers it puts back. The `GrelmicroConfigWarning` channel is unchanged, so `-W error` suites are unaffected.

## Say the switch out loud in a deployment guide

There was no deployment page at all, so nothing told an operator to put `GREL_ENV_LOAD=1` in the image. [Deployment](https://grelmicro.grel.info/deployment/) leads with that, in the image rather than the manifest, where one copy always forgets it. Then the log format and probe noise, the probe endpoints, the shutdown window against `Tasks(shutdown_timeout=...)`, replicas and providers, and a manifest that applies as it stands.

`docs/config.md` stated the resolution order as though the flag gated every environment variable. It does not gate a Provider: `RedisProvider()` reads `REDIS_URL` with no flag, because that name belongs to the deployment rather than to grelmicro, and a missing one fails at construction naming the variable it wanted instead of falling back to a default. That claim is now scoped, and `docs/providers.md` says the same where a reader of the env-driven recipe will see it.

## Checks

Two review rounds found defects in the first cut, both fixed and both covered by a test that fails without the fix. Full pre-commit passed, including the integration tier, the 100% coverage gate and `mkdocs build --strict`.

Known and out of scope: under the `loguru` and `structlog` backends, stdlib records do not reach those sinks, so this report falls back to `logging.lastResort`. That is pre-existing for all 17 grelmicro modules that log through stdlib, and bridging it would change every library log line in a loguru app.