### PR TITLE
📝 Use a current dependency in the commit title example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,7 @@ a partially-correct PR is faster than guessing.
   - `👷 Add attestations and wheel verification to the release`
   - `📝 Update the changelog for the next release`
   - `♻️ Bind the algorithm to the strategy once at construction`
-  - `⬆️ Bump pydantic-extra-types from 2.11.1 to 2.11.2`
+  - `⬆️ Bump pydantic-settings from 2.14.1 to 2.14.2`
 
 - The PR number is appended automatically on squash merge
   (`... (#123)`), so you do not write it in the title yourself.


### PR DESCRIPTION
`CONTRIBUTING.md` used `⬆️ Bump pydantic-extra-types from 2.11.1 to 2.11.2` as its sample commit title. 0.36.0 removed that dependency, so the example points at a package the project no longer has. Swapped for `pydantic-settings`, which it does.

The two remaining mentions of `pydantic-extra-types` are historical changelog entries and stay as they are.

Docs only, no release needed.