### PR TITLE
🔖 Prepare the 0.36.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.36.0 - 2026-08-09
 
 ### Breaking
 


### PR DESCRIPTION
Dates the changelog section for 0.36.0.

Minor bump, matching how this project has versioned every release carrying a `### Breaking` section (0.34.0, 0.35.0).

The release covers [`ReadWriteLock`](https://github.com/grelinfo/grelmicro/issues/686) and the [task timezone](https://github.com/grelinfo/grelmicro/issues/645) work, which also removes the `pydantic-extra-types` dependency and fixes three pre-existing bugs: an `ImportError` on images with no timezone database, a cron double fire when the clocks go back, and a busy loop through the repeated hour.