### PR TITLE
🔖 Prepare the 0.35.2 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.35.2 - 2026-08-06
 
 ### Fixed
 


### PR DESCRIPTION
Dates the changelog section for 0.35.2, shipping today.

Carries the ignored-variable report on the `grelmicro` logger and the new Deployment guide, from #676.

Full tier verified locally (`just test-full`): 100% coverage across the unit, slow and integration tiers.