### PR TITLE
✨ Add a distributed read-write lock on every coordination backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? S
 |---|---|
 | [**Cache**](https://grelmicro.grel.info/cache/) | `@cached` decorator with local and distributed stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
 | [**Idempotency**](https://grelmicro.grel.info/idempotency/) | Idempotency keys that make a retried operation safe. Store the response once, replay it on repeat, single-flight across replicas. |
-| [**Coordination**](https://grelmicro.grel.info/coordination/) | Distributed `Lock`, `TaskLock`, and `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
+| [**Coordination**](https://grelmicro.grel.info/coordination/) | Distributed `Lock`, `ReadWriteLock`, `TaskLock`, and `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
 | [**Outbox**](https://grelmicro.grel.info/outbox/) | Transactional outbox. `publish` a message inside your database transaction and a background relay delivers it at least once with retries and dead-lettering. PostgreSQL, in-memory. |
 | [**Task Scheduler**](https://grelmicro.grel.info/task/) | Interval and cron tasks with durable, distributed at-most-once execution. A modern, lightweight alternative to APScheduler and Celery beat. |
 | [**Resilience**](https://grelmicro.grel.info/resilience/) | [Circuit Breaker](https://grelmicro.grel.info/resilience/circuit-breaker/) and [Rate Limiter](https://grelmicro.grel.info/resilience/rate-limiter/) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,9 +6,9 @@ The [roadmap](https://github.com/grelinfo/grelmicro/issues/124) carries the live
 
 ## Vocabulary
 
-- **Pattern**: user-facing class. `Lock`, `LeaderElection`, `TaskLock`, `TTLCache`, `RateLimiter`, `CircuitBreaker`, `Idempotency`, `Outbox`, `Retry`, `Bulkhead`, `Fallback`, `Timeout`, `Shield`.
+- **Pattern**: user-facing class. `Lock`, `ReadWriteLock`, `LeaderElection`, `TaskLock`, `TTLCache`, `RateLimiter`, `CircuitBreaker`, `Idempotency`, `Outbox`, `Retry`, `Bulkhead`, `Fallback`, `Timeout`, `Shield`.
 - **Adapter**: concrete implementation of a Backend Protocol. `RedisLockAdapter`, `PostgresLockAdapter`, `MemoryCacheAdapter`, `PostgresOutboxAdapter`, `SQLiteLockAdapter`, `KubernetesLockAdapter`, and so on.
-- **Backend**: the Protocol class an Adapter satisfies. `LockBackend`, `LeaderElectionBackend`, `CacheBackend`, `RateLimiterBackend`, `CircuitBreakerBackend`, `OutboxBackend`.
+- **Backend**: the Protocol class an Adapter satisfies. `LockBackend`, `ReadWriteLockBackend`, `LeaderElectionBackend`, `CacheBackend`, `RateLimiterBackend`, `CircuitBreakerBackend`, `OutboxBackend`.
 - **Provider**: vendor configuration plus native client, shared by Adapters that talk to the same service. `RedisProvider`, `PostgresProvider`, `SQLiteProvider`. Memory and Kubernetes Adapters do not use a Provider.
 
 See [Backends and Adapters](architecture/backends.md) for the full model.
@@ -18,6 +18,7 @@ See [Backends and Adapters](architecture/backends.md) for the full model.
 | Pattern | Memory | Redis | Postgres | SQLite | Kubernetes |
 | --- | :---: | :---: | :---: | :---: | :---: |
 | `Lock` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `ReadWriteLock` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `TaskLock` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `LeaderElection` | ✅ | ✅ | ✅ | N/A | ✅ |
 | `@tasks.cron` | ✅ | ✅ | ✅ | ✅ | N/A |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+* ✨ Add [`ReadWriteLock`](coordination.md#read-write-lock), a distributed lock that lets every reader in at once and keeps writers alone. `lock.read` and `lock.write` are two views of one lock, each with `acquire`, `acquire_nowait`, `extend`, `release`, and a `from_thread` adapter. It is writer-preferring: a writer that finds readers in the way records an intent, so readers arriving after it wait and writers never starve. Every holder has its own lease, so a reader that died is reaped by the next acquire instead of blocking a writer until a shared expiry fires. `ReadGuard` and `WriteGuard` are distinct types, so a function that writes can demand the write guard in its signature, and reading a token from a spent guard raises `LockNotOwnedError` instead of handing back a stale one. `WriteGuard.poisoned` says the previous writer's lease expired without a release, and `await guard.downgrade()` turns a write lease into a read lease with no gap for another writer. Upgrading raises `LockUpgradeError` rather than shipping a deadlock. Redis, Valkey, PostgreSQL, SQLite, Kubernetes, and Memory all ship an adapter and pass one shared conformance suite. ([#686](https://github.com/grelinfo/grelmicro/issues/686))
+
 ## 0.35.2 - 2026-08-06
 
 ### Fixed

--- a/docs/coordination.md
+++ b/docs/coordination.md
@@ -1,17 +1,19 @@
 # Coordination
 
-The `coordination` package gives you distributed `Lock`, `TaskLock`, and
-`LeaderElection`: the primitives that keep work correct when your service runs as
-many replicas.
+The `coordination` package gives you distributed `Lock`, `ReadWriteLock`,
+`TaskLock`, and `LeaderElection`: the primitives that keep work correct when your
+service runs as many replicas.
 
 - **[Lock](#lock)**: mutual exclusion across workers. Hold a shared resource one
   caller at a time.
+- **[Read-Write Lock](#read-write-lock)**: many readers at once, one writer
+  alone. For a resource read far more often than it is written.
 - **[Task Lock](#task-lock)**: a lock for scheduled tasks. It holds long enough to
   stop another worker re-running the same tick.
 - **[Leader Election](#leader-election)**: elect one worker to play a long-lived
   role. Run a job at most once across all replicas.
 
-All three are technology agnostic and run on the same backends (see
+All four are technology agnostic and run on the same backends (see
 [Backends](#backends)). Pick Redis, PostgreSQL, SQLite, Kubernetes, or in-memory
 without changing your code.
 
@@ -82,11 +84,12 @@ Wire a `Coordination` component like this:
     Store connection URLs in a proper place, such as environment variables, not
     inline like the examples above.
 
-A `Provider` resolves both primitives in one line: `Coordination(redis)` calls
-`redis.lock()` for the lock backend and `redis.leaderelection()` for the
-election backend. Set each backend on its own with `lock=` and `election=`, so
-locks can run on one vendor and leader election on another. Each argument accepts
-a `Provider`, a backend instance, or a zero-arg class.
+A `Provider` resolves every primitive in one line: `Coordination(redis)` calls
+`redis.lock()` for the lock backend, `redis.readwritelock()` for the read-write
+lock backend, and `redis.leaderelection()` for the election backend. Set each
+backend on its own with `lock=`, `rwlock=`, and `election=`, so locks can run on
+one vendor and leader election on another. Each argument accepts a `Provider`, a
+backend instance, or a zero-arg class.
 
 | | Redis | PostgreSQL | Kubernetes | SQLite | Memory |
 |---|---|---|---|---|---|
@@ -98,8 +101,8 @@ a `Provider`, a backend instance, or a zero-arg class.
 
 !!! tip
     Feel free to create your own backend and contribute it. The backend
-    protocols (`LockBackend`, `LeaderElectionBackend`, `ScheduleBackend`) are
-    exported from `grelmicro.coordination`.
+    protocols (`LockBackend`, `ReadWriteLockBackend`, `LeaderElectionBackend`,
+    `ScheduleBackend`) are exported from `grelmicro.coordination`.
 
 ### Choosing a backend
 
@@ -280,6 +283,110 @@ strictly monotonic against its master.
 ```python
 --8<-- "coordination/fencing.py"
 ```
+
+## Read-Write Lock
+
+A `Lock` lets one caller in at a time, readers included. A `ReadWriteLock` lets
+every reader in at once and keeps writers alone. Reach for it when a resource is
+read far more often than it is written: a catalog, a routing table, a rendered
+report, a config blob in object storage.
+
+```python
+--8<-- "coordination/readwritelock.py"
+```
+
+`catalog.read` and `catalog.write` are two views of one lock. Each is a full
+primitive with `acquire(timeout=...)`, `acquire_nowait()`, `extend()`,
+`release()`, and a `from_thread` adapter, exactly like `Lock`.
+
+### Guards
+
+Entering a mode binds a guard. The guard is the only thing that carries the
+proof you hold the lock, so a function that writes can demand one in its
+signature and the type checker rejects a caller who never took the lock:
+
+```python
+--8<-- "coordination/readwritelock_guards.py"
+```
+
+`ReadGuard` and `WriteGuard` are different types. A function annotated
+`guard: WriteGuard` cannot be called with a read guard. Reading
+`guard.fencing_token` after the guard is released, or after its lease expired,
+raises `LockNotOwnedError` instead of handing back a stale token.
+
+| Guard | Carries | Use it for |
+|---|---|---|
+| `ReadGuard` | `generation`, `expires_in` | Detecting that a writer landed since you read. |
+| `WriteGuard` | `fencing_token`, `poisoned`, `expires_in` | Fencing every write, and spotting a crashed predecessor. |
+
+### Writers never starve
+
+The lock is writer-preferring. A writer that finds readers in the way records an
+intent, and new readers wait behind it. Readers already inside finish and the
+writer goes in next. Without this, a steady stream of readers holds a writer out
+forever.
+
+The intent carries its own lease. A writer that dies while waiting stops holding
+readers back as soon as that lease expires.
+
+### Poison
+
+A write that crashes halfway leaves the resource in whatever state it reached.
+The next writer sees `poisoned` set to `True`, which says the previous holder's
+lease expired without a release:
+
+```python
+--8<-- "coordination/readwritelock_downgrade.py"
+```
+
+`poisoned` is a fact, not a lock state. The write lock is yours either way, and
+what a half-finished predecessor means is yours to decide.
+
+### Downgrade, and why there is no upgrade
+
+`await guard.downgrade()` turns a held write lock into a read lock with no gap in
+between, so no other writer can slip in. Use it to publish a rebuilt value and
+then keep reading it.
+
+There is no upgrade. Two callers that both hold a read lock and both wait to
+become the writer wait for each other forever. `ReadWriteLock` raises
+`LockUpgradeError` rather than shipping a deadlock. Take the write lock from the
+start when you might write.
+
+### Backends
+
+Every coordination backend implements it.
+
+```python
+--8<-- "coordination/readwritelock_redis.py"
+```
+
+| Backend | Holds readers in | Notes |
+|---|---|---|
+| Redis, Valkey | A sorted set of reader leases, updated in one server-side step | Fastest. On a cluster, the prefix needs a hash tag. |
+| PostgreSQL | Reader rows, updated under an advisory lock | Tables are created on first connect. Pass `auto_migrate=False` to manage them yourself. |
+| SQLite | Reader rows, updated in one write transaction | One host only. Lease durations round up to whole seconds. |
+| Kubernetes | Annotations on the Lease that holds the writer | Coarse-grained. Every reader renewal writes to etcd, and annotation size caps readers in the hundreds. |
+| Memory | A process-local dict | Tests and single-process apps. |
+
+Every holder has its own lease, so a reader that died is dropped by the next
+writer's acquire rather than blocking it until a shared expiry fires.
+
+### Configuration
+
+Same fields as `Lock`, read from `GREL_READWRITELOCK_{NAME_UPPER}_*`. The
+default instance drops the name segment and reads `GREL_READWRITELOCK_*`.
+
+--8<-- "env_gate.md"
+
+| Env var | Config field | Type | Default |
+|---|---|---|---|
+| `GREL_READWRITELOCK_{NAME_UPPER}_WORKER` | `worker` | `str \| UUID` | generated UUID |
+| `GREL_READWRITELOCK_{NAME_UPPER}_LEASE_DURATION` | `lease_duration` | `float` (> 0) | `60` |
+| `GREL_READWRITELOCK_{NAME_UPPER}_RETRY_INTERVAL` | `retry_interval` | `float` (>= 0.001) | `0.1` |
+| `GREL_READWRITELOCK_{NAME_UPPER}_RETRY_JITTER` | `retry_jitter` | `float` [0, 1) | `0.1` |
+
+`lease_duration` covers a reader lease, a writer lease, and a writer intent.
 
 ## Task Lock
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? S
 |---|---|
 | [**Cache**](https://grelmicro.grel.info/cache/) | `@cached` decorator with local and distributed stampede protection. In-memory `TTLCache` or `RedisCacheAdapter`. |
 | [**Idempotency**](https://grelmicro.grel.info/idempotency/) | Idempotency keys that make a retried operation safe. Store the response once, replay it on repeat, single-flight across replicas. |
-| [**Coordination**](https://grelmicro.grel.info/coordination/) | Distributed `Lock`, `TaskLock`, and `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
+| [**Coordination**](https://grelmicro.grel.info/coordination/) | Distributed `Lock`, `ReadWriteLock`, `TaskLock`, and `LeaderElection`. Redis, PostgreSQL, SQLite, Kubernetes, in-memory. |
 | [**Outbox**](https://grelmicro.grel.info/outbox/) | Transactional outbox. `publish` a message inside your database transaction and a background relay delivers it at least once with retries and dead-lettering. PostgreSQL, in-memory. |
 | [**Task Scheduler**](https://grelmicro.grel.info/task/) | Interval and cron tasks with durable, distributed at-most-once execution. A modern, lightweight alternative to APScheduler and Celery beat. |
 | [**Resilience**](https://grelmicro.grel.info/resilience/) | [Circuit Breaker](https://grelmicro.grel.info/resilience/circuit-breaker/) and [Rate Limiter](https://grelmicro.grel.info/resilience/rate-limiter/) with pluggable algorithms (`TokenBucketConfig`, `SlidingWindowConfig`). |

--- a/docs/reference/coordination.md
+++ b/docs/reference/coordination.md
@@ -1,7 +1,7 @@
 # Coordination
 
 - **Start here**: [Coordination guide](../coordination.md)
-- **Common recipes**: [`Lock`](../coordination.md#lock), [`TaskLock`](../coordination.md#task-lock), [`LeaderElection`](../coordination.md#leader-election)
+- **Common recipes**: [`Lock`](../coordination.md#lock), [`ReadWriteLock`](../coordination.md#read-write-lock), [`TaskLock`](../coordination.md#task-lock), [`LeaderElection`](../coordination.md#leader-election)
 - **Backends**: [backend selection](../coordination.md#backends)
 
 ::: grelmicro.coordination
@@ -10,10 +10,17 @@
       members:
         - Coordination
         - Lock
+        - ReadWriteLock
+        - ReadWriteLockConfig
+        - ReadGuard
+        - WriteGuard
         - TaskLock
         - LeaderElection
         - LeaderElectionConfig
         - LeaderElectionBackend
         - LockBackend
+        - ReadWriteLockBackend
+        - ReadWriteLockState
+        - WriteGrant
         - LeaderRecord
         - CoordinationError

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ Demand-gated. Built when a concrete need shows up.
 
 - **Fleet-wide retry budgets**: cap the retry-to-call ratio across replicas through distributed backends.
 - **Request hedging on Shield**: fire a backup attempt after a latency threshold, take the fastest, cancel the loser.
-- **Distributed `Semaphore`, then read-write locks**: new classes on `LockBackend`. No hooks needed.
+- **Distributed `Semaphore`**: a new class alongside `Lock` and `ReadWriteLock`. No hooks needed.
 - **Adaptive `Bulkhead`**: the CUBIC machinery inside Shield, exposed as `Bulkhead.adaptive()`.
 - **Deadline propagation**: a contextvar deadline that `Timeout`, `Retry`, and `Shield` respect.
 - **Resilience composition**: a horizontal `compose()` for assembling a policy list at runtime, plus slow-call rate as a trip input to the failure-rate breaker.

--- a/docs/snippets/coordination/readwritelock.py
+++ b/docs/snippets/coordination/readwritelock.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from grelmicro.coordination import ReadWriteLock
+from grelmicro.providers.memory import MemoryProvider
+
+
+async def main() -> None:
+    async with MemoryProvider() as provider:
+        catalog = ReadWriteLock("catalog", backend=provider.readwritelock())
+
+        async with catalog.read as reading:
+            print("read under generation", reading.generation)
+
+        async with catalog.write as writing:
+            print("write with fencing token", writing.fencing_token)
+
+
+asyncio.run(main())

--- a/docs/snippets/coordination/readwritelock_downgrade.py
+++ b/docs/snippets/coordination/readwritelock_downgrade.py
@@ -1,0 +1,24 @@
+import asyncio
+
+from grelmicro.coordination import ReadWriteLock
+from grelmicro.providers.memory import MemoryProvider
+
+
+async def rebuild(rows: list[str]) -> list[str]:
+    return sorted(rows)
+
+
+async def main() -> None:
+    async with MemoryProvider() as provider:
+        catalog = ReadWriteLock("catalog", backend=provider.readwritelock())
+
+        async with catalog.write as writing:
+            if writing.poisoned:
+                print("the previous writer died mid-write, repairing")
+            rows = await rebuild(["pear", "apple"])
+
+            reading = await writing.downgrade()
+            print("still holding, now as a reader", reading.generation, rows)
+
+
+asyncio.run(main())

--- a/docs/snippets/coordination/readwritelock_guards.py
+++ b/docs/snippets/coordination/readwritelock_guards.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from grelmicro.coordination import ReadGuard, ReadWriteLock, WriteGuard
+from grelmicro.providers.memory import MemoryProvider
+
+
+class Catalog:
+    """A resource that only accepts writes carrying a higher fencing token."""
+
+    def __init__(self) -> None:
+        self.rows: list[str] = []
+        self.highest_token = 0
+
+    def read_all(self, guard: ReadGuard) -> list[str]:
+        print("reading catalog", guard.name)
+        return list(self.rows)
+
+    def replace_all(self, guard: WriteGuard, rows: list[str]) -> bool:
+        if guard.fencing_token <= self.highest_token:
+            return False
+        self.highest_token = guard.fencing_token
+        self.rows = rows
+        return True
+
+
+async def main() -> None:
+    catalog = Catalog()
+
+    async with MemoryProvider() as provider:
+        lock = ReadWriteLock("catalog", backend=provider.readwritelock())
+
+        async with lock.write as writing:
+            assert catalog.replace_all(writing, ["apple", "pear"])
+
+        async with lock.read as reading:
+            assert catalog.read_all(reading) == ["apple", "pear"]
+
+
+asyncio.run(main())

--- a/docs/snippets/coordination/readwritelock_redis.py
+++ b/docs/snippets/coordination/readwritelock_redis.py
@@ -1,0 +1,8 @@
+from grelmicro import Grelmicro
+from grelmicro.coordination import Coordination, ReadWriteLock
+from grelmicro.providers.redis import RedisProvider
+
+redis = RedisProvider("redis://localhost:6379/0")
+micro = Grelmicro(uses=[Coordination(redis)])
+
+catalog = ReadWriteLock("catalog")

--- a/grelmicro/coordination/__init__.py
+++ b/grelmicro/coordination/__init__.py
@@ -1,13 +1,17 @@
 """Coordination primitives for distributed locking and leader election."""
 
 from grelmicro.coordination._component import Coordination
+from grelmicro.coordination._guards import ReadGuard, WriteGuard
 from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination._protocol import (
     LeaderElectionBackend,
     LeaderRecord,
     LockBackend,
     LockPrimitive,
+    ReadWriteLockBackend,
+    ReadWriteLockState,
     ScheduleBackend,
+    WriteGrant,
 )
 from grelmicro.coordination.errors import (
     CoordinationBackendError,
@@ -20,6 +24,7 @@ from grelmicro.coordination.errors import (
     LockOwnedCheckError,
     LockReentrantError,
     LockReleaseError,
+    LockUpgradeError,
     WouldBlockError,
 )
 from grelmicro.coordination.leaderelection import (
@@ -27,6 +32,10 @@ from grelmicro.coordination.leaderelection import (
     LeaderElectionConfig,
 )
 from grelmicro.coordination.lock import Lock
+from grelmicro.coordination.readwritelock import (
+    ReadWriteLock,
+    ReadWriteLockConfig,
+)
 from grelmicro.coordination.tasklock import TaskLock
 
 __all__ = [
@@ -49,7 +58,15 @@ __all__ = [
     "LockPrimitive",
     "LockReentrantError",
     "LockReleaseError",
+    "LockUpgradeError",
+    "ReadGuard",
+    "ReadWriteLock",
+    "ReadWriteLockBackend",
+    "ReadWriteLockConfig",
+    "ReadWriteLockState",
     "ScheduleBackend",
     "TaskLock",
     "WouldBlockError",
+    "WriteGrant",
+    "WriteGuard",
 ]

--- a/grelmicro/coordination/_component.py
+++ b/grelmicro/coordination/_component.py
@@ -10,6 +10,7 @@ from grelmicro._component import instantiate_if_class
 from grelmicro.coordination.errors import CoordinationBackendError
 from grelmicro.coordination.leaderelection import LeaderElection
 from grelmicro.coordination.lock import Lock
+from grelmicro.coordination.readwritelock import ReadWriteLock
 from grelmicro.coordination.tasklock import TaskLock
 from grelmicro.providers._base import Provider
 
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
     from grelmicro.coordination._protocol import (
         LeaderElectionBackend,
         LockBackend,
+        ReadWriteLockBackend,
         ScheduleBackend,
     )
 
@@ -98,6 +100,21 @@ class Coordination:
                 """,
             ),
         ] = None,
+        rwlock: Annotated[
+            Provider
+            | ReadWriteLockBackend
+            | type[Provider | ReadWriteLockBackend]
+            | None,
+            Doc(
+                """
+                The read-write lock backend. A `Provider` resolves it via
+                `provider.readwritelock()`, a `ReadWriteLockBackend` instance
+                is used directly, and a zero-arg class is instantiated for
+                you. Overrides the read-write lock backend resolved from
+                `source`.
+                """,
+            ),
+        ] = None,
         schedule: Annotated[
             Provider
             | ScheduleBackend
@@ -125,6 +142,7 @@ class Coordination:
         """Initialize the component with the wrapped backends."""
         self._name = name
         self._lock_backend: LockBackend | None = None
+        self._rwlock_backend: ReadWriteLockBackend | None = None
         self._election_backend: LeaderElectionBackend | None = None
         self._schedule_backend: ScheduleBackend | None = None
 
@@ -137,6 +155,10 @@ class Coordination:
                 self._lock_backend = provider.lock()
             except (AttributeError, NotImplementedError):
                 self._lock_backend = None
+            try:
+                self._rwlock_backend = provider.readwritelock()
+            except (AttributeError, NotImplementedError):
+                self._rwlock_backend = None
             try:
                 self._election_backend = provider.leaderelection()
             except (AttributeError, NotImplementedError):
@@ -155,6 +177,17 @@ class Coordination:
                 resolved_lock.lock()
                 if isinstance(resolved_lock, Provider)
                 else resolved_lock
+            )
+
+        if rwlock is not None:
+            resolved_rwlock = cast(
+                "Provider | ReadWriteLockBackend",
+                instantiate_if_class(rwlock),
+            )
+            self._rwlock_backend = (
+                resolved_rwlock.readwritelock()
+                if isinstance(resolved_rwlock, Provider)
+                else resolved_rwlock
             )
 
         if election is not None:
@@ -199,6 +232,22 @@ class Coordination:
             )
             raise CoordinationBackendError(msg)
         return self._lock_backend
+
+    @property
+    def rwlock_backend(self) -> ReadWriteLockBackend:
+        """The underlying `ReadWriteLockBackend`.
+
+        Raises:
+            CoordinationBackendError: If no read-write lock backend is wired.
+        """
+        if self._rwlock_backend is None:
+            msg = (
+                "Coordination has no read-write lock backend. "
+                "Pass a read-write lock provider as Coordination(provider) or "
+                "Coordination(rwlock=...)."
+            )
+            raise CoordinationBackendError(msg)
+        return self._rwlock_backend
 
     @property
     def election_backend(self) -> LeaderElectionBackend:
@@ -248,6 +297,14 @@ class Coordination:
         """
         return TaskLock(name, backend=self.lock_backend, **kwargs)
 
+    def readwritelock(self, name: str, **kwargs: Any) -> ReadWriteLock:  # noqa: ANN401
+        """Construct a `ReadWriteLock` bound to this component's backend.
+
+        Raises:
+            CoordinationBackendError: If no read-write lock backend is wired.
+        """
+        return ReadWriteLock(name, backend=self.rwlock_backend, **kwargs)
+
     def leaderelection(
         self,
         name: str,
@@ -264,6 +321,8 @@ class Coordination:
         """Open whichever backends are set."""
         if self._lock_backend is not None:
             await self._lock_backend.__aenter__()
+        if self._rwlock_backend is not None:
+            await self._rwlock_backend.__aenter__()
         if self._election_backend is not None:
             await self._election_backend.__aenter__()
         if self._schedule_backend is not None:
@@ -282,8 +341,16 @@ class Coordination:
                 await self._lock_backend.__aexit__(exc_type, exc, tb)
         finally:
             try:
-                if self._election_backend is not None:
-                    await self._election_backend.__aexit__(exc_type, exc, tb)
+                if self._rwlock_backend is not None:
+                    await self._rwlock_backend.__aexit__(exc_type, exc, tb)
             finally:
-                if self._schedule_backend is not None:
-                    await self._schedule_backend.__aexit__(exc_type, exc, tb)
+                try:
+                    if self._election_backend is not None:
+                        await self._election_backend.__aexit__(
+                            exc_type, exc, tb
+                        )
+                finally:
+                    if self._schedule_backend is not None:
+                        await self._schedule_backend.__aexit__(
+                            exc_type, exc, tb
+                        )

--- a/grelmicro/coordination/_guards.py
+++ b/grelmicro/coordination/_guards.py
@@ -1,0 +1,204 @@
+"""Read-write lock guards."""
+
+from __future__ import annotations
+
+from time import monotonic
+from typing import TYPE_CHECKING
+
+from grelmicro.coordination.errors import LockNotOwnedError
+
+if TYPE_CHECKING:
+    from grelmicro.coordination.readwritelock import ReadMode, WriteMode
+
+
+class _BaseGuard:
+    """State shared by the read and write guards."""
+
+    __slots__ = ("_expires_at", "_name", "_released", "_token")
+
+    def __init__(self, *, name: str, token: str, expires_at: float) -> None:
+        """Initialize the guard."""
+        self._name = name
+        self._token = token
+        self._expires_at = expires_at
+        self._released = False
+
+    @property
+    def name(self) -> str:
+        """The lock name, as passed to `ReadWriteLock(name)`."""
+        return self._name
+
+    @property
+    def token(self) -> str:
+        """The opaque ownership token the backend stored for this holder."""
+        return self._token
+
+    @property
+    def expires_in(self) -> float:
+        """Seconds left on the lease, `0.0` once it has run out."""
+        return max(0.0, self._expires_at - monotonic())
+
+    @property
+    def valid(self) -> bool:
+        """Whether the guard still holds the lock, as far as this process knows.
+
+        `False` once the guard was released or its lease ran out. A lease
+        taken over on the backend while this process was paused still reads
+        as valid until it runs out, which is what the fencing token is for.
+        """
+        return not self._released and self._expires_at > monotonic()
+
+    def _renewed(self, expires_at: float) -> None:
+        """Record a renewed lease deadline."""
+        self._expires_at = expires_at
+
+    def _invalidate(self) -> None:
+        """Mark the guard as no longer holding the lock."""
+        self._released = True
+
+    def _check(self) -> None:
+        """Raise unless the guard still holds the lock.
+
+        Raises:
+            LockNotOwnedError: The guard was released or its lease ran out.
+        """
+        if not self.valid:
+            raise LockNotOwnedError(name=self._name)
+
+
+class ReadGuard(_BaseGuard):
+    """The result of a granted read acquisition.
+
+    Bound by `async with lock.read`, and returned by `acquire`,
+    `acquire_nowait`, and `WriteGuard.downgrade`. Each acquisition produces
+    its own guard, so a `ReadWriteLock` shared by several tasks gives each
+    reader a distinct guard.
+    """
+
+    __slots__ = ("_generation", "_owner")
+
+    def __init__(
+        self,
+        *,
+        owner: ReadMode,
+        name: str,
+        token: str,
+        generation: int,
+        expires_at: float,
+    ) -> None:
+        """Initialize the read guard."""
+        super().__init__(name=name, token=token, expires_at=expires_at)
+        self._owner = owner
+        self._generation = generation
+
+    @property
+    def generation(self) -> int:
+        """The fencing token of the write this read observes.
+
+        Compare it across two reads to tell whether a writer landed in
+        between.
+
+        Raises:
+            LockNotOwnedError: The guard was released or its lease ran out.
+        """
+        self._check()
+        return self._generation
+
+    async def extend(self) -> None:
+        """Renew this reader's lease for another `lease_duration`.
+
+        Raises:
+            LockNotOwnedError: This reader no longer holds a live lease.
+            LockAcquireError: The backend call failed.
+        """
+        self._check()
+        await self._owner.do_extend(self)
+
+    def __repr__(self) -> str:
+        """Return the guard representation."""
+        return (
+            f"ReadGuard(name={self._name!r}, generation={self._generation},"
+            f" valid={self.valid})"
+        )
+
+
+class WriteGuard(_BaseGuard):
+    """The result of a granted write acquisition.
+
+    Bound by `async with lock.write`, and returned by `acquire` and
+    `acquire_nowait`.
+    """
+
+    __slots__ = ("_fencing_token", "_owner", "_poisoned")
+
+    def __init__(
+        self,
+        *,
+        owner: WriteMode,
+        name: str,
+        token: str,
+        fencing_token: int,
+        poisoned: bool,
+        expires_at: float,
+    ) -> None:
+        """Initialize the write guard."""
+        super().__init__(name=name, token=token, expires_at=expires_at)
+        self._owner = owner
+        self._fencing_token = fencing_token
+        self._poisoned = poisoned
+
+    @property
+    def fencing_token(self) -> int:
+        """A strictly increasing integer minted by the backend for this name.
+
+        Pass it to the protected resource so the resource can reject any
+        write that carries a lower or equal token.
+
+        Raises:
+            LockNotOwnedError: The guard was released or its lease ran out.
+        """
+        self._check()
+        return self._fencing_token
+
+    @property
+    def poisoned(self) -> bool:
+        """Whether the previous writer's lease expired without a release.
+
+        Stays readable after release, because it describes how this
+        acquisition came about rather than whether the lock is still held.
+        """
+        return self._poisoned
+
+    async def extend(self) -> None:
+        """Renew the write lease for another `lease_duration`.
+
+        The fencing token is unchanged.
+
+        Raises:
+            LockNotOwnedError: This writer no longer holds the lock.
+            LockAcquireError: The backend call failed.
+        """
+        self._check()
+        await self._owner.do_extend(self)
+
+    async def downgrade(self) -> ReadGuard:
+        """Turn this write lease into a read lease in one step.
+
+        No other writer takes the lock in between. This guard is spent
+        afterwards, and the returned `ReadGuard` is released when the
+        `async with lock.write` block exits.
+
+        Raises:
+            LockNotOwnedError: This writer no longer holds the lock.
+            LockAcquireError: The backend call failed.
+        """
+        self._check()
+        return await self._owner.do_downgrade(self)
+
+    def __repr__(self) -> str:
+        """Return the guard representation."""
+        return (
+            f"WriteGuard(name={self._name!r},"
+            f" fencing_token={self._fencing_token},"
+            f" poisoned={self._poisoned}, valid={self.valid})"
+        )

--- a/grelmicro/coordination/_protocol.py
+++ b/grelmicro/coordination/_protocol.py
@@ -153,6 +153,227 @@ class LockPrimitive(Protocol):
         ...
 
 
+@dataclass(frozen=True, slots=True)
+class WriteGrant:
+    """The result of a granted write acquisition."""
+
+    fencing_token: Annotated[
+        int,
+        Doc(
+            "A strictly increasing integer minted for this lock name on"
+            " every free-to-held write transition. A renewal by the same"
+            " holder keeps the same value."
+        ),
+    ]
+    poisoned: Annotated[
+        bool,
+        Doc(
+            "`True` when this acquisition took over from a writer whose"
+            " lease expired without a release, so the resource may hold a"
+            " half-finished write."
+        ),
+    ]
+
+
+@dataclass(frozen=True, slots=True)
+class ReadWriteLockState:
+    """A point-in-time view of a read-write lock."""
+
+    generation: Annotated[
+        int,
+        Doc("The fencing token of the most recent write acquisition."),
+    ]
+    writing: Annotated[
+        bool,
+        Doc("`True` when a writer currently holds the lock."),
+    ]
+    readers: Annotated[
+        int,
+        Doc("Number of readers holding a live lease."),
+    ]
+    waiting_writers: Annotated[
+        int,
+        Doc("Number of writers holding a live intent while they wait."),
+    ]
+
+
+@runtime_checkable
+class ReadWriteLockBackend(Protocol):
+    """Read-Write Lock Backend Protocol.
+
+    The low-level API behind `ReadWriteLock`, platform agnostic. Many
+    readers hold the lock at once, one writer holds it alone, and a writer
+    waiting behind readers records an intent that keeps new readers out.
+
+    Every holder, reader or writer, has its own lease under its own token.
+    An acquire reaps the leases and intents that expired, so a holder that
+    died never blocks anyone longer than its lease.
+
+    Implementations capture the running event loop on `__aenter__` in a
+    `_loop` attribute so the `from_thread` adapters can dispatch coroutines
+    back into it, mirroring `LockBackend`.
+    """
+
+    _loop: asyncio.AbstractEventLoop | None
+
+    async def __aenter__(self) -> Self:
+        """Open the read-write lock backend."""
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the read-write lock backend."""
+        ...
+
+    async def acquire_read(
+        self,
+        *,
+        name: Annotated[
+            str,
+            Doc("Identifier of the lock to acquire for reading."),
+        ],
+        token: Annotated[
+            str,
+            Doc("Caller-supplied reader token, unique per holder."),
+        ],
+        duration: Annotated[
+            float,
+            Doc("Seconds this reader's lease is held before it expires."),
+        ],
+    ) -> int | None:
+        """Acquire the lock for reading.
+
+        Returns the current generation when granted, `None` when a writer
+        holds the lock or waits for it. A token already in the reader set
+        renews its own lease and is granted even while a writer waits, so
+        a reader can always finish and let the writer in.
+        """
+        ...
+
+    async def acquire_write(
+        self,
+        *,
+        name: Annotated[
+            str,
+            Doc("Identifier of the lock to acquire for writing."),
+        ],
+        token: Annotated[
+            str,
+            Doc("Caller-supplied writer token, unique per holder."),
+        ],
+        duration: Annotated[
+            float,
+            Doc(
+                "Seconds the writer's lease, or its intent while waiting,"
+                " is held before it expires."
+            ),
+        ],
+        intent: Annotated[
+            bool,
+            Doc(
+                "Whether a refused call records an intent that holds new"
+                " readers out. `False` for a non-blocking try."
+            ),
+        ] = True,
+    ) -> WriteGrant | None:
+        """Acquire the lock for writing.
+
+        Returns the `WriteGrant` when granted, `None` when readers or
+        another writer hold the lock. A refused call with `intent=True`
+        records this token's intent, so readers arriving afterwards wait.
+        """
+        ...
+
+    async def release_read(
+        self,
+        *,
+        name: Annotated[str, Doc("Identifier of the lock to release.")],
+        token: Annotated[str, Doc("Reader token previously granted.")],
+    ) -> bool:
+        """Drop this reader's lease.
+
+        Returns `True` when the lease was dropped, `False` when the token
+        held no live lease.
+        """
+        ...
+
+    async def release_write(
+        self,
+        *,
+        name: Annotated[str, Doc("Identifier of the lock to release.")],
+        token: Annotated[str, Doc("Writer token previously granted.")],
+    ) -> bool:
+        """Drop this writer's lease, leaving the lock clean.
+
+        Returns `True` when the lease was dropped, `False` when the token
+        did not hold the lock. The generation counter is kept, so fencing
+        tokens keep climbing across release and re-acquire cycles.
+        """
+        ...
+
+    async def cancel_intent(
+        self,
+        *,
+        name: Annotated[str, Doc("Identifier of the lock to stop waiting on.")],
+        token: Annotated[str, Doc("Writer token that recorded the intent.")],
+    ) -> bool:
+        """Withdraw this writer's intent.
+
+        Returns `True` when an intent was withdrawn. A writer that stops
+        waiting calls this so readers are not held out until the intent
+        lease expires on its own.
+        """
+        ...
+
+    async def downgrade(
+        self,
+        *,
+        name: Annotated[str, Doc("Identifier of the lock to downgrade.")],
+        token: Annotated[str, Doc("Writer token that holds the lock.")],
+        duration: Annotated[
+            float,
+            Doc("Seconds the resulting reader lease is held."),
+        ],
+    ) -> int | None:
+        """Turn a held write lease into a read lease in one step.
+
+        Returns the generation of the resulting read lease, `None` when
+        the token did not hold the write lock. No other writer can take
+        the lock in between.
+        """
+        ...
+
+    async def state(
+        self,
+        *,
+        name: Annotated[str, Doc("Identifier of the lock to inspect.")],
+    ) -> ReadWriteLockState:
+        """Return a point-in-time view, counting live leases only."""
+        ...
+
+    async def owned_read(
+        self,
+        *,
+        name: Annotated[str, Doc("Identifier of the lock to inspect.")],
+        token: Annotated[str, Doc("Reader token to look for.")],
+    ) -> bool:
+        """Return `True` when `token` holds a live read lease."""
+        ...
+
+    async def owned_write(
+        self,
+        *,
+        name: Annotated[str, Doc("Identifier of the lock to inspect.")],
+        token: Annotated[str, Doc("Writer token to compare against.")],
+    ) -> bool:
+        """Return `True` when `token` holds the live write lease."""
+        ...
+
+
 Seconds = PositiveFloat
 
 

--- a/grelmicro/coordination/errors.py
+++ b/grelmicro/coordination/errors.py
@@ -17,6 +17,7 @@ __all__ = [
     "LockOwnedCheckError",
     "LockReentrantError",
     "LockReleaseError",
+    "LockUpgradeError",
     "WouldBlockError",
 ]
 
@@ -49,6 +50,24 @@ class LockReentrantError(CoordinationError):
             f"Lock does not support nested usage: name={name}."
             f" The lock is already acquired by this instance."
             f" Use separate instances if you need independent locks."
+        )
+
+
+class LockUpgradeError(CoordinationError):
+    """Lock Upgrade Error.
+
+    This error is raised when a task that holds a read lock asks for the
+    write lock on the same `ReadWriteLock`. Two readers upgrading at once
+    wait for each other forever, so the upgrade is refused. Take the write
+    lock from the start when the body may write.
+    """
+
+    def __init__(self, *, name: str) -> None:
+        """Initialize the error."""
+        super().__init__(
+            f"Read-write lock does not support upgrade: name={name}."
+            f" This task holds the read lock and asked for the write lock."
+            f" Acquire the write lock first when the body may write."
         )
 
 

--- a/grelmicro/coordination/kubernetes.py
+++ b/grelmicro/coordination/kubernetes.py
@@ -1,6 +1,7 @@
 """Kubernetes Coordination Adapters."""
 
 import asyncio
+import json
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
@@ -17,7 +18,13 @@ from lightkube.resources.coordination_v1 import Lease
 from pydantic_settings import BaseSettings
 from typing_extensions import Doc
 
-from grelmicro.coordination._protocol import LeaderRecord, LockBackend
+from grelmicro.coordination._protocol import (
+    LeaderRecord,
+    LockBackend,
+    ReadWriteLockBackend,
+    ReadWriteLockState,
+    WriteGrant,
+)
 from grelmicro.coordination.errors import CoordinationSettingsValidationError
 from grelmicro.errors import OutOfContextError
 
@@ -431,6 +438,450 @@ class KubernetesLockAdapter(LockBackend):
             raise
 
         return True
+
+
+_READERS_ANNOTATION = f"{_METADATA_ANNOTATION_PREFIX}readers"
+_INTENTS_ANNOTATION = f"{_METADATA_ANNOTATION_PREFIX}intents"
+_CONFLICT_RETRIES = 5
+
+
+class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
+    """Kubernetes Read-Write Lock Adapter.
+
+    Holds each lock in a `coordination.k8s.io/v1` Lease object, one per lock.
+    The writer sits in the Lease spec, the same place a plain lock sits:
+    `holderIdentity` carries the token, `renewTime` and
+    `leaseDurationSeconds` carry the lease, and `leaseTransitions` is the
+    generation. Reader leases and writer intents live in two annotations, a
+    JSON map of token to expiry epoch each.
+
+    Atomicity comes from Kubernetes optimistic concurrency. Every operation
+    reads the Lease with its `resourceVersion` and writes it back with the
+    same one, so a concurrent writer loses with a 409 Conflict and the call
+    retries. A refused acquire that needs no write costs one read.
+
+    This backend is coarse-grained on purpose. Every reader acquire and
+    renewal is a full object write against the API server and etcd, and the
+    annotation size limit caps the reader set in the hundreds. Use it for a
+    Kubernetes-native deployment with few, long-lived readers. Reach for
+    Redis or PostgreSQL for a hot read path.
+    """
+
+    def __init__(
+        self,
+        namespace: Annotated[
+            str | None,
+            Doc("""
+                The Kubernetes namespace.
+
+                If not provided, the namespace will be taken from the
+                environment variable KUBE_NAMESPACE.
+                """),
+        ] = None,
+        *,
+        prefix: Annotated[
+            str,
+            Doc("""
+                Prefix prepended to lease names to avoid conflicts with other
+                applications in the same namespace.
+
+                By default no prefix is added.
+                """),
+        ] = "",
+        kubeconfig: Annotated[
+            str | None,
+            Doc("Path to the kubeconfig file."),
+        ] = None,
+    ) -> None:
+        """Initialize the read-write lock backend."""
+        self._namespace = namespace or _get_kube_namespace()
+        self._prefix = prefix
+        self._kubeconfig = kubeconfig
+        self._client: AsyncClient | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def __aenter__(self) -> Self:
+        """Open the read-write lock backend."""
+        self._loop = asyncio.get_running_loop()
+        config = (
+            KubeConfig.from_file(self._kubeconfig) if self._kubeconfig else None
+        )
+        self._client = AsyncClient(config=config)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the read-write lock backend."""
+        if self._client:  # pragma: no branch
+            await self._client.close()
+            self._client = None
+
+    def _require_client(self, operation: str) -> AsyncClient:
+        """Return the open client.
+
+        Raises:
+            OutOfContextError: The backend is not open.
+        """
+        if not self._client:
+            raise OutOfContextError(self, operation)
+        return self._client
+
+    def _lease_name(self, name: str) -> str:
+        """Return the Lease name for a lock name."""
+        return _sanitize_lease_name(f"{self._prefix}{name}")
+
+    async def _read(self, lease_name: str) -> Lease | None:
+        """Return the Lease, or `None` when it does not exist yet."""
+        client = self._require_client("read")
+        try:
+            return await client.get(
+                Lease, name=lease_name, namespace=self._namespace
+            )
+        except ApiError as e:
+            if e.status.code == HTTPStatus.NOT_FOUND:
+                return None
+            raise
+
+    @staticmethod
+    def _live_holders(
+        lease: Lease, annotation: str, now: datetime
+    ) -> dict[str, float]:
+        """Read one holder map from an annotation, without expired entries."""
+        annotations = (
+            (lease.metadata.annotations or {}) if lease.metadata else {}
+        )
+        raw = annotations.get(annotation)
+        if not raw:
+            return {}
+        stored: Mapping[str, float] = json.loads(raw)
+        cutoff = now.timestamp()
+        return {
+            token: expire_at
+            for token, expire_at in stored.items()
+            if expire_at > cutoff
+        }
+
+    async def _write(
+        self,
+        lease_name: str,
+        lease: Lease | None,
+        *,
+        holder: str | None,
+        duration: float | None,
+        transitions: int,
+        readers: dict[str, float],
+        intents: dict[str, float],
+        acquire_time: datetime | None = None,
+        renew_time: datetime | None = None,
+    ) -> bool:
+        """Write the Lease back, returning `False` on a conflict.
+
+        `renew_time` carries the writer's stored renewal forward. A reader
+        operation writes the whole Lease, so without it every reader would
+        push the current writer's lease out.
+        """
+        client = self._require_client("write")
+        now = datetime.now(tz=UTC)
+        annotations = {
+            _READERS_ANNOTATION: json.dumps(readers),
+            _INTENTS_ANNOTATION: json.dumps(intents),
+        }
+        metadata = ObjectMeta(
+            name=lease_name,
+            namespace=self._namespace,
+            labels={_LABEL_MANAGED_BY: _LABEL_MANAGED_BY_VALUE},
+            annotations=annotations,
+        )
+        spec = LeaseSpec(
+            holderIdentity=holder,
+            leaseDurationSeconds=ceil(duration) if duration else None,
+            acquireTime=acquire_time if holder else None,
+            renewTime=(renew_time or now) if holder else None,
+            leaseTransitions=transitions,
+        )
+        try:
+            if lease is None:
+                await client.create(Lease(metadata=metadata, spec=spec))
+            else:
+                assert lease.metadata  # noqa: S101
+                metadata.resourceVersion = lease.metadata.resourceVersion
+                await client.replace(Lease(metadata=metadata, spec=spec))
+        except ApiError as e:
+            if e.status.code in (HTTPStatus.CONFLICT, HTTPStatus.NOT_FOUND):
+                return False
+            raise
+        return True
+
+    @staticmethod
+    def _writer(lease: Lease | None, now: datetime) -> tuple[str | None, bool]:
+        """Return the stored writer token and whether its lease is live."""
+        if lease is None or lease.spec is None:
+            return None, False
+        holder = lease.spec.holderIdentity
+        expire_at = _get_expire_at(lease)
+        return holder, holder is not None and expire_at is not None and (
+            expire_at > now
+        )
+
+    @staticmethod
+    def _generation(lease: Lease | None) -> int:
+        """Return the generation counter stored on the Lease."""
+        if lease is None or lease.spec is None:
+            return 0
+        return lease.spec.leaseTransitions or 0
+
+    async def acquire_read(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Acquire a read lease, returning the generation or `None`."""
+        lease_name = self._lease_name(name)
+        for _ in range(_CONFLICT_RETRIES):
+            lease = await self._read(lease_name)
+            now = datetime.now(tz=UTC)
+            readers = (
+                self._live_holders(lease, _READERS_ANNOTATION, now)
+                if lease
+                else {}
+            )
+            intents = (
+                self._live_holders(lease, _INTENTS_ANNOTATION, now)
+                if lease
+                else {}
+            )
+            holder, writing = self._writer(lease, now)
+            generation = self._generation(lease)
+            if token not in readers and (writing or intents):
+                return None
+            readers[token] = (now + timedelta(seconds=duration)).timestamp()
+            if await self._write(
+                lease_name,
+                lease,
+                holder=holder if writing else None,
+                duration=duration if writing else None,
+                transitions=generation,
+                readers=readers,
+                intents=intents,
+                acquire_time=lease.spec.acquireTime
+                if writing and lease and lease.spec
+                else None,
+                renew_time=lease.spec.renewTime
+                if writing and lease and lease.spec
+                else None,
+            ):
+                return generation
+        return None
+
+    async def acquire_write(
+        self, *, name: str, token: str, duration: float, intent: bool = True
+    ) -> WriteGrant | None:
+        """Acquire the write lease, returning the grant or `None`."""
+        lease_name = self._lease_name(name)
+        for _ in range(_CONFLICT_RETRIES):
+            lease = await self._read(lease_name)
+            now = datetime.now(tz=UTC)
+            readers = (
+                self._live_holders(lease, _READERS_ANNOTATION, now)
+                if lease
+                else {}
+            )
+            intents = (
+                self._live_holders(lease, _INTENTS_ANNOTATION, now)
+                if lease
+                else {}
+            )
+            holder, writing = self._writer(lease, now)
+            generation = self._generation(lease)
+
+            if writing and holder == token:
+                acquired = (
+                    lease.spec.acquireTime
+                    if lease and lease.spec and lease.spec.acquireTime
+                    else now
+                )
+                if await self._write(
+                    lease_name,
+                    lease,
+                    holder=token,
+                    duration=duration,
+                    transitions=generation,
+                    readers=readers,
+                    intents=intents,
+                    acquire_time=acquired,
+                ):
+                    return WriteGrant(fencing_token=generation, poisoned=False)
+                continue
+
+            if writing or readers:
+                if not intent:
+                    return None
+                intents[token] = (now + timedelta(seconds=duration)).timestamp()
+                if await self._write(
+                    lease_name,
+                    lease,
+                    holder=holder if writing else None,
+                    duration=duration if writing else None,
+                    transitions=generation,
+                    readers=readers,
+                    intents=intents,
+                    acquire_time=lease.spec.acquireTime
+                    if writing and lease and lease.spec
+                    else None,
+                    renew_time=lease.spec.renewTime
+                    if writing and lease and lease.spec
+                    else None,
+                ):
+                    return None
+                continue
+
+            intents.pop(token, None)
+            if await self._write(
+                lease_name,
+                lease,
+                holder=token,
+                duration=duration,
+                transitions=generation + 1,
+                readers=readers,
+                intents=intents,
+                acquire_time=now,
+            ):
+                return WriteGrant(
+                    fencing_token=generation + 1, poisoned=holder is not None
+                )
+        return None
+
+    async def _drop_holder(
+        self, name: str, token: str, annotation: str
+    ) -> bool:
+        """Drop `token` from one holder map, returning whether it was there."""
+        lease_name = self._lease_name(name)
+        for _ in range(_CONFLICT_RETRIES):
+            lease = await self._read(lease_name)
+            if lease is None:
+                return False
+            now = datetime.now(tz=UTC)
+            readers = self._live_holders(lease, _READERS_ANNOTATION, now)
+            intents = self._live_holders(lease, _INTENTS_ANNOTATION, now)
+            target = readers if annotation == _READERS_ANNOTATION else intents
+            if token not in target:
+                return False
+            del target[token]
+            holder, writing = self._writer(lease, now)
+            if await self._write(
+                lease_name,
+                lease,
+                holder=holder if writing else None,
+                duration=lease.spec.leaseDurationSeconds
+                if writing and lease.spec
+                else None,
+                transitions=self._generation(lease),
+                readers=readers,
+                intents=intents,
+                acquire_time=lease.spec.acquireTime
+                if writing and lease.spec
+                else None,
+                renew_time=lease.spec.renewTime
+                if writing and lease.spec
+                else None,
+            ):
+                return True
+        return False
+
+    async def release_read(self, *, name: str, token: str) -> bool:
+        """Drop a read lease."""
+        return await self._drop_holder(name, token, _READERS_ANNOTATION)
+
+    async def cancel_intent(self, *, name: str, token: str) -> bool:
+        """Withdraw a writer intent."""
+        return await self._drop_holder(name, token, _INTENTS_ANNOTATION)
+
+    async def release_write(self, *, name: str, token: str) -> bool:
+        """Drop the write lease, leaving the Lease object and its counter."""
+        lease_name = self._lease_name(name)
+        for _ in range(_CONFLICT_RETRIES):
+            lease = await self._read(lease_name)
+            if lease is None:
+                return False
+            now = datetime.now(tz=UTC)
+            holder, writing = self._writer(lease, now)
+            if not writing or holder != token:
+                return False
+            if await self._write(
+                lease_name,
+                lease,
+                holder=None,
+                duration=None,
+                transitions=self._generation(lease),
+                readers=self._live_holders(lease, _READERS_ANNOTATION, now),
+                intents=self._live_holders(lease, _INTENTS_ANNOTATION, now),
+            ):
+                return True
+        return False
+
+    async def downgrade(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Turn a held write lease into a read lease."""
+        lease_name = self._lease_name(name)
+        for _ in range(_CONFLICT_RETRIES):
+            lease = await self._read(lease_name)
+            if lease is None:
+                return None
+            now = datetime.now(tz=UTC)
+            holder, writing = self._writer(lease, now)
+            if not writing or holder != token:
+                return None
+            readers = self._live_holders(lease, _READERS_ANNOTATION, now)
+            readers[token] = (now + timedelta(seconds=duration)).timestamp()
+            generation = self._generation(lease)
+            if await self._write(
+                lease_name,
+                lease,
+                holder=None,
+                duration=None,
+                transitions=generation,
+                readers=readers,
+                intents=self._live_holders(lease, _INTENTS_ANNOTATION, now),
+            ):
+                return generation
+        return None
+
+    async def state(self, *, name: str) -> ReadWriteLockState:
+        """Return a point-in-time view of the lock."""
+        lease = await self._read(self._lease_name(name))
+        now = datetime.now(tz=UTC)
+        if lease is None:
+            return ReadWriteLockState(
+                generation=0, writing=False, readers=0, waiting_writers=0
+            )
+        _holder, writing = self._writer(lease, now)
+        return ReadWriteLockState(
+            generation=self._generation(lease),
+            writing=writing,
+            readers=len(self._live_holders(lease, _READERS_ANNOTATION, now)),
+            waiting_writers=len(
+                self._live_holders(lease, _INTENTS_ANNOTATION, now)
+            ),
+        )
+
+    async def owned_read(self, *, name: str, token: str) -> bool:
+        """Check whether `token` holds a live read lease."""
+        lease = await self._read(self._lease_name(name))
+        if lease is None:
+            return False
+        now = datetime.now(tz=UTC)
+        return token in self._live_holders(lease, _READERS_ANNOTATION, now)
+
+    async def owned_write(self, *, name: str, token: str) -> bool:
+        """Check whether `token` holds the live write lease."""
+        lease = await self._read(self._lease_name(name))
+        if lease is None:
+            return False
+        holder, writing = self._writer(lease, datetime.now(tz=UTC))
+        return writing and holder == token
 
 
 def _get_expire_at(lease: Lease) -> datetime | None:

--- a/grelmicro/coordination/kubernetes.py
+++ b/grelmicro/coordination/kubernetes.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from math import ceil
@@ -440,6 +441,16 @@ class KubernetesLockAdapter(LockBackend):
         return True
 
 
+@dataclass(frozen=True, slots=True)
+class _WriterSpec:
+    """The Lease spec fields that describe the writer."""
+
+    holder: str
+    duration_seconds: int | None
+    acquire_time: datetime | None
+    renew_time: datetime | None
+
+
 _READERS_ANNOTATION = f"{_METADATA_ANNOTATION_PREFIX}readers"
 _INTENTS_ANNOTATION = f"{_METADATA_ANNOTATION_PREFIX}intents"
 _CONFLICT_RETRIES = 5
@@ -570,22 +581,19 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
         lease_name: str,
         lease: Lease | None,
         *,
-        holder: str | None,
-        duration: float | None,
+        writer: _WriterSpec | None,
         transitions: int,
         readers: dict[str, float],
         intents: dict[str, float],
-        acquire_time: datetime | None = None,
-        renew_time: datetime | None = None,
     ) -> bool:
         """Write the Lease back, returning `False` on a conflict.
 
-        `renew_time` carries the writer's stored renewal forward. A reader
-        operation writes the whole Lease, so without it every reader would
-        push the current writer's lease out.
+        Every operation writes the whole Lease, so an operation that only
+        touches readers or intents passes the stored writer back verbatim.
+        Rebuilding it would push a live writer's lease out, and dropping an
+        expired one would lose the poison the next writer needs to see.
         """
         client = self._require_client("write")
-        now = datetime.now(tz=UTC)
         annotations = {
             _READERS_ANNOTATION: json.dumps(readers),
             _INTENTS_ANNOTATION: json.dumps(intents),
@@ -597,10 +605,10 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
             annotations=annotations,
         )
         spec = LeaseSpec(
-            holderIdentity=holder,
-            leaseDurationSeconds=ceil(duration) if duration else None,
-            acquireTime=acquire_time if holder else None,
-            renewTime=(renew_time or now) if holder else None,
+            holderIdentity=writer.holder if writer else None,
+            leaseDurationSeconds=writer.duration_seconds if writer else None,
+            acquireTime=writer.acquire_time if writer else None,
+            renewTime=writer.renew_time if writer else None,
             leaseTransitions=transitions,
         )
         try:
@@ -615,6 +623,22 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
                 return False
             raise
         return True
+
+    @staticmethod
+    def _stored_writer(lease: Lease | None) -> _WriterSpec | None:
+        """Return the writer fields exactly as stored, expired or not."""
+        if (
+            lease is None
+            or lease.spec is None
+            or lease.spec.holderIdentity is None
+        ):
+            return None
+        return _WriterSpec(
+            holder=lease.spec.holderIdentity,
+            duration_seconds=lease.spec.leaseDurationSeconds,
+            acquire_time=lease.spec.acquireTime,
+            renew_time=lease.spec.renewTime,
+        )
 
     @staticmethod
     def _writer(lease: Lease | None, now: datetime) -> tuple[str | None, bool]:
@@ -652,7 +676,7 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
                 if lease
                 else {}
             )
-            holder, writing = self._writer(lease, now)
+            _holder, writing = self._writer(lease, now)
             generation = self._generation(lease)
             if token not in readers and (writing or intents):
                 return None
@@ -660,17 +684,10 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
             if await self._write(
                 lease_name,
                 lease,
-                holder=holder if writing else None,
-                duration=duration if writing else None,
+                writer=self._stored_writer(lease),
                 transitions=generation,
                 readers=readers,
                 intents=intents,
-                acquire_time=lease.spec.acquireTime
-                if writing and lease and lease.spec
-                else None,
-                renew_time=lease.spec.renewTime
-                if writing and lease and lease.spec
-                else None,
             ):
                 return generation
         return None
@@ -705,12 +722,15 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
                 if await self._write(
                     lease_name,
                     lease,
-                    holder=token,
-                    duration=duration,
+                    writer=_WriterSpec(
+                        holder=token,
+                        duration_seconds=ceil(duration),
+                        acquire_time=acquired,
+                        renew_time=now,
+                    ),
                     transitions=generation,
                     readers=readers,
                     intents=intents,
-                    acquire_time=acquired,
                 ):
                     return WriteGrant(fencing_token=generation, poisoned=False)
                 continue
@@ -722,17 +742,10 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
                 if await self._write(
                     lease_name,
                     lease,
-                    holder=holder if writing else None,
-                    duration=duration if writing else None,
+                    writer=self._stored_writer(lease),
                     transitions=generation,
                     readers=readers,
                     intents=intents,
-                    acquire_time=lease.spec.acquireTime
-                    if writing and lease and lease.spec
-                    else None,
-                    renew_time=lease.spec.renewTime
-                    if writing and lease and lease.spec
-                    else None,
                 ):
                     return None
                 continue
@@ -741,12 +754,15 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
             if await self._write(
                 lease_name,
                 lease,
-                holder=token,
-                duration=duration,
+                writer=_WriterSpec(
+                    holder=token,
+                    duration_seconds=ceil(duration),
+                    acquire_time=now,
+                    renew_time=now,
+                ),
                 transitions=generation + 1,
                 readers=readers,
                 intents=intents,
-                acquire_time=now,
             ):
                 return WriteGrant(
                     fencing_token=generation + 1, poisoned=holder is not None
@@ -769,23 +785,13 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
             if token not in target:
                 return False
             del target[token]
-            holder, writing = self._writer(lease, now)
             if await self._write(
                 lease_name,
                 lease,
-                holder=holder if writing else None,
-                duration=lease.spec.leaseDurationSeconds
-                if writing and lease.spec
-                else None,
+                writer=self._stored_writer(lease),
                 transitions=self._generation(lease),
                 readers=readers,
                 intents=intents,
-                acquire_time=lease.spec.acquireTime
-                if writing and lease.spec
-                else None,
-                renew_time=lease.spec.renewTime
-                if writing and lease.spec
-                else None,
             ):
                 return True
         return False
@@ -812,8 +818,7 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
             if await self._write(
                 lease_name,
                 lease,
-                holder=None,
-                duration=None,
+                writer=None,
                 transitions=self._generation(lease),
                 readers=self._live_holders(lease, _READERS_ANNOTATION, now),
                 intents=self._live_holders(lease, _INTENTS_ANNOTATION, now),
@@ -840,8 +845,7 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
             if await self._write(
                 lease_name,
                 lease,
-                holder=None,
-                duration=None,
+                writer=None,
                 transitions=generation,
                 readers=readers,
                 intents=self._live_holders(lease, _INTENTS_ANNOTATION, now),

--- a/grelmicro/coordination/lock.py
+++ b/grelmicro/coordination/lock.py
@@ -45,7 +45,7 @@ _NAME_MAX_LEN = 200
 _NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\-]*$")
 
 
-def _validate_lock_name(name: str) -> None:
+def validate_lock_name(name: str) -> None:
     """Reject lock names that would land as ugly or ambiguous backend keys.
 
     The pattern accepts letters, digits, and the separators ``._:/-`` after
@@ -310,7 +310,7 @@ class Lock(Reconfigurable[LockConfig], BaseLock):
         backend: LockBackend | str | None,
     ) -> None:
         """Wire the validated config and runtime deps onto the instance."""
-        _validate_lock_name(name)
+        validate_lock_name(name)
         self._name = name
         self._config = config
         self._reconfigure_lock = asyncio.Lock()

--- a/grelmicro/coordination/memory.py
+++ b/grelmicro/coordination/memory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import replace
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from time import monotonic
 from typing import TYPE_CHECKING, Self
@@ -11,7 +11,10 @@ from typing import TYPE_CHECKING, Self
 from grelmicro.coordination._protocol import (
     LeaderRecord,
     LockBackend,
+    ReadWriteLockBackend,
+    ReadWriteLockState,
     ScheduleBackend,
+    WriteGrant,
 )
 
 if TYPE_CHECKING:
@@ -83,6 +86,148 @@ class MemoryLockAdapter(LockBackend):
         """Check if the lock is owned."""
         current_token, expire_at = self._locks.get(name, (None, 0))
         return current_token == token and expire_at >= monotonic()
+
+
+@dataclass(slots=True)
+class _MemoryReadWriteState:
+    """The state of one in-memory read-write lock."""
+
+    generation: int = 0
+    writer: str | None = None
+    writer_expire_at: float = 0.0
+    writer_expired: bool = False
+    readers: dict[str, float] = field(default_factory=dict)
+    intents: dict[str, float] = field(default_factory=dict)
+
+
+class MemoryReadWriteLockAdapter(ReadWriteLockBackend):
+    """Memory Read-Write Lock Adapter.
+
+    Runs the same reader set, writer intent, and reaping algorithm as the
+    distributed backends against a process-local dict. State disappears on
+    restart and does not coordinate across nodes, so every process believes
+    it holds the lock. Use a Redis, Postgres, SQLite, or Kubernetes backend
+    across nodes.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the read-write lock backend."""
+        self._states: dict[str, _MemoryReadWriteState] = {}
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def __aenter__(self) -> Self:
+        """Open the read-write lock backend."""
+        self._loop = asyncio.get_running_loop()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the read-write lock backend."""
+        self._states.clear()
+
+    def _reap(self, name: str) -> _MemoryReadWriteState:
+        """Return the state for `name`, with every expired lease dropped."""
+        state = self._states.get(name)
+        if state is None:
+            state = _MemoryReadWriteState()
+            self._states[name] = state
+        now = monotonic()
+        if state.writer is not None and state.writer_expire_at < now:
+            state.writer = None
+            state.writer_expired = True
+        for token, expire_at in list(state.readers.items()):
+            if expire_at < now:
+                del state.readers[token]
+        for token, expire_at in list(state.intents.items()):
+            if expire_at < now:
+                del state.intents[token]
+        return state
+
+    async def acquire_read(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Acquire a read lease, returning the generation or `None`."""
+        state = self._reap(name)
+        if token in state.readers:
+            state.readers[token] = monotonic() + duration
+            return state.generation
+        if state.writer is not None or state.intents:
+            return None
+        state.readers[token] = monotonic() + duration
+        return state.generation
+
+    async def acquire_write(
+        self, *, name: str, token: str, duration: float, intent: bool = True
+    ) -> WriteGrant | None:
+        """Acquire the write lease, returning the grant or `None`."""
+        state = self._reap(name)
+        if state.writer == token:
+            state.writer_expire_at = monotonic() + duration
+            return WriteGrant(fencing_token=state.generation, poisoned=False)
+        if state.writer is not None or state.readers:
+            if intent:
+                state.intents[token] = monotonic() + duration
+            return None
+        state.intents.pop(token, None)
+        state.generation += 1
+        state.writer = token
+        state.writer_expire_at = monotonic() + duration
+        poisoned = state.writer_expired
+        state.writer_expired = False
+        return WriteGrant(fencing_token=state.generation, poisoned=poisoned)
+
+    async def release_read(self, *, name: str, token: str) -> bool:
+        """Drop a read lease."""
+        state = self._reap(name)
+        return state.readers.pop(token, None) is not None
+
+    async def release_write(self, *, name: str, token: str) -> bool:
+        """Drop the write lease, leaving the lock clean."""
+        state = self._reap(name)
+        if state.writer != token:
+            return False
+        state.writer = None
+        state.writer_expired = False
+        return True
+
+    async def cancel_intent(self, *, name: str, token: str) -> bool:
+        """Withdraw a writer intent."""
+        state = self._reap(name)
+        return state.intents.pop(token, None) is not None
+
+    async def downgrade(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Turn a held write lease into a read lease."""
+        state = self._reap(name)
+        if state.writer != token:
+            return None
+        state.writer = None
+        state.writer_expired = False
+        state.readers[token] = monotonic() + duration
+        return state.generation
+
+    async def state(self, *, name: str) -> ReadWriteLockState:
+        """Return a point-in-time view of the lock."""
+        state = self._reap(name)
+        return ReadWriteLockState(
+            generation=state.generation,
+            writing=state.writer is not None,
+            readers=len(state.readers),
+            waiting_writers=len(state.intents),
+        )
+
+    async def owned_read(self, *, name: str, token: str) -> bool:
+        """Check whether `token` holds a live read lease."""
+        return token in self._reap(name).readers
+
+    async def owned_write(self, *, name: str, token: str) -> bool:
+        """Check whether `token` holds the live write lease."""
+        return self._reap(name).writer == token
 
 
 class MemoryScheduleAdapter(ScheduleBackend):

--- a/grelmicro/coordination/postgres.py
+++ b/grelmicro/coordination/postgres.py
@@ -12,7 +12,10 @@ from typing_extensions import Doc
 from grelmicro.coordination._protocol import (
     LeaderRecord,
     LockBackend,
+    ReadWriteLockBackend,
+    ReadWriteLockState,
     ScheduleBackend,
+    WriteGrant,
 )
 from grelmicro.providers.postgres import PostgresProvider
 
@@ -215,6 +218,459 @@ class PostgresLockAdapter(LockBackend):
         """Check if the lock is owned."""
         return bool(
             await self._provider.client.fetchval(self._owned_sql, name, token),
+        )
+
+
+_READ_WRITE_ADVISORY_NAMESPACE = 0x67726C72_776C636B
+"""Advisory-lock namespace for read-write locks.
+
+`hashtextextended` is the Postgres 64-bit text hash with a configurable
+seed. A distinct seed gives read-write lock names their own 64-bit lock id
+space, isolated from any other advisory lock in the same database.
+"""
+
+
+class PostgresReadWriteLockAdapter(ReadWriteLockBackend):
+    """PostgreSQL Read-Write Lock Adapter.
+
+    Wraps a `PostgresProvider` and implements the `ReadWriteLockBackend`
+    protocol. One row per lock holds the writer token, the writer's expiry,
+    and the generation counter. A side table holds one row per reader lease
+    and one per writer intent.
+
+    Every decision runs inside a PL/pgSQL function that takes
+    `pg_advisory_xact_lock` for the lock name first, so the reap, the
+    decision, and the write apply atomically across replicas.
+
+    Reader leases are individual rows, so a reader that died is dropped by
+    the next acquire instead of holding writers out until some shared expiry
+    fires.
+    """
+
+    _SQL_CREATE_TABLES = """
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            name TEXT PRIMARY KEY,
+            writer TEXT,
+            writer_expire_at TIMESTAMPTZ,
+            generation BIGINT NOT NULL DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS {table_name}_holders (
+            name TEXT NOT NULL,
+            token TEXT NOT NULL,
+            kind CHAR(1) NOT NULL,
+            expire_at TIMESTAMPTZ NOT NULL,
+            PRIMARY KEY (name, token, kind)
+        );
+    """
+
+    _SQL_CREATE_FN_ACQUIRE_READ = """
+        CREATE OR REPLACE FUNCTION {table_name}_acquire_read(
+            p_name TEXT, p_token TEXT, p_duration DOUBLE PRECISION
+        ) RETURNS BIGINT AS $$
+        DECLARE
+            v_now TIMESTAMPTZ := NOW();
+            v_expire_at TIMESTAMPTZ;
+            v_generation BIGINT;
+            v_writer TEXT;
+            v_writer_expire_at TIMESTAMPTZ;
+            v_intents INT;
+            v_held BOOLEAN;
+        BEGIN
+            PERFORM pg_advisory_xact_lock(
+                hashtextextended(p_name, {lock_namespace})
+            );
+            v_expire_at := v_now + make_interval(secs => p_duration);
+            DELETE FROM {table_name}_holders
+                WHERE name = p_name AND expire_at < v_now;
+            INSERT INTO {table_name} (name) VALUES (p_name)
+                ON CONFLICT (name) DO NOTHING;
+            SELECT t.writer, t.writer_expire_at, t.generation
+                INTO v_writer, v_writer_expire_at, v_generation
+                FROM {table_name} t WHERE t.name = p_name;
+            SELECT EXISTS(
+                SELECT 1 FROM {table_name}_holders h
+                    WHERE h.name = p_name AND h.token = p_token
+                      AND h.kind = 'r'
+            ) INTO v_held;
+            IF v_held THEN
+                UPDATE {table_name}_holders SET expire_at = v_expire_at
+                    WHERE name = p_name AND token = p_token AND kind = 'r';
+                RETURN v_generation;
+            END IF;
+            IF v_writer IS NOT NULL AND v_writer_expire_at > v_now THEN
+                RETURN NULL;
+            END IF;
+            SELECT count(*) INTO v_intents FROM {table_name}_holders h
+                WHERE h.name = p_name AND h.kind = 'i';
+            IF v_intents > 0 THEN
+                RETURN NULL;
+            END IF;
+            INSERT INTO {table_name}_holders (name, token, kind, expire_at)
+                VALUES (p_name, p_token, 'r', v_expire_at);
+            RETURN v_generation;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+
+    _SQL_CREATE_FN_ACQUIRE_WRITE = """
+        CREATE OR REPLACE FUNCTION {table_name}_acquire_write(
+            p_name TEXT, p_token TEXT, p_duration DOUBLE PRECISION,
+            p_intent BOOLEAN
+        ) RETURNS TABLE(r_fence BIGINT, r_poisoned BOOLEAN) AS $$
+        DECLARE
+            v_now TIMESTAMPTZ := NOW();
+            v_expire_at TIMESTAMPTZ;
+            v_generation BIGINT;
+            v_writer TEXT;
+            v_writer_expire_at TIMESTAMPTZ;
+            v_readers INT;
+        BEGIN
+            PERFORM pg_advisory_xact_lock(
+                hashtextextended(p_name, {lock_namespace})
+            );
+            v_expire_at := v_now + make_interval(secs => p_duration);
+            DELETE FROM {table_name}_holders
+                WHERE name = p_name AND expire_at < v_now;
+            INSERT INTO {table_name} (name) VALUES (p_name)
+                ON CONFLICT (name) DO NOTHING;
+            SELECT t.writer, t.writer_expire_at, t.generation
+                INTO v_writer, v_writer_expire_at, v_generation
+                FROM {table_name} t WHERE t.name = p_name;
+
+            IF v_writer = p_token AND v_writer_expire_at > v_now THEN
+                UPDATE {table_name} SET writer_expire_at = v_expire_at
+                    WHERE name = p_name;
+                RETURN QUERY SELECT v_generation, FALSE;
+                RETURN;
+            END IF;
+
+            IF v_writer IS NOT NULL AND v_writer_expire_at > v_now THEN
+                IF p_intent THEN
+                    INSERT INTO {table_name}_holders
+                        (name, token, kind, expire_at)
+                        VALUES (p_name, p_token, 'i', v_expire_at)
+                        ON CONFLICT (name, token, kind)
+                        DO UPDATE SET expire_at = EXCLUDED.expire_at;
+                END IF;
+                RETURN;
+            END IF;
+
+            SELECT count(*) INTO v_readers FROM {table_name}_holders h
+                WHERE h.name = p_name AND h.kind = 'r';
+            IF v_readers > 0 THEN
+                IF p_intent THEN
+                    INSERT INTO {table_name}_holders
+                        (name, token, kind, expire_at)
+                        VALUES (p_name, p_token, 'i', v_expire_at)
+                        ON CONFLICT (name, token, kind)
+                        DO UPDATE SET expire_at = EXCLUDED.expire_at;
+                END IF;
+                RETURN;
+            END IF;
+
+            DELETE FROM {table_name}_holders
+                WHERE name = p_name AND token = p_token AND kind = 'i';
+            UPDATE {table_name}
+                SET generation = generation + 1,
+                    writer = p_token,
+                    writer_expire_at = v_expire_at
+                WHERE name = p_name
+                RETURNING generation INTO v_generation;
+            RETURN QUERY SELECT v_generation, (v_writer IS NOT NULL);
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+
+    _SQL_CREATE_FN_DOWNGRADE = """
+        CREATE OR REPLACE FUNCTION {table_name}_downgrade(
+            p_name TEXT, p_token TEXT, p_duration DOUBLE PRECISION
+        ) RETURNS BIGINT AS $$
+        DECLARE
+            v_now TIMESTAMPTZ := NOW();
+            v_generation BIGINT;
+        BEGIN
+            PERFORM pg_advisory_xact_lock(
+                hashtextextended(p_name, {lock_namespace})
+            );
+            SELECT t.generation INTO v_generation FROM {table_name} t
+                WHERE t.name = p_name AND t.writer = p_token
+                  AND t.writer_expire_at > v_now;
+            IF v_generation IS NULL THEN
+                RETURN NULL;
+            END IF;
+            UPDATE {table_name}
+                SET writer = NULL, writer_expire_at = NULL
+                WHERE name = p_name;
+            INSERT INTO {table_name}_holders (name, token, kind, expire_at)
+                VALUES (
+                    p_name, p_token, 'r',
+                    v_now + make_interval(secs => p_duration)
+                )
+                ON CONFLICT (name, token, kind)
+                DO UPDATE SET expire_at = EXCLUDED.expire_at;
+            RETURN v_generation;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+
+    _SQL_ACQUIRE_READ = "SELECT {table_name}_acquire_read($1, $2, $3);"
+    _SQL_ACQUIRE_WRITE = (
+        "SELECT * FROM {table_name}_acquire_write($1, $2, $3, $4);"
+    )
+    _SQL_DOWNGRADE = "SELECT {table_name}_downgrade($1, $2, $3);"
+
+    _SQL_RELEASE_READ = """
+        DELETE FROM {table_name}_holders
+        WHERE name = $1 AND token = $2 AND kind = 'r' AND expire_at >= NOW()
+        RETURNING 1;
+    """
+
+    _SQL_RELEASE_WRITE = """
+        UPDATE {table_name}
+        SET writer = NULL, writer_expire_at = NULL
+        WHERE name = $1 AND writer = $2 AND writer_expire_at >= NOW()
+        RETURNING 1;
+    """
+
+    _SQL_CANCEL_INTENT = """
+        DELETE FROM {table_name}_holders
+        WHERE name = $1 AND token = $2 AND kind = 'i' AND expire_at >= NOW()
+        RETURNING 1;
+    """
+
+    _SQL_STATE = """
+        SELECT t.generation,
+               (t.writer IS NOT NULL AND t.writer_expire_at >= NOW())
+                   AS writing,
+               (SELECT count(*) FROM {table_name}_holders h
+                    WHERE h.name = t.name AND h.kind = 'r'
+                      AND h.expire_at >= NOW()) AS readers,
+               (SELECT count(*) FROM {table_name}_holders h
+                    WHERE h.name = t.name AND h.kind = 'i'
+                      AND h.expire_at >= NOW()) AS waiting_writers
+        FROM {table_name} t WHERE t.name = $1;
+    """
+
+    _SQL_OWNED_READ = """
+        SELECT 1 FROM {table_name}_holders
+        WHERE name = $1 AND token = $2 AND kind = 'r' AND expire_at >= NOW();
+    """
+
+    _SQL_OWNED_WRITE = """
+        SELECT 1 FROM {table_name}
+        WHERE name = $1 AND writer = $2 AND writer_expire_at >= NOW();
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: Annotated[
+            PostgresProvider | None,
+            Doc(
+                """
+                A pre-built `PostgresProvider`. When set, the adapter
+                borrows the provider's pool and does not manage its
+                lifecycle.
+                """,
+            ),
+        ] = None,
+        env_prefix: Annotated[
+            str,
+            Doc(
+                """
+                Environment variable prefix used by the implicit
+                `PostgresProvider` when `provider` is not set. Defaults
+                to `POSTGRES_`. Use a custom prefix to split pools.
+                """,
+            ),
+        ] = "POSTGRES_",
+        table_name: Annotated[
+            str,
+            Doc(
+                """
+                Table that stores read-write locks. A side table named
+                `{table_name}_holders` stores reader leases and writer
+                intents. Auto-created on first connect (set
+                `auto_migrate=False` to opt out).
+                """
+            ),
+        ] = "grelmicro_rwlocks",
+        auto_migrate: Annotated[
+            bool,
+            Doc(
+                """
+                When True (the default), the adapter creates the tables and
+                SQL functions on `__aenter__`. Set to False when the schema
+                is managed by your own migration tool.
+                """
+            ),
+        ] = True,
+    ) -> None:
+        """Initialize the adapter."""
+        if not re.fullmatch(r"[a-zA-Z_][a-zA-Z0-9_]*", table_name):
+            msg = f"Table name '{table_name}' is not a valid SQL identifier"
+            raise ValueError(msg)
+
+        if provider is None:
+            self._provider = PostgresProvider(env_prefix=env_prefix)
+            self._owns_provider = True
+        else:
+            self._provider = provider
+            self._owns_provider = False
+        self._env_prefix = env_prefix
+        self._table_name = table_name
+        self._auto_migrate = auto_migrate
+        self._sql = {
+            key: template.format(table_name=table_name)
+            for key, template in {
+                "acquire_read": self._SQL_ACQUIRE_READ,
+                "acquire_write": self._SQL_ACQUIRE_WRITE,
+                "downgrade": self._SQL_DOWNGRADE,
+                "release_read": self._SQL_RELEASE_READ,
+                "release_write": self._SQL_RELEASE_WRITE,
+                "cancel_intent": self._SQL_CANCEL_INTENT,
+                "state": self._SQL_STATE,
+                "owned_read": self._SQL_OWNED_READ,
+                "owned_write": self._SQL_OWNED_WRITE,
+            }.items()
+        }
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def provider(self) -> PostgresProvider:
+        """The bound `PostgresProvider`."""
+        return self._provider
+
+    def _rebind_provider(self, provider: PostgresProvider) -> None:
+        """Swap the underlying provider (used by `Grelmicro` for sharing)."""
+        self._provider = provider
+        self._owns_provider = False
+
+    async def __aenter__(self) -> Self:
+        """Open the adapter and install the schema when `auto_migrate=True`."""
+        if self._owns_provider:
+            await self._provider.__aenter__()
+        self._loop = asyncio.get_running_loop()
+        if self._auto_migrate:  # pragma: no branch
+            await self._migrate()
+        return self
+
+    async def _migrate(self) -> None:
+        """Install the schema, guarded so replicas do not race."""
+        async with (
+            self._provider.client.acquire() as conn,
+            conn.transaction(),
+        ):
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtext($1))", self._table_name
+            )
+            for sql in (
+                self._SQL_CREATE_TABLES,
+                self._SQL_CREATE_FN_ACQUIRE_READ,
+                self._SQL_CREATE_FN_ACQUIRE_WRITE,
+                self._SQL_CREATE_FN_DOWNGRADE,
+            ):
+                await conn.execute(
+                    sql.format(
+                        table_name=self._table_name,
+                        lock_namespace=_READ_WRITE_ADVISORY_NAMESPACE,
+                    )
+                )
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the provider when owned. External providers are left alone."""
+        if self._owns_provider:
+            await self._provider.__aexit__(exc_type, exc_value, traceback)
+
+    async def acquire_read(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Acquire a read lease, returning the generation or `None`."""
+        generation = await self._provider.client.fetchval(
+            self._sql["acquire_read"], name, token, duration
+        )
+        return int(generation) if generation is not None else None
+
+    async def acquire_write(
+        self, *, name: str, token: str, duration: float, intent: bool = True
+    ) -> WriteGrant | None:
+        """Acquire the write lease, returning the grant or `None`."""
+        row = await self._provider.client.fetchrow(
+            self._sql["acquire_write"], name, token, duration, intent
+        )
+        if row is None:
+            return None
+        return WriteGrant(
+            fencing_token=int(row["r_fence"]),
+            poisoned=bool(row["r_poisoned"]),
+        )
+
+    async def release_read(self, *, name: str, token: str) -> bool:
+        """Drop a read lease."""
+        return bool(
+            await self._provider.client.fetchval(
+                self._sql["release_read"], name, token
+            )
+        )
+
+    async def release_write(self, *, name: str, token: str) -> bool:
+        """Drop the write lease, leaving the lock clean."""
+        return bool(
+            await self._provider.client.fetchval(
+                self._sql["release_write"], name, token
+            )
+        )
+
+    async def cancel_intent(self, *, name: str, token: str) -> bool:
+        """Withdraw a writer intent."""
+        return bool(
+            await self._provider.client.fetchval(
+                self._sql["cancel_intent"], name, token
+            )
+        )
+
+    async def downgrade(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Turn a held write lease into a read lease."""
+        generation = await self._provider.client.fetchval(
+            self._sql["downgrade"], name, token, duration
+        )
+        return int(generation) if generation is not None else None
+
+    async def state(self, *, name: str) -> ReadWriteLockState:
+        """Return a point-in-time view of the lock."""
+        row = await self._provider.client.fetchrow(self._sql["state"], name)
+        if row is None:
+            return ReadWriteLockState(
+                generation=0, writing=False, readers=0, waiting_writers=0
+            )
+        return ReadWriteLockState(
+            generation=int(row["generation"]),
+            writing=bool(row["writing"]),
+            readers=int(row["readers"]),
+            waiting_writers=int(row["waiting_writers"]),
+        )
+
+    async def owned_read(self, *, name: str, token: str) -> bool:
+        """Check whether `token` holds a live read lease."""
+        return bool(
+            await self._provider.client.fetchval(
+                self._sql["owned_read"], name, token
+            )
+        )
+
+    async def owned_write(self, *, name: str, token: str) -> bool:
+        """Check whether `token` holds the live write lease."""
+        return bool(
+            await self._provider.client.fetchval(
+                self._sql["owned_write"], name, token
+            )
         )
 
 

--- a/grelmicro/coordination/readwritelock.py
+++ b/grelmicro/coordination/readwritelock.py
@@ -1,0 +1,1129 @@
+"""Read-Write Lock."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from threading import get_ident
+from time import monotonic
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self
+from weakref import WeakKeyDictionary
+
+from typing_extensions import Doc
+
+from grelmicro._app import Grelmicro
+from grelmicro._async import raise_backend_not_open
+from grelmicro._config import (
+    Reconfigurable,
+    default_env_prefix,
+    resolve_config,
+)
+from grelmicro.coordination._base import (
+    assert_worker_unchanged,
+    jittered_interval,
+)
+from grelmicro.coordination._guards import ReadGuard, WriteGuard
+from grelmicro.coordination._tokens import (
+    generate_task_token,
+    generate_thread_token,
+)
+from grelmicro.coordination.errors import (
+    LockAcquireError,
+    LockNotOwnedError,
+    LockOwnedCheckError,
+    LockReentrantError,
+    LockReleaseError,
+    LockUpgradeError,
+)
+from grelmicro.coordination.lock import LockConfig, validate_lock_name
+from grelmicro.errors import WouldBlockError
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from types import TracebackType
+    from uuid import UUID
+
+    from grelmicro.coordination._protocol import (
+        ReadWriteLockBackend,
+        ReadWriteLockState,
+        Seconds,
+        WriteGrant,
+    )
+
+
+class ReadWriteLockConfig(LockConfig):
+    """Read-Write Lock Config.
+
+    Same fields as `LockConfig`. `lease_duration` covers a reader lease, a
+    writer lease, and the intent a waiting writer records.
+    """
+
+
+class ReadWriteLock(Reconfigurable[ReadWriteLockConfig]):
+    """Read-Write Lock.
+
+    A distributed lock that lets many readers hold a resource at once and
+    keeps writers alone. `read` and `write` are two views of the same lock,
+    each a full primitive with `acquire`, `acquire_nowait`, `extend`,
+    `release`, and a `from_thread` adapter.
+
+    The lock is writer-preferring: a writer refused because readers hold the
+    lock records an intent, and readers arriving after it wait. Readers
+    already inside keep their lease and can renew it until they finish.
+
+    Supports live reconfiguration via `reconfigure(new_config)`. A swap takes
+    effect on the next call. In-flight calls keep the config they started
+    with. The `worker` field cannot change. Changing it raises `ValueError`.
+    See [Live reconfiguration](../architecture/reconfigure.md).
+    """
+
+    _LOCK_PREFIX = "rwlock"
+
+    _IMMUTABLE_RECONFIGURE_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"worker"}
+    )
+
+    def __init__(
+        self,
+        name: Annotated[
+            str,
+            Doc(
+                """
+                The name of the resource to lock.
+
+                It will be used as the lock name so make sure it is unique on
+                the read-write lock backend.
+                """,
+            ),
+        ],
+        *,
+        backend: Annotated[
+            ReadWriteLockBackend | str | None,
+            Doc("""
+                The read-write lock backend used to acquire and release the
+                lock.
+
+                Accepts a backend instance, the name of a registered backend
+                (e.g. `"analytics"`), or `None` to use the registered
+                `"default"` backend.
+                """),
+        ] = None,
+        worker: Annotated[
+            str | UUID | None,
+            Doc(
+                """
+                The worker identity.
+
+                By default, a random 16-character hex token is generated.
+                """,
+            ),
+        ] = None,
+        lease_duration: Annotated[
+            Seconds | None,
+            Doc(
+                """
+                The duration in seconds a lease is held by default.
+
+                Default: 60. Covers a reader lease, a writer lease, and a
+                waiting writer's intent. When unset and env reads are enabled
+                (see ``env_load`` and ``GREL_ENV_LOAD``), resolves from
+                `GREL_READWRITELOCK_LEASE_DURATION` for the default instance
+                (`GREL_READWRITELOCK_{NAME_UPPER}_LEASE_DURATION` for a named
+                one) if present, otherwise falls back to the
+                `ReadWriteLockConfig` default.
+                """,
+            ),
+        ] = None,
+        retry_interval: Annotated[
+            Seconds | None,
+            Doc(
+                """
+                The duration in seconds between attempts to acquire the lock.
+
+                Default: 0.1. Must be >= 0.001 to prevent flooding the
+                backend. Resolves from `GREL_READWRITELOCK_RETRY_INTERVAL`
+                when unset and env reads are enabled.
+                """,
+            ),
+        ] = None,
+        retry_jitter: Annotated[
+            float | None,
+            Doc(
+                """
+                Factor for randomized jitter applied to each retry sleep.
+
+                Default: 0.1. Each sleep becomes
+                retry_interval * uniform(1 - retry_jitter, 1 + retry_jitter).
+                Set to 0 to disable jitter. Resolves from
+                `GREL_READWRITELOCK_RETRY_JITTER` when unset and env reads are
+                enabled.
+                """,
+            ),
+        ] = None,
+        env_prefix: Annotated[
+            str | None,
+            Doc(
+                """
+                Override the auto-derived environment variable prefix.
+
+                Default: `GREL_READWRITELOCK_` for the default instance,
+                `GREL_READWRITELOCK_{NAME_UPPER}_` for a named one.
+                """,
+            ),
+        ] = None,
+        env_load: Annotated[
+            bool | None,
+            Doc(
+                """
+                Whether to read environment variables.
+
+                When None (the default), follow the process-wide
+                ``GREL_ENV_LOAD`` flag. Pass True or False to override the
+                flag for this construction.
+                """,
+            ),
+        ] = None,
+    ) -> None:
+        """Initialize the read-write lock."""
+        resolved_env_prefix = env_prefix or default_env_prefix(
+            "READWRITELOCK", name
+        )
+        config = resolve_config(
+            ReadWriteLockConfig,
+            explicit=None,
+            kwargs={
+                "worker": worker,
+                "lease_duration": lease_duration,
+                "retry_interval": retry_interval,
+                "retry_jitter": retry_jitter,
+            },
+            env_prefix=resolved_env_prefix,
+            env_load=env_load,
+        )
+        self._setup(name, config, backend)
+        self._track_reconfigure(resolved_env_prefix)
+
+    @classmethod
+    def from_config(
+        cls,
+        name: Annotated[
+            str,
+            Doc("The name of the resource to lock."),
+        ],
+        config: Annotated[
+            ReadWriteLockConfig,
+            Doc(
+                """
+                The pre-built configuration.
+
+                Use this path when the configuration is assembled at startup
+                from a settings tree. The environment path is bypassed and the
+                config is used as-is.
+                """,
+            ),
+        ],
+        *,
+        backend: Annotated[
+            ReadWriteLockBackend | str | None,
+            Doc("The read-write lock backend, a registered name, or `None`."),
+        ] = None,
+    ) -> Self:
+        """Construct a `ReadWriteLock` from a name and a pre-built config."""
+        instance = cls.__new__(cls)
+        instance._setup(name, config, backend)  # noqa: SLF001
+        return instance
+
+    def _setup(
+        self,
+        name: str,
+        config: ReadWriteLockConfig,
+        backend: ReadWriteLockBackend | str | None,
+    ) -> None:
+        """Wire the validated config and runtime deps onto the instance."""
+        validate_lock_name(name)
+        self._name = name
+        self._config = config
+        self._reconfigure_lock = asyncio.Lock()
+        self._lock_name = f"{self._LOCK_PREFIX}:{name}"
+        self._backend: ReadWriteLockBackend | None = (
+            backend if not isinstance(backend, str) else None
+        )
+        self._backend_name: str | None = (
+            backend if isinstance(backend, str) else None
+        )
+        self.read = ReadMode(self)
+        self.write = WriteMode(self)
+
+    @property
+    def name(self) -> str:
+        """Return the lock identity."""
+        return self._name
+
+    @property
+    def backend(self) -> ReadWriteLockBackend:
+        """Bound read-write lock backend, resolved on each call.
+
+        When a backend instance was passed at construction it is always
+        returned. Otherwise the active `Grelmicro` app is consulted via
+        `Grelmicro.current()` on every access so that
+        `micro.override(Coordination(...))` blocks take effect.
+
+        Raises:
+            OutOfContextError: No backend resolved in this scope. Pass
+                `backend=` (a `MemoryReadWriteLockAdapter()` for a per-process
+                lock), register a `Coordination` Component, or run the call
+                inside `async with micro:` or after `micro.install(app)`.
+        """
+        if self._backend is not None:
+            return self._backend
+        from grelmicro._app import (  # noqa: PLC0415
+            ComponentNotRegisteredError,
+            NoActiveAppError,
+        )
+        from grelmicro.errors import OutOfContextError  # noqa: PLC0415
+
+        try:
+            coordination = Grelmicro.current().get(
+                "coordination", self._backend_name or "default"
+            )
+        except (NoActiveAppError, ComponentNotRegisteredError):
+            msg = (
+                f"ReadWriteLock({self._name!r}) resolved no backend. Pass "
+                f"backend= (MemoryReadWriteLockAdapter() for a per-process "
+                f"lock), register a Coordination component, or run the call "
+                f"inside `async with micro:` or after `micro.install(app)`."
+            )
+            raise OutOfContextError(msg) from None
+        return coordination.rwlock_backend
+
+    async def state(self) -> ReadWriteLockState:
+        """Return a point-in-time view of the lock.
+
+        Raises:
+            LockOwnedCheckError: The backend call failed.
+        """
+        backend = self.backend
+        try:
+            return await backend.state(name=self._lock_name)
+        except Exception as exc:
+            raise LockOwnedCheckError(name=self._name) from exc
+
+    async def _apply_reconfigure(self, new_config: ReadWriteLockConfig) -> None:
+        """Validate the immutable `worker` field before publishing."""
+        assert_worker_unchanged(self._config, new_config)
+
+
+class _Mode:
+    """State and retry loop shared by the read and write views."""
+
+    __slots__ = ("_lock", "_thread_adapter")
+
+    def __init__(self, lock: ReadWriteLock) -> None:
+        """Initialize the mode."""
+        self._lock = lock
+
+    @property
+    def name(self) -> str:
+        """Return the lock identity."""
+        return self._lock.name
+
+    @property
+    def backend(self) -> ReadWriteLockBackend:
+        """Return the bound backend."""
+        return self._lock.backend
+
+    def _running_task(self) -> asyncio.Task[object]:
+        """Return the running task."""
+        task = asyncio.current_task()
+        if task is None:  # pragma: no cover
+            msg = (
+                "ReadWriteLock async APIs must be called from a running"
+                " asyncio task"
+            )
+            raise RuntimeError(msg)
+        return task
+
+    async def _retry_until[T](
+        self,
+        attempt: Callable[[], Awaitable[T | None]],
+        *,
+        timeout: float | None,  # noqa: ASYNC109
+    ) -> T:
+        """Call `attempt` until it grants, or until the deadline passes.
+
+        Raises:
+            TimeoutError: `timeout` elapsed before the lock was granted.
+        """
+        config = self._lock._config  # noqa: SLF001
+        deadline = (
+            asyncio.get_running_loop().time() + timeout
+            if timeout is not None
+            else None
+        )
+        granted = await attempt()
+        while granted is None:
+            if (
+                deadline is not None
+                and asyncio.get_running_loop().time() >= deadline
+            ):
+                msg = f"Lock not acquired within timeout: name={self.name}"
+                raise TimeoutError(msg)
+            await asyncio.sleep(
+                jittered_interval(config.retry_interval, config.retry_jitter)
+            )
+            granted = await attempt()
+        return granted
+
+
+class ReadMode(_Mode):
+    """The read view of a `ReadWriteLock`.
+
+    Many readers hold it at once. A reader waits while a writer holds the
+    lock or waits for it.
+    """
+
+    __slots__ = ("_task_guards", "_thread_guards")
+
+    def __init__(self, lock: ReadWriteLock) -> None:
+        """Initialize the read view."""
+        super().__init__(lock)
+        self._task_guards: WeakKeyDictionary[
+            asyncio.Task[object], ReadGuard
+        ] = WeakKeyDictionary()
+        self._thread_guards: dict[int, ReadGuard] = {}
+        self._thread_adapter: ThreadReadAdapter | None = None
+
+    async def __aenter__(self) -> ReadGuard:
+        """Acquire the read lock.
+
+        Raises:
+            LockReentrantError: This task already holds this lock.
+            LockAcquireError: The backend call failed.
+        """
+        return await self.acquire()
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Release the read lock.
+
+        Raises:
+            LockNotOwnedError: This task no longer holds the lock.
+            LockReleaseError: The backend call failed.
+        """
+        await self.release()
+
+    @property
+    def from_thread(self) -> ThreadReadAdapter:
+        """Return the read adapter for a worker thread."""
+        if self._thread_adapter is None:
+            self._thread_adapter = ThreadReadAdapter(mode=self)
+        return self._thread_adapter
+
+    async def acquire(
+        self,
+        *,
+        timeout: Annotated[  # noqa: ASYNC109
+            Seconds | None,
+            Doc(
+                """
+                Maximum number of seconds to wait for the lock.
+
+                When None (the default), waits indefinitely. When set,
+                retries until the deadline then raises TimeoutError.
+                """,
+            ),
+        ] = None,
+    ) -> ReadGuard:
+        """Acquire the read lock, waiting for any writer to finish.
+
+        Raises:
+            LockReentrantError: This task already holds this lock.
+            LockAcquireError: The backend call failed.
+            TimeoutError: `timeout` elapsed before the lock was granted.
+        """
+        task = self._running_task()
+        self._assert_free(task)
+        token = generate_task_token(self._lock._config.worker)  # noqa: SLF001
+        duration = self._lock._config.lease_duration  # noqa: SLF001
+        generation = await self._retry_until(
+            lambda: self.do_acquire(token, duration=duration),
+            timeout=timeout,
+        )
+        guard = self._new_guard(token, generation, duration)
+        self._task_guards[task] = guard
+        return guard
+
+    async def acquire_nowait(self) -> ReadGuard:
+        """Acquire the read lock, without waiting.
+
+        Raises:
+            LockReentrantError: This task already holds this lock.
+            WouldBlockError: A writer holds the lock or waits for it.
+            LockAcquireError: The backend call failed.
+        """
+        task = self._running_task()
+        self._assert_free(task)
+        token = generate_task_token(self._lock._config.worker)  # noqa: SLF001
+        duration = self._lock._config.lease_duration  # noqa: SLF001
+        generation = await self.do_acquire(token, duration=duration)
+        if generation is None:
+            msg = f"Read lock not acquired: name={self.name}, token={token}"
+            raise WouldBlockError(msg)
+        guard = self._new_guard(token, generation, duration)
+        self._task_guards[task] = guard
+        return guard
+
+    async def extend(self) -> None:
+        """Renew this task's read lease.
+
+        Raises:
+            LockNotOwnedError: This task holds no live read lease.
+            LockAcquireError: The backend call failed.
+        """
+        await self.do_extend(self._guard_or_raise(self._running_task()))
+
+    async def release(self) -> None:
+        """Release this task's read lease.
+
+        Raises:
+            LockNotOwnedError: This task holds no live read lease.
+            LockReleaseError: The backend call failed.
+        """
+        task = self._running_task()
+        guard = self._guard_or_raise(task)
+        released = await self._drop_lease(guard)
+        del self._task_guards[task]
+        if not released:
+            raise LockNotOwnedError(name=self.name)
+
+    async def owned(self) -> bool:
+        """Return whether this task holds a live read lease.
+
+        Raises:
+            LockOwnedCheckError: The backend call failed.
+        """
+        guard = self._task_guards.get(self._running_task())
+        if guard is None:
+            return False
+        return await self._owned_on_backend(guard.token)
+
+    def _assert_free(self, task: asyncio.Task[object]) -> None:
+        """Reject a nested acquire from a task that already holds the lock.
+
+        Raises:
+            LockReentrantError: The task holds the read or the write lock.
+        """
+        if task in self._task_guards or task in self._lock.write._task_guards:  # noqa: SLF001
+            raise LockReentrantError(name=self.name)
+
+    def _guard_or_raise(self, holder: asyncio.Task[object]) -> ReadGuard:
+        """Return the guard held by `holder`.
+
+        Raises:
+            LockNotOwnedError: The holder holds no read lease.
+        """
+        guard = self._task_guards.get(holder)
+        if guard is None:
+            raise LockNotOwnedError(name=self.name)
+        return guard
+
+    def _new_guard(
+        self, token: str, generation: int, duration: float
+    ) -> ReadGuard:
+        """Build a guard for a granted read lease."""
+        return ReadGuard(
+            owner=self,
+            name=self.name,
+            token=token,
+            generation=generation,
+            expires_at=monotonic() + duration,
+        )
+
+    async def _drop_lease(self, guard: ReadGuard) -> bool:
+        """Drop a read lease on the backend and spend its guard.
+
+        Returns whether the backend still held the lease.
+
+        Raises:
+            LockReleaseError: The backend call failed.
+        """
+        backend = self.backend
+        try:
+            released = await backend.release_read(
+                name=self._lock._lock_name,  # noqa: SLF001
+                token=guard.token,
+            )
+        except Exception as exc:
+            raise LockReleaseError(name=self.name) from exc
+        guard._invalidate()  # noqa: SLF001
+        return released
+
+    async def _owned_on_backend(self, token: str) -> bool:
+        """Ask the backend whether `token` holds a live read lease.
+
+        Raises:
+            LockOwnedCheckError: The backend call failed.
+        """
+        backend = self.backend
+        try:
+            return await backend.owned_read(
+                name=self._lock._lock_name,  # noqa: SLF001
+                token=token,
+            )
+        except Exception as exc:
+            raise LockOwnedCheckError(name=self.name) from exc
+
+    async def do_acquire(self, token: str, *, duration: float) -> int | None:
+        """Ask the backend for a read lease.
+
+        Raises:
+            LockAcquireError: The backend call failed.
+        """
+        backend = self.backend
+        try:
+            return await backend.acquire_read(
+                name=self._lock._lock_name,  # noqa: SLF001
+                token=token,
+                duration=duration,
+            )
+        except Exception as exc:
+            raise LockAcquireError(name=self.name) from exc
+
+    async def do_extend(self, guard: ReadGuard) -> None:
+        """Renew the lease behind `guard`.
+
+        Raises:
+            LockNotOwnedError: The lease was lost.
+            LockAcquireError: The backend call failed.
+        """
+        duration = self._lock._config.lease_duration  # noqa: SLF001
+        generation = await self.do_acquire(guard.token, duration=duration)
+        if generation is None:
+            guard._invalidate()  # noqa: SLF001
+            raise LockNotOwnedError(name=self.name)
+        guard._renewed(monotonic() + duration)  # noqa: SLF001
+
+    def _adopt(self, guard: ReadGuard, holder: asyncio.Task[object]) -> None:
+        """Register a guard produced by a downgrade."""
+        self._task_guards[holder] = guard
+
+    async def do_thread_acquire(
+        self,
+        thread_id: int,
+        *,
+        timeout: Seconds | None = None,  # noqa: ASYNC109
+    ) -> ReadGuard:
+        """Acquire the read lock for a worker thread.
+
+        Raises:
+            LockReentrantError: This thread already holds this lock.
+            LockAcquireError: The backend call failed.
+            TimeoutError: `timeout` elapsed before the lock was granted.
+        """
+        if (
+            thread_id in self._thread_guards
+            or thread_id in self._lock.write._thread_guards  # noqa: SLF001
+        ):
+            raise LockReentrantError(name=self.name)
+        config = self._lock._config  # noqa: SLF001
+        token = generate_thread_token(config.worker, thread_id=thread_id)
+        duration = config.lease_duration
+        generation = await self._retry_until(
+            lambda: self.do_acquire(token, duration=duration),
+            timeout=timeout,
+        )
+        guard = self._new_guard(token, generation, duration)
+        self._thread_guards[thread_id] = guard
+        return guard
+
+    async def do_thread_release(self, thread_id: int) -> None:
+        """Release the read lease held by a worker thread.
+
+        Raises:
+            LockNotOwnedError: This thread holds no live read lease.
+            LockReleaseError: The backend call failed.
+        """
+        guard = self._thread_guards.get(thread_id)
+        if guard is None:
+            raise LockNotOwnedError(name=self.name)
+        released = await self._drop_lease(guard)
+        del self._thread_guards[thread_id]
+        if not released:
+            raise LockNotOwnedError(name=self.name)
+
+    async def do_thread_extend(self, thread_id: int) -> None:
+        """Renew the read lease held by a worker thread.
+
+        Raises:
+            LockNotOwnedError: This thread holds no live read lease.
+            LockAcquireError: The backend call failed.
+        """
+        guard = self._thread_guards.get(thread_id)
+        if guard is None:
+            raise LockNotOwnedError(name=self.name)
+        await self.do_extend(guard)
+
+
+class WriteMode(_Mode):
+    """The write view of a `ReadWriteLock`.
+
+    One writer holds it alone. A writer that finds readers in the way records
+    an intent so readers arriving afterwards wait behind it.
+    """
+
+    __slots__ = ("_task_guards", "_thread_guards")
+
+    def __init__(self, lock: ReadWriteLock) -> None:
+        """Initialize the write view."""
+        super().__init__(lock)
+        self._task_guards: WeakKeyDictionary[
+            asyncio.Task[object], WriteGuard
+        ] = WeakKeyDictionary()
+        self._thread_guards: dict[int, WriteGuard] = {}
+        self._thread_adapter: ThreadWriteAdapter | None = None
+
+    async def __aenter__(self) -> WriteGuard:
+        """Acquire the write lock.
+
+        Raises:
+            LockReentrantError: This task already holds the write lock.
+            LockUpgradeError: This task holds the read lock.
+            LockAcquireError: The backend call failed.
+        """
+        return await self.acquire()
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Release whatever this task holds, write lease or downgraded read.
+
+        Raises:
+            LockNotOwnedError: This task holds neither lease.
+            LockReleaseError: The backend call failed.
+        """
+        task = self._running_task()
+        if task in self._task_guards:
+            await self.release()
+            return
+        await self._lock.read.release()
+
+    @property
+    def from_thread(self) -> ThreadWriteAdapter:
+        """Return the write adapter for a worker thread."""
+        if self._thread_adapter is None:
+            self._thread_adapter = ThreadWriteAdapter(mode=self)
+        return self._thread_adapter
+
+    async def acquire(
+        self,
+        *,
+        timeout: Annotated[  # noqa: ASYNC109
+            Seconds | None,
+            Doc(
+                """
+                Maximum number of seconds to wait for the lock.
+
+                When None (the default), waits indefinitely. When set,
+                retries until the deadline then raises TimeoutError and
+                withdraws the intent.
+                """,
+            ),
+        ] = None,
+    ) -> WriteGuard:
+        """Acquire the write lock, waiting for readers and writers to finish.
+
+        Raises:
+            LockReentrantError: This task already holds the write lock.
+            LockUpgradeError: This task holds the read lock.
+            LockAcquireError: The backend call failed.
+            TimeoutError: `timeout` elapsed before the lock was granted.
+        """
+        task = self._running_task()
+        self._assert_free(task)
+        token = generate_task_token(self._lock._config.worker)  # noqa: SLF001
+        duration = self._lock._config.lease_duration  # noqa: SLF001
+        grant = await self._acquire_with_intent(
+            token, duration=duration, timeout=timeout
+        )
+        guard = self._new_guard(token, grant, duration)
+        self._task_guards[task] = guard
+        return guard
+
+    async def acquire_nowait(self) -> WriteGuard:
+        """Acquire the write lock, without waiting and without an intent.
+
+        A try that does not wait records no intent, so it never holds
+        readers out.
+
+        Raises:
+            LockReentrantError: This task already holds the write lock.
+            LockUpgradeError: This task holds the read lock.
+            WouldBlockError: Readers or another writer hold the lock.
+            LockAcquireError: The backend call failed.
+        """
+        task = self._running_task()
+        self._assert_free(task)
+        token = generate_task_token(self._lock._config.worker)  # noqa: SLF001
+        duration = self._lock._config.lease_duration  # noqa: SLF001
+        grant = await self.do_acquire(token, duration=duration, intent=False)
+        if grant is None:
+            msg = f"Write lock not acquired: name={self.name}, token={token}"
+            raise WouldBlockError(msg)
+        guard = self._new_guard(token, grant, duration)
+        self._task_guards[task] = guard
+        return guard
+
+    async def extend(self) -> None:
+        """Renew this task's write lease.
+
+        Raises:
+            LockNotOwnedError: This task no longer holds the write lock.
+            LockAcquireError: The backend call failed.
+        """
+        await self.do_extend(self._guard_or_raise(self._running_task()))
+
+    async def release(self) -> None:
+        """Release this task's write lease.
+
+        Raises:
+            LockNotOwnedError: This task no longer holds the write lock.
+            LockReleaseError: The backend call failed.
+        """
+        task = self._running_task()
+        guard = self._guard_or_raise(task)
+        released = await self._drop_lease(guard)
+        del self._task_guards[task]
+        if not released:
+            raise LockNotOwnedError(name=self.name)
+
+    async def owned(self) -> bool:
+        """Return whether this task holds the live write lease.
+
+        Raises:
+            LockOwnedCheckError: The backend call failed.
+        """
+        guard = self._task_guards.get(self._running_task())
+        if guard is None:
+            return False
+        backend = self.backend
+        try:
+            return await backend.owned_write(
+                name=self._lock._lock_name,  # noqa: SLF001
+                token=guard.token,
+            )
+        except Exception as exc:
+            raise LockOwnedCheckError(name=self.name) from exc
+
+    def _assert_free(self, task: asyncio.Task[object]) -> None:
+        """Reject a nested acquire, and reject an upgrade from read to write.
+
+        Raises:
+            LockUpgradeError: The task holds the read lock.
+            LockReentrantError: The task already holds the write lock.
+        """
+        if task in self._lock.read._task_guards:  # noqa: SLF001
+            raise LockUpgradeError(name=self.name)
+        if task in self._task_guards:
+            raise LockReentrantError(name=self.name)
+
+    def _guard_or_raise(self, holder: asyncio.Task[object]) -> WriteGuard:
+        """Return the guard held by `holder`.
+
+        Raises:
+            LockNotOwnedError: The holder holds no write lease.
+        """
+        guard = self._task_guards.get(holder)
+        if guard is None:
+            raise LockNotOwnedError(name=self.name)
+        return guard
+
+    def _new_guard(
+        self, token: str, grant: WriteGrant, duration: float
+    ) -> WriteGuard:
+        """Build a guard for a granted write lease."""
+        return WriteGuard(
+            owner=self,
+            name=self.name,
+            token=token,
+            fencing_token=grant.fencing_token,
+            poisoned=grant.poisoned,
+            expires_at=monotonic() + duration,
+        )
+
+    async def _acquire_with_intent(
+        self,
+        token: str,
+        *,
+        duration: float,
+        timeout: float | None,  # noqa: ASYNC109
+    ) -> WriteGrant:
+        """Retry until granted, withdrawing the intent if the wait ends badly.
+
+        Raises:
+            LockAcquireError: The backend call failed.
+            TimeoutError: `timeout` elapsed before the lock was granted.
+        """
+        try:
+            grant = await self._retry_until(
+                lambda: self.do_acquire(token, duration=duration, intent=True),
+                timeout=timeout,
+            )
+        except BaseException:
+            with suppress(Exception):
+                await self.backend.cancel_intent(
+                    name=self._lock._lock_name,  # noqa: SLF001
+                    token=token,
+                )
+            raise
+        return grant
+
+    async def _drop_lease(self, guard: WriteGuard) -> bool:
+        """Drop a write lease on the backend and spend its guard.
+
+        Returns whether the backend still held the lease.
+
+        Raises:
+            LockReleaseError: The backend call failed.
+        """
+        backend = self.backend
+        try:
+            released = await backend.release_write(
+                name=self._lock._lock_name,  # noqa: SLF001
+                token=guard.token,
+            )
+        except Exception as exc:
+            raise LockReleaseError(name=self.name) from exc
+        guard._invalidate()  # noqa: SLF001
+        return released
+
+    async def do_acquire(
+        self, token: str, *, duration: float, intent: bool
+    ) -> WriteGrant | None:
+        """Ask the backend for a write lease.
+
+        Raises:
+            LockAcquireError: The backend call failed.
+        """
+        backend = self.backend
+        try:
+            return await backend.acquire_write(
+                name=self._lock._lock_name,  # noqa: SLF001
+                token=token,
+                duration=duration,
+                intent=intent,
+            )
+        except Exception as exc:
+            raise LockAcquireError(name=self.name) from exc
+
+    async def do_extend(self, guard: WriteGuard) -> None:
+        """Renew the lease behind `guard`.
+
+        A lease that was lost and retaken in the same call keeps the guard
+        usable, with the new fencing token and `poisoned` set, because the
+        writes made under the old token are now fenced out.
+
+        Raises:
+            LockNotOwnedError: The lease was lost to another holder.
+            LockAcquireError: The backend call failed.
+        """
+        duration = self._lock._config.lease_duration  # noqa: SLF001
+        grant = await self.do_acquire(
+            guard.token, duration=duration, intent=False
+        )
+        if grant is None:
+            guard._invalidate()  # noqa: SLF001
+            raise LockNotOwnedError(name=self.name)
+        guard._renewed(monotonic() + duration)  # noqa: SLF001
+        if grant.fencing_token != guard._fencing_token:  # noqa: SLF001
+            guard._fencing_token = grant.fencing_token  # noqa: SLF001
+            guard._poisoned = True  # noqa: SLF001
+
+    async def do_downgrade(self, guard: WriteGuard) -> ReadGuard:
+        """Turn the write lease behind `guard` into a read lease.
+
+        Raises:
+            LockNotOwnedError: This holder no longer holds the write lock.
+            LockAcquireError: The backend call failed.
+        """
+        task = self._running_task()
+        duration = self._lock._config.lease_duration  # noqa: SLF001
+        backend = self.backend
+        try:
+            generation = await backend.downgrade(
+                name=self._lock._lock_name,  # noqa: SLF001
+                token=guard.token,
+                duration=duration,
+            )
+        except Exception as exc:
+            raise LockAcquireError(name=self.name) from exc
+        if generation is None:
+            guard._invalidate()  # noqa: SLF001
+            self._task_guards.pop(task, None)
+            raise LockNotOwnedError(name=self.name)
+        guard._invalidate()  # noqa: SLF001
+        self._task_guards.pop(task, None)
+        read_guard = self._lock.read._new_guard(  # noqa: SLF001
+            guard.token, generation, duration
+        )
+        self._lock.read._adopt(read_guard, task)  # noqa: SLF001
+        return read_guard
+
+    async def do_thread_acquire(
+        self,
+        thread_id: int,
+        *,
+        timeout: Seconds | None = None,  # noqa: ASYNC109
+    ) -> WriteGuard:
+        """Acquire the write lock for a worker thread.
+
+        Raises:
+            LockReentrantError: This thread already holds the write lock.
+            LockUpgradeError: This thread holds the read lock.
+            LockAcquireError: The backend call failed.
+            TimeoutError: `timeout` elapsed before the lock was granted.
+        """
+        if thread_id in self._lock.read._thread_guards:  # noqa: SLF001
+            raise LockUpgradeError(name=self.name)
+        if thread_id in self._thread_guards:
+            raise LockReentrantError(name=self.name)
+        config = self._lock._config  # noqa: SLF001
+        token = generate_thread_token(config.worker, thread_id=thread_id)
+        duration = config.lease_duration
+        grant = await self._acquire_with_intent(
+            token, duration=duration, timeout=timeout
+        )
+        guard = self._new_guard(token, grant, duration)
+        self._thread_guards[thread_id] = guard
+        return guard
+
+    async def do_thread_release(self, thread_id: int) -> None:
+        """Release the write lease held by a worker thread.
+
+        Raises:
+            LockNotOwnedError: This thread holds no live write lease.
+            LockReleaseError: The backend call failed.
+        """
+        guard = self._thread_guards.get(thread_id)
+        if guard is None:
+            raise LockNotOwnedError(name=self.name)
+        released = await self._drop_lease(guard)
+        del self._thread_guards[thread_id]
+        if not released:
+            raise LockNotOwnedError(name=self.name)
+
+    async def do_thread_extend(self, thread_id: int) -> None:
+        """Renew the write lease held by a worker thread.
+
+        Raises:
+            LockNotOwnedError: This thread holds no live write lease.
+            LockAcquireError: The backend call failed.
+        """
+        guard = self._thread_guards.get(thread_id)
+        if guard is None:
+            raise LockNotOwnedError(name=self.name)
+        await self.do_extend(guard)
+
+
+class _ThreadAdapter[ModeT: _Mode]:
+    """Dispatch a mode's coroutines onto the backend's event loop."""
+
+    __slots__ = ("_mode",)
+
+    def __init__(self, mode: ModeT) -> None:
+        """Initialize the adapter."""
+        self._mode = mode
+
+    @property
+    def _backend_loop(self) -> asyncio.AbstractEventLoop:
+        """Return the event loop the backend captured on `__aenter__`."""
+        loop = self._mode.backend._loop  # noqa: SLF001
+        if loop is None:
+            raise_backend_not_open(f"ReadWriteLock {self._mode.name!r}")
+        return loop
+
+
+class ThreadReadAdapter(_ThreadAdapter[ReadMode]):
+    """Read adapter for a worker thread spawned from an event loop."""
+
+    __slots__ = ()
+
+    def __enter__(self) -> ReadGuard:
+        """Acquire the read lock."""
+        return self.acquire()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Release the read lock."""
+        self.release()
+
+    def acquire(self, *, timeout: Seconds | None = None) -> ReadGuard:
+        """Acquire the read lock, blocking this thread."""
+        return asyncio.run_coroutine_threadsafe(
+            self._mode.do_thread_acquire(get_ident(), timeout=timeout),
+            self._backend_loop,
+        ).result()
+
+    def extend(self) -> None:
+        """Renew this thread's read lease."""
+        asyncio.run_coroutine_threadsafe(
+            self._mode.do_thread_extend(get_ident()),
+            self._backend_loop,
+        ).result()
+
+    def release(self) -> None:
+        """Release this thread's read lease."""
+        asyncio.run_coroutine_threadsafe(
+            self._mode.do_thread_release(get_ident()),
+            self._backend_loop,
+        ).result()
+
+
+class ThreadWriteAdapter(_ThreadAdapter[WriteMode]):
+    """Write adapter for a worker thread spawned from an event loop."""
+
+    __slots__ = ()
+
+    def __enter__(self) -> WriteGuard:
+        """Acquire the write lock."""
+        return self.acquire()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Release the write lock."""
+        self.release()
+
+    def acquire(self, *, timeout: Seconds | None = None) -> WriteGuard:
+        """Acquire the write lock, blocking this thread."""
+        return asyncio.run_coroutine_threadsafe(
+            self._mode.do_thread_acquire(get_ident(), timeout=timeout),
+            self._backend_loop,
+        ).result()
+
+    def extend(self) -> None:
+        """Renew this thread's write lease."""
+        asyncio.run_coroutine_threadsafe(
+            self._mode.do_thread_extend(get_ident()),
+            self._backend_loop,
+        ).result()
+
+    def release(self) -> None:
+        """Release this thread's write lease."""
+        asyncio.run_coroutine_threadsafe(
+            self._mode.do_thread_release(get_ident()),
+            self._backend_loop,
+        ).result()

--- a/grelmicro/coordination/redis.py
+++ b/grelmicro/coordination/redis.py
@@ -12,7 +12,10 @@ from typing_extensions import Doc
 from grelmicro.coordination._protocol import (
     LeaderRecord,
     LockBackend,
+    ReadWriteLockBackend,
+    ReadWriteLockState,
     ScheduleBackend,
+    WriteGrant,
 )
 from grelmicro.providers.redis import RedisProvider, require_cluster_hash_tag
 
@@ -191,6 +194,374 @@ class RedisLockAdapter(LockBackend):
         value = stored.decode() if isinstance(stored, bytes) else stored
         _fence, sep, holder = value.partition(":")
         return sep == ":" and holder == token
+
+
+class RedisReadWriteLockAdapter(ReadWriteLockBackend):
+    """Redis Read-Write Lock Adapter.
+
+    Wraps a `RedisProvider` and implements the `ReadWriteLockBackend`
+    protocol. Every operation is one Lua script, so the reap, the decision,
+    and the write apply atomically across processes and machines.
+
+    Each lock name uses three keys: a hash holding the writer token, the
+    writer's expiry, and the generation counter, a sorted set of reader
+    tokens scored by their lease expiry, and a sorted set of writer intents
+    scored the same way. Expiry is computed inside Lua against the Redis
+    server clock rather than a key TTL, so an expired writer stays readable
+    and the next writer learns that its predecessor died mid-write.
+
+    Individual reader leases are what let a writer in promptly: the writer's
+    own acquire drops the readers that expired instead of waiting for a
+    whole-key TTL.
+    """
+
+    _LUA_NOW = """
+        local t = redis.call('TIME')
+        local now = t[1] * 1000 + math.floor(t[2] / 1000)
+    """
+    _LUA_REAP = """
+        redis.call('ZREMRANGEBYSCORE', KEYS[2], '-inf', now)
+        redis.call('ZREMRANGEBYSCORE', KEYS[3], '-inf', now)
+    """
+
+    _LUA_ACQUIRE_READ = (
+        _LUA_NOW
+        + _LUA_REAP
+        + """
+        local gen = tonumber(redis.call('HGET', KEYS[1], 'g')) or 0
+        local exp = now + tonumber(ARGV[2])
+        if redis.call('ZSCORE', KEYS[2], ARGV[1]) then
+            redis.call('ZADD', KEYS[2], exp, ARGV[1])
+            return gen
+        end
+        local we = tonumber(redis.call('HGET', KEYS[1], 'we'))
+        if we and we > now then
+            return nil
+        end
+        if redis.call('ZCARD', KEYS[3]) > 0 then
+            return nil
+        end
+        redis.call('ZADD', KEYS[2], exp, ARGV[1])
+        return gen
+    """
+    )
+
+    _LUA_ACQUIRE_WRITE = (
+        _LUA_NOW
+        + _LUA_REAP
+        + """
+        local w = redis.call('HGET', KEYS[1], 'w')
+        local we = tonumber(redis.call('HGET', KEYS[1], 'we'))
+        local gen = tonumber(redis.call('HGET', KEYS[1], 'g')) or 0
+        local exp = now + tonumber(ARGV[2])
+        if w and we and we > now then
+            if w == ARGV[1] then
+                redis.call('HSET', KEYS[1], 'we', exp)
+                return {gen, 0}
+            end
+            if ARGV[3] == '1' then
+                redis.call('ZADD', KEYS[3], exp, ARGV[1])
+            end
+            return nil
+        end
+        if redis.call('ZCARD', KEYS[2]) > 0 then
+            if ARGV[3] == '1' then
+                redis.call('ZADD', KEYS[3], exp, ARGV[1])
+            end
+            return nil
+        end
+        local poisoned = 0
+        if w then
+            poisoned = 1
+        end
+        redis.call('ZREM', KEYS[3], ARGV[1])
+        gen = gen + 1
+        redis.call('HSET', KEYS[1], 'g', gen, 'w', ARGV[1], 'we', exp)
+        return {gen, poisoned}
+    """
+    )
+
+    _LUA_RELEASE_READ = (
+        _LUA_NOW
+        + _LUA_REAP
+        + """
+        return redis.call('ZREM', KEYS[2], ARGV[1])
+    """
+    )
+
+    _LUA_RELEASE_WRITE = (
+        _LUA_NOW
+        + _LUA_REAP
+        + """
+        local w = redis.call('HGET', KEYS[1], 'w')
+        local we = tonumber(redis.call('HGET', KEYS[1], 'we'))
+        if w == ARGV[1] and we and we > now then
+            redis.call('HDEL', KEYS[1], 'w', 'we')
+            return 1
+        end
+        return 0
+    """
+    )
+
+    _LUA_CANCEL_INTENT = (
+        _LUA_NOW
+        + _LUA_REAP
+        + """
+        return redis.call('ZREM', KEYS[3], ARGV[1])
+    """
+    )
+
+    _LUA_DOWNGRADE = (
+        _LUA_NOW
+        + _LUA_REAP
+        + """
+        local w = redis.call('HGET', KEYS[1], 'w')
+        local we = tonumber(redis.call('HGET', KEYS[1], 'we'))
+        if w ~= ARGV[1] or not we or we <= now then
+            return nil
+        end
+        local gen = tonumber(redis.call('HGET', KEYS[1], 'g')) or 0
+        redis.call('HDEL', KEYS[1], 'w', 'we')
+        redis.call('ZADD', KEYS[2], now + tonumber(ARGV[2]), ARGV[1])
+        return gen
+    """
+    )
+
+    _LUA_STATE = (
+        _LUA_NOW
+        + _LUA_REAP
+        + """
+        local gen = tonumber(redis.call('HGET', KEYS[1], 'g')) or 0
+        local we = tonumber(redis.call('HGET', KEYS[1], 'we'))
+        local writing = 0
+        if we and we > now then
+            writing = 1
+        end
+        return {
+            gen, writing,
+            redis.call('ZCARD', KEYS[2]),
+            redis.call('ZCARD', KEYS[3])
+        }
+    """
+    )
+
+    _LUA_OWNED_READ = (
+        _LUA_NOW
+        + _LUA_REAP
+        + """
+        if redis.call('ZSCORE', KEYS[2], ARGV[1]) then
+            return 1
+        end
+        return 0
+    """
+    )
+
+    _LUA_OWNED_WRITE = (
+        _LUA_NOW
+        + """
+        local w = redis.call('HGET', KEYS[1], 'w')
+        local we = tonumber(redis.call('HGET', KEYS[1], 'we'))
+        if w == ARGV[1] and we and we > now then
+            return 1
+        end
+        return 0
+    """
+    )
+
+    def __init__(
+        self,
+        *,
+        provider: Annotated[
+            RedisProvider | None,
+            Doc(
+                """
+                A pre-built `RedisProvider`. When set, the adapter borrows
+                the provider's client and does not manage its lifecycle.
+                """,
+            ),
+        ] = None,
+        env_prefix: Annotated[
+            str,
+            Doc(
+                """
+                Environment variable prefix used by the implicit
+                `RedisProvider` when `provider` is not set. Defaults to
+                `REDIS_`. Use a custom prefix to split pools.
+                """,
+            ),
+        ] = "REDIS_",
+        prefix: Annotated[
+            str,
+            Doc("Prefix prepended to every Redis key (lock isolation)."),
+        ] = "",
+    ) -> None:
+        """Initialize the adapter."""
+        if provider is None:
+            self._provider = RedisProvider(env_prefix=env_prefix)
+            self._owns_provider = True
+        else:
+            self._provider = provider
+            self._owns_provider = False
+        self._env_prefix = env_prefix
+        self._key_prefix = prefix
+        self._bind_scripts()
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def provider(self) -> RedisProvider:
+        """The bound `RedisProvider`."""
+        return self._provider
+
+    def _bind_scripts(self) -> None:
+        """(Re)register the Lua scripts against the current client."""
+        require_cluster_hash_tag(
+            self._provider,
+            self._key_prefix,
+            adapter="RedisReadWriteLockAdapter",
+        )
+        client = self._provider.client
+        self._lua_acquire_read = client.register_script(self._LUA_ACQUIRE_READ)
+        self._lua_acquire_write = client.register_script(
+            self._LUA_ACQUIRE_WRITE
+        )
+        self._lua_release_read = client.register_script(self._LUA_RELEASE_READ)
+        self._lua_release_write = client.register_script(
+            self._LUA_RELEASE_WRITE
+        )
+        self._lua_cancel_intent = client.register_script(
+            self._LUA_CANCEL_INTENT
+        )
+        self._lua_downgrade = client.register_script(self._LUA_DOWNGRADE)
+        self._lua_state = client.register_script(self._LUA_STATE)
+        self._lua_owned_read = client.register_script(self._LUA_OWNED_READ)
+        self._lua_owned_write = client.register_script(self._LUA_OWNED_WRITE)
+
+    def _rebind_provider(self, provider: RedisProvider) -> None:
+        """Swap the underlying provider (used by `Grelmicro` for sharing)."""
+        self._provider = provider
+        self._owns_provider = False
+        self._bind_scripts()
+
+    async def __aenter__(self) -> Self:
+        """Open the adapter and its provider when owned."""
+        self._loop = asyncio.get_running_loop()
+        if self._owns_provider:
+            await self._provider.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the provider when owned. External providers are left alone."""
+        if self._owns_provider:
+            await self._provider.__aexit__(exc_type, exc_value, traceback)
+
+    def _keys(self, name: str) -> list[str]:
+        """Return the hash, reader, and intent keys for a lock name."""
+        base = f"{self._key_prefix}{name}"
+        return [base, f"{base}:r", f"{base}:i"]
+
+    async def acquire_read(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Acquire a read lease, returning the generation or `None`."""
+        generation = await self._lua_acquire_read(
+            keys=self._keys(name),
+            args=[token, int(duration * 1000)],
+            client=self._provider.client,
+        )
+        return int(generation) if generation is not None else None
+
+    async def acquire_write(
+        self, *, name: str, token: str, duration: float, intent: bool = True
+    ) -> WriteGrant | None:
+        """Acquire the write lease, returning the grant or `None`."""
+        result = await self._lua_acquire_write(
+            keys=self._keys(name),
+            args=[token, int(duration * 1000), "1" if intent else "0"],
+            client=self._provider.client,
+        )
+        if result is None:
+            return None
+        fence, poisoned = result
+        return WriteGrant(fencing_token=int(fence), poisoned=bool(poisoned))
+
+    async def release_read(self, *, name: str, token: str) -> bool:
+        """Drop a read lease."""
+        return bool(
+            await self._lua_release_read(
+                keys=self._keys(name),
+                args=[token],
+                client=self._provider.client,
+            )
+        )
+
+    async def release_write(self, *, name: str, token: str) -> bool:
+        """Drop the write lease, leaving the lock clean."""
+        return bool(
+            await self._lua_release_write(
+                keys=self._keys(name),
+                args=[token],
+                client=self._provider.client,
+            )
+        )
+
+    async def cancel_intent(self, *, name: str, token: str) -> bool:
+        """Withdraw a writer intent."""
+        return bool(
+            await self._lua_cancel_intent(
+                keys=self._keys(name),
+                args=[token],
+                client=self._provider.client,
+            )
+        )
+
+    async def downgrade(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Turn a held write lease into a read lease."""
+        generation = await self._lua_downgrade(
+            keys=self._keys(name),
+            args=[token, int(duration * 1000)],
+            client=self._provider.client,
+        )
+        return int(generation) if generation is not None else None
+
+    async def state(self, *, name: str) -> ReadWriteLockState:
+        """Return a point-in-time view of the lock."""
+        generation, writing, readers, intents = await self._lua_state(
+            keys=self._keys(name),
+            client=self._provider.client,
+        )
+        return ReadWriteLockState(
+            generation=int(generation),
+            writing=bool(writing),
+            readers=int(readers),
+            waiting_writers=int(intents),
+        )
+
+    async def owned_read(self, *, name: str, token: str) -> bool:
+        """Check whether `token` holds a live read lease."""
+        return bool(
+            await self._lua_owned_read(
+                keys=self._keys(name),
+                args=[token],
+                client=self._provider.client,
+            )
+        )
+
+    async def owned_write(self, *, name: str, token: str) -> bool:
+        """Check whether `token` holds the live write lease."""
+        return bool(
+            await self._lua_owned_write(
+                keys=self._keys(name),
+                args=[token],
+                client=self._provider.client,
+            )
+        )
 
 
 class RedisScheduleAdapter(ScheduleBackend):

--- a/grelmicro/coordination/redis.py
+++ b/grelmicro/coordination/redis.py
@@ -470,7 +470,7 @@ class RedisReadWriteLockAdapter(ReadWriteLockBackend):
         """Acquire a read lease, returning the generation or `None`."""
         generation = await self._lua_acquire_read(
             keys=self._keys(name),
-            args=[token, int(duration * 1000)],
+            args=[token, _duration_ms(duration)],
             client=self._provider.client,
         )
         return int(generation) if generation is not None else None
@@ -481,7 +481,7 @@ class RedisReadWriteLockAdapter(ReadWriteLockBackend):
         """Acquire the write lease, returning the grant or `None`."""
         result = await self._lua_acquire_write(
             keys=self._keys(name),
-            args=[token, int(duration * 1000), "1" if intent else "0"],
+            args=[token, _duration_ms(duration), "1" if intent else "0"],
             client=self._provider.client,
         )
         if result is None:
@@ -525,7 +525,7 @@ class RedisReadWriteLockAdapter(ReadWriteLockBackend):
         """Turn a held write lease into a read lease."""
         generation = await self._lua_downgrade(
             keys=self._keys(name),
-            args=[token, int(duration * 1000)],
+            args=[token, _duration_ms(duration)],
             client=self._provider.client,
         )
         return int(generation) if generation is not None else None
@@ -960,6 +960,16 @@ class RedisLeaderElectionAdapter:
         if raw is None:
             return None
         return self._to_record(raw)
+
+
+def _duration_ms(duration: float) -> int:
+    """Return the lease duration in whole milliseconds, never zero.
+
+    A duration under a millisecond would floor to zero, and a lease that
+    expires the moment it is granted is never what a positive duration
+    asked for.
+    """
+    return max(1, int(duration * 1000))
 
 
 def _as_str(value: bytes | str | None) -> str:

--- a/grelmicro/coordination/sqlite.py
+++ b/grelmicro/coordination/sqlite.py
@@ -4,16 +4,26 @@ from __future__ import annotations
 
 import asyncio
 import re
+from contextlib import asynccontextmanager
 from math import ceil
-from typing import TYPE_CHECKING, Annotated, Self
+from typing import TYPE_CHECKING, Annotated, Any, Self
 
 from typing_extensions import Doc
 
-from grelmicro.coordination._protocol import LockBackend, ScheduleBackend
+from grelmicro.coordination._protocol import (
+    LockBackend,
+    ReadWriteLockBackend,
+    ReadWriteLockState,
+    ScheduleBackend,
+    WriteGrant,
+)
 from grelmicro.providers.sqlite import SQLiteProvider
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from types import TracebackType
+
+    from aiosqlite import Connection
 
 
 class SQLiteLockAdapter(LockBackend):
@@ -238,6 +248,352 @@ class SQLiteLockAdapter(LockBackend):
         ):
             result = await cursor.fetchone()
         return result is not None
+
+
+class SQLiteReadWriteLockAdapter(ReadWriteLockBackend):
+    """SQLite Read-Write Lock Adapter.
+
+    Borrows the connection and a shared lock from a `SQLiteProvider` and
+    implements the `ReadWriteLockBackend` protocol on a single host. One row
+    per lock holds the writer token, the writer's expiry, and the generation
+    counter. A side table holds one row per reader lease and one per writer
+    intent.
+
+    Every operation runs inside a `BEGIN IMMEDIATE` transaction, so the reap,
+    the decision, and the write apply as one step. The provider's lock
+    serializes the single connection within the process, and the
+    transaction's write lock serializes across processes sharing the file.
+
+    Lease durations are rounded up to whole seconds, the resolution SQLite
+    date functions work at.
+    """
+
+    _SQL_CREATE_TABLES = (
+        """
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            name TEXT PRIMARY KEY,
+            writer TEXT,
+            writer_expire_at TEXT,
+            generation INTEGER NOT NULL DEFAULT 0
+        );
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS {table_name}_holders (
+            name TEXT NOT NULL,
+            token TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            expire_at TEXT NOT NULL,
+            PRIMARY KEY (name, token, kind)
+        );
+        """,
+    )
+
+    _SQL_REAP = """
+        DELETE FROM {table_name}_holders
+        WHERE name = ? AND expire_at < datetime('now');
+    """
+
+    _SQL_ENSURE_ROW = """
+        INSERT INTO {table_name} (name) VALUES (?)
+        ON CONFLICT (name) DO NOTHING;
+    """
+
+    _SQL_SELECT_LOCK = """
+        SELECT writer, writer_expire_at, generation,
+               (writer IS NOT NULL AND writer_expire_at >= datetime('now'))
+        FROM {table_name} WHERE name = ?;
+    """
+
+    _SQL_COUNT_HOLDERS = """
+        SELECT count(*) FROM {table_name}_holders
+        WHERE name = ? AND kind = ? AND expire_at >= datetime('now');
+    """
+
+    _SQL_HOLDER_EXISTS = """
+        SELECT 1 FROM {table_name}_holders
+        WHERE name = ? AND token = ? AND kind = ?
+          AND expire_at >= datetime('now');
+    """
+
+    _SQL_UPSERT_HOLDER = """
+        INSERT INTO {table_name}_holders (name, token, kind, expire_at)
+        VALUES (?, ?, ?, datetime('now', '+' || ? || ' seconds'))
+        ON CONFLICT (name, token, kind)
+        DO UPDATE SET expire_at = excluded.expire_at;
+    """
+
+    _SQL_DELETE_HOLDER = """
+        DELETE FROM {table_name}_holders
+        WHERE name = ? AND token = ? AND kind = ?
+          AND expire_at >= datetime('now')
+        RETURNING 1;
+    """
+
+    _SQL_SET_WRITER = """
+        UPDATE {table_name}
+        SET writer = ?,
+            writer_expire_at = datetime('now', '+' || ? || ' seconds'),
+            generation = generation + 1
+        WHERE name = ?
+        RETURNING generation;
+    """
+
+    _SQL_RENEW_WRITER = """
+        UPDATE {table_name}
+        SET writer_expire_at = datetime('now', '+' || ? || ' seconds')
+        WHERE name = ?;
+    """
+
+    _SQL_CLEAR_WRITER = """
+        UPDATE {table_name}
+        SET writer = NULL, writer_expire_at = NULL
+        WHERE name = ? AND writer = ? AND writer_expire_at >= datetime('now')
+        RETURNING generation;
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: Annotated[
+            SQLiteProvider | None,
+            Doc(
+                """
+                A pre-built `SQLiteProvider`. When set, the adapter borrows
+                the provider's connection and does not manage its lifecycle.
+                """,
+            ),
+        ] = None,
+        env_prefix: Annotated[
+            str,
+            Doc(
+                """
+                Environment variable prefix used by the implicit
+                `SQLiteProvider` when `provider` is not set. Resolves the
+                path from `SQLITE_PATH` by default.
+                """,
+            ),
+        ] = "SQLITE_",
+        table_name: Annotated[
+            str, Doc("The table name to store the read-write locks.")
+        ] = "rwlocks",
+    ) -> None:
+        """Initialize the read-write lock backend."""
+        if not re.fullmatch(r"[a-zA-Z_][a-zA-Z0-9_]*", table_name):
+            msg = f"Table name '{table_name}' is not a valid SQL identifier"
+            raise ValueError(msg)
+
+        if provider is None:
+            self._provider = SQLiteProvider(env_prefix=env_prefix)
+            self._owns_provider = True
+        else:
+            self._provider = provider
+            self._owns_provider = False
+        self._env_prefix = env_prefix
+        self._table_name = table_name
+        self._sql = {
+            key: template.format(table_name=table_name)
+            for key, template in {
+                "reap": self._SQL_REAP,
+                "ensure_row": self._SQL_ENSURE_ROW,
+                "select_lock": self._SQL_SELECT_LOCK,
+                "count_holders": self._SQL_COUNT_HOLDERS,
+                "holder_exists": self._SQL_HOLDER_EXISTS,
+                "upsert_holder": self._SQL_UPSERT_HOLDER,
+                "delete_holder": self._SQL_DELETE_HOLDER,
+                "set_writer": self._SQL_SET_WRITER,
+                "renew_writer": self._SQL_RENEW_WRITER,
+                "clear_writer": self._SQL_CLEAR_WRITER,
+            }.items()
+        }
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def provider(self) -> SQLiteProvider:
+        """The bound `SQLiteProvider`."""
+        return self._provider
+
+    def _rebind_provider(self, provider: SQLiteProvider) -> None:
+        """Swap the underlying provider (used by `Grelmicro` for sharing)."""
+        self._provider = provider
+        self._owns_provider = False
+
+    async def __aenter__(self) -> Self:
+        """Open the adapter and its provider when owned."""
+        if self._owns_provider:
+            await self._provider.__aenter__()
+        self._loop = asyncio.get_running_loop()
+        async with self._provider.connection_lock:
+            for sql in self._SQL_CREATE_TABLES:
+                await self._provider.client.execute(
+                    sql.format(table_name=self._table_name)
+                )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the provider when owned. External providers are left alone."""
+        if self._owns_provider:
+            await self._provider.__aexit__(exc_type, exc_value, traceback)
+
+    @asynccontextmanager
+    async def _transaction(self) -> AsyncIterator[Connection]:
+        """Run a body inside `BEGIN IMMEDIATE` on the shared connection."""
+        conn = self._provider.client
+        async with self._provider.connection_lock:
+            await conn.execute("BEGIN IMMEDIATE;")
+            try:
+                yield conn
+            except BaseException:
+                await conn.execute("ROLLBACK;")
+                raise
+            await conn.execute("COMMIT;")
+
+    async def _fetch(
+        self, conn: Connection, key: str, params: tuple[object, ...]
+    ) -> Any:  # noqa: ANN401
+        """Run a statement and return its first row."""
+        async with conn.execute(self._sql[key], params) as cursor:
+            return await cursor.fetchone()
+
+    async def acquire_read(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Acquire a read lease, returning the generation or `None`."""
+        seconds = ceil(duration)
+        async with self._transaction() as conn:
+            await conn.execute(self._sql["reap"], (name,))
+            await conn.execute(self._sql["ensure_row"], (name,))
+            row = await self._fetch(conn, "select_lock", (name,))
+            assert row is not None  # noqa: S101
+            generation, writing = int(row[2]), bool(row[3])
+            held = await self._fetch(conn, "holder_exists", (name, token, "r"))
+            if held is None:
+                if writing:
+                    return None
+                intents = await self._fetch(conn, "count_holders", (name, "i"))
+                assert intents is not None  # noqa: S101
+                if int(intents[0]) > 0:
+                    return None
+            await conn.execute(
+                self._sql["upsert_holder"], (name, token, "r", seconds)
+            )
+            return generation
+
+    async def acquire_write(
+        self, *, name: str, token: str, duration: float, intent: bool = True
+    ) -> WriteGrant | None:
+        """Acquire the write lease, returning the grant or `None`."""
+        seconds = ceil(duration)
+        async with self._transaction() as conn:
+            await conn.execute(self._sql["reap"], (name,))
+            await conn.execute(self._sql["ensure_row"], (name,))
+            row = await self._fetch(conn, "select_lock", (name,))
+            assert row is not None  # noqa: S101
+            writer, generation, writing = row[0], int(row[2]), bool(row[3])
+            if writing and writer == token:
+                await conn.execute(self._sql["renew_writer"], (seconds, name))
+                return WriteGrant(fencing_token=generation, poisoned=False)
+            readers = await self._fetch(conn, "count_holders", (name, "r"))
+            assert readers is not None  # noqa: S101
+            if writing or int(readers[0]) > 0:
+                if intent:
+                    await conn.execute(
+                        self._sql["upsert_holder"],
+                        (name, token, "i", seconds),
+                    )
+                return None
+            await conn.execute(
+                f"DELETE FROM {self._table_name}_holders"  # noqa: S608
+                " WHERE name = ? AND token = ? AND kind = 'i';",
+                (name, token),
+            )
+            granted = await self._fetch(
+                conn, "set_writer", (token, seconds, name)
+            )
+            assert granted is not None  # noqa: S101
+            return WriteGrant(
+                fencing_token=int(granted[0]), poisoned=writer is not None
+            )
+
+    async def release_read(self, *, name: str, token: str) -> bool:
+        """Drop a read lease."""
+        async with self._transaction() as conn:
+            row = await self._fetch(conn, "delete_holder", (name, token, "r"))
+            return row is not None
+
+    async def release_write(self, *, name: str, token: str) -> bool:
+        """Drop the write lease, leaving the lock clean."""
+        async with self._transaction() as conn:
+            row = await self._fetch(conn, "clear_writer", (name, token))
+            return row is not None
+
+    async def cancel_intent(self, *, name: str, token: str) -> bool:
+        """Withdraw a writer intent."""
+        async with self._transaction() as conn:
+            row = await self._fetch(conn, "delete_holder", (name, token, "i"))
+            return row is not None
+
+    async def downgrade(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        """Turn a held write lease into a read lease."""
+        seconds = ceil(duration)
+        async with self._transaction() as conn:
+            row = await self._fetch(conn, "clear_writer", (name, token))
+            if row is None:
+                return None
+            await conn.execute(
+                self._sql["upsert_holder"], (name, token, "r", seconds)
+            )
+            return int(row[0])
+
+    async def state(self, *, name: str) -> ReadWriteLockState:
+        """Return a point-in-time view of the lock."""
+        async with self._transaction() as conn:
+            await conn.execute(self._sql["reap"], (name,))
+            row = await self._fetch(conn, "select_lock", (name,))
+            if row is None:
+                return ReadWriteLockState(
+                    generation=0,
+                    writing=False,
+                    readers=0,
+                    waiting_writers=0,
+                )
+            readers = await self._fetch(conn, "count_holders", (name, "r"))
+            intents = await self._fetch(conn, "count_holders", (name, "i"))
+            assert readers is not None  # noqa: S101
+            assert intents is not None  # noqa: S101
+            return ReadWriteLockState(
+                generation=int(row[2]),
+                writing=bool(row[3]),
+                readers=int(readers[0]),
+                waiting_writers=int(intents[0]),
+            )
+
+    async def owned_read(self, *, name: str, token: str) -> bool:
+        """Check whether `token` holds a live read lease."""
+        conn = self._provider.client
+        async with (
+            self._provider.connection_lock,
+            conn.execute(
+                self._sql["holder_exists"], (name, token, "r")
+            ) as cursor,
+        ):
+            return await cursor.fetchone() is not None
+
+    async def owned_write(self, *, name: str, token: str) -> bool:
+        """Check whether `token` holds the live write lease."""
+        conn = self._provider.client
+        async with (
+            self._provider.connection_lock,
+            conn.execute(self._sql["select_lock"], (name,)) as cursor,
+        ):
+            row = await cursor.fetchone()
+        return row is not None and row[0] == token and bool(row[3])
 
 
 class SQLiteScheduleAdapter(ScheduleBackend):

--- a/grelmicro/providers/_base.py
+++ b/grelmicro/providers/_base.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from grelmicro.coordination._protocol import (
         LeaderElectionBackend,
         LockBackend,
+        ReadWriteLockBackend,
         ScheduleBackend,
     )
     from grelmicro.health._types import HealthDetails
@@ -48,6 +49,23 @@ class Provider(AbstractAsyncContextManager["Provider"]):
         msg = (
             f"{type(self).__name__} has no lock adapter. "
             f"Pass a LockBackend instance to Coordination(lock=...) directly."
+        )
+        raise NotImplementedError(msg)
+
+    def readwritelock(
+        self,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> ReadWriteLockBackend:
+        """Return the matching `ReadWriteLockBackend` adapter for this Provider.
+
+        Raises:
+            NotImplementedError: If this Provider does not ship a read-write
+                lock adapter.
+        """
+        msg = (
+            f"{type(self).__name__} has no read-write lock adapter. "
+            f"Pass a ReadWriteLockBackend instance to Coordination(rwlock=...) "
+            f"directly."
         )
         raise NotImplementedError(msg)
 

--- a/grelmicro/providers/memory.py
+++ b/grelmicro/providers/memory.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from grelmicro.coordination.memory import (
         MemoryLeaderElectionAdapter,
         MemoryLockAdapter,
+        MemoryReadWriteLockAdapter,
         MemoryScheduleAdapter,
     )
     from grelmicro.resilience.circuitbreaker.memory import (
@@ -57,6 +58,7 @@ class MemoryProvider(Provider):
         self._lock: MemoryLockAdapter | None = None
         self._leaderelection: MemoryLeaderElectionAdapter | None = None
         self._schedule: MemoryScheduleAdapter | None = None
+        self._rwlock: MemoryReadWriteLockAdapter | None = None
         self._cache: MemoryCacheAdapter | None = None
         self._ratelimiter: MemoryRateLimiterAdapter | None = None
         self._circuitbreaker: MemoryCircuitBreakerAdapter | None = None
@@ -74,6 +76,19 @@ class MemoryProvider(Provider):
 
             self._lock = MemoryLockAdapter(**kwargs)
         return self._lock
+
+    def readwritelock(
+        self,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> MemoryReadWriteLockAdapter:
+        """Return the shared `MemoryReadWriteLockAdapter` for this provider."""
+        if self._rwlock is None:
+            from grelmicro.coordination.memory import (  # noqa: PLC0415
+                MemoryReadWriteLockAdapter,
+            )
+
+            self._rwlock = MemoryReadWriteLockAdapter(**kwargs)
+        return self._rwlock
 
     def leaderelection(
         self,

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from grelmicro.coordination.postgres import (
         PostgresLeaderElectionAdapter,
         PostgresLockAdapter,
+        PostgresReadWriteLockAdapter,
         PostgresScheduleAdapter,
     )
     from grelmicro.outbox.postgres import PostgresOutboxAdapter
@@ -320,6 +321,17 @@ class PostgresProvider(Provider):
         )
 
         return PostgresLockAdapter(provider=self, **kwargs)
+
+    def readwritelock(
+        self,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> PostgresReadWriteLockAdapter:
+        """Build a `PostgresReadWriteLockAdapter` bound to this provider."""
+        from grelmicro.coordination.postgres import (  # noqa: PLC0415
+            PostgresReadWriteLockAdapter,
+        )
+
+        return PostgresReadWriteLockAdapter(provider=self, **kwargs)
 
     def leaderelection(
         self,

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from grelmicro.coordination.redis import (
         RedisLeaderElectionAdapter,
         RedisLockAdapter,
+        RedisReadWriteLockAdapter,
         RedisScheduleAdapter,
     )
     from grelmicro.resilience.circuitbreaker.redis import (
@@ -468,6 +469,17 @@ class RedisProvider(Provider):
         )
 
         return RedisLockAdapter(provider=self, **kwargs)
+
+    def readwritelock(
+        self,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> RedisReadWriteLockAdapter:
+        """Return a `RedisReadWriteLockAdapter` bound to this provider."""
+        from grelmicro.coordination.redis import (  # noqa: PLC0415
+            RedisReadWriteLockAdapter,
+        )
+
+        return RedisReadWriteLockAdapter(provider=self, **kwargs)
 
     def leaderelection(
         self,

--- a/grelmicro/providers/sqlite.py
+++ b/grelmicro/providers/sqlite.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from grelmicro.cache.sqlite import SQLiteCacheAdapter
     from grelmicro.coordination.sqlite import (
         SQLiteLockAdapter,
+        SQLiteReadWriteLockAdapter,
         SQLiteScheduleAdapter,
     )
     from grelmicro.resilience.circuitbreaker.sqlite import (
@@ -217,6 +218,17 @@ class SQLiteProvider(Provider):
         )
 
         return SQLiteLockAdapter(provider=self, **kwargs)
+
+    def readwritelock(
+        self,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> SQLiteReadWriteLockAdapter:
+        """Build a `SQLiteReadWriteLockAdapter` bound to this provider."""
+        from grelmicro.coordination.sqlite import (  # noqa: PLC0415
+            SQLiteReadWriteLockAdapter,
+        )
+
+        return SQLiteReadWriteLockAdapter(provider=self, **kwargs)
 
     def schedule(self, **kwargs: Any) -> SQLiteScheduleAdapter:  # noqa: ANN401
         """Build a `SQLiteScheduleAdapter` bound to this provider."""

--- a/grelmicro/providers/valkey.py
+++ b/grelmicro/providers/valkey.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from grelmicro.coordination.redis import (
         RedisLeaderElectionAdapter,
         RedisLockAdapter,
+        RedisReadWriteLockAdapter,
         RedisScheduleAdapter,
     )
     from grelmicro.resilience.circuitbreaker.redis import (
@@ -268,6 +269,13 @@ class ValkeyProvider(RedisProvider):
         )
 
         return RedisLockAdapter(provider=self, **kwargs)
+
+    def readwritelock(
+        self,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> RedisReadWriteLockAdapter:
+        """Return a `RedisReadWriteLockAdapter` bound to this provider."""
+        return super().readwritelock(**kwargs)
 
     def leaderelection(
         self,

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -112,7 +112,7 @@
   },
   "grelmicro.coordination": {
     "Coordination": {
-      "()": "(source=..., *, lock=..., election=..., schedule=..., name=...)"
+      "()": "(source=..., *, lock=..., election=..., rwlock=..., schedule=..., name=...)"
     },
     "CoordinationBackendError": null,
     "CoordinationError": null,
@@ -164,6 +164,25 @@
     "LockReleaseError": {
       "()": "(*, name, reason=...)"
     },
+    "LockUpgradeError": {
+      "()": "(*, name)"
+    },
+    "ReadGuard": {
+      "()": "(*, owner, name, token, generation, expires_at)"
+    },
+    "ReadWriteLock": {
+      "()": "(name, *, backend=..., worker=..., lease_duration=..., retry_interval=..., retry_jitter=..., env_prefix=..., env_load=...)",
+      ".from_config": "(name, config, *, backend=...)"
+    },
+    "ReadWriteLockBackend": {
+      "()": "(*args, **kwargs)"
+    },
+    "ReadWriteLockConfig": {
+      "()": "(*, worker=..., lease_duration=..., retry_interval=..., retry_jitter=...)"
+    },
+    "ReadWriteLockState": {
+      "()": "(generation, writing, readers, waiting_writers)"
+    },
     "ScheduleBackend": {
       "()": "(*args, **kwargs)"
     },
@@ -171,7 +190,13 @@
       "()": "(name=..., *, backend=..., worker=..., min_hold_duration=..., lease_duration=..., env_prefix=..., env_load=...)",
       ".from_config": "(name, config, *, backend=...)"
     },
-    "WouldBlockError": null
+    "WouldBlockError": null,
+    "WriteGrant": {
+      "()": "(fencing_token, poisoned)"
+    },
+    "WriteGuard": {
+      "()": "(*, owner, name, token, fencing_token, poisoned, expires_at)"
+    }
   },
   "grelmicro.health": {
     "CheckResult": null,

--- a/tests/coordination/test_kubernetes_rwlock.py
+++ b/tests/coordination/test_kubernetes_rwlock.py
@@ -1,0 +1,325 @@
+"""Tests for the Kubernetes read-write lock adapter, mocked.
+
+The conformance suite runs this adapter against a real API server. These
+tests cover what a live server will not produce on demand: a conflicting
+writer on every retry, a Lease that vanishes mid-operation, and an API
+error that is not a conflict.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+from unittest.mock import AsyncMock
+
+import pytest
+from lightkube.core.exceptions import ApiError
+from lightkube.models.coordination_v1 import LeaseSpec
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.coordination_v1 import Lease
+
+from grelmicro.coordination.kubernetes import (
+    _INTENTS_ANNOTATION,
+    _READERS_ANNOTATION,
+    KubernetesReadWriteLockAdapter,
+)
+from grelmicro.errors import OutOfContextError
+
+pytestmark = [pytest.mark.timeout(10)]
+
+TOKEN = "test-token"
+OTHER = "other-token"
+
+
+def _api_error(code: int) -> ApiError:
+    """Build an `ApiError` carrying `code`."""
+    return ApiError(
+        status={"code": code, "message": "error", "status": "Failure"}
+    )
+
+
+def _lease(
+    *,
+    holder: str | None = None,
+    expired: bool = False,
+    readers: dict[str, float] | None = None,
+    intents: dict[str, float] | None = None,
+    transitions: int = 0,
+) -> Lease:
+    """Build a Lease in the shape the adapter writes."""
+    now = datetime.now(tz=UTC)
+    renew_time = now - timedelta(seconds=10) if expired else now
+    return Lease(
+        metadata=ObjectMeta(
+            name="catalog",
+            namespace="default",
+            resourceVersion="1",
+            annotations={
+                _READERS_ANNOTATION: json.dumps(readers or {}),
+                _INTENTS_ANNOTATION: json.dumps(intents or {}),
+            },
+        ),
+        spec=LeaseSpec(
+            holderIdentity=holder,
+            leaseDurationSeconds=1 if holder else None,
+            acquireTime=renew_time if holder else None,
+            renewTime=renew_time if holder else None,
+            leaseTransitions=transitions,
+        ),
+    )
+
+
+def _adapter(**client_attrs: AsyncMock) -> KubernetesReadWriteLockAdapter:
+    """Build an adapter with a mocked client."""
+    adapter = KubernetesReadWriteLockAdapter(namespace="default")
+    client = AsyncMock()
+    for attr, mock in client_attrs.items():
+        setattr(client, attr, mock)
+    adapter._client = client
+    return adapter
+
+
+def _live(seconds: float = 60) -> float:
+    """Return an expiry epoch that is still in the future."""
+    return (datetime.now(tz=UTC) + timedelta(seconds=seconds)).timestamp()
+
+
+async def test_out_of_context_errors() -> None:
+    """Every operation refuses to run before the backend is open."""
+    adapter = KubernetesReadWriteLockAdapter(namespace="default")
+
+    with pytest.raises(OutOfContextError):
+        await adapter.acquire_read(name="catalog", token=TOKEN, duration=1)
+    with pytest.raises(OutOfContextError):
+        await adapter.acquire_write(name="catalog", token=TOKEN, duration=1)
+    with pytest.raises(OutOfContextError):
+        await adapter.state(name="catalog")
+
+
+async def test_aenter_and_aexit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The backend opens a client and closes it on exit."""
+    adapter = KubernetesReadWriteLockAdapter(namespace="default")
+    client = AsyncMock()
+    monkeypatch.setattr(
+        "grelmicro.coordination.kubernetes.AsyncClient",
+        lambda **_kwargs: client,
+    )
+
+    await adapter.__aenter__()
+    assert adapter._client is client
+
+    await adapter.__aexit__(None, None, None)
+    client.close.assert_awaited_once()
+    assert adapter._client is None
+
+
+async def test_read_reraises_a_non_missing_error() -> None:
+    """An API error that is not a 404 propagates."""
+    adapter = _adapter(
+        get=AsyncMock(side_effect=_api_error(HTTPStatus.INTERNAL_SERVER_ERROR))
+    )
+
+    with pytest.raises(ApiError):
+        await adapter.state(name="catalog")
+
+
+async def test_write_reraises_a_non_conflict_error() -> None:
+    """An API error that is neither conflict nor missing propagates."""
+    adapter = _adapter(
+        get=AsyncMock(side_effect=_api_error(HTTPStatus.NOT_FOUND)),
+        create=AsyncMock(
+            side_effect=_api_error(HTTPStatus.INTERNAL_SERVER_ERROR)
+        ),
+    )
+
+    with pytest.raises(ApiError):
+        await adapter.acquire_read(name="catalog", token=TOKEN, duration=1)
+
+
+async def test_acquire_read_gives_up_after_repeated_conflicts() -> None:
+    """A reader that loses every write race reports a refusal."""
+    adapter = _adapter(
+        get=AsyncMock(return_value=_lease()),
+        replace=AsyncMock(side_effect=_api_error(HTTPStatus.CONFLICT)),
+    )
+
+    granted = await adapter.acquire_read(
+        name="catalog", token=TOKEN, duration=1
+    )
+
+    assert granted is None
+
+
+async def test_acquire_write_gives_up_after_repeated_conflicts() -> None:
+    """A writer that loses every write race reports a refusal."""
+    adapter = _adapter(
+        get=AsyncMock(return_value=_lease()),
+        replace=AsyncMock(side_effect=_api_error(HTTPStatus.CONFLICT)),
+    )
+
+    granted = await adapter.acquire_write(
+        name="catalog", token=TOKEN, duration=1
+    )
+
+    assert granted is None
+
+
+async def test_write_renewal_retries_on_conflict() -> None:
+    """The holder renewing under a conflict retries and then gives up."""
+    adapter = _adapter(
+        get=AsyncMock(return_value=_lease(holder=TOKEN)),
+        replace=AsyncMock(side_effect=_api_error(HTTPStatus.CONFLICT)),
+    )
+
+    granted = await adapter.acquire_write(
+        name="catalog", token=TOKEN, duration=1
+    )
+
+    assert granted is None
+
+
+async def test_intent_write_retries_on_conflict() -> None:
+    """Recording an intent under a conflict retries and then gives up."""
+    adapter = _adapter(
+        get=AsyncMock(return_value=_lease(readers={OTHER: _live()})),
+        replace=AsyncMock(side_effect=_api_error(HTTPStatus.CONFLICT)),
+    )
+
+    granted = await adapter.acquire_write(
+        name="catalog", token=TOKEN, duration=1
+    )
+
+    assert granted is None
+
+
+async def test_nowait_writer_behind_a_reader_records_nothing() -> None:
+    """A try that does not wait returns without writing at all."""
+    replace = AsyncMock()
+    adapter = _adapter(
+        get=AsyncMock(return_value=_lease(readers={OTHER: _live()})),
+        replace=replace,
+    )
+
+    granted = await adapter.acquire_write(
+        name="catalog", token=TOKEN, duration=1, intent=False
+    )
+
+    assert granted is None
+    replace.assert_not_awaited()
+
+
+async def test_release_and_downgrade_on_a_missing_lease() -> None:
+    """Nothing is held when the Lease does not exist."""
+    adapter = _adapter(
+        get=AsyncMock(side_effect=_api_error(HTTPStatus.NOT_FOUND))
+    )
+
+    assert not await adapter.release_read(name="catalog", token=TOKEN)
+    assert not await adapter.release_write(name="catalog", token=TOKEN)
+    assert not await adapter.cancel_intent(name="catalog", token=TOKEN)
+    assert await adapter.downgrade(name="catalog", token=TOKEN, duration=1) is (
+        None
+    )
+    assert not await adapter.owned_read(name="catalog", token=TOKEN)
+    assert not await adapter.owned_write(name="catalog", token=TOKEN)
+    state = await adapter.state(name="catalog")
+    assert state.generation == 0
+
+
+async def test_release_write_by_a_non_holder() -> None:
+    """A token that does not hold the write lease releases nothing."""
+    adapter = _adapter(get=AsyncMock(return_value=_lease(holder=OTHER)))
+
+    assert not await adapter.release_write(name="catalog", token=TOKEN)
+    assert await adapter.downgrade(name="catalog", token=TOKEN, duration=1) is (
+        None
+    )
+
+
+async def test_release_read_by_a_non_holder() -> None:
+    """A token with no reader lease releases nothing."""
+    adapter = _adapter(get=AsyncMock(return_value=_lease()))
+
+    assert not await adapter.release_read(name="catalog", token=TOKEN)
+
+
+async def test_release_write_gives_up_after_repeated_conflicts() -> None:
+    """A release that loses every write race reports failure."""
+    adapter = _adapter(
+        get=AsyncMock(return_value=_lease(holder=TOKEN)),
+        replace=AsyncMock(side_effect=_api_error(HTTPStatus.CONFLICT)),
+    )
+
+    assert not await adapter.release_write(name="catalog", token=TOKEN)
+
+
+async def test_release_read_gives_up_after_repeated_conflicts() -> None:
+    """A reader release that loses every write race reports failure."""
+    adapter = _adapter(
+        get=AsyncMock(return_value=_lease(readers={TOKEN: _live()})),
+        replace=AsyncMock(side_effect=_api_error(HTTPStatus.CONFLICT)),
+    )
+
+    assert not await adapter.release_read(name="catalog", token=TOKEN)
+
+
+async def test_downgrade_gives_up_after_repeated_conflicts() -> None:
+    """A downgrade that loses every write race reports failure."""
+    adapter = _adapter(
+        get=AsyncMock(return_value=_lease(holder=TOKEN)),
+        replace=AsyncMock(side_effect=_api_error(HTTPStatus.CONFLICT)),
+    )
+
+    assert await adapter.downgrade(name="catalog", token=TOKEN, duration=1) is (
+        None
+    )
+
+
+async def test_an_expired_writer_reads_as_free() -> None:
+    """A Lease whose writer expired lets a reader in and poisons the next."""
+    adapter = _adapter(
+        get=AsyncMock(return_value=_lease(holder=OTHER, expired=True)),
+        replace=AsyncMock(),
+    )
+
+    generation = await adapter.acquire_read(
+        name="catalog", token=TOKEN, duration=1
+    )
+    grant = await adapter.acquire_write(name="catalog", token=TOKEN, duration=1)
+
+    assert generation == 0
+    assert grant is not None
+    assert grant.poisoned
+
+
+async def test_holders_without_annotations() -> None:
+    """A Lease written by an older version carries no holder maps."""
+    lease = Lease(
+        metadata=ObjectMeta(
+            name="catalog", namespace="default", resourceVersion="1"
+        ),
+        spec=LeaseSpec(leaseTransitions=3),
+    )
+    adapter = _adapter(get=AsyncMock(return_value=lease))
+
+    state = await adapter.state(name="catalog")
+
+    assert state.readers == 0
+    assert state.waiting_writers == 0
+    assert state.generation == 3  # noqa: PLR2004
+
+
+async def test_a_reader_release_does_not_extend_the_writer() -> None:
+    """Writing the Lease for a reader keeps the writer's own renewal."""
+    lease = _lease(holder=OTHER, readers={TOKEN: _live()})
+    assert lease.spec is not None
+    stored_renew = lease.spec.renewTime
+    replace = AsyncMock()
+    adapter = _adapter(get=AsyncMock(return_value=lease), replace=replace)
+
+    assert await adapter.release_read(name="catalog", token=TOKEN)
+
+    call = replace.await_args
+    assert call is not None
+    written = call.args[0]
+    assert written.spec.renewTime == stored_renew
+    assert written.spec.holderIdentity == OTHER

--- a/tests/coordination/test_kubernetes_rwlock.py
+++ b/tests/coordination/test_kubernetes_rwlock.py
@@ -323,3 +323,39 @@ async def test_a_reader_release_does_not_extend_the_writer() -> None:
     written = call.args[0]
     assert written.spec.renewTime == stored_renew
     assert written.spec.holderIdentity == OTHER
+
+
+async def test_a_reader_keeps_an_expired_writer_on_record() -> None:
+    """A reader write leaves the dead writer in place, so poison survives."""
+    lease = _lease(holder=OTHER, expired=True)
+    assert lease.spec is not None
+    stored_renew = lease.spec.renewTime
+    replace = AsyncMock()
+    adapter = _adapter(get=AsyncMock(return_value=lease), replace=replace)
+
+    await adapter.acquire_read(name="catalog", token=TOKEN, duration=1)
+
+    call = replace.await_args
+    assert call is not None
+    written = call.args[0]
+    assert written.spec.holderIdentity == OTHER
+    assert written.spec.renewTime == stored_renew
+
+
+async def test_an_intent_does_not_touch_the_writer_lease() -> None:
+    """Recording an intent leaves the active writer's lease as it stands."""
+    lease = _lease(holder=OTHER, readers={"reader": _live()})
+    assert lease.spec is not None
+    stored_duration = lease.spec.leaseDurationSeconds
+    stored_renew = lease.spec.renewTime
+    replace = AsyncMock()
+    adapter = _adapter(get=AsyncMock(return_value=lease), replace=replace)
+
+    await adapter.acquire_write(name="catalog", token=TOKEN, duration=900)
+
+    call = replace.await_args
+    assert call is not None
+    written = call.args[0]
+    assert written.spec.leaseDurationSeconds == stored_duration
+    assert written.spec.renewTime == stored_renew
+    assert written.spec.holderIdentity == OTHER

--- a/tests/coordination/test_readwritelock.py
+++ b/tests/coordination/test_readwritelock.py
@@ -1,0 +1,648 @@
+"""Test Read-Write Lock."""
+
+import asyncio
+from collections.abc import AsyncGenerator
+from types import TracebackType
+from typing import Self
+
+import pytest
+
+from grelmicro import Grelmicro
+from grelmicro.coordination import (
+    Coordination,
+    LockAcquireError,
+    LockNotOwnedError,
+    LockOwnedCheckError,
+    LockReentrantError,
+    LockReleaseError,
+    LockUpgradeError,
+    ReadWriteLock,
+    ReadWriteLockConfig,
+)
+from grelmicro.coordination._protocol import (
+    ReadWriteLockState,
+    WriteGrant,
+)
+from grelmicro.coordination.errors import (
+    CoordinationBackendError,
+    CoordinationSettingsValidationError,
+)
+from grelmicro.coordination.memory import MemoryReadWriteLockAdapter
+from grelmicro.errors import OutOfContextError, WouldBlockError
+
+pytestmark = [pytest.mark.timeout(10, func_only=True)]
+
+_READERS = 3
+_RETAKEN_FENCE = 2
+_ENV_LEASE_DURATION = 12
+_RECONFIGURED_LEASE_DURATION = 30
+
+
+@pytest.fixture
+async def backend() -> AsyncGenerator[MemoryReadWriteLockAdapter]:
+    """In-process backend for the primitive under test."""
+    async with MemoryReadWriteLockAdapter() as backend:
+        yield backend
+
+
+@pytest.fixture
+def lock(backend: MemoryReadWriteLockAdapter) -> ReadWriteLock:
+    """Read-write lock bound to the in-process backend."""
+    return ReadWriteLock(
+        "catalog", backend=backend, lease_duration=5, retry_interval=0.001
+    )
+
+
+class _FailingBackend:
+    """Backend whose every call raises."""
+
+    _loop: asyncio.AbstractEventLoop | None = None
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def acquire_read(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        raise RuntimeError(name or token or duration)
+
+    async def acquire_write(
+        self, *, name: str, token: str, duration: float, intent: bool = True
+    ) -> WriteGrant | None:
+        raise RuntimeError(name or token or duration or intent)
+
+    async def release_read(self, *, name: str, token: str) -> bool:
+        raise RuntimeError(name or token)
+
+    async def release_write(self, *, name: str, token: str) -> bool:
+        raise RuntimeError(name or token)
+
+    async def cancel_intent(self, *, name: str, token: str) -> bool:
+        raise RuntimeError(name or token)
+
+    async def downgrade(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        raise RuntimeError(name or token or duration)
+
+    async def state(self, *, name: str) -> ReadWriteLockState:
+        raise RuntimeError(name)
+
+    async def owned_read(self, *, name: str, token: str) -> bool:
+        raise RuntimeError(name or token)
+
+    async def owned_write(self, *, name: str, token: str) -> bool:
+        raise RuntimeError(name or token)
+
+
+async def test_read_and_write_context_managers(lock: ReadWriteLock) -> None:
+    """The two views bind their own guard and release on exit."""
+    async with lock.read as reading:
+        assert reading.name == "catalog"
+        assert reading.generation == 0
+        assert reading.valid
+        assert reading.expires_in > 0
+
+    async with lock.write as writing:
+        assert writing.fencing_token == 1
+        assert not writing.poisoned
+
+    assert await lock.state() == ReadWriteLockState(
+        generation=1, writing=False, readers=0, waiting_writers=0
+    )
+
+
+async def test_readers_run_together(lock: ReadWriteLock) -> None:
+    """Several tasks hold the read lock at the same time."""
+    inside = asyncio.Event()
+    peak = 0
+    current = 0
+
+    async def reader() -> None:
+        nonlocal peak, current
+        async with lock.read:
+            current += 1
+            peak = max(peak, current)
+            if current == _READERS:
+                inside.set()
+            await inside.wait()
+            current -= 1
+
+    await asyncio.gather(*[reader() for _ in range(_READERS)])
+
+    assert peak == _READERS
+
+
+async def test_writer_waits_for_the_reader(lock: ReadWriteLock) -> None:
+    """A writer retries until the reader releases."""
+    released = asyncio.Event()
+
+    async def reader() -> None:
+        async with lock.read:
+            await asyncio.sleep(0.05)
+        released.set()
+
+    async def writer() -> int:
+        async with lock.write as writing:
+            assert released.is_set()
+            return writing.fencing_token
+
+    reader_task = asyncio.create_task(reader())
+    await asyncio.sleep(0)
+    fencing_token = await writer()
+    await reader_task
+
+    assert fencing_token == 1
+
+
+async def test_waiting_writer_holds_new_readers_out(
+    lock: ReadWriteLock, backend: MemoryReadWriteLockAdapter
+) -> None:
+    """The writer's intent stops a reader that arrives after it."""
+
+    async def hold_read() -> None:
+        async with lock.read:
+            await asyncio.sleep(0.15)
+
+    async def write_and_release() -> int:
+        async with lock.write as writing:
+            return writing.fencing_token
+
+    reader_task = asyncio.create_task(hold_read())
+    await asyncio.sleep(0.01)
+    writer_task = asyncio.create_task(write_and_release())
+    await asyncio.sleep(0.02)
+
+    assert (await lock.state()).waiting_writers == 1
+    assert (
+        await backend.acquire_read(
+            name="rwlock:catalog", token="latecomer", duration=5
+        )
+        is None
+    )
+
+    await reader_task
+    assert await writer_task == 1
+
+
+async def test_write_timeout_withdraws_the_intent(
+    lock: ReadWriteLock,
+) -> None:
+    """A writer that gives up stops holding readers out."""
+
+    async def hold_read() -> None:
+        async with lock.read:
+            await asyncio.sleep(0.2)
+
+    reader_task = asyncio.create_task(hold_read())
+    await asyncio.sleep(0.01)
+
+    with pytest.raises(TimeoutError):
+        await lock.write.acquire(timeout=0.02)
+
+    assert (await lock.state()).waiting_writers == 0
+    await reader_task
+
+
+async def test_acquire_nowait_refuses(lock: ReadWriteLock) -> None:
+    """A non-blocking try raises rather than waiting."""
+
+    async def read_nowait() -> None:
+        await lock.read.acquire_nowait()
+
+    async def write_nowait() -> None:
+        await lock.write.acquire_nowait()
+
+    async with lock.write:
+        with pytest.raises(WouldBlockError):
+            await asyncio.create_task(read_nowait())
+
+    async with lock.read:
+        with pytest.raises(WouldBlockError):
+            await asyncio.create_task(write_nowait())
+
+
+async def test_nested_acquire_is_refused(lock: ReadWriteLock) -> None:
+    """The same task cannot take either view twice."""
+    async with lock.read:
+        with pytest.raises(LockReentrantError):
+            await lock.read.acquire()
+
+    async with lock.write:
+        with pytest.raises(LockReentrantError):
+            await lock.write.acquire()
+        with pytest.raises(LockReentrantError):
+            await lock.read.acquire()
+
+
+async def test_upgrade_is_refused(lock: ReadWriteLock) -> None:
+    """A reader asking for the write lock gets an error, not a deadlock."""
+    async with lock.read:
+        with pytest.raises(LockUpgradeError):
+            await lock.write.acquire()
+
+
+async def test_downgrade_keeps_the_lock(lock: ReadWriteLock) -> None:
+    """A downgrade turns the write lease into a read lease with no gap."""
+    async with lock.write as writing:
+        reading = await writing.downgrade()
+
+        assert reading.generation == 1
+        assert not writing.valid
+        assert await lock.read.owned()
+        assert not await lock.write.owned()
+
+    assert await lock.state() == ReadWriteLockState(
+        generation=1, writing=False, readers=0, waiting_writers=0
+    )
+
+
+async def test_downgrade_after_losing_the_lease(
+    lock: ReadWriteLock, backend: MemoryReadWriteLockAdapter
+) -> None:
+    """A downgrade without the write lease raises."""
+    writing = await lock.write.acquire()
+    await backend.release_write(name="rwlock:catalog", token=writing.token)
+
+    with pytest.raises(LockNotOwnedError):
+        await writing.downgrade()
+
+    assert not writing.valid
+
+
+async def test_guard_after_release(lock: ReadWriteLock) -> None:
+    """A spent guard hands back no token."""
+    async with lock.write as writing:
+        assert writing.fencing_token == 1
+
+    assert not writing.valid
+    assert writing.poisoned is False
+    with pytest.raises(LockNotOwnedError):
+        _ = writing.fencing_token
+
+    async with lock.read as reading:
+        assert reading.generation == 1
+    with pytest.raises(LockNotOwnedError):
+        _ = reading.generation
+
+
+async def test_guard_repr(lock: ReadWriteLock) -> None:
+    """Guards print what they hold."""
+    async with lock.write as writing:
+        assert "fencing_token=1" in repr(writing)
+    async with lock.read as reading:
+        assert "generation=1" in repr(reading)
+
+
+async def test_extend_renews_the_lease(lock: ReadWriteLock) -> None:
+    """Extending keeps the same token and pushes the deadline out."""
+    async with lock.write as writing:
+        before = writing.expires_in
+        await asyncio.sleep(0.01)
+        await writing.extend()
+
+        assert writing.fencing_token == 1
+        assert writing.expires_in >= before - 0.01
+
+    async with lock.read as reading:
+        await reading.extend()
+        assert reading.generation == 1
+
+
+async def test_extend_reports_a_lost_read_lease(
+    lock: ReadWriteLock, backend: MemoryReadWriteLockAdapter
+) -> None:
+    """A read lease taken over while paused surfaces on the next extend."""
+    reading = await lock.read.acquire()
+    await backend.release_read(name="rwlock:catalog", token=reading.token)
+    await backend.acquire_write(
+        name="rwlock:catalog", token="someone-else", duration=5
+    )
+
+    with pytest.raises(LockNotOwnedError):
+        await reading.extend()
+    assert not reading.valid
+    await backend.release_write(name="rwlock:catalog", token="someone-else")
+
+
+async def test_extend_reports_a_retaken_write_lease(
+    lock: ReadWriteLock, backend: MemoryReadWriteLockAdapter
+) -> None:
+    """A write lease lost and retaken carries the new token, marked poisoned."""
+    writing = await lock.write.acquire()
+    await backend.release_write(name="rwlock:catalog", token=writing.token)
+
+    await writing.extend()
+
+    assert writing.fencing_token == _RETAKEN_FENCE
+    assert writing.poisoned
+    await lock.write.release()
+
+
+async def test_extend_after_the_write_lease_moved(
+    lock: ReadWriteLock, backend: MemoryReadWriteLockAdapter
+) -> None:
+    """Extending after another writer took over raises."""
+    writing = await lock.write.acquire()
+    await backend.release_write(name="rwlock:catalog", token=writing.token)
+    await backend.acquire_write(
+        name="rwlock:catalog", token="someone-else", duration=5
+    )
+
+    with pytest.raises(LockNotOwnedError):
+        await writing.extend()
+    assert not writing.valid
+
+
+async def test_release_without_holding(lock: ReadWriteLock) -> None:
+    """Releasing what this task never took raises."""
+    with pytest.raises(LockNotOwnedError):
+        await lock.read.release()
+    with pytest.raises(LockNotOwnedError):
+        await lock.write.release()
+    with pytest.raises(LockNotOwnedError):
+        await lock.read.extend()
+    with pytest.raises(LockNotOwnedError):
+        await lock.write.extend()
+
+
+async def test_release_of_a_lost_lease(
+    lock: ReadWriteLock, backend: MemoryReadWriteLockAdapter
+) -> None:
+    """A lease already gone on the backend reports as not owned."""
+    reading = await lock.read.acquire()
+    await backend.release_read(name="rwlock:catalog", token=reading.token)
+    with pytest.raises(LockNotOwnedError):
+        await lock.read.release()
+
+    writing = await lock.write.acquire()
+    await backend.release_write(name="rwlock:catalog", token=writing.token)
+    with pytest.raises(LockNotOwnedError):
+        await lock.write.release()
+
+
+async def test_owned_without_holding(lock: ReadWriteLock) -> None:
+    """A task that holds nothing owns nothing."""
+    assert not await lock.read.owned()
+    assert not await lock.write.owned()
+
+
+async def test_backend_errors_are_wrapped() -> None:
+    """A backend that raises surfaces as a coordination error."""
+    lock = ReadWriteLock("catalog", backend=_FailingBackend())
+
+    with pytest.raises(LockAcquireError):
+        await lock.read.acquire_nowait()
+    with pytest.raises(LockAcquireError):
+        await lock.write.acquire_nowait()
+    with pytest.raises(LockOwnedCheckError):
+        await lock.state()
+
+
+async def test_release_errors_are_wrapped(
+    backend: MemoryReadWriteLockAdapter,
+) -> None:
+    """A backend that raises on release surfaces as a release error."""
+    lock = ReadWriteLock("catalog", backend=backend, lease_duration=5)
+    guard = await lock.read.acquire()
+    lock._backend = _FailingBackend()
+
+    with pytest.raises(LockReleaseError):
+        await lock.read.release()
+    with pytest.raises(LockOwnedCheckError):
+        await lock.read.owned()
+
+    lock._backend = backend
+    await backend.release_read(name="rwlock:catalog", token=guard.token)
+
+
+async def test_write_release_and_owned_errors_are_wrapped(
+    backend: MemoryReadWriteLockAdapter,
+) -> None:
+    """The write view wraps backend failures the same way."""
+    lock = ReadWriteLock("catalog", backend=backend, lease_duration=5)
+    guard = await lock.write.acquire()
+    lock._backend = _FailingBackend()
+
+    with pytest.raises(LockReleaseError):
+        await lock.write.release()
+    with pytest.raises(LockOwnedCheckError):
+        await lock.write.owned()
+    with pytest.raises(LockAcquireError):
+        await guard.downgrade()
+
+    lock._backend = backend
+    await backend.release_write(name="rwlock:catalog", token=guard.token)
+
+
+async def test_backend_resolves_from_the_app(
+    backend: MemoryReadWriteLockAdapter,
+) -> None:
+    """A lock with no backend resolves through the active app."""
+    micro = Grelmicro(uses=[Coordination(rwlock=backend, name="default")])
+    lock = ReadWriteLock("catalog", lease_duration=5)
+
+    async with micro, lock.write as writing:
+        assert writing.fencing_token == 1
+
+
+async def test_backend_without_an_app() -> None:
+    """A lock with nothing wired says what to do about it."""
+    lock = ReadWriteLock("catalog")
+
+    with pytest.raises(OutOfContextError, match="MemoryReadWriteLockAdapter"):
+        await lock.read.acquire_nowait()
+
+
+async def test_component_without_a_backend() -> None:
+    """A component with no read-write lock backend says so."""
+    component = Coordination()
+
+    with pytest.raises(CoordinationBackendError, match="rwlock"):
+        _ = component.rwlock_backend
+
+
+async def test_component_builds_the_lock(
+    backend: MemoryReadWriteLockAdapter,
+) -> None:
+    """The component hands back a lock bound to its backend."""
+    component = Coordination(rwlock=backend)
+
+    lock = component.readwritelock("catalog", lease_duration=5)
+
+    async with lock.read as reading:
+        assert reading.generation == 0
+
+
+async def test_from_config(backend: MemoryReadWriteLockAdapter) -> None:
+    """The declarative path skips the environment."""
+    lock = ReadWriteLock.from_config(
+        "catalog",
+        ReadWriteLockConfig(lease_duration=5, worker="web-1"),
+        backend=backend,
+    )
+
+    async with lock.write as writing:
+        assert writing.token.startswith("web-1:")
+
+
+async def test_environment_configuration(
+    backend: MemoryReadWriteLockAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fields resolve from `GREL_READWRITELOCK_{NAME}_*`."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv("GREL_READWRITELOCK_CATALOG_LEASE_DURATION", "12")
+
+    lock = ReadWriteLock("catalog", backend=backend)
+
+    assert lock.config.lease_duration == _ENV_LEASE_DURATION
+
+
+async def test_reconfigure_keeps_the_worker(
+    backend: MemoryReadWriteLockAdapter,
+) -> None:
+    """The worker identity cannot change under a live lease."""
+    lock = ReadWriteLock("catalog", backend=backend, worker="web-1")
+
+    await lock.reconfigure(
+        lock.config.model_copy(
+            update={"lease_duration": _RECONFIGURED_LEASE_DURATION}
+        )
+    )
+    assert lock.config.lease_duration == _RECONFIGURED_LEASE_DURATION
+
+    with pytest.raises(
+        CoordinationSettingsValidationError, match="worker is immutable"
+    ):
+        await lock.reconfigure(
+            lock.config.model_copy(update={"worker": "web-2"})
+        )
+
+
+async def test_from_thread(lock: ReadWriteLock) -> None:
+    """Worker threads take both views through the adapters."""
+
+    def body() -> tuple[int, int]:
+        with lock.read.from_thread as reading:
+            lock.read.from_thread.extend()
+            generation = reading.generation
+        with lock.write.from_thread as writing:
+            lock.write.from_thread.extend()
+            fencing_token = writing.fencing_token
+        return generation, fencing_token
+
+    generation, fencing_token = await asyncio.to_thread(body)
+
+    assert generation == 0
+    assert fencing_token == 1
+
+
+async def test_from_thread_rejects_nesting(lock: ReadWriteLock) -> None:
+    """A thread cannot take a view twice, nor upgrade."""
+
+    def body() -> None:
+        with lock.read.from_thread:
+            with pytest.raises(LockReentrantError):
+                lock.read.from_thread.acquire()
+            with pytest.raises(LockUpgradeError):
+                lock.write.from_thread.acquire()
+        with lock.write.from_thread, pytest.raises(LockReentrantError):
+            lock.write.from_thread.acquire()
+
+    await asyncio.to_thread(body)
+
+
+async def test_from_thread_without_holding(lock: ReadWriteLock) -> None:
+    """A thread that holds nothing cannot release or extend."""
+
+    def body() -> None:
+        with pytest.raises(LockNotOwnedError):
+            lock.read.from_thread.release()
+        with pytest.raises(LockNotOwnedError):
+            lock.write.from_thread.release()
+        with pytest.raises(LockNotOwnedError):
+            lock.read.from_thread.extend()
+        with pytest.raises(LockNotOwnedError):
+            lock.write.from_thread.extend()
+
+    await asyncio.to_thread(body)
+
+
+async def test_from_thread_needs_an_open_backend() -> None:
+    """A closed backend says so rather than hanging the thread."""
+    lock = ReadWriteLock("catalog", backend=MemoryReadWriteLockAdapter())
+
+    def body() -> None:
+        with pytest.raises(RuntimeError, match="before its backend is opened"):
+            lock.read.from_thread.acquire()
+
+    await asyncio.to_thread(body)
+
+
+async def test_acquire_nowait_grants(lock: ReadWriteLock) -> None:
+    """A non-blocking try that finds the lock free hands back a guard."""
+    reading = await lock.read.acquire_nowait()
+    assert reading.generation == 0
+    await lock.read.release()
+
+    writing = await lock.write.acquire_nowait()
+    assert writing.fencing_token == 1
+    await lock.write.release()
+
+
+async def test_from_thread_release_of_a_lost_lease(
+    lock: ReadWriteLock, backend: MemoryReadWriteLockAdapter
+) -> None:
+    """A thread releasing a lease that is already gone is told so."""
+
+    def read_body() -> None:
+        guard = lock.read.from_thread.acquire()
+        loop = backend._loop
+        assert loop is not None
+        asyncio.run_coroutine_threadsafe(
+            backend.release_read(name="rwlock:catalog", token=guard.token),
+            loop,
+        ).result()
+        with pytest.raises(LockNotOwnedError):
+            lock.read.from_thread.release()
+
+    def write_body() -> None:
+        guard = lock.write.from_thread.acquire()
+        loop = backend._loop
+        assert loop is not None
+        asyncio.run_coroutine_threadsafe(
+            backend.release_write(name="rwlock:catalog", token=guard.token),
+            loop,
+        ).result()
+        with pytest.raises(LockNotOwnedError):
+            lock.write.from_thread.release()
+
+    await asyncio.to_thread(read_body)
+    await asyncio.to_thread(write_body)
+
+
+async def test_expired_intent_is_reaped(
+    backend: MemoryReadWriteLockAdapter,
+) -> None:
+    """An intent left by a writer that died stops holding readers out."""
+    await backend.acquire_read(name="catalog", token="reader", duration=10)
+    await backend.acquire_write(name="catalog", token="dead", duration=0.05)
+    await asyncio.sleep(0.1)
+
+    state = await backend.state(name="catalog")
+
+    assert state.waiting_writers == 0
+    assert (
+        await backend.acquire_read(
+            name="catalog", token="latecomer", duration=10
+        )
+        is not None
+    )

--- a/tests/coordination/test_rwlock_adapters.py
+++ b/tests/coordination/test_rwlock_adapters.py
@@ -1,0 +1,183 @@
+"""Test the read-write lock adapter wiring outside the conformance suite."""
+
+from types import TracebackType
+from typing import Self
+from unittest.mock import MagicMock
+
+import pytest
+
+from grelmicro.coordination.memory import MemoryReadWriteLockAdapter
+from grelmicro.coordination.postgres import PostgresReadWriteLockAdapter
+from grelmicro.coordination.redis import RedisReadWriteLockAdapter
+from grelmicro.coordination.sqlite import SQLiteReadWriteLockAdapter
+from grelmicro.providers.memory import MemoryProvider
+from grelmicro.providers.postgres import PostgresProvider
+from grelmicro.providers.redis import RedisProvider
+from grelmicro.providers.sqlite import SQLiteProvider
+from grelmicro.providers.valkey import ValkeyProvider
+
+pytestmark = [pytest.mark.timeout(10)]
+
+REDIS_URL = "redis://:test_password@test_host:1234/0"
+POSTGRES_URL = "postgresql://test:test@test_host:5432/test"
+
+
+class _StubProvider:
+    """Minimal provider-shaped stub tracking enter and exit calls."""
+
+    is_cluster = False
+
+    def __init__(self) -> None:
+        self.client = MagicMock()
+        self.enter_count = 0
+        self.exit_count = 0
+
+    async def __aenter__(self) -> Self:
+        self.enter_count += 1
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.exit_count += 1
+
+
+# --- Redis ---
+
+
+def test_redis_implicit_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without `provider=`, the adapter builds its own from env vars."""
+    monkeypatch.setenv("REDIS_URL", REDIS_URL)
+
+    adapter = RedisReadWriteLockAdapter()
+
+    assert adapter.provider.url == REDIS_URL
+    assert adapter._owns_provider is True
+
+
+def test_redis_rebind_provider() -> None:
+    """A rebound provider is borrowed and the scripts follow it."""
+    adapter = RedisReadWriteLockAdapter(provider=RedisProvider(REDIS_URL))
+    other = RedisProvider(REDIS_URL)
+
+    adapter._rebind_provider(other)
+
+    assert adapter.provider is other
+    assert adapter._owns_provider is False
+
+
+async def test_redis_owned_provider_opens_and_closes() -> None:
+    """When owned, the adapter opens and closes its provider."""
+    stub = _StubProvider()
+    adapter = RedisReadWriteLockAdapter(provider=stub)  # ty: ignore[invalid-argument-type]
+    adapter._owns_provider = True
+
+    async with adapter:
+        pass
+
+    assert stub.enter_count == 1
+    assert stub.exit_count == 1
+
+
+def test_redis_provider_factory() -> None:
+    """`RedisProvider.readwritelock()` returns a bound adapter."""
+    provider = RedisProvider(REDIS_URL)
+
+    adapter = provider.readwritelock()
+
+    assert isinstance(adapter, RedisReadWriteLockAdapter)
+    assert adapter.provider is provider
+
+
+def test_valkey_provider_factory() -> None:
+    """`ValkeyProvider.readwritelock()` reuses the Redis adapter."""
+    provider = ValkeyProvider("valkey://test_host:1234/0")
+
+    adapter = provider.readwritelock()
+
+    assert isinstance(adapter, RedisReadWriteLockAdapter)
+    assert adapter.provider is provider
+
+
+# --- Postgres ---
+
+
+def test_postgres_table_name_must_be_an_identifier() -> None:
+    """A table name that is not an identifier is refused at construction."""
+    with pytest.raises(ValueError, match="not a valid SQL identifier"):
+        PostgresReadWriteLockAdapter(table_name="rw; DROP TABLE users")
+
+
+def test_postgres_implicit_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without `provider=`, the adapter builds its own from env vars."""
+    monkeypatch.setenv("POSTGRES_URL", POSTGRES_URL)
+
+    adapter = PostgresReadWriteLockAdapter()
+
+    assert adapter._owns_provider is True
+
+
+def test_postgres_rebind_provider() -> None:
+    """A rebound provider is borrowed rather than owned."""
+    adapter = PostgresReadWriteLockAdapter(
+        provider=PostgresProvider(POSTGRES_URL)
+    )
+    other = PostgresProvider(POSTGRES_URL)
+
+    adapter._rebind_provider(other)
+
+    assert adapter.provider is other
+    assert adapter._owns_provider is False
+
+
+async def test_postgres_owned_provider_opens_and_closes() -> None:
+    """When owned, the adapter opens and closes its provider."""
+    stub = _StubProvider()
+    adapter = PostgresReadWriteLockAdapter(
+        provider=stub,  # ty: ignore[invalid-argument-type]
+        auto_migrate=False,
+    )
+    adapter._owns_provider = True
+
+    async with adapter:
+        pass
+
+    assert stub.enter_count == 1
+    assert stub.exit_count == 1
+
+
+def test_postgres_provider_factory() -> None:
+    """`PostgresProvider.readwritelock()` returns a bound adapter."""
+    provider = PostgresProvider(POSTGRES_URL)
+
+    adapter = provider.readwritelock()
+
+    assert isinstance(adapter, PostgresReadWriteLockAdapter)
+    assert adapter.provider is provider
+
+
+# --- SQLite and Memory ---
+
+
+def test_sqlite_provider_factory() -> None:
+    """`SQLiteProvider.readwritelock()` returns a bound adapter."""
+    provider = SQLiteProvider(":memory:")
+
+    adapter = provider.readwritelock()
+
+    assert isinstance(adapter, SQLiteReadWriteLockAdapter)
+    assert adapter.provider is provider
+
+
+def test_memory_provider_caches_one_adapter() -> None:
+    """`MemoryProvider.readwritelock()` hands back one shared adapter."""
+    provider = MemoryProvider()
+
+    first = provider.readwritelock()
+    second = provider.readwritelock()
+
+    assert isinstance(first, MemoryReadWriteLockAdapter)
+    assert first is second

--- a/tests/coordination/test_rwlock_adapters.py
+++ b/tests/coordination/test_rwlock_adapters.py
@@ -8,7 +8,10 @@ import pytest
 
 from grelmicro.coordination.memory import MemoryReadWriteLockAdapter
 from grelmicro.coordination.postgres import PostgresReadWriteLockAdapter
-from grelmicro.coordination.redis import RedisReadWriteLockAdapter
+from grelmicro.coordination.redis import (
+    RedisReadWriteLockAdapter,
+    _duration_ms,
+)
 from grelmicro.coordination.sqlite import SQLiteReadWriteLockAdapter
 from grelmicro.providers.memory import MemoryProvider
 from grelmicro.providers.postgres import PostgresProvider
@@ -100,6 +103,17 @@ def test_valkey_provider_factory() -> None:
 
     assert isinstance(adapter, RedisReadWriteLockAdapter)
     assert adapter.provider is provider
+
+
+@pytest.mark.parametrize(
+    ("duration", "expected"),
+    [(1.5, 1500), (0.001, 1), (0.0001, 1)],
+)
+def test_redis_duration_never_floors_to_zero(
+    duration: float, expected: int
+) -> None:
+    """A positive duration always reaches Redis as at least one millisecond."""
+    assert _duration_ms(duration) == expected
 
 
 # --- Postgres ---

--- a/tests/coordination/test_rwlock_backends.py
+++ b/tests/coordination/test_rwlock_backends.py
@@ -1,0 +1,444 @@
+"""Test Read-Write Lock Backends.
+
+One conformance suite every backend must pass. The invariants are the same
+everywhere: a writer is never concurrent with a reader, the generation only
+grows, a waiting writer keeps new readers out, and an expired holder never
+blocks anyone.
+"""
+
+from asyncio import sleep
+from collections.abc import AsyncGenerator, Generator
+from uuid import uuid4
+
+import pytest
+from testcontainers.core.container import DockerContainer
+from testcontainers.postgres import PostgresContainer
+from testcontainers.redis import RedisContainer
+
+from grelmicro.coordination._protocol import ReadWriteLockBackend
+from grelmicro.coordination.kubernetes import KubernetesReadWriteLockAdapter
+from grelmicro.coordination.memory import MemoryReadWriteLockAdapter
+from grelmicro.coordination.postgres import PostgresReadWriteLockAdapter
+from grelmicro.coordination.redis import RedisReadWriteLockAdapter
+from grelmicro.coordination.sqlite import SQLiteReadWriteLockAdapter
+from grelmicro.providers.postgres import PostgresProvider
+from grelmicro.providers.redis import RedisProvider
+from grelmicro.providers.sqlite import SQLiteProvider
+
+pytestmark = [pytest.mark.timeout(30, func_only=True)]
+
+_READERS = 3
+
+
+@pytest.fixture(scope="module")
+def monkeypatch() -> Generator[pytest.MonkeyPatch, None, None]:
+    """Monkeypatch Module Scope."""
+    monkeypatch = pytest.MonkeyPatch()
+    yield monkeypatch
+    monkeypatch.undo()
+
+
+@pytest.fixture(
+    params=[
+        "memory",
+        "sqlite",
+        pytest.param("redis", marks=[pytest.mark.integration]),
+        pytest.param("postgres", marks=[pytest.mark.integration]),
+        pytest.param(
+            "kubernetes",
+            marks=[
+                pytest.mark.integration,
+                pytest.mark.xdist_group("k3s"),
+            ],
+        ),
+    ],
+    scope="module",
+)
+def backend_name(request: pytest.FixtureRequest) -> str:
+    """Backend Name."""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def container(
+    backend_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> Generator[DockerContainer | None, None, None]:
+    """Test Container for each Backend."""
+    if backend_name == "redis":
+        with RedisContainer() as container:
+            yield container
+    elif backend_name == "postgres":
+        monkeypatch.setenv("POSTGRES_HOST", "localhost")
+        monkeypatch.setenv("POSTGRES_PORT", "5432")
+        monkeypatch.setenv("POSTGRES_DB", "test")
+        monkeypatch.setenv("POSTGRES_USER", "test")
+        monkeypatch.setenv("POSTGRES_PASSWORD", "test")
+        with PostgresContainer() as container:
+            yield container
+    elif backend_name == "kubernetes":
+        monkeypatch.setenv(
+            "KUBECONFIG", request.getfixturevalue("k3s_kubeconfig")
+        )
+        monkeypatch.setenv("KUBE_NAMESPACE", "default")
+        yield None
+    elif backend_name in ("memory", "sqlite"):
+        yield None
+
+
+@pytest.fixture(scope="module")
+def expire_duration(backend_name: str) -> float:
+    """Lease duration for expiration tests, scaled per backend.
+
+    SQLite and Kubernetes round the duration up to whole seconds, and the
+    networked backends need enough margin to survive container-side clock
+    drift. Only the in-process Memory backend can use a sub-second value.
+    """
+    if backend_name == "memory":
+        return 0.2
+    return 1.0
+
+
+@pytest.fixture(scope="module")
+def expire_wait(backend_name: str, expire_duration: float) -> float:
+    """Sleep duration to wait past lease expiration."""
+    if backend_name in ("sqlite", "kubernetes"):
+        return expire_duration + 1.0
+    return expire_duration + 0.3
+
+
+@pytest.fixture(scope="module")
+async def backend(
+    backend_name: str, container: DockerContainer | None
+) -> AsyncGenerator[ReadWriteLockBackend]:
+    """Read-write lock backend under test."""
+    if backend_name == "redis" and container:
+        port = container.get_exposed_port(6379)
+        provider = RedisProvider(f"redis://localhost:{port}/0")
+        async with RedisReadWriteLockAdapter(provider=provider) as backend:
+            yield backend
+    elif backend_name == "postgres" and container:
+        port = container.get_exposed_port(5432)
+        provider = PostgresProvider(
+            f"postgresql://test:test@localhost:{port}/test"
+        )
+        async with (
+            provider,
+            PostgresReadWriteLockAdapter(provider=provider) as backend,
+        ):
+            yield backend
+    elif backend_name == "memory":
+        async with MemoryReadWriteLockAdapter() as backend:
+            yield backend
+    elif backend_name == "sqlite":
+        provider = SQLiteProvider(":memory:")
+        async with (
+            provider,
+            SQLiteReadWriteLockAdapter(provider=provider) as backend,
+        ):
+            yield backend
+    elif backend_name == "kubernetes":
+        # `container` points the adapter at the shared k3s server through
+        # the environment, so it is a dependency even though it yields None.
+        async with KubernetesReadWriteLockAdapter(
+            namespace="default"
+        ) as backend:
+            yield backend
+
+
+async def test_readers_share(backend: ReadWriteLockBackend) -> None:
+    """Several readers hold the lock at the same time."""
+    name = "test_readers_share"
+    tokens = [uuid4().hex for _ in range(_READERS)]
+
+    granted = [
+        await backend.acquire_read(name=name, token=token, duration=10)
+        for token in tokens
+    ]
+
+    assert all(generation is not None for generation in granted)
+    state = await backend.state(name=name)
+    assert state.readers == _READERS
+    assert not state.writing
+
+
+async def test_writer_excludes_readers(backend: ReadWriteLockBackend) -> None:
+    """A live writer keeps readers out."""
+    name = "test_writer_excludes_readers"
+    writer, reader = uuid4().hex, uuid4().hex
+
+    grant = await backend.acquire_write(name=name, token=writer, duration=10)
+    refused = await backend.acquire_read(name=name, token=reader, duration=10)
+
+    assert grant is not None
+    assert refused is None
+
+
+async def test_readers_exclude_writer(backend: ReadWriteLockBackend) -> None:
+    """A reader keeps a writer out, and the writer records an intent."""
+    name = "test_readers_exclude_writer"
+    reader, writer = uuid4().hex, uuid4().hex
+
+    await backend.acquire_read(name=name, token=reader, duration=10)
+    refused = await backend.acquire_write(name=name, token=writer, duration=10)
+
+    assert refused is None
+    assert (await backend.state(name=name)).waiting_writers == 1
+
+
+async def test_waiting_writer_blocks_new_readers(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """A recorded intent keeps new readers out while old readers finish."""
+    name = "test_waiting_writer_blocks_new_readers"
+    reader, writer, latecomer = uuid4().hex, uuid4().hex, uuid4().hex
+
+    await backend.acquire_read(name=name, token=reader, duration=10)
+    await backend.acquire_write(name=name, token=writer, duration=10)
+
+    assert (
+        await backend.acquire_read(name=name, token=latecomer, duration=10)
+        is None
+    )
+    assert (
+        await backend.acquire_read(name=name, token=reader, duration=10)
+        is not None
+    )
+
+
+async def test_writer_enters_after_last_reader_leaves(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """The waiting writer is granted once the last reader releases."""
+    name = "test_writer_enters_after_last_reader_leaves"
+    reader, writer = uuid4().hex, uuid4().hex
+
+    await backend.acquire_read(name=name, token=reader, duration=10)
+    await backend.acquire_write(name=name, token=writer, duration=10)
+    assert await backend.release_read(name=name, token=reader)
+
+    grant = await backend.acquire_write(name=name, token=writer, duration=10)
+
+    assert grant is not None
+    assert not grant.poisoned
+    assert (await backend.state(name=name)).waiting_writers == 0
+
+
+async def test_nowait_writer_records_no_intent(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """A try that does not wait leaves readers free to arrive."""
+    name = "test_nowait_writer_records_no_intent"
+    reader, writer, latecomer = uuid4().hex, uuid4().hex, uuid4().hex
+
+    await backend.acquire_read(name=name, token=reader, duration=10)
+    refused = await backend.acquire_write(
+        name=name, token=writer, duration=10, intent=False
+    )
+
+    assert refused is None
+    assert (await backend.state(name=name)).waiting_writers == 0
+    assert (
+        await backend.acquire_read(name=name, token=latecomer, duration=10)
+        is not None
+    )
+
+
+async def test_cancel_intent_lets_readers_in(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """A writer that stops waiting stops holding readers out."""
+    name = "test_cancel_intent_lets_readers_in"
+    reader, writer, latecomer = uuid4().hex, uuid4().hex, uuid4().hex
+
+    await backend.acquire_read(name=name, token=reader, duration=10)
+    await backend.acquire_write(name=name, token=writer, duration=10)
+    assert await backend.cancel_intent(name=name, token=writer)
+    assert not await backend.cancel_intent(name=name, token=writer)
+
+    assert (
+        await backend.acquire_read(name=name, token=latecomer, duration=10)
+        is not None
+    )
+
+
+async def test_generation_grows_per_write(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """Each write acquisition mints a strictly greater fencing token."""
+    name = "test_generation_grows_per_write"
+    first, second = uuid4().hex, uuid4().hex
+
+    grant_first = await backend.acquire_write(
+        name=name, token=first, duration=10
+    )
+    assert grant_first is not None
+    await backend.release_write(name=name, token=first)
+    grant_second = await backend.acquire_write(
+        name=name, token=second, duration=10
+    )
+
+    assert grant_second is not None
+    assert grant_second.fencing_token > grant_first.fencing_token
+
+
+async def test_same_writer_extend_keeps_generation(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """A renewal by the holder keeps its fencing token."""
+    name = "test_same_writer_extend_keeps_generation"
+    writer = uuid4().hex
+
+    first = await backend.acquire_write(name=name, token=writer, duration=10)
+    second = await backend.acquire_write(name=name, token=writer, duration=10)
+
+    assert first is not None
+    assert second is not None
+    assert first.fencing_token == second.fencing_token
+
+
+async def test_reader_sees_write_generation(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """A read taken after a write observes that write's generation."""
+    name = "test_reader_sees_write_generation"
+    writer, reader = uuid4().hex, uuid4().hex
+
+    grant = await backend.acquire_write(name=name, token=writer, duration=10)
+    assert grant is not None
+    await backend.release_write(name=name, token=writer)
+    generation = await backend.acquire_read(
+        name=name, token=reader, duration=10
+    )
+
+    assert generation == grant.fencing_token
+
+
+async def test_expired_reader_does_not_block_writer(
+    backend: ReadWriteLockBackend,
+    expire_duration: float,
+    expire_wait: float,
+) -> None:
+    """A reader that died is reaped by the writer's own acquire."""
+    name = "test_expired_reader_does_not_block_writer"
+    reader, writer = uuid4().hex, uuid4().hex
+
+    await backend.acquire_read(
+        name=name, token=reader, duration=expire_duration
+    )
+    await sleep(expire_wait)
+    grant = await backend.acquire_write(name=name, token=writer, duration=10)
+
+    assert grant is not None
+
+
+async def test_expired_writer_poisons_the_next(
+    backend: ReadWriteLockBackend,
+    expire_duration: float,
+    expire_wait: float,
+) -> None:
+    """A writer that died without releasing is reported to its successor."""
+    name = "test_expired_writer_poisons_the_next"
+    dead, next_writer = uuid4().hex, uuid4().hex
+
+    await backend.acquire_write(name=name, token=dead, duration=expire_duration)
+    await sleep(expire_wait)
+    grant = await backend.acquire_write(
+        name=name, token=next_writer, duration=10
+    )
+
+    assert grant is not None
+    assert grant.poisoned
+
+
+async def test_clean_release_does_not_poison(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """A writer that released cleanly leaves no poison behind."""
+    name = "test_clean_release_does_not_poison"
+    first, second = uuid4().hex, uuid4().hex
+
+    await backend.acquire_write(name=name, token=first, duration=10)
+    assert await backend.release_write(name=name, token=first)
+    grant = await backend.acquire_write(name=name, token=second, duration=10)
+
+    assert grant is not None
+    assert not grant.poisoned
+
+
+async def test_downgrade_hands_no_gap_to_another_writer(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """A downgrade leaves the caller reading and keeps writers out."""
+    name = "test_downgrade_hands_no_gap"
+    writer, other = uuid4().hex, uuid4().hex
+
+    grant = await backend.acquire_write(name=name, token=writer, duration=10)
+    assert grant is not None
+    generation = await backend.downgrade(name=name, token=writer, duration=10)
+
+    assert generation == grant.fencing_token
+    assert await backend.owned_read(name=name, token=writer)
+    assert not await backend.owned_write(name=name, token=writer)
+    assert (
+        await backend.acquire_write(
+            name=name, token=other, duration=10, intent=False
+        )
+        is None
+    )
+
+
+async def test_downgrade_without_the_lock(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """A caller that does not hold the write lock cannot downgrade."""
+    name = "test_downgrade_without_the_lock"
+
+    assert (
+        await backend.downgrade(name=name, token=uuid4().hex, duration=10)
+        is None
+    )
+
+
+async def test_release_reports_what_it_did(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """Releasing a lease that is not held reports `False`."""
+    name = "test_release_reports_what_it_did"
+    token = uuid4().hex
+
+    assert not await backend.release_read(name=name, token=token)
+    assert not await backend.release_write(name=name, token=token)
+    await backend.acquire_read(name=name, token=token, duration=10)
+    assert await backend.release_read(name=name, token=token)
+
+
+async def test_owned_and_state_on_a_fresh_name(
+    backend: ReadWriteLockBackend,
+) -> None:
+    """A name nobody touched reads as free."""
+    name = f"test_fresh_{uuid4().hex}"
+
+    state = await backend.state(name=name)
+
+    assert state == type(state)(
+        generation=0, writing=False, readers=0, waiting_writers=0
+    )
+    assert not await backend.owned_read(name=name, token="nobody")
+    assert not await backend.owned_write(name=name, token="nobody")
+
+
+async def test_owned_tracks_the_holder(backend: ReadWriteLockBackend) -> None:
+    """`owned_read` and `owned_write` follow the live holder."""
+    name = "test_owned_tracks_the_holder"
+    reader, writer = uuid4().hex, uuid4().hex
+
+    await backend.acquire_read(name=name, token=reader, duration=10)
+    assert await backend.owned_read(name=name, token=reader)
+    assert not await backend.owned_write(name=name, token=reader)
+    await backend.release_read(name=name, token=reader)
+
+    await backend.acquire_write(name=name, token=writer, duration=10)
+    assert await backend.owned_write(name=name, token=writer)
+    assert not await backend.owned_read(name=name, token=writer)

--- a/tests/coordination/test_sqlite_rwlock.py
+++ b/tests/coordination/test_sqlite_rwlock.py
@@ -1,0 +1,52 @@
+"""Test the SQLite read-write lock adapter paths outside the conformance suite."""
+
+import pytest
+
+from grelmicro.coordination.sqlite import SQLiteReadWriteLockAdapter
+from grelmicro.providers.sqlite import SQLiteProvider
+
+pytestmark = [pytest.mark.timeout(10, func_only=True)]
+
+
+def test_table_name_must_be_an_identifier() -> None:
+    """A table name that is not an identifier is refused at construction."""
+    with pytest.raises(ValueError, match="not a valid SQL identifier"):
+        SQLiteReadWriteLockAdapter(table_name="rwlocks; DROP TABLE users")
+
+
+async def test_owns_its_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a provider the adapter builds and lifecycles its own."""
+    monkeypatch.setenv("SQLITE_PATH", ":memory:")
+
+    adapter = SQLiteReadWriteLockAdapter()
+
+    async with adapter:
+        assert adapter.provider.client is not None
+        assert (
+            await adapter.acquire_read(name="catalog", token="r", duration=10)
+            == 0
+        )
+
+
+async def test_rebind_provider() -> None:
+    """A rebound provider is borrowed rather than owned."""
+    first = SQLiteProvider(":memory:")
+    second = SQLiteProvider(":memory:")
+    adapter = SQLiteReadWriteLockAdapter(provider=first)
+
+    adapter._rebind_provider(second)
+
+    assert adapter.provider is second
+
+
+async def test_transaction_rolls_back_on_error() -> None:
+    """A statement that fails rolls the transaction back and propagates."""
+    provider = SQLiteProvider(":memory:")
+    async with provider, SQLiteReadWriteLockAdapter(provider=provider) as rw:
+        rw._sql["select_lock"] = "SELECT * FROM does_not_exist;"
+
+        with pytest.raises(Exception, match="does_not_exist"):
+            await rw.state(name="catalog")
+
+        # The connection is usable again, so the rollback ran.
+        assert await provider.client.execute("SELECT 1;") is not None

--- a/tests/providers/test_redis_provider.py
+++ b/tests/providers/test_redis_provider.py
@@ -10,7 +10,10 @@ from redis.asyncio.sentinel import Sentinel
 
 from grelmicro import Grelmicro, GrelmicroConfigWarning
 from grelmicro.cache.redis import RedisCacheAdapter
-from grelmicro.coordination.redis import RedisLockAdapter
+from grelmicro.coordination.redis import (
+    RedisLockAdapter,
+    RedisReadWriteLockAdapter,
+)
 from grelmicro.providers.redis import (
     RedisConfig,
     RedisProvider,
@@ -726,6 +729,25 @@ class TestClusterHashTagGuard:
     ) -> None:
         """A prefix carrying a hash tag is accepted on Cluster."""
         adapter = RedisLockAdapter(provider=cluster_provider, prefix="{app}")
+
+        assert adapter.provider is cluster_provider
+
+    def test_rwlock_without_hash_tag_raises(
+        self, cluster_provider: RedisProvider
+    ) -> None:
+        """The read-write lock adapter rejects a tag-less prefix on Cluster."""
+        with pytest.raises(ValueError, match="hash tag"):
+            RedisReadWriteLockAdapter(
+                provider=cluster_provider, prefix="rwlock:"
+            )
+
+    def test_rwlock_with_hash_tag_passes(
+        self, cluster_provider: RedisProvider
+    ) -> None:
+        """A prefix carrying a hash tag is accepted on Cluster."""
+        adapter = RedisReadWriteLockAdapter(
+            provider=cluster_provider, prefix="{app}"
+        )
 
         assert adapter.provider is cluster_provider
 

--- a/tests/test_adapter_contracts.py
+++ b/tests/test_adapter_contracts.py
@@ -19,6 +19,7 @@ LOOP_PROTOCOLS = frozenset(
         "CacheBackend",
         "CircuitBreakerBackend",
         "LockBackend",
+        "ReadWriteLockBackend",
         "ScheduleBackend",
     }
 )

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -8,9 +8,15 @@ from pytest_mock import MockerFixture
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.coordination.kubernetes import KubernetesLockAdapter
-from grelmicro.coordination.memory import MemoryLockAdapter
+from grelmicro.coordination.memory import (
+    MemoryLockAdapter,
+    MemoryReadWriteLockAdapter,
+)
 from grelmicro.coordination.postgres import PostgresLockAdapter
-from grelmicro.coordination.redis import RedisLockAdapter
+from grelmicro.coordination.redis import (
+    RedisLockAdapter,
+    RedisReadWriteLockAdapter,
+)
 from grelmicro.coordination.sqlite import SQLiteLockAdapter
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.resilience.ratelimiter.postgres import PostgresRateLimiterAdapter
@@ -120,4 +126,18 @@ async def test_rate_limiter_postgres_async_with(
         AsyncMock(return_value=mock_pool),
     )
     async with PostgresRateLimiterAdapter():
+        pass
+
+
+async def test_rwlock_memory_async_with() -> None:
+    """Test read-write lock memory backend async with."""
+    async with MemoryReadWriteLockAdapter():
+        pass
+
+
+async def test_rwlock_redis_async_with(mock_redis: MagicMock) -> None:  # noqa: ARG001
+    """Test read-write lock redis backend async with."""
+    async with RedisReadWriteLockAdapter(
+        provider=RedisProvider("redis://localhost")
+    ):
         pass


### PR DESCRIPTION
Closes #686.

`ReadWriteLock` lets every reader in at once and keeps writers alone. Reach for it when a resource is read far more often than it is written.

```python
catalog = ReadWriteLock("catalog")

async with catalog.read as reading:
    ...

async with catalog.write as writing:
    await store.replace_all(rows, fencing_token=writing.fencing_token)
```

`lock.read` and `lock.write` are two views of one lock, each a full primitive with `acquire(timeout=...)`, `acquire_nowait()`, `extend()`, `release()`, and a `from_thread` adapter.

## Design

- **Writers never starve.** The lock is writer-preferring. A writer that finds readers in the way records an intent, and readers arriving after it wait. The intent carries its own lease, so a writer that dies while waiting stops holding readers back.
- **Per-holder leases.** Readers live in a set with one lease each, not behind a counter. A counter cannot tell three live readers from one live and two crashed. The next writer's acquire reaps what expired.
- **Typed guards.** `ReadGuard` and `WriteGuard` are distinct types, so a function that writes can demand the write guard in its signature and the type checker rejects a caller that never took the lock. Reading a token from a spent or expired guard raises `LockNotOwnedError` rather than handing back a stale one.
- **Poison.** `WriteGuard.poisoned` says the previous writer's lease expired without a release, so the resource may hold a half-finished write.
- **Downgrade, no upgrade.** `await guard.downgrade()` turns a write lease into a read lease with no gap for another writer. Upgrading raises `LockUpgradeError` instead of shipping a deadlock.

## Backends

Redis, Valkey, PostgreSQL, SQLite, Kubernetes, and Memory. Every one passes the same conformance suite, which asserts the invariants rather than the implementation: a writer is never concurrent with a reader, the generation only grows, a waiting writer keeps new readers out, and an expired holder never blocks anyone.

- Redis and Valkey: one server-side step per operation, a hash for the writer and generation plus two sorted sets for readers and intents.
- PostgreSQL: PL/pgSQL under `pg_advisory_xact_lock`, the pattern the leader election adapter already uses.
- SQLite: one write transaction per operation.
- Kubernetes: the writer in the Lease spec, readers and intents in annotations, written under `resourceVersion` compare-and-set. Coarse-grained on purpose, and the docs say so.

## Wiring

`Provider.readwritelock()`, `Coordination(rwlock=...)`, and `micro.coordination.readwritelock(...)`. `Coordination(redis)` resolves it along with the other backends.

## Tests

- One conformance suite over all five backends.
- Primitive tests for the guards, the retry loops, intent withdrawal on timeout, the reentrancy and upgrade rules, and both `from_thread` adapters.
- Mocked Kubernetes tests for what a live API server will not produce on demand: a conflict on every retry, a Lease that vanishes mid-operation, and an error that is not a conflict.
- Full tier green at 100% coverage.

## Docs

New [Read-Write Lock](https://grelmicro.grel.info/coordination/#read-write-lock) section with four runnable snippets, plus the module tables, the capability matrix, the API reference, and the roadmap entry.