### PR TITLE
✨ Warn or refuse when a backend cannot keep its component's promise

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -32,7 +32,7 @@ Not every Pattern needs a backend, and the ones that do behave differently when 
 
 The tiers above say what a Pattern does with no backend at all. A backend that is present but too small is the harder case, because the Pattern works: a `Lock` on `MemoryLockAdapter` acquires, releases, and excludes nothing beyond the process.
 
-So an Adapter declares its **backend scope** and a Component declares the scope it **requires**. Kubernetes names the same axis the same way, with `scope: Namespaced | Cluster` on a CRD.
+So an Adapter declares the **backend scope** it provides and a Component declares the scope it **requires**.
 
 ```python
 class MemoryLockAdapter:
@@ -41,7 +41,7 @@ class MemoryLockAdapter:
 
 Three values, ordered: `process` (Memory) is held inside one process, `host` (SQLite) across the processes sharing one file, `cluster` (Redis, Valkey, Postgres, Kubernetes) across every process that connects to the backend. A Component is satisfied when the backend's scope is at least what it requires. `Coordination` and `Outbox` require `cluster`, the resilience Components and `Cache` require `process`, and `requires=` overrides either way.
 
-The environment decides the severity, not the verdict: `GREL_ENVIRONMENT=production` makes an unmet requirement a `BackendScopeError` at startup, an undeclared environment makes it a warning, and `development` or `test` silences it. [Deployment](../deployment.md#the-backend-check) has the user-facing rules.
+The environment decides the severity, not the verdict: `production` and `staging` make an unmet requirement a `BackendScopeError` at startup, an undeclared environment makes it a warning, and `development` and `test` silence it. [Deployment](../deployment.md#the-backend-check) has the user-facing rules.
 
 An Adapter that declares no `scope` is not reported. A third-party Adapter is the author's promise to keep, and grelmicro has no way to size a store it has never seen.
 

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -28,6 +28,25 @@ Not every Pattern needs a backend, and the ones that do behave differently when 
 
 **Purely local.** `Retry`, `Timeout`, `Bulkhead`, `Shield`, and `Fallback` hold no shared state and never take a backend. Construct and use them directly.
 
+## Backend scope and requirement
+
+The tiers above say what a Pattern does with no backend at all. A backend that is present but too small is the harder case, because the Pattern works: a `Lock` on `MemoryLockAdapter` acquires, releases, and excludes nothing beyond the process.
+
+So an Adapter declares its **backend scope** and a Component declares the scope it **requires**. Kubernetes names the same axis the same way, with `scope: Namespaced | Cluster` on a CRD.
+
+```python
+class MemoryLockAdapter:
+    scope: ClassVar[BackendScope] = "process"
+```
+
+Three values, ordered: `process` (Memory) is held inside one process, `host` (SQLite) across the processes sharing one file, `cluster` (Redis, Valkey, Postgres, Kubernetes) across every process that connects to the backend. A Component is satisfied when the backend's scope is at least what it requires. `Coordination` and `Outbox` require `cluster`, the resilience Components and `Cache` require `process`, and `requires=` overrides either way.
+
+The environment decides the severity, not the verdict: `GREL_ENVIRONMENT=production` makes an unmet requirement a `BackendScopeError` at startup, an undeclared environment makes it a warning, and `development` or `test` silences it. [Deployment](../deployment.md#the-backend-check) has the user-facing rules.
+
+An Adapter that declares no `scope` is not reported. A third-party Adapter is the author's promise to keep, and grelmicro has no way to size a store it has never seen.
+
+## Grouping
+
 `Coordination` groups the coordination backends (lock, leader election, schedule) under one Component because they belong to one domain, though you can still wire each to a different backend (`Coordination(lock=..., election=..., schedule=...)`). Resilience instead exposes one Component per shared Pattern, because each carries an independent sharing decision.
 
 ## Construction vs registration

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -35,6 +35,8 @@ See [Backends and Adapters](architecture/backends.md) for the full model.
 
 Valkey has no column of its own: `ValkeyProvider` serves the Redis adapters through `valkey-py`, so read the Redis column for it.
 
+Each column also has a **backend scope**, which is how far its state is shared: `process` for Memory, `host` for SQLite, `cluster` for Redis, Valkey, Postgres, and Kubernetes. A ✅ says the combination ships, not that it holds across replicas. [Deployment](deployment.md#the-backend-check) covers the startup check that keeps a `process` backend out of a `cluster` job.
+
 Legend:
 
 - ✅ ships today.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+* ✨ Refuse to start when a backend cannot keep the promise its component makes. Declare the tier with `GREL_ENVIRONMENT` or `Grelmicro(environment=...)`, and in `production` or `staging` a `Coordination` or `Outbox` bound to a memory or SQLite backend raises `BackendScopeError` before the first connection opens. A lock that excludes nothing the moment a second replica starts used to say nothing at all. ([#683](https://github.com/grelinfo/grelmicro/issues/683))
+* ✨ Add `scope` to every adapter and `requires=` to every component that holds a backend. A backend provides a scope (`process`, `host` or `cluster`), a component requires one, and `Coordination(memory, requires="process")` declares a single-process deployment instead of muting a check. `RateLimiterComponent(redis, requires="cluster")` reads the other way and fails the day someone points it at memory. ([#683](https://github.com/grelinfo/grelmicro/issues/683))
+* ✨ Report the same finding as a warning on two channels when no tier is declared, and stay silent in `development` and `test`. A value naming no tier, such as `preprod`, warns and reads as undeclared, so a fleet with its own tier names keeps booting and `prodution` is loud instead of silent. ([#683](https://github.com/grelinfo/grelmicro/issues/683))
+* ✨ Add `micro.check_backends()`, which answers for production from a process that declares something else, so a test catches the wiring before a pod does. It raises `BackendScopeError` naming every binding that does not hold. ([#683](https://github.com/grelinfo/grelmicro/issues/683))
+* ✨ Set the OpenTelemetry `deployment.environment.name` resource attribute from the declared tier, so one variable gates the check and names the environment in every trace. ([#683](https://github.com/grelinfo/grelmicro/issues/683))
+
 ### Breaking
 
 * 💥 Settle on **Component** as the one word for app-level wiring. `RateLimiterRegistry` becomes `RateLimiterComponent` and `CircuitBreakerRegistry` becomes `CircuitBreakerComponent`. Neither ever registered anything: each wraps one backend, so the name borrowed a contract it did not honor. Update `uses=[...]` and imports. ([#682](https://github.com/grelinfo/grelmicro/issues/682))

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,6 +23,12 @@ variable that is missing fails at construction and names the variable it
 wanted, so there is no silent default to protect you from. Pass
 `env_load=False` to a provider to turn its env reads off.
 
+Two `GREL_*` names sit outside the flag as well, because neither fills a
+component field. `GREL_ENV_LOAD` is the flag. `GREL_ENVIRONMENT` says where
+the app runs, which decides how a backend that cannot keep a promise across
+replicas is reported: see
+[the backend check](deployment.md#the-backend-check).
+
 Step 2 is the one that surprises people. `GREL_ENV_LOAD` is a single
 process-wide switch, so a variable set without it is ignored and the default
 applies. That situation reports at startup instead of passing silently, naming

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,6 +3,139 @@
 What a container image and a Kubernetes manifest need before they run a
 grelmicro application in production.
 
+## Declare the environment
+
+Set `GREL_ENVIRONMENT=production` in the manifest of every deployed
+environment:
+
+```bash
+GREL_ENVIRONMENT=production
+```
+
+Four values gate: `development`, `test`, `staging`, and `production`. They are
+the well-known values of the OpenTelemetry
+[`deployment.environment.name`](https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/)
+attribute, and grelmicro writes the declared value into that attribute on the
+tracer resource, so the same variable names your environment in every trace.
+
+Declaring `production` or `staging` turns on the backend check below. This is
+the one place to set it per environment, so unlike `GREL_ENV_LOAD` it belongs
+in the manifest rather than the image.
+
+Any other value still reaches your traces, because OpenTelemetry allows one,
+but it names no tier grelmicro can act on, so the check reads it as
+undeclared and says so:
+
+```
+GrelmicroConfigWarning: GREL_ENVIRONMENT='preprod' is not one of development,
+test, staging, production, so the backend check runs as if it were
+undeclared.
+```
+
+A fleet that calls its tiers `qa` and `preprod` keeps booting, and
+`prodution` is loud instead of silent.
+
+The value names a tier, not the name your organisation gave the environment.
+Map yours to the closest of the four: a deployed environment that runs more
+than one replica is `staging`, a throwaway CI run is `test`. You know which
+one an environment called `integration` is, and grelmicro does not.
+
+### The backend check
+
+A `Lock` on a memory backend is not a lock. It excludes nothing once a second
+replica runs, and without a check it says nothing about it. So in `production`
+and `staging`, a pattern that promises a guarantee across replicas refuses to
+start on a backend that cannot deliver it:
+
+```
+BackendScopeError: Coordination('default') is bound to MemoryLockAdapter,
+which provides scope 'process', but requires scope 'cluster' in environment
+'production'. Use a Redis, Valkey, Postgres, or Kubernetes backend, or pass
+requires= to say what reach you want.
+```
+
+A backend provides a scope, a component requires one. The message names both
+sides, so the fix is in the sentence that reports the problem.
+
+The check runs before the first connection opens, so a misconfigured pod
+fails at boot instead of on the request that needed the lock.
+
+Every backend has a **scope**, and every component **requires** one:
+
+| Backend scope | Backends | State is shared by |
+| --- | --- | --- |
+| `process` | Memory | One process |
+| `host` | SQLite | The processes on one host |
+| `cluster` | Redis, Valkey, Postgres, Kubernetes | Every process that connects |
+
+`cluster` means every process connected to that backend, wherever those
+processes run. One Redis serving two Kubernetes clusters still holds one lock.
+
+`Coordination` and `Outbox` require `cluster`, because a lock, a leader, a
+distributed cron and an outbox all promise something across replicas. `Cache`,
+`RateLimiterComponent` and `CircuitBreakerComponent` require `process`: a
+per-replica cache and a per-replica circuit breaker are the standard shape,
+not a mistake.
+
+Say what you want with `requires=` and the default no longer applies:
+
+```python
+--8<-- "deployment/requires.py"
+```
+
+It reads in both directions. Lower the bar to accept the scope you have, or
+raise it to make the wiring you meant a startup condition: a
+`RateLimiterComponent(redis, requires="cluster")` fails at boot the day
+someone points it at memory. A `Cache` that an
+[`Idempotency`](idempotency.md) reads from wants `requires="cluster"` too,
+because a replay has to find the stored response wherever the retry lands.
+
+Only a bound backend is checked. A component you never registered is the
+[documented way](architecture/backends.md#distribution-model) to say you want
+local behavior: a `@cron` with no `Coordination` fires on every replica on
+purpose. Wiring a memory schedule backend instead says you expected the fleet
+to agree, so that one is reported.
+
+### When the environment is not declared
+
+An undeclared environment still reports a backend that cannot keep its
+promise. The report is a `GrelmicroConfigWarning` and a `WARNING` on the
+`grelmicro` logger, once at startup, on both channels like the
+[ignored-variable report](#when-the-flag-is-missing):
+
+```
+GrelmicroConfigWarning: Coordination('default') is bound to MemoryLockAdapter,
+which provides scope 'process', but requires scope 'cluster'. Set
+GREL_ENVIRONMENT to declare where this runs, or pass requires='process' to
+say that is the reach you want.
+```
+
+So the three states differ in severity, not in what they find:
+
+| `GREL_ENVIRONMENT` | A backend that cannot keep the promise |
+| --- | --- |
+| `production`, `staging` | `BackendScopeError` at startup |
+| unset | Warning on both channels, once |
+| `development`, `test` | Nothing |
+
+Declare `test` in your test suite and the memory backends every test wires up
+go quiet. [Testing](testing.md#declare-the-test-environment) shows where.
+
+### Check it before it deploys
+
+`micro.check_backends()` asks the question the deployed app will ask, from a
+process that declares something else, so a test catches the wiring before a
+pod does. It raises the same `BackendScopeError`, naming every binding that
+does not hold:
+
+```python
+def test_backends_hold_across_replicas() -> None:
+    micro.check_backends()
+```
+
+It checks against `production` by default. Pass `environment=` to ask about
+another one.
+
 ## Turn on environment configuration
 
 Set `GREL_ENV_LOAD=1` in the image:
@@ -11,10 +144,14 @@ Set `GREL_ENV_LOAD=1` in the image:
 ENV GREL_ENV_LOAD=1
 ```
 
-Every `GREL_*` variable is read only when this flag is truthy (`1`, `true`,
-`yes`, `on`). Without it, a pod that sets `GREL_LOG_LEVEL=DEBUG` logs at
-`INFO`, and a pod that sets `GREL_LOCK_CART_LEASE_DURATION=120` keeps the
-60 second default.
+Every `GREL_*` variable that fills a component field is read only when this
+flag is truthy (`1`, `true`, `yes`, `on`). Without it, a pod that sets
+`GREL_LOG_LEVEL=DEBUG` logs at `INFO`, and a pod that sets
+`GREL_LOCK_CART_LEASE_DURATION=120` keeps the 60 second default.
+
+`GREL_ENVIRONMENT` is the exception, along with the flag itself. Neither
+fills a component field, and a safety check behind an opt-in flag would be
+off in the pods that need it most.
 
 Provider variables are not gated. `REDIS_URL`, `VALKEY_URL`, `POSTGRES_URL`
 and `SQLITE_PATH` are read out of the box, because those names belong to your
@@ -161,6 +298,8 @@ spec:
           ports:
             - containerPort: 8000
           env:
+            - name: GREL_ENVIRONMENT
+              value: production
             - name: GREL_LOG_LEVEL
               value: INFO
             - name: GREL_LOCK_CART_LEASE_DURATION
@@ -200,6 +339,8 @@ change the image, and then put it in every copy of the manifest.
 
 ## Checklist
 
+- [ ] `GREL_ENVIRONMENT` is set in every deployed environment.
+- [ ] `micro.check_backends()` is asserted in a test.
 - [ ] `GREL_ENV_LOAD=1` is in the image.
 - [ ] The startup logs carry no `variable` field.
 - [ ] `GREL_LOG_LEVEL` is set per environment, and the format is left to `AUTO`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,9 +22,8 @@ Declaring `production` or `staging` turns on the backend check below. This is
 the one place to set it per environment, so unlike `GREL_ENV_LOAD` it belongs
 in the manifest rather than the image.
 
-Any other value still reaches your traces, because OpenTelemetry allows a
-custom one, but it names no tier grelmicro can act on, so the check reads it
-as undeclared and says so:
+Any other value names no tier grelmicro can act on, so it neither gates the
+check nor reaches the trace attribute. It reads as undeclared, and says so:
 
 ```
 GrelmicroConfigWarning: GREL_ENVIRONMENT='preprod' is not one of development,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,8 +12,8 @@ environment:
 GREL_ENVIRONMENT=production
 ```
 
-Four values gate: `development`, `test`, `staging`, and `production`. They are
-the well-known values of the OpenTelemetry
+Four values name a tier: `development`, `test`, `staging`, and `production`.
+They are the well-known values of the OpenTelemetry
 [`deployment.environment.name`](https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/)
 attribute, and grelmicro writes the declared value into that attribute on the
 tracer resource, so the same variable names your environment in every trace.
@@ -22,9 +22,9 @@ Declaring `production` or `staging` turns on the backend check below. This is
 the one place to set it per environment, so unlike `GREL_ENV_LOAD` it belongs
 in the manifest rather than the image.
 
-Any other value still reaches your traces, because OpenTelemetry allows one,
-but it names no tier grelmicro can act on, so the check reads it as
-undeclared and says so:
+Any other value still reaches your traces, because OpenTelemetry allows a
+custom one, but it names no tier grelmicro can act on, so the check reads it
+as undeclared and says so:
 
 ```
 GrelmicroConfigWarning: GREL_ENVIRONMENT='preprod' is not one of development,
@@ -54,13 +54,11 @@ which provides scope 'process', but requires scope 'cluster' in environment
 requires= to say what reach you want.
 ```
 
-A backend provides a scope, a component requires one. The message names both
-sides, so the fix is in the sentence that reports the problem.
-
 The check runs before the first connection opens, so a misconfigured pod
 fails at boot instead of on the request that needed the lock.
 
-Every backend has a **scope**, and every component **requires** one:
+A backend **provides** a scope, and a component **requires** one. The message
+names both sides, so the fix is in the sentence that reports the problem.
 
 | Backend scope | Backends | State is shared by |
 | --- | --- | --- |
@@ -95,6 +93,10 @@ Only a bound backend is checked. A component you never registered is the
 local behavior: a `@cron` with no `Coordination` fires on every replica on
 purpose. Wiring a memory schedule backend instead says you expected the fleet
 to agree, so that one is reported.
+
+A [`Bulkhead(uses=[...])`](resilience/bulkhead.md) holds components the app
+never registers, so those are checked on first entry to the scope instead of
+at startup.
 
 ### When the environment is not declared
 

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -46,6 +46,12 @@ The first request with a given key runs `do_charge` and stores the response. Any
 
 Redis needs the `redis` extra: `pip install "grelmicro[redis]"`. Tests swap the provider for the memory backend, see [Testing](testing.md).
 
+A replay has to find the stored response wherever the retry lands, so the `Cache` behind an `Idempotency` has to be shared by every replica. A `Cache` alone is happy on the memory backend, so say what this one is for and the [backend check](deployment.md#the-backend-check) holds you to it:
+
+```python
+micro = Grelmicro(uses=[redis, Cache(redis, requires="cluster")])
+```
+
 ## HTTP middleware
 
 The quick start reads the key and opens a block in every handler that needs one. `IdempotencyMiddleware` does it once, for the whole app.

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -46,10 +46,10 @@ The first request with a given key runs `do_charge` and stores the response. Any
 
 Redis needs the `redis` extra: `pip install "grelmicro[redis]"`. Tests swap the provider for the memory backend, see [Testing](testing.md).
 
-A replay has to find the stored response wherever the retry lands, so the `Cache` behind an `Idempotency` has to be shared by every replica. A `Cache` alone is happy on the memory backend, so say what this one is for and the [backend check](deployment.md#the-backend-check) holds you to it:
+A replay has to find the stored response wherever the retry lands, so the `Cache` behind an `Idempotency` has to be shared by every replica. A `Cache` alone is happy on the memory backend, so name the `Cache` this one rides and the [backend check](deployment.md#the-backend-check) holds you to it:
 
 ```python
-micro = Grelmicro(uses=[redis, Cache(redis, requires="cluster")])
+micro = Grelmicro(uses=[Cache(redis, requires="cluster")])
 ```
 
 ## HTTP middleware

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -9,3 +9,5 @@
         - SecretUrl
         - TimeZoneName
         - LogLevel
+        - Environment
+        - BackendScope

--- a/docs/resilience/bulkhead.md
+++ b/docs/resilience/bulkhead.md
@@ -36,6 +36,8 @@ The default fails fast: with no `max_wait`, a full bulkhead rejects immediately.
 
 The bulkhead opens its `uses=` on first entry and closes them when the app shuts down, so an active `Grelmicro` app is required. List the Provider before the Component that borrows it, exactly as in `Grelmicro(uses=[...])`.
 
+These Components are not registered on the app, so the [backend check](../deployment.md#the-backend-check) cannot run at startup for them. It runs on first entry instead, with the same rules.
+
 ## Configuration
 
 `Bulkhead` follows the three-paths configuration contract.

--- a/docs/snippets/deployment/requires.py
+++ b/docs/snippets/deployment/requires.py
@@ -1,0 +1,17 @@
+from grelmicro import Grelmicro
+from grelmicro.coordination import Coordination
+from grelmicro.providers.memory import MemoryProvider
+from grelmicro.providers.redis import RedisProvider
+from grelmicro.resilience import RateLimiterComponent
+
+memory = MemoryProvider()
+redis = RedisProvider("redis://localhost:6379/0")
+
+micro = Grelmicro(
+    uses=[
+        # One replica owns this schedule, and a restart may repeat a run.
+        Coordination(memory, name="cron", requires="process"),
+        # A budget shared by every replica, or the app does not start.
+        RateLimiterComponent(redis, requires="cluster"),
+    ]
+)

--- a/docs/snippets/env_gate.md
+++ b/docs/snippets/env_gate.md
@@ -1,6 +1,8 @@
 !!! warning "Environment variables are opt-in"
-    `GREL_*` variables are read only when `GREL_ENV_LOAD` is truthy (`1`, `true`,
-    `yes`, `on`). Without it the variable is ignored and the default applies.
+    A `GREL_*` variable that fills a component field is read only when
+    `GREL_ENV_LOAD` is truthy (`1`, `true`, `yes`, `on`), the flag itself and
+    `GREL_ENVIRONMENT` excepted. Without it the variable is ignored and the
+    default applies.
     Setting one while the flag is unset warns at startup, so the mistake is not
     silent. Passing `env_load=False` is a deliberate opt-out and stays quiet. See
     [How a value is resolved](https://grelmicro.grel.info/config/#how-a-value-is-resolved)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,6 +3,23 @@
 grelmicro gives you three tools for tests: swap a backend for the test, drive
 time by hand, and record the calls a pattern makes.
 
+## Declare the test environment
+
+Tests wire memory backends, and a memory backend behind a `Lock` is what the
+[backend check](deployment.md#the-backend-check) reports. Declare the
+environment once in `conftest.py` and the report stops, in the suite where it
+has nothing to say:
+
+```python
+import os
+
+os.environ.setdefault("GREL_ENVIRONMENT", "test")
+```
+
+`Grelmicro(environment="test")` does the same for one app. Keep calling
+`micro.check_backends()` for the app you deploy: it answers for production
+whatever this process declares.
+
 ## Swap a backend
 
 Inside an active app, `micro.override(...)` replaces a component for the duration

--- a/grelmicro/__init__.py
+++ b/grelmicro/__init__.py
@@ -14,6 +14,7 @@ from grelmicro.config import ExternalConfig
 from grelmicro.errors import (
     AdapterNotRegisteredError,
     AdmissionError,
+    BackendScopeError,
     DependencyNotFoundError,
     GrelmicroConfigWarning,
     GrelmicroError,
@@ -28,6 +29,7 @@ __all__ = [
     "AdmissionError",
     "AmbientBindingError",
     "AmbiguousProviderError",
+    "BackendScopeError",
     "Component",
     "ComponentAlreadyRegisteredError",
     "ComponentNotRegisteredError",

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -14,7 +14,14 @@ from typing import TYPE_CHECKING, Annotated, Any, Protocol, Self, cast
 from typing_extensions import Doc
 
 from grelmicro._component import Component, Usable, instantiate_if_class
+from grelmicro._environment import (
+    report_unmet_requirements,
+    resolve_environment,
+    strict_message,
+    unmet_requirements,
+)
 from grelmicro.errors import (
+    BackendScopeError,
     GrelmicroError,
     MultipleActiveAppsError,
     OutOfContextError,
@@ -29,6 +36,7 @@ if TYPE_CHECKING:
     from grelmicro.coordination._component import Coordination
     from grelmicro.log._component import Log
     from grelmicro.trace._component import Trace
+    from grelmicro.types import Environment
 else:
     # Runtime fallback so `typing.get_type_hints(Grelmicro)` resolves the
     # `coordination` / `cache` property annotations without forcing first-party
@@ -36,6 +44,7 @@ else:
     # static type checkers via the `TYPE_CHECKING` branch above.
     Cache = Any
     Coordination = Any
+    Environment = Any
     Log = Any
     Trace = Any
 
@@ -158,6 +167,24 @@ class Grelmicro:
                 """,
             ),
         ] = None,
+        environment: Annotated[
+            Environment | None,
+            Doc(
+                """
+                The deployment tier this app runs in: `"development"`,
+                `"test"`, `"staging"` or `"production"`. Falls back to
+                `GREL_ENVIRONMENT`, which is read whatever `GREL_ENV_LOAD`
+                says, and stays `None` when neither declares one.
+
+                `"staging"` and `"production"` make an unmet backend scope a
+                `BackendScopeError` at startup, `"development"` and `"test"`
+                silence it, and an undeclared tier reports it once as a
+                warning. The declared value also becomes the OpenTelemetry
+                `deployment.environment.name` resource attribute. See
+                [the backend check](deployment.md#the-backend-check).
+                """,
+            ),
+        ] = None,
         strict: Annotated[
             bool,
             Doc(
@@ -191,6 +218,7 @@ class Grelmicro:
         self._exit_stack: AsyncExitStack | None = None
         self._token: Any = None
         self._strict = strict
+        self._environment = resolve_environment(environment)
         self._allow_multiple = allow_multiple
         self._pending_providers: list[Provider] = []
         self._deferring_provider_defaults = uses is not None
@@ -204,6 +232,47 @@ class Grelmicro:
             finally:
                 self._deferring_provider_defaults = False
             self._register_provider_defaults()
+
+    @property
+    def environment(self) -> Environment | None:
+        """The declared deployment tier, or `None` when nothing declares one.
+
+        Resolved once at construction from `Grelmicro(environment=...)`, then
+        `GREL_ENVIRONMENT`. A value naming no tier reads as `None`.
+        """
+        return self._environment
+
+    def check_backends(
+        self,
+        environment: Annotated[
+            Environment,
+            Doc(
+                """
+                The tier to answer for. Defaults to `"production"`, so the
+                answer holds for the deployment rather than for the process
+                running the check.
+                """,
+            ),
+        ] = "production",
+    ) -> None:
+        """Check every bound backend against what its component requires.
+
+        Asks the question the deployed app will ask, from a process that
+        declares something else, so a test catches the wiring before a pod
+        does:
+
+        ```python
+        def test_backends_hold_across_replicas() -> None:
+            micro.check_backends()
+        ```
+
+        Raises:
+            BackendScopeError: If any bound backend reaches less far than its
+                component requires, naming every one of them.
+        """
+        unmet = unmet_requirements(self._items)
+        if unmet:
+            raise BackendScopeError(strict_message(unmet, environment))
 
     @classmethod
     def current(cls) -> Grelmicro:
@@ -904,6 +973,9 @@ class Grelmicro:
             self._discover_shared_providers()
             self._order_providers_before_dependents()
             self._resolve_provider_sharing()
+            report_unmet_requirements(
+                unmet_requirements(self._items), self._environment
+            )
             self._exit_stack = AsyncExitStack()
             await self._exit_stack.__aenter__()
             self._token = _current_micro.set(self)

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -38,7 +38,7 @@ from grelmicro.errors import GrelmicroConfigWarning
 
 if TYPE_CHECKING:
     import asyncio
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
     from grelmicro.errors import SettingsValidationError
 else:
@@ -232,6 +232,13 @@ A component resolves its config before logging is configured, so the names
 queue here until `flush_ignored_env_reports` drains them.
 """
 
+_pending_reports: deque[Callable[[], None]] = deque()
+"""Startup reports from elsewhere in grelmicro, waiting for logging.
+
+Same queue discipline as `_pending_ignored_env`, for a report that carries
+more than a variable name. `_environment` puts the backend scope report here.
+"""
+
 _logging_configured = False
 """True while `grelmicro.log` has its handlers installed."""
 
@@ -308,6 +315,21 @@ def flush_ignored_env_reports() -> None:
     _logging_configured = True
     while _pending_ignored_env:
         _log_ignored_env(_pending_ignored_env.popleft())
+    while _pending_reports:
+        _pending_reports.popleft()()
+
+
+def defer_report(emit: Callable[[], None]) -> None:
+    """Emit a startup log record now, or queue it until logging is configured.
+
+    The `warnings` channel fires where the report is made. The log record
+    waits, so a report made before `Log` installs its handlers still lands in
+    the log stream instead of a root logger with nothing on it.
+    """
+    if _logging_configured:
+        emit()
+    else:
+        _pending_reports.append(emit)
 
 
 def hold_ignored_env_reports() -> None:

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -25,6 +25,11 @@ import os
 import re
 import warnings
 from collections import deque
+
+# Imported at runtime, not under `TYPE_CHECKING`: both appear in the
+# annotations of `resolve_config` and `defer_report`, which
+# `typing.get_type_hints` has to resolve from module globals.
+from collections.abc import Callable, Mapping  # noqa: TC003
 from copy import copy
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
@@ -38,14 +43,14 @@ from grelmicro.errors import GrelmicroConfigWarning
 
 if TYPE_CHECKING:
     import asyncio
-    from collections.abc import Callable, Mapping
 
     from grelmicro.errors import SettingsValidationError
 else:
     # Runtime fallback so `typing.get_type_hints(resolve_config)` resolves the
     # `error_type` annotation without importing a name used only in
     # annotations. The real type reaches static checkers via the
-    # `TYPE_CHECKING` branch above.
+    # `TYPE_CHECKING` branch above. See the `collections.abc` import above for
+    # the other half of the same requirement.
     SettingsValidationError = Any
 
 C = TypeVar("C", bound=BaseModel)

--- a/grelmicro/_environment.py
+++ b/grelmicro/_environment.py
@@ -270,8 +270,12 @@ def strict_message(
         f"{entry.requires!r} in environment {environment!r}."
         for entry in unmet
     ]
+    backends = (
+        "a SQLite, Redis, Valkey, Postgres, or Kubernetes backend"
+        if all(entry.requires == "host" for entry in unmet)
+        else "a Redis, Valkey, Postgres, or Kubernetes backend"
+    )
     lines.append(
-        "Use a Redis, Valkey, Postgres, or Kubernetes backend, or pass "
-        "requires= to say what reach you want."
+        f"Use {backends}, or pass requires= to say what reach you want."
     )
     return " ".join(lines)

--- a/grelmicro/_environment.py
+++ b/grelmicro/_environment.py
@@ -143,20 +143,10 @@ def _report_unknown_environment(value: str) -> None:
         return
     _reported_unknown.add(value)
     known = ", ".join(ENVIRONMENTS)
-    warnings.warn(
-        _UNKNOWN_ENVIRONMENT_MESSAGE % (ENVIRONMENT_VAR, value, known),
-        GrelmicroConfigWarning,
-        stacklevel=4,
-    )
+    message = _UNKNOWN_ENVIRONMENT_MESSAGE % (ENVIRONMENT_VAR, value, known)
+    warnings.warn(message, GrelmicroConfigWarning, stacklevel=4)
     defer_report(
-        partial(
-            logger.warning,
-            _UNKNOWN_ENVIRONMENT_MESSAGE,
-            ENVIRONMENT_VAR,
-            value,
-            known,
-            extra={"variable": ENVIRONMENT_VAR},
-        )
+        partial(logger.warning, message, extra={"variable": ENVIRONMENT_VAR})
     )
 
 
@@ -222,7 +212,7 @@ def report_unmet_requirements(
     if environment in STRICT_ENVIRONMENTS:
         raise BackendScopeError(strict_message(unmet, environment))
     entry = unmet[0]
-    arguments = (
+    message = _UNDECLARED_MESSAGE % (
         entry.component,
         entry.backend,
         entry.provides,
@@ -232,16 +222,14 @@ def report_unmet_requirements(
         ENVIRONMENT_VAR,
         entry.scope,
     )
-    warnings.warn(
-        _UNDECLARED_MESSAGE % arguments,
-        GrelmicroConfigWarning,
-        stacklevel=4,
-    )
+    warnings.warn(message, GrelmicroConfigWarning, stacklevel=4)
+    # Rendered before it reaches `logging`, so both channels carry the same
+    # sentence and the record holds no positional arguments a formatter
+    # could read as something else.
     defer_report(
         partial(
             logger.warning,
-            _UNDECLARED_MESSAGE,
-            *arguments,
+            message,
             extra={
                 "component": entry.component,
                 "backend_scope": entry.scope,

--- a/grelmicro/_environment.py
+++ b/grelmicro/_environment.py
@@ -33,9 +33,8 @@ logger = logging.getLogger("grelmicro")
 ENVIRONMENT_VAR: Final = "GREL_ENVIRONMENT"
 """Variable naming the tier, read whatever `GREL_ENV_LOAD` says.
 
-The flag gates the variables that fill component fields. This one selects a
-policy, and a safety check an unset flag turns off would be off in the
-deployments that need it.
+The flag gates the variables that fill component fields. This one selects the
+severity of the backend scope check, so it is read either way.
 """
 
 ENVIRONMENTS: Final[tuple[Environment, ...]] = get_args(Environment.__value__)
@@ -78,8 +77,8 @@ _UNDECLARED_MESSAGE: Final = (
 )
 """Report text for an unmet requirement with no tier declared.
 
-Both words in one sentence: a backend provides a scope, a component requires
-one. The traceback teaches the pair where it matters.
+Names both sides of the match: a backend provides a scope, a component
+requires one.
 """
 
 _reported_unknown: set[str] = set()
@@ -90,8 +89,9 @@ _reported_unknown: set[str] = set()
 class Unmet:
     """One component whose backends do not reach as far as it requires.
 
-    A `Coordination` holds four backends, and one memory provider behind all
-    four is one mistake, so they are reported together.
+    Backends of the same scope under one component are held together, so a
+    `Coordination` whose four backends all come from one memory provider is
+    reported once.
     """
 
     component: str
@@ -123,8 +123,7 @@ def resolve_environment(explicit: Environment | None) -> Environment | None:
     """Return the declared tier, or `None` when nothing declares one.
 
     An explicit argument wins over `GREL_ENVIRONMENT`. A value outside the
-    four tiers is reported once and read as undeclared, so a fleet that names
-    a tier `preprod` keeps booting and `prodution` is loud instead of silent.
+    four tiers is reported once and read as undeclared.
     """
     if explicit is not None:
         return explicit
@@ -164,8 +163,7 @@ def _report_unknown_environment(value: str) -> None:
 def scope_of(backend: object) -> BackendScope | None:
     """Return how far `backend` shares state, or `None` when it says nothing.
 
-    An Adapter that declares no `scope` is never reported. A third-party
-    author knows how far their store reaches, and grelmicro does not.
+    An Adapter that declares no `scope` is never reported.
     """
     scope = getattr(backend, "scope", None)
     return scope if scope in _SCOPE_RANK else None
@@ -174,8 +172,8 @@ def scope_of(backend: object) -> BackendScope | None:
 def unmet_requirements(items: Iterable[object]) -> list[Unmet]:
     """Return every bound backend that falls short of its component.
 
-    Only a bound backend is checked. A component that was never registered is
-    the documented way to ask for local behavior, so absence is no finding.
+    Only a bound backend is checked. A component that holds none, or that
+    declares no requirement, is passed over.
     """
     grouped: dict[tuple[str, BackendScope, BackendScope], list[str]] = {}
     for item in items:

--- a/grelmicro/_environment.py
+++ b/grelmicro/_environment.py
@@ -1,0 +1,279 @@
+"""Deployment environment and the backend scope check.
+
+Exposes:
+
+- `resolve_environment`: read the declared tier from an argument or
+  `GREL_ENVIRONMENT`.
+- `unmet_requirements`: walk registered items and return every backend whose
+  scope falls short of what its component requires.
+- `report_unmet_requirements`: raise or warn, by declared tier.
+
+The user-facing rules are in `docs/deployment.md`, the model in
+`docs/architecture/backends.md`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import warnings
+from dataclasses import dataclass
+from functools import partial
+from typing import TYPE_CHECKING, Final, get_args
+
+from grelmicro._config import defer_report
+from grelmicro.errors import BackendScopeError, GrelmicroConfigWarning
+from grelmicro.types import BackendScope, Environment
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+logger = logging.getLogger("grelmicro")
+
+ENVIRONMENT_VAR: Final = "GREL_ENVIRONMENT"
+"""Variable naming the tier, read whatever `GREL_ENV_LOAD` says.
+
+The flag gates the variables that fill component fields. This one selects a
+policy, and a safety check an unset flag turns off would be off in the
+deployments that need it.
+"""
+
+ENVIRONMENTS: Final[tuple[Environment, ...]] = get_args(Environment.__value__)
+"""The tiers that gate, in the order the messages list them."""
+
+STRICT_ENVIRONMENTS: Final = frozenset({"staging", "production"})
+"""Tiers where an unmet requirement is an error instead of a warning."""
+
+QUIET_ENVIRONMENTS: Final = frozenset({"development", "test"})
+"""Tiers that report nothing."""
+
+BACKEND_ATTRIBUTES: Final = (
+    "backend",
+    "_lock_backend",
+    "_rwlock_backend",
+    "_election_backend",
+    "_schedule_backend",
+)
+"""Where a Component keeps a bound backend.
+
+Most keep one on `backend`. `Coordination` holds four, any of which may come
+from a different Provider, so each is checked on its own.
+"""
+
+_SCOPE_RANK: Final[dict[str, int]] = {
+    scope: rank for rank, scope in enumerate(get_args(BackendScope.__value__))
+}
+"""Scope by how far it shares, so `>=` answers whether a requirement is met."""
+
+_UNKNOWN_ENVIRONMENT_MESSAGE: Final = (
+    "%s=%r is not one of %s, so the backend check runs as if it were "
+    "undeclared."
+)
+"""Report text, shared by the `warnings` and the `logging` channel."""
+
+_UNDECLARED_MESSAGE: Final = (
+    "%s is bound to %s, which %s scope %r, but requires scope %r.%s Set %s to "
+    "declare where this runs, or pass requires=%r to say that is the reach "
+    "you want."
+)
+"""Report text for an unmet requirement with no tier declared.
+
+Both words in one sentence: a backend provides a scope, a component requires
+one. The traceback teaches the pair where it matters.
+"""
+
+_reported_unknown: set[str] = set()
+"""Values already reported, so a second read stays quiet."""
+
+
+@dataclass(frozen=True)
+class Unmet:
+    """One component whose backends do not reach as far as it requires.
+
+    A `Coordination` holds four backends, and one memory provider behind all
+    four is one mistake, so they are reported together.
+    """
+
+    component: str
+    """Label of the component holding them, `Coordination('default')`."""
+
+    backends: tuple[str, ...]
+    """Class names of the bound backends that fall short."""
+
+    scope: BackendScope
+    """How far those backends share what they hold."""
+
+    requires: BackendScope
+    """How far the component needs it shared."""
+
+    @property
+    def backend(self) -> str:
+        """The backend names, read as a list."""
+        if len(self.backends) == 1:
+            return self.backends[0]
+        return f"{', '.join(self.backends[:-1])} and {self.backends[-1]}"
+
+    @property
+    def provides(self) -> str:
+        """`provides` or `provide`, agreeing with how many are named."""
+        return "provides" if len(self.backends) == 1 else "provide"
+
+
+def resolve_environment(explicit: Environment | None) -> Environment | None:
+    """Return the declared tier, or `None` when nothing declares one.
+
+    An explicit argument wins over `GREL_ENVIRONMENT`. A value outside the
+    four tiers is reported once and read as undeclared, so a fleet that names
+    a tier `preprod` keeps booting and `prodution` is loud instead of silent.
+    """
+    if explicit is not None:
+        return explicit
+    value = os.environ.get(ENVIRONMENT_VAR, "").strip()
+    if not value:
+        return None
+    for environment in ENVIRONMENTS:
+        if value == environment:
+            return environment
+    _report_unknown_environment(value)
+    return None
+
+
+def _report_unknown_environment(value: str) -> None:
+    """Report a value that names no tier, on both channels, once."""
+    if value in _reported_unknown:
+        return
+    _reported_unknown.add(value)
+    known = ", ".join(ENVIRONMENTS)
+    warnings.warn(
+        _UNKNOWN_ENVIRONMENT_MESSAGE % (ENVIRONMENT_VAR, value, known),
+        GrelmicroConfigWarning,
+        stacklevel=4,
+    )
+    defer_report(
+        partial(
+            logger.warning,
+            _UNKNOWN_ENVIRONMENT_MESSAGE,
+            ENVIRONMENT_VAR,
+            value,
+            known,
+            extra={"variable": ENVIRONMENT_VAR},
+        )
+    )
+
+
+def scope_of(backend: object) -> BackendScope | None:
+    """Return how far `backend` shares state, or `None` when it says nothing.
+
+    An Adapter that declares no `scope` is never reported. A third-party
+    author knows how far their store reaches, and grelmicro does not.
+    """
+    scope = getattr(backend, "scope", None)
+    return scope if scope in _SCOPE_RANK else None
+
+
+def unmet_requirements(items: Iterable[object]) -> list[Unmet]:
+    """Return every bound backend that falls short of its component.
+
+    Only a bound backend is checked. A component that was never registered is
+    the documented way to ask for local behavior, so absence is no finding.
+    """
+    grouped: dict[tuple[str, BackendScope, BackendScope], list[str]] = {}
+    for item in items:
+        requires = getattr(item, "requires", None)
+        if requires not in _SCOPE_RANK:
+            continue
+        for attribute in BACKEND_ATTRIBUTES:
+            backend = getattr(item, attribute, None)
+            scope = scope_of(backend) if backend is not None else None
+            if scope is None or _SCOPE_RANK[scope] >= _SCOPE_RANK[requires]:
+                continue
+            names = grouped.setdefault((label(item), scope, requires), [])
+            name = type(backend).__name__
+            if name not in names:
+                names.append(name)
+    return [
+        Unmet(
+            component=component,
+            backends=tuple(names),
+            scope=scope,
+            requires=requires,
+        )
+        for (component, scope, requires), names in grouped.items()
+    ]
+
+
+def label(item: object) -> str:
+    """Return `Coordination('default')` for a component, its class otherwise."""
+    name = getattr(item, "name", None)
+    if isinstance(name, str):
+        return f"{type(item).__name__}({name!r})"
+    return type(item).__name__
+
+
+def report_unmet_requirements(
+    unmet: Sequence[Unmet],
+    environment: Environment | None,
+) -> None:
+    """Raise in a strict tier, warn when no tier is declared, else stay quiet.
+
+    Raises:
+        BackendScopeError: If the tier is `staging` or `production`.
+    """
+    if not unmet or environment in QUIET_ENVIRONMENTS:
+        return
+    if environment in STRICT_ENVIRONMENTS:
+        raise BackendScopeError(strict_message(unmet, environment))
+    entry = unmet[0]
+    arguments = (
+        entry.component,
+        entry.backend,
+        entry.provides,
+        entry.scope,
+        entry.requires,
+        _others(len(unmet)),
+        ENVIRONMENT_VAR,
+        entry.scope,
+    )
+    warnings.warn(
+        _UNDECLARED_MESSAGE % arguments,
+        GrelmicroConfigWarning,
+        stacklevel=4,
+    )
+    defer_report(
+        partial(
+            logger.warning,
+            _UNDECLARED_MESSAGE,
+            *arguments,
+            extra={
+                "component": entry.component,
+                "backend_scope": entry.scope,
+                "requires": entry.requires,
+            },
+        )
+    )
+
+
+def _others(count: int) -> str:
+    """Return the clause counting the findings the message does not name."""
+    if count < 2:  # noqa: PLR2004
+        return ""
+    if count == 2:  # noqa: PLR2004
+        return " One other binding does not hold either."
+    return f" {count - 1} other bindings do not hold either."
+
+
+def strict_message(
+    unmet: Sequence[Unmet], environment: Environment | str
+) -> str:
+    """Render the error a strict tier raises, one sentence per finding."""
+    lines = [
+        f"{entry.component} is bound to {entry.backend}, which "
+        f"{entry.provides} scope {entry.scope!r}, but requires scope "
+        f"{entry.requires!r} in environment {environment!r}."
+        for entry in unmet
+    ]
+    lines.append(
+        "Use a Redis, Valkey, Postgres, or Kubernetes backend, or pass "
+        "requires= to say what reach you want."
+    )
+    return " ".join(lines)

--- a/grelmicro/cache/_component.py
+++ b/grelmicro/cache/_component.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
     from grelmicro.cache._protocol import CacheBackend
     from grelmicro.cache.serializers import CacheSerializer
+    from grelmicro.types import BackendScope
 
 
 class Cache:
@@ -54,6 +55,9 @@ class Cache:
 
     kind: ClassVar[str] = "cache"
 
+    default_requires: ClassVar[BackendScope] = "process"
+    """A cache per replica is the standard shape, so any backend will do."""
+
     def __init__(
         self,
         source: Annotated[
@@ -68,6 +72,20 @@ class Cache:
             ),
         ],
         *,
+        requires: Annotated[
+            BackendScope | None,
+            Doc(
+                """
+                The smallest backend scope this component accepts:
+                `"process"`, `"host"` or `"cluster"`. Defaults to `"process"`,
+                since a cache per replica is a normal thing to want. Raise it
+                to `"cluster"` for a cache an `Idempotency` reads from, where
+                a replay has to find the stored response wherever the retry
+                lands. Checked when the app opens, see
+                [the backend check](../deployment.md#the-backend-check).
+                """,
+            ),
+        ] = None,
         name: Annotated[
             str,
             Doc(
@@ -80,6 +98,7 @@ class Cache:
     ) -> None:
         """Initialize the component with the wrapped backend."""
         self._name = name
+        self._requires: BackendScope = requires or self.default_requires
         resolved = cast(
             "Provider | CacheBackend",
             instantiate_if_class(source),
@@ -93,6 +112,11 @@ class Cache:
     def name(self) -> str:
         """Return the registration name."""
         return self._name
+
+    @property
+    def requires(self) -> BackendScope:
+        """The smallest backend scope this component accepts."""
+        return self._requires
 
     @property
     def backend(self) -> CacheBackend:

--- a/grelmicro/cache/_component.py
+++ b/grelmicro/cache/_component.py
@@ -56,7 +56,7 @@ class Cache:
     kind: ClassVar[str] = "cache"
 
     default_requires: ClassVar[BackendScope] = "process"
-    """A cache per replica is the standard shape, so any backend will do."""
+    """Default `requires=`: a cache holds per replica unless told otherwise."""
 
     def __init__(
         self,
@@ -77,11 +77,11 @@ class Cache:
             Doc(
                 """
                 The smallest backend scope this component accepts:
-                `"process"`, `"host"` or `"cluster"`. Defaults to `"process"`,
-                since a cache per replica is a normal thing to want. Raise it
-                to `"cluster"` for a cache an `Idempotency` reads from, where
-                a replay has to find the stored response wherever the retry
-                lands. Checked when the app opens, see
+                `"process"`, `"host"` or `"cluster"`. Defaults to
+                `"process"`, so any cache backend is accepted. Raise it to
+                `"cluster"` for the cache an `Idempotency` rides, which has
+                to hold the stored response for every replica. Checked when
+                the app opens, see
                 [the backend check](../deployment.md#the-backend-check).
                 """,
             ),

--- a/grelmicro/cache/memory.py
+++ b/grelmicro/cache/memory.py
@@ -4,9 +4,10 @@ import asyncio
 from collections.abc import Iterable, Mapping, Sequence
 from time import monotonic
 from types import TracebackType
-from typing import Self
+from typing import ClassVar, Self
 
 from grelmicro.cache._protocol import CacheBackend
+from grelmicro.types import BackendScope
 
 
 class MemoryCacheAdapter(CacheBackend):
@@ -21,6 +22,9 @@ class MemoryCacheAdapter(CacheBackend):
     the key from every tag it belonged to, so no tag ever points at a
     key that is gone.
     """
+
+    scope: ClassVar[BackendScope] = "process"
+    """State lives in this process and is not shared beyond it."""
 
     def __init__(self) -> None:
         """Initialize the memory cache backend."""

--- a/grelmicro/cache/postgres.py
+++ b/grelmicro/cache/postgres.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import re
 from logging import getLogger
-from typing import TYPE_CHECKING, Annotated, Self
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self
 
 from typing_extensions import Doc
 
@@ -26,6 +26,8 @@ _JANITOR_JITTER = 0.2
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from types import TracebackType
+
+    from grelmicro.types import BackendScope
 
 
 class PostgresCacheAdapter(CacheBackend):
@@ -61,6 +63,9 @@ class PostgresCacheAdapter(CacheBackend):
 
     Read more in the [Cache](../cache.md) docs.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     _SQL_CREATE_TABLE = """
         CREATE TABLE IF NOT EXISTS {table_name} (

--- a/grelmicro/cache/redis.py
+++ b/grelmicro/cache/redis.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Annotated, Any, Self
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
 
 from typing_extensions import Doc
 
@@ -13,6 +13,8 @@ from grelmicro.providers.redis import RedisProvider, require_cluster_hash_tag
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from types import TracebackType
+
+    from grelmicro.types import BackendScope
 
 _CLEAR_BATCH_SIZE = 1000
 _TAG_SCAN_BATCH_SIZE = 500
@@ -88,6 +90,9 @@ class RedisCacheAdapter(CacheBackend):
     with the value, so an expired key never leaves a stale tag entry
     behind. Both live under the cache prefix, so `clear` sweeps them too.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     def __init__(
         self,

--- a/grelmicro/cache/sqlite.py
+++ b/grelmicro/cache/sqlite.py
@@ -7,7 +7,7 @@ import contextlib
 import re
 from logging import getLogger
 from time import time
-from typing import TYPE_CHECKING, Annotated, Self
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self
 
 from typing_extensions import Doc
 
@@ -27,6 +27,8 @@ _JANITOR_JITTER = 0.2
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from types import TracebackType
+
+    from grelmicro.types import BackendScope
 
 
 class SQLiteCacheAdapter(CacheBackend):
@@ -68,6 +70,9 @@ class SQLiteCacheAdapter(CacheBackend):
 
     Read more in the [Cache](../cache.md) docs.
     """
+
+    scope: ClassVar[BackendScope] = "host"
+    """State is shared by the processes that open the same file."""
 
     _SQL_CREATE_TABLE = """
         CREATE TABLE IF NOT EXISTS {table_name} (

--- a/grelmicro/coordination/_component.py
+++ b/grelmicro/coordination/_component.py
@@ -61,7 +61,7 @@ class Coordination:
     kind: ClassVar[str] = "coordination"
 
     default_requires: ClassVar[BackendScope] = "cluster"
-    """A lock, a leader and a cron fire all promise the whole fleet agrees."""
+    """Default `requires=`: a lock, a leader and a cron fire hold fleet-wide."""
 
     def __init__(
         self,
@@ -139,10 +139,9 @@ class Coordination:
                 """
                 The smallest backend scope this component accepts:
                 `"process"`, `"host"` or `"cluster"`. Defaults to
-                `"cluster"`, because a lock that excludes nothing beyond one
-                process is not a lock. Lower it to declare a single-process
-                or single-host deployment, where a narrower reach is what you
-                want. Checked when the app opens, see
+                `"cluster"`, so a lock, a leader and a cron fire hold across
+                every replica. Lower it to declare a single-process or
+                single-host deployment. Checked when the app opens, see
                 [the backend check](../deployment.md#the-backend-check).
                 """,
             ),

--- a/grelmicro/coordination/_component.py
+++ b/grelmicro/coordination/_component.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         ReadWriteLockBackend,
         ScheduleBackend,
     )
+    from grelmicro.types import BackendScope
 
 
 class Coordination:
@@ -58,6 +59,9 @@ class Coordination:
     """
 
     kind: ClassVar[str] = "coordination"
+
+    default_requires: ClassVar[BackendScope] = "cluster"
+    """A lock, a leader and a cron fire all promise the whole fleet agrees."""
 
     def __init__(
         self,
@@ -129,6 +133,20 @@ class Coordination:
                 """,
             ),
         ] = None,
+        requires: Annotated[
+            BackendScope | None,
+            Doc(
+                """
+                The smallest backend scope this component accepts:
+                `"process"`, `"host"` or `"cluster"`. Defaults to
+                `"cluster"`, because a lock that excludes nothing beyond one
+                process is not a lock. Lower it to declare a single-process
+                or single-host deployment, where a narrower reach is what you
+                want. Checked when the app opens, see
+                [the backend check](../deployment.md#the-backend-check).
+                """,
+            ),
+        ] = None,
         name: Annotated[
             str,
             Doc(
@@ -141,6 +159,7 @@ class Coordination:
     ) -> None:
         """Initialize the component with the wrapped backends."""
         self._name = name
+        self._requires: BackendScope = requires or self.default_requires
         self._lock_backend: LockBackend | None = None
         self._rwlock_backend: ReadWriteLockBackend | None = None
         self._election_backend: LeaderElectionBackend | None = None
@@ -216,6 +235,11 @@ class Coordination:
     def name(self) -> str:
         """Return the registration name."""
         return self._name
+
+    @property
+    def requires(self) -> BackendScope:
+        """The smallest backend scope this component accepts."""
+        return self._requires
 
     @property
     def lock_backend(self) -> LockBackend:

--- a/grelmicro/coordination/kubernetes.py
+++ b/grelmicro/coordination/kubernetes.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from math import ceil
 from types import TracebackType
-from typing import Annotated, Self
+from typing import Annotated, ClassVar, Self
 
 from lightkube import AsyncClient, KubeConfig
 from lightkube.core.exceptions import ApiError
@@ -28,6 +28,7 @@ from grelmicro.coordination._protocol import (
 )
 from grelmicro.coordination.errors import CoordinationSettingsValidationError
 from grelmicro.errors import OutOfContextError
+from grelmicro.types import BackendScope
 
 _LABEL_MANAGED_BY = "app.kubernetes.io/managed-by"
 _LABEL_MANAGED_BY_VALUE = "grelmicro"
@@ -123,6 +124,9 @@ class KubernetesLockAdapter(LockBackend):
     across release and re-acquire cycles. The Lease is never deleted while the
     backend is open.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     def __init__(
         self,
@@ -477,6 +481,9 @@ class KubernetesReadWriteLockAdapter(ReadWriteLockBackend):
     Kubernetes-native deployment with few, long-lived readers. Reach for
     Redis or PostgreSQL for a hot read path.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     def __init__(
         self,
@@ -943,6 +950,9 @@ class KubernetesLeaderElectionAdapter:
     with its `resourceVersion` and written back with it, so a concurrent writer
     loses the race with a 409 Conflict.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     def __init__(
         self,

--- a/grelmicro/coordination/memory.py
+++ b/grelmicro/coordination/memory.py
@@ -6,7 +6,7 @@ import asyncio
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from time import monotonic
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, ClassVar, Self
 
 from grelmicro.coordination._protocol import (
     LeaderRecord,
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from types import TracebackType
 
+    from grelmicro.types import BackendScope
+
 
 class MemoryLockAdapter(LockBackend):
     """Memory Lock Adapter.
@@ -28,6 +30,9 @@ class MemoryLockAdapter(LockBackend):
     This is not a backend with a real distributed lock. It is a local lock that can be used for
     testing purposes or for locking operations that are executed in the same asyncio event loop.
     """
+
+    scope: ClassVar[BackendScope] = "process"
+    """State lives in this process and is not shared beyond it."""
 
     def __init__(self) -> None:
         """Initialize the lock backend."""
@@ -109,6 +114,9 @@ class MemoryReadWriteLockAdapter(ReadWriteLockBackend):
     it holds the lock. Use a Redis, Postgres, SQLite, or Kubernetes backend
     across nodes.
     """
+
+    scope: ClassVar[BackendScope] = "process"
+    """State lives in this process and is not shared beyond it."""
 
     def __init__(self) -> None:
         """Initialize the read-write lock backend."""
@@ -240,6 +248,9 @@ class MemoryScheduleAdapter(ScheduleBackend):
     SQLite backend for durable distributed cron.
     """
 
+    scope: ClassVar[BackendScope] = "process"
+    """State lives in this process and is not shared beyond it."""
+
     def __init__(self) -> None:
         """Initialize an empty schedule store."""
         self._last_fired: dict[str, float] = {}
@@ -283,6 +294,9 @@ class MemoryLeaderElectionAdapter:
     process believes it leads. Use a Redis, Postgres, or Kubernetes backend
     for real elections.
     """
+
+    scope: ClassVar[BackendScope] = "process"
+    """State lives in this process and is not shared beyond it."""
 
     def __init__(self) -> None:
         """Initialize an empty record store."""

--- a/grelmicro/coordination/postgres.py
+++ b/grelmicro/coordination/postgres.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from types import TracebackType
 
+    from grelmicro.types import BackendScope
+
 
 class PostgresLockAdapter(LockBackend):
     """PostgreSQL Lock Adapter.
@@ -38,6 +40,9 @@ class PostgresLockAdapter(LockBackend):
     clears the holder and expiry but keeps the row and its fence, so the
     fence is strictly monotonic per name across release and re-acquire cycles.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """
                 CREATE TABLE IF NOT EXISTS {table_name} (
@@ -246,6 +251,9 @@ class PostgresReadWriteLockAdapter(ReadWriteLockBackend):
     the next acquire instead of holding writers out until some shared expiry
     fires.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     _SQL_CREATE_TABLES = """
         CREATE TABLE IF NOT EXISTS {table_name} (
@@ -687,6 +695,9 @@ class PostgresScheduleAdapter(ScheduleBackend):
     on the default `env_prefix=` to build one from environment variables.
     """
 
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
+
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """
                 CREATE TABLE IF NOT EXISTS {table_name} (
                     name TEXT PRIMARY KEY,
@@ -850,6 +861,9 @@ class PostgresLeaderElectionAdapter:
     backend = PostgresLeaderElectionAdapter(provider=postgres)
     ```
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     is_shared: ClassVar[bool] = True
 

--- a/grelmicro/coordination/redis.py
+++ b/grelmicro/coordination/redis.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Annotated, Self
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self
 
 from typing_extensions import Doc
 
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from types import TracebackType
 
+    from grelmicro.types import BackendScope
+
 
 class RedisLockAdapter(LockBackend):
     """Redis Lock Adapter.
@@ -39,6 +41,9 @@ class RedisLockAdapter(LockBackend):
     re-acquire keeps climbing. Tokens are strictly monotonic against a single
     Redis master.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     _LUA_ACQUIRE_OR_EXTEND = """
         -- KEYS[1] = lock key, KEYS[2] = fence counter key
@@ -214,6 +219,9 @@ class RedisReadWriteLockAdapter(ReadWriteLockBackend):
     own acquire drops the readers that expired instead of waiting for a
     whole-key TTL.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     _LUA_NOW = """
         local t = redis.call('TIME')
@@ -576,6 +584,9 @@ class RedisScheduleAdapter(ScheduleBackend):
     rely on the default `env_prefix=` to build one from environment variables.
     """
 
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
+
     _LUA_CLAIM = """
         -- KEYS[1] = last_fired key
         -- ARGV[1] = due epoch
@@ -700,6 +711,9 @@ class RedisLeaderElectionAdapter:
     rely on the default `env_prefix=` to build one from environment
     variables.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     _LUA_ACQUIRE_OR_RENEW = """
         local key = KEYS[1]

--- a/grelmicro/coordination/sqlite.py
+++ b/grelmicro/coordination/sqlite.py
@@ -6,7 +6,7 @@ import asyncio
 import re
 from contextlib import asynccontextmanager
 from math import ceil
-from typing import TYPE_CHECKING, Annotated, Any, Self
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
 
 from typing_extensions import Doc
 
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from aiosqlite import Connection
+
+    from grelmicro.types import BackendScope
 
 
 class SQLiteLockAdapter(LockBackend):
@@ -56,6 +58,9 @@ class SQLiteLockAdapter(LockBackend):
     micro = Grelmicro(uses=[sqlite, Coordination(lock=sqlite)])
     ```
     """
+
+    scope: ClassVar[BackendScope] = "host"
+    """State is shared by the processes that open the same file."""
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """
                 CREATE TABLE IF NOT EXISTS {table_name} (
@@ -267,6 +272,9 @@ class SQLiteReadWriteLockAdapter(ReadWriteLockBackend):
     Lease durations are rounded up to whole seconds, the resolution SQLite
     date functions work at.
     """
+
+    scope: ClassVar[BackendScope] = "host"
+    """State is shared by the processes that open the same file."""
 
     _SQL_CREATE_TABLES = (
         """
@@ -620,6 +628,9 @@ class SQLiteScheduleAdapter(ScheduleBackend):
     micro = Grelmicro(uses=[sqlite, Coordination(schedule=sqlite)])
     ```
     """
+
+    scope: ClassVar[BackendScope] = "host"
+    """State is shared by the processes that open the same file."""
 
     _SQL_CREATE_TABLE_IF_NOT_EXISTS = """
                 CREATE TABLE IF NOT EXISTS {table_name} (

--- a/grelmicro/errors.py
+++ b/grelmicro/errors.py
@@ -19,6 +19,20 @@ class GrelmicroConfigWarning(UserWarning):
     """
 
 
+class BackendScopeError(GrelmicroError, RuntimeError):
+    """Raised when a backend does not reach as far as its component requires.
+
+    A `Lock` on a memory backend excludes nothing once a second replica runs.
+    So in `staging` and `production`, a component bound to a backend whose
+    `scope` falls short of what it requires refuses to open, before the first
+    connection is made. Wire a backend that reaches far enough, or pass
+    `requires=` to declare the reach you meant.
+
+    `micro.check_backends()` raises the same error from a test, so the wiring
+    is answered for before a pod answers for it.
+    """
+
+
 class AdmissionError(GrelmicroError):
     """Raised when a gatekeeping primitive refuses a call.
 

--- a/grelmicro/outbox/_component.py
+++ b/grelmicro/outbox/_component.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
     from grelmicro.outbox._message import Message
     from grelmicro.outbox._protocol import OutboxBackend
+    from grelmicro.types import BackendScope
 
 
 class Outbox:
@@ -58,6 +59,9 @@ class Outbox:
 
     kind: ClassVar[str] = "outbox"
 
+    default_requires: ClassVar[BackendScope] = "cluster"
+    """One replica stages the message, another may relay it."""
+
     def __init__(  # noqa: PLR0913
         self,
         source: Annotated[
@@ -71,6 +75,20 @@ class Outbox:
             ),
         ],
         *,
+        requires: Annotated[
+            BackendScope | None,
+            Doc(
+                """
+                The smallest backend scope this component accepts:
+                `"process"`, `"host"` or `"cluster"`. Defaults to
+                `"cluster"`: the outbox stages a message on one replica for a
+                relay that may run on another. Lower it to declare a
+                single-process or single-host deployment. Checked when the
+                app opens, see
+                [the backend check](../deployment.md#the-backend-check).
+                """,
+            ),
+        ] = None,
         name: Annotated[str, Doc("Registration name.")] = "default",
         config: Annotated[
             OutboxConfig | None,
@@ -129,6 +147,7 @@ class Outbox:
     ) -> None:
         """Initialize the component and resolve its config and backend."""
         self._name = name
+        self._requires: BackendScope = requires or self.default_requires
         self._config = resolve_config(
             OutboxConfig,
             explicit=config,
@@ -172,6 +191,11 @@ class Outbox:
     def name(self) -> str:
         """Return the registration name."""
         return self._name
+
+    @property
+    def requires(self) -> BackendScope:
+        """The smallest backend scope this component accepts."""
+        return self._requires
 
     @property
     def config(self) -> OutboxConfig:

--- a/grelmicro/outbox/_component.py
+++ b/grelmicro/outbox/_component.py
@@ -60,7 +60,7 @@ class Outbox:
     kind: ClassVar[str] = "outbox"
 
     default_requires: ClassVar[BackendScope] = "cluster"
-    """One replica stages the message, another may relay it."""
+    """Default `requires=`: a staged message reaches a relay on any replica."""
 
     def __init__(  # noqa: PLR0913
         self,
@@ -81,8 +81,8 @@ class Outbox:
                 """
                 The smallest backend scope this component accepts:
                 `"process"`, `"host"` or `"cluster"`. Defaults to
-                `"cluster"`: the outbox stages a message on one replica for a
-                relay that may run on another. Lower it to declare a
+                `"cluster"`, so a message staged on one replica reaches the
+                relay running on another. Lower it to declare a
                 single-process or single-host deployment. Checked when the
                 app opens, see
                 [the backend check](../deployment.md#the-backend-check).

--- a/grelmicro/outbox/memory.py
+++ b/grelmicro/outbox/memory.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Literal, Self
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from grelmicro.outbox._message import OutboxRecord
+    from grelmicro.types import BackendScope
 
 
 @dataclass
@@ -35,6 +36,9 @@ class _Row:
 
 class MemoryOutboxAdapter:
     """In-memory outbox storage backend."""
+
+    scope: ClassVar[BackendScope] = "process"
+    """State lives in this process and is not shared beyond it."""
 
     def __init__(self) -> None:
         """Initialize an empty in-memory backend."""

--- a/grelmicro/outbox/postgres.py
+++ b/grelmicro/outbox/postgres.py
@@ -8,7 +8,7 @@ import re
 from datetime import UTC, datetime
 from functools import partial
 from logging import getLogger
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Self
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Self
 
 import asyncpg
 from typing_extensions import Doc
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     from types import TracebackType
     from uuid import UUID
 
+    from grelmicro.types import BackendScope
+
 
 class PostgresOutboxAdapter(OutboxBackend):
     """Postgres outbox storage backend.
@@ -40,6 +42,9 @@ class PostgresOutboxAdapter(OutboxBackend):
     rely on the default `env_prefix=` to build one from environment
     variables.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     _SQL_MIGRATE = """
         CREATE TABLE IF NOT EXISTS {table} (

--- a/grelmicro/resilience/_components.py
+++ b/grelmicro/resilience/_components.py
@@ -55,7 +55,7 @@ class RateLimiterComponent:
     kind: ClassVar[str] = "ratelimiter"
 
     default_requires: ClassVar[BackendScope] = "process"
-    """A budget per replica is a normal shape, so any backend will do."""
+    """Default `requires=`: a budget counts per replica unless told otherwise."""
 
     def __init__(
         self,
@@ -76,10 +76,10 @@ class RateLimiterComponent:
                 """
                 The smallest backend scope this component accepts:
                 `"process"`, `"host"` or `"cluster"`. Defaults to
-                `"process"`, since a budget per replica is a normal thing to
-                want. Raise it to `"cluster"` for one budget shared by the
-                fleet, and the app refuses to start on a backend that cannot
-                share it. Checked when the app opens, see
+                `"process"`, so any rate limiter backend is accepted. Raise
+                it to `"cluster"` for one budget shared by the fleet, and the
+                app refuses to start on a backend that cannot share it.
+                Checked when the app opens, see
                 [the backend check](../deployment.md#the-backend-check).
                 """,
             ),
@@ -178,7 +178,7 @@ class CircuitBreakerComponent:
     kind: ClassVar[str] = "circuitbreaker"
 
     default_requires: ClassVar[BackendScope] = "process"
-    """A breaker reacting to what one replica sees is the standard shape."""
+    """Default `requires=`: a breaker trips on what one replica sees."""
 
     def __init__(
         self,
@@ -201,9 +201,9 @@ class CircuitBreakerComponent:
                 """
                 The smallest backend scope this component accepts:
                 `"process"`, `"host"` or `"cluster"`. Defaults to
-                `"process"`: a breaker that trips on what one replica sees is
-                the standard shape. Raise it to `"cluster"` for one shared
-                verdict across the fleet. Checked when the app opens, see
+                `"process"`, so a breaker trips on what one replica sees.
+                Raise it to `"cluster"` for one verdict shared by the fleet.
+                Checked when the app opens, see
                 [the backend check](../deployment.md#the-backend-check).
                 """,
             ),

--- a/grelmicro/resilience/_components.py
+++ b/grelmicro/resilience/_components.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
         CircuitBreakerBackend,
         RateLimiterBackend,
     )
+    from grelmicro.types import BackendScope
 
 
 class RateLimiterComponent:
@@ -53,6 +54,9 @@ class RateLimiterComponent:
 
     kind: ClassVar[str] = "ratelimiter"
 
+    default_requires: ClassVar[BackendScope] = "process"
+    """A budget per replica is a normal shape, so any backend will do."""
+
     def __init__(
         self,
         source: Annotated[
@@ -66,6 +70,20 @@ class RateLimiterComponent:
             ),
         ],
         *,
+        requires: Annotated[
+            BackendScope | None,
+            Doc(
+                """
+                The smallest backend scope this component accepts:
+                `"process"`, `"host"` or `"cluster"`. Defaults to
+                `"process"`, since a budget per replica is a normal thing to
+                want. Raise it to `"cluster"` for one budget shared by the
+                fleet, and the app refuses to start on a backend that cannot
+                share it. Checked when the app opens, see
+                [the backend check](../deployment.md#the-backend-check).
+                """,
+            ),
+        ] = None,
         name: Annotated[
             str,
             Doc(
@@ -78,6 +96,7 @@ class RateLimiterComponent:
     ) -> None:
         """Initialize the Component with the wrapped backend."""
         self._name = name
+        self._requires: BackendScope = requires or self.default_requires
         resolved = cast(
             "Provider | RateLimiterBackend",
             instantiate_if_class(source),
@@ -91,6 +110,11 @@ class RateLimiterComponent:
     def name(self) -> str:
         """Return the registration name."""
         return self._name
+
+    @property
+    def requires(self) -> BackendScope:
+        """The smallest backend scope this component accepts."""
+        return self._requires
 
     @property
     def backend(self) -> RateLimiterBackend:
@@ -153,6 +177,9 @@ class CircuitBreakerComponent:
 
     kind: ClassVar[str] = "circuitbreaker"
 
+    default_requires: ClassVar[BackendScope] = "process"
+    """A breaker reacting to what one replica sees is the standard shape."""
+
     def __init__(
         self,
         source: Annotated[
@@ -168,6 +195,19 @@ class CircuitBreakerComponent:
             ),
         ],
         *,
+        requires: Annotated[
+            BackendScope | None,
+            Doc(
+                """
+                The smallest backend scope this component accepts:
+                `"process"`, `"host"` or `"cluster"`. Defaults to
+                `"process"`: a breaker that trips on what one replica sees is
+                the standard shape. Raise it to `"cluster"` for one shared
+                verdict across the fleet. Checked when the app opens, see
+                [the backend check](../deployment.md#the-backend-check).
+                """,
+            ),
+        ] = None,
         name: Annotated[
             str,
             Doc(
@@ -180,6 +220,7 @@ class CircuitBreakerComponent:
     ) -> None:
         """Initialize the Component with the wrapped backend."""
         self._name = name
+        self._requires: BackendScope = requires or self.default_requires
         resolved = cast(
             "Provider | CircuitBreakerBackend",
             instantiate_if_class(source),
@@ -193,6 +234,11 @@ class CircuitBreakerComponent:
     def name(self) -> str:
         """Return the registration name."""
         return self._name
+
+    @property
+    def requires(self) -> BackendScope:
+        """The smallest backend scope this component accepts."""
+        return self._requires
 
     @property
     def backend(self) -> CircuitBreakerBackend:

--- a/grelmicro/resilience/bulkhead.py
+++ b/grelmicro/resilience/bulkhead.py
@@ -19,6 +19,10 @@ from grelmicro._config import (
     default_env_prefix,
     resolve_config,
 )
+from grelmicro._environment import (
+    report_unmet_requirements,
+    unmet_requirements,
+)
 from grelmicro.metrics import _emit
 from grelmicro.resilience.errors import BulkheadFullError
 
@@ -290,14 +294,22 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
         Entered in order so a Component borrows a provider opened just
         before it. Registered on the active app's exit stack, so they
         close when the app shuts down rather than per scope.
+
+        These components are not registered on the app, so the app cannot
+        check their backend scope at startup. They are checked here instead,
+        the first time the scope opens.
         """
         async with self._open_lock:
             if self._opened:
                 return
-            exit_stack = Grelmicro.current()._exit_stack  # noqa: SLF001
+            micro = Grelmicro.current()
+            exit_stack = micro._exit_stack  # noqa: SLF001
             if exit_stack is None:  # pragma: no cover
                 msg = "Bulkhead uses= requires an open Grelmicro app"
                 raise RuntimeError(msg)
+            report_unmet_requirements(
+                unmet_requirements(self._uses), micro.environment
+            )
             for item in self._uses:
                 await exit_stack.enter_async_context(item)
             self._opened = True

--- a/grelmicro/resilience/circuitbreaker/memory.py
+++ b/grelmicro/resilience/circuitbreaker/memory.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from grelmicro.resilience.circuitbreaker.consecutive_count import (
         ConsecutiveCountConfig,
     )
+    from grelmicro.types import BackendScope
 
 
 _CULL_LIMIT = 32
@@ -68,6 +69,9 @@ class MemoryCircuitBreakerAdapter(CircuitBreakerBackend):
     Use it for tests and single-process deployments. Use
     `RedisCircuitBreakerAdapter` for fleet-wide shared state.
     """
+
+    scope: ClassVar[BackendScope] = "process"
+    """State lives in this process and is not shared beyond it."""
 
     is_shared: ClassVar[bool] = False
 

--- a/grelmicro/resilience/circuitbreaker/postgres.py
+++ b/grelmicro/resilience/circuitbreaker/postgres.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from grelmicro.resilience.circuitbreaker.consecutive_count import (
         ConsecutiveCountConfig,
     )
+    from grelmicro.types import BackendScope
 
 
 _CIRCUIT_BREAKER_ADVISORY_NAMESPACE = 0x67726362_2D636972
@@ -90,6 +91,9 @@ class PostgresCircuitBreakerAdapter(CircuitBreakerBackend):
 
     Read more in the [Circuit Breaker](../resilience/circuit-breaker.md) docs.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     is_shared: ClassVar[bool] = True
 

--- a/grelmicro/resilience/circuitbreaker/redis.py
+++ b/grelmicro/resilience/circuitbreaker/redis.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from grelmicro.resilience.circuitbreaker.consecutive_count import (
         ConsecutiveCountConfig,
     )
+    from grelmicro.types import BackendScope
 
 
 class RedisCircuitBreakerAdapter(CircuitBreakerBackend):
@@ -57,6 +58,9 @@ class RedisCircuitBreakerAdapter(CircuitBreakerBackend):
 
     Read more in the [Circuit Breaker](../resilience/circuit-breaker.md) docs.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     is_shared: ClassVar[bool] = True
 

--- a/grelmicro/resilience/circuitbreaker/sqlite.py
+++ b/grelmicro/resilience/circuitbreaker/sqlite.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from grelmicro.resilience.circuitbreaker.consecutive_count import (
         ConsecutiveCountConfig,
     )
+    from grelmicro.types import BackendScope
 
 
 class SQLiteCircuitBreakerAdapter(CircuitBreakerBackend):
@@ -83,6 +84,9 @@ class SQLiteCircuitBreakerAdapter(CircuitBreakerBackend):
 
     Read more in the [Circuit Breaker](../resilience/circuit-breaker.md) docs.
     """
+
+    scope: ClassVar[BackendScope] = "host"
+    """State is shared by the processes that open the same file."""
 
     is_shared: ClassVar[bool] = True
 

--- a/grelmicro/resilience/ratelimiter/memory.py
+++ b/grelmicro/resilience/ratelimiter/memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from threading import Lock
-from typing import TYPE_CHECKING, Annotated, Self, assert_never
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self, assert_never
 
 from typing_extensions import Doc
 
@@ -19,6 +19,8 @@ from grelmicro.resilience.ratelimiter.token_bucket import TokenBucketConfig
 
 if TYPE_CHECKING:
     from types import TracebackType
+
+    from grelmicro.types import BackendScope
 
 _EVICTION_THRESHOLD = 1000
 
@@ -186,6 +188,9 @@ class MemoryRateLimiterAdapter(RateLimiterBackend):
 
     Read more in the [Rate Limiter](../resilience/rate-limiter.md) docs.
     """
+
+    scope: ClassVar[BackendScope] = "process"
+    """State lives in this process and is not shared beyond it."""
 
     def __init__(self) -> None:
         """Initialize the rate limiter adapter."""

--- a/grelmicro/resilience/ratelimiter/postgres.py
+++ b/grelmicro/resilience/ratelimiter/postgres.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Annotated, Self, assert_never
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self, assert_never
 
 from typing_extensions import Doc
 
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from asyncpg import Pool
+
+    from grelmicro.types import BackendScope
 
 
 _RATE_LIMITER_ADVISORY_NAMESPACE = 0x67726C72_72746C6D
@@ -59,6 +61,9 @@ class PostgresRateLimiterAdapter(RateLimiterBackend):
 
     Read more in the [Rate Limiter](../resilience/rate-limiter.md) docs.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     _SQL_CREATE_TABLE = """
         CREATE TABLE IF NOT EXISTS {table_name} (

--- a/grelmicro/resilience/ratelimiter/redis.py
+++ b/grelmicro/resilience/ratelimiter/redis.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Any, Self, assert_never
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self, assert_never
 
 from typing_extensions import Doc
 
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from redis.asyncio import Redis
+
+    from grelmicro.types import BackendScope
 
 
 class RedisRateLimiterAdapter(RateLimiterBackend):
@@ -46,6 +48,9 @@ class RedisRateLimiterAdapter(RateLimiterBackend):
 
     Read more in the [Rate Limiter](../resilience/rate-limiter.md) docs.
     """
+
+    scope: ClassVar[BackendScope] = "cluster"
+    """State is shared by every process that connects to it."""
 
     def __init__(
         self,

--- a/grelmicro/resilience/ratelimiter/sqlite.py
+++ b/grelmicro/resilience/ratelimiter/sqlite.py
@@ -6,7 +6,7 @@ import asyncio
 import math
 import re
 from time import time
-from typing import TYPE_CHECKING, Annotated, Self, assert_never
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self, assert_never
 
 from typing_extensions import Doc
 
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     import aiosqlite
+
+    from grelmicro.types import BackendScope
 
 
 class SQLiteRateLimiterAdapter(RateLimiterBackend):
@@ -48,6 +50,9 @@ class SQLiteRateLimiterAdapter(RateLimiterBackend):
 
     Read more in the [Rate Limiter](../resilience/rate-limiter.md) docs.
     """
+
+    scope: ClassVar[BackendScope] = "host"
+    """State is shared by the processes that open the same file."""
 
     _SQL_CREATE_TABLE = """
         CREATE TABLE IF NOT EXISTS {table_name} (

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
 from typing_extensions import Doc
 
 from grelmicro._config import resolve_config
+from grelmicro._environment import resolve_environment
 from grelmicro.errors import DependencyNotFoundError
 from grelmicro.trace.config import (
     TraceConfig,
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from grelmicro.trace._autoinstrument import InstrumentDirective
+    from grelmicro.types import Environment
 
 
 _logger = logging.getLogger(__name__)
@@ -316,7 +318,7 @@ class Trace:
             )
             raise TraceError(msg)
         self._prior_provider = trace._TRACER_PROVIDER  # noqa: SLF001
-        self._provider = _build_provider(config)
+        self._provider = _build_provider(config, _declared_environment())
         trace._TRACER_PROVIDER = self._provider  # noqa: SLF001
         return self
 
@@ -399,8 +401,30 @@ async def _run_with_timeout(fn: Any, timeout: float) -> bool:  # noqa: ANN401, A
     return finished
 
 
-def _build_provider(config: TraceConfig) -> Any:  # noqa: ANN401
-    """Build a `TracerProvider` from a `TraceConfig`."""
+def _declared_environment() -> Environment | None:
+    """Return the tier the active app declares, or `None`.
+
+    `Trace` opens inside `async with micro:`, so the app is resolvable. A
+    `Trace` opened on its own reads `GREL_ENVIRONMENT` directly.
+    """
+    from grelmicro._app import Grelmicro, NoActiveAppError  # noqa: PLC0415
+
+    try:
+        return Grelmicro.current().environment
+    except NoActiveAppError:
+        return resolve_environment(None)
+
+
+def _build_provider(
+    config: TraceConfig, environment: Environment | None = None
+) -> Any:  # noqa: ANN401
+    """Build a `TracerProvider` from a `TraceConfig`.
+
+    A declared environment becomes the `deployment.environment.name` resource
+    attribute. Passing it after the detectors is what makes it win over an
+    `OTEL_RESOURCE_ATTRIBUTES` that says otherwise, so the tier that gates the
+    backend check is the tier every span reports.
+    """
     try:
         from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
         from opentelemetry.sdk.trace import TracerProvider  # noqa: PLC0415
@@ -421,6 +445,8 @@ def _build_provider(config: TraceConfig) -> Any:  # noqa: ANN401
     resource_attrs: dict[str, Any] = dict(config.resource_attributes)
     if config.service_name is not None:
         resource_attrs["service.name"] = config.service_name
+    if environment is not None:
+        resource_attrs.setdefault("deployment.environment.name", environment)
     resource = Resource.create(resource_attrs) if resource_attrs else None
 
     sampler: Sampler

--- a/grelmicro/types.py
+++ b/grelmicro/types.py
@@ -10,7 +10,13 @@ from typing_extensions import TypeVar
 from grelmicro._redact import redact_url
 from grelmicro._timezone import normalize_timezone_name
 
-__all__ = ["LogLevel", "SecretUrl", "TimeZoneName"]
+__all__ = [
+    "BackendScope",
+    "Environment",
+    "LogLevel",
+    "SecretUrl",
+    "TimeZoneName",
+]
 
 _TZ_ERROR_CODE = "time_zone_name"
 """Error code pydantic reports for an unusable timezone name."""
@@ -20,6 +26,24 @@ _TZ_ERROR_TEMPLATE = "{reason}"
 
 type LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 """Standard logging level names, matching `logging.getLevelName` output."""
+
+type Environment = Literal["development", "test", "staging", "production"]
+"""Deployment tier the application runs in.
+
+The well-known values of the OpenTelemetry `deployment.environment.name`
+attribute. `Grelmicro(environment=...)` and `GREL_ENVIRONMENT` take one, and
+`staging` and `production` turn the backend scope check into an error. A tier
+your organisation calls something else maps onto the closest of the four.
+"""
+
+type BackendScope = Literal["process", "host", "cluster"]
+"""How far a backend shares the state it holds.
+
+Ordered: `process` is one process (Memory), `host` is the processes on one
+host (SQLite), `cluster` is every process that connects to the backend
+(Redis, Valkey, Postgres, Kubernetes). An Adapter declares its own as a
+`scope` class attribute, and a Component `requires` at least one of them.
+"""
 
 
 class TimeZoneName(str):

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -6,6 +6,7 @@
     "AdmissionError": null,
     "AmbientBindingError": null,
     "AmbiguousProviderError": null,
+    "BackendScopeError": null,
     "Component": {
       "()": "(*args, **kwargs)"
     },
@@ -18,7 +19,7 @@
       "()": "(config=..., *, secrets=..., reload_interval=...)"
     },
     "Grelmicro": {
-      "()": "(*, uses=..., strict=..., allow_multiple=...)",
+      "()": "(*, uses=..., environment=..., strict=..., allow_multiple=...)",
       ".current": "()"
     },
     "GrelmicroConfigWarning": null,
@@ -41,7 +42,7 @@
   },
   "grelmicro.cache": {
     "Cache": {
-      "()": "(source, *, name=...)",
+      "()": "(source, *, requires=..., name=...)",
       ".cached": "(cache=..., *, ttl=..., maxsize=..., key=..., key_maker=..., skip=..., typed=..., lock=..., early=..., stale_ttl=..., tags=...)"
     },
     "CacheBackend": {
@@ -112,7 +113,7 @@
   },
   "grelmicro.coordination": {
     "Coordination": {
-      "()": "(source=..., *, lock=..., election=..., rwlock=..., schedule=..., name=...)"
+      "()": "(source=..., *, lock=..., election=..., rwlock=..., schedule=..., requires=..., name=...)"
     },
     "CoordinationBackendError": null,
     "CoordinationError": null,
@@ -365,7 +366,7 @@
       "()": "(*args, **kwargs)"
     },
     "CircuitBreakerComponent": {
-      "()": "(source, *, name=...)"
+      "()": "(source, *, requires=..., name=...)"
     },
     "CircuitBreakerConfig": {
       "()": "(*args, **kwargs)"
@@ -472,7 +473,7 @@
       "()": "(*args, **kwargs)"
     },
     "RateLimiterComponent": {
-      "()": "(source, *, name=...)"
+      "()": "(source, *, requires=..., name=...)"
     },
     "RateLimiterConfig": {
       "()": "(*args, **kwargs)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator
 
 import pytest
 
-from grelmicro import _config
+from grelmicro import _config, _environment
 from grelmicro.clock import VirtualClock
 
 
@@ -36,6 +36,19 @@ def _opt_in_env_config(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _declare_test_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Declare the tier so the backend scope check stays quiet by default.
+
+    The suite wires memory backends everywhere, which an undeclared
+    environment reports once per app, and `filterwarnings = ["error"]` turns
+    every report into a failure. Declaring `test` is what the docs ask of a
+    test suite, so the suite does it. Tests that exercise the check set
+    `GREL_ENVIRONMENT` themselves or pass `environment=`.
+    """
+    monkeypatch.setenv("GREL_ENVIRONMENT", "test")
+
+
+@pytest.fixture(autouse=True)
 def _reset_ignored_env_reports(monkeypatch: pytest.MonkeyPatch) -> None:
     """Reset the process-wide ignored-variable report state.
 
@@ -45,4 +58,6 @@ def _reset_ignored_env_reports(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     _config._warned_ignored_env.clear()
     _config._pending_ignored_env.clear()
+    _config._pending_reports.clear()
+    _environment._reported_unknown.clear()
     monkeypatch.setattr(_config, "_logging_configured", False)

--- a/tests/test_backend_scope.py
+++ b/tests/test_backend_scope.py
@@ -1,0 +1,374 @@
+"""Tests for the deployment environment and the backend scope check."""
+
+import logging
+import warnings
+from pathlib import Path
+
+import pytest
+
+from grelmicro import BackendScopeError, Grelmicro, GrelmicroConfigWarning
+from grelmicro._config import flush_ignored_env_reports
+from grelmicro._environment import unmet_requirements
+from grelmicro.cache import Cache
+from grelmicro.cache.memory import MemoryCacheAdapter
+from grelmicro.coordination import Coordination
+from grelmicro.coordination.memory import MemoryLockAdapter
+from grelmicro.coordination.redis import RedisLockAdapter
+from grelmicro.coordination.sqlite import SQLiteLockAdapter
+from grelmicro.outbox import Outbox
+from grelmicro.outbox.memory import MemoryOutboxAdapter
+from grelmicro.providers.memory import MemoryProvider
+from grelmicro.providers.sqlite import SQLiteProvider
+from grelmicro.resilience import CircuitBreakerComponent, RateLimiterComponent
+from grelmicro.resilience.circuitbreaker.memory import (
+    MemoryCircuitBreakerAdapter,
+)
+from grelmicro.resilience.ratelimiter.memory import MemoryRateLimiterAdapter
+from grelmicro.types import Environment
+
+STRICT_ENVIRONMENTS: list[Environment] = ["staging", "production"]
+QUIET_ENVIRONMENTS: list[Environment] = ["development", "test"]
+
+
+@pytest.fixture
+def _undeclared(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Override the autouse fixture and declare no tier at all."""
+    monkeypatch.delenv("GREL_ENVIRONMENT", raising=False)
+
+
+def test_adapters_declare_their_scope() -> None:
+    """Every first-party adapter says how far it shares what it holds."""
+    assert MemoryLockAdapter.scope == "process"
+    assert SQLiteLockAdapter.scope == "host"
+    assert RedisLockAdapter.scope == "cluster"
+
+
+def test_components_default_to_the_scope_their_promise_needs() -> None:
+    """Coordination and Outbox need the fleet, the rest do not."""
+    assert Coordination.default_requires == "cluster"
+    assert Outbox.default_requires == "cluster"
+    assert Cache.default_requires == "process"
+    assert RateLimiterComponent.default_requires == "process"
+    assert CircuitBreakerComponent.default_requires == "process"
+
+
+@pytest.mark.parametrize("environment", STRICT_ENVIRONMENTS)
+async def test_strict_environment_refuses_a_backend_that_falls_short(
+    environment: Environment,
+) -> None:
+    """A memory lock in a deployed environment is an error, not a warning."""
+    micro = Grelmicro(
+        uses=[Coordination(lock=MemoryLockAdapter())],
+        environment=environment,
+    )
+
+    with pytest.raises(BackendScopeError) as error:
+        await micro.__aenter__()
+
+    assert "MemoryLockAdapter" in str(error.value)
+    assert "provides scope 'process'" in str(error.value)
+    assert "requires scope 'cluster'" in str(error.value)
+    assert environment in str(error.value)
+
+
+async def test_strict_environment_reports_every_component() -> None:
+    """One message names each component that does not hold."""
+    micro = Grelmicro(
+        uses=[
+            Coordination(lock=MemoryLockAdapter()),
+            Cache(MemoryCacheAdapter(), requires="cluster"),
+        ],
+        environment="production",
+    )
+
+    with pytest.raises(BackendScopeError) as error:
+        await micro.__aenter__()
+
+    assert "Coordination('default')" in str(error.value)
+    assert "Cache('default')" in str(error.value)
+
+
+async def test_one_component_reports_its_backends_together() -> None:
+    """A provider behind four coordination backends is one mistake."""
+    micro = Grelmicro(uses=[MemoryProvider()], environment="production")
+
+    with pytest.raises(BackendScopeError) as error:
+        await micro.__aenter__()
+
+    message = str(error.value)
+    assert message.count("Coordination('default')") == 1
+    assert "MemoryLockAdapter, " in message
+    assert "MemoryScheduleAdapter" in message
+    assert "provide scope 'process'" in message
+
+
+@pytest.mark.parametrize("environment", QUIET_ENVIRONMENTS)
+async def test_quiet_environment_reports_nothing(
+    environment: Environment,
+) -> None:
+    """Development and test wire memory backends on purpose."""
+    micro = Grelmicro(
+        uses=[Coordination(lock=MemoryLockAdapter())],
+        environment=environment,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        async with micro:
+            pass
+
+
+@pytest.mark.usefixtures("_undeclared")
+async def test_undeclared_environment_warns_once_on_both_channels(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The report names the backend, the tier variable, and the way out."""
+    micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+
+    with caplog.at_level(logging.WARNING, logger="grelmicro"):
+        with pytest.warns(GrelmicroConfigWarning, match="MemoryLockAdapter"):
+            await micro.__aenter__()
+        flush_ignored_env_reports()
+        await micro.__aexit__(None, None, None)
+
+    record = caplog.records[0].__dict__
+    assert record["component"] == "Coordination('default')"
+    assert record["backend_scope"] == "process"
+    message = caplog.records[0].getMessage()
+    assert "GREL_ENVIRONMENT" in message
+    assert "requires='process'" in message
+
+
+@pytest.mark.usefixtures("_undeclared")
+async def test_undeclared_environment_counts_the_findings_it_omits() -> None:
+    """A second finding is counted rather than repeated in full."""
+    micro = Grelmicro(
+        uses=[
+            Coordination(lock=MemoryLockAdapter()),
+            Cache(MemoryCacheAdapter(), requires="cluster"),
+        ]
+    )
+
+    with pytest.warns(
+        GrelmicroConfigWarning, match="One other binding does not hold"
+    ):
+        await micro.__aenter__()
+
+    await micro.__aexit__(None, None, None)
+
+
+async def test_requires_lowers_the_bar_for_a_single_process_deployment() -> (
+    None
+):
+    """A declared single-process deployment boots on memory in production."""
+    micro = Grelmicro(
+        uses=[
+            Coordination(lock=MemoryLockAdapter(), requires="process"),
+            Outbox(MemoryOutboxAdapter(), requires="process"),
+        ],
+        environment="production",
+    )
+
+    async with micro:
+        assert micro.environment == "production"
+
+
+async def test_requires_raises_the_bar_for_a_shared_budget() -> None:
+    """A rate limiter told to be fleet-wide refuses a per-replica backend."""
+    micro = Grelmicro(
+        uses=[
+            RateLimiterComponent(MemoryRateLimiterAdapter(), requires="cluster")
+        ],
+        environment="production",
+    )
+
+    with pytest.raises(BackendScopeError, match="MemoryRateLimiterAdapter"):
+        await micro.__aenter__()
+
+
+def test_sqlite_holds_across_processes_but_not_across_hosts(
+    tmp_path: Path,
+) -> None:
+    """`host` satisfies a host requirement and fails a cluster one."""
+    provider = SQLiteProvider(path=str(tmp_path / "cache.db"))
+
+    Grelmicro(
+        uses=[Cache(provider, requires="host")],
+        environment="production",
+    ).check_backends()
+
+    stricter = Grelmicro(uses=[Cache(provider, requires="cluster")])
+    with pytest.raises(BackendScopeError, match="provides scope 'host'"):
+        stricter.check_backends()
+
+
+async def test_a_local_pattern_on_memory_is_left_alone() -> None:
+    """A per-replica cache and circuit breaker are the standard shape."""
+    micro = Grelmicro(
+        uses=[
+            Cache(MemoryCacheAdapter()),
+            CircuitBreakerComponent(MemoryCircuitBreakerAdapter()),
+        ],
+        environment="production",
+    )
+
+    async with micro:
+        pass
+
+
+async def test_an_adapter_that_declares_no_scope_is_not_reported() -> None:
+    """A third-party author knows their reach, and grelmicro does not."""
+    adapter = MemoryLockAdapter()
+    del type(adapter).scope
+    try:
+        micro = Grelmicro(
+            uses=[Coordination(lock=adapter)], environment="production"
+        )
+        micro.check_backends()
+    finally:
+        MemoryLockAdapter.scope = "process"
+
+
+def test_check_backends_answers_for_production_from_a_test_process() -> None:
+    """The declared tier is `test`, and the answer is still production's."""
+    micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+    assert micro.environment == "test"
+
+    with pytest.raises(BackendScopeError, match="'production'"):
+        micro.check_backends()
+
+
+def test_check_backends_takes_the_tier_to_answer_for() -> None:
+    """The question is visible at the call site."""
+    micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+
+    with pytest.raises(BackendScopeError, match="'staging'"):
+        micro.check_backends(environment="staging")
+
+
+def test_check_backends_passes_on_a_wiring_that_holds() -> None:
+    """Nothing is raised when every bound backend reaches far enough."""
+    micro = Grelmicro(
+        uses=[Coordination(lock=MemoryLockAdapter(), requires="process")]
+    )
+
+    micro.check_backends()
+
+
+def test_environment_comes_from_the_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`GREL_ENVIRONMENT` declares the tier without a constructor argument."""
+    monkeypatch.setenv("GREL_ENVIRONMENT", "staging")
+    assert Grelmicro().environment == "staging"
+
+
+def test_the_argument_wins_over_the_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit tier outranks the environment, as everywhere else."""
+    monkeypatch.setenv("GREL_ENVIRONMENT", "production")
+    assert Grelmicro(environment="development").environment == "development"
+
+
+def test_the_variable_is_read_without_the_env_load_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A safety check behind an opt-in flag would be off where it matters."""
+    monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
+    monkeypatch.setenv("GREL_ENVIRONMENT", "production")
+    assert Grelmicro().environment == "production"
+
+
+@pytest.mark.parametrize("value", ["preprod", "qa", "prodution", "PRODUCTION"])
+def test_a_value_naming_no_tier_warns_and_reads_as_undeclared(
+    value: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A fleet with its own tier names keeps booting, and a typo is loud."""
+    monkeypatch.setenv("GREL_ENVIRONMENT", value)
+
+    with caplog.at_level(logging.WARNING, logger="grelmicro"):
+        with pytest.warns(GrelmicroConfigWarning, match="is not one of"):
+            micro = Grelmicro()
+        flush_ignored_env_reports()
+
+    assert micro.environment is None
+    assert caplog.records[0].__dict__["variable"] == "GREL_ENVIRONMENT"
+
+
+def test_a_value_naming_no_tier_is_reported_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second app with the same value stays quiet."""
+    monkeypatch.setenv("GREL_ENVIRONMENT", "preprod")
+
+    with pytest.warns(GrelmicroConfigWarning, match="is not one of"):
+        Grelmicro()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert Grelmicro().environment is None
+
+
+class _Bare:
+    """A component-shaped object with no registration name."""
+
+    kind = "bare"
+
+    def __init__(self) -> None:
+        self.requires = "cluster"
+        self.backend = MemoryLockAdapter()
+        self._lock_backend = self.backend
+
+
+def test_a_component_without_a_name_is_labelled_by_its_class() -> None:
+    """The label falls back to the class when there is no name to show."""
+    unmet = unmet_requirements([_Bare()])
+
+    assert unmet[0].component == "_Bare"
+
+
+def test_the_same_backend_behind_two_slots_is_named_once() -> None:
+    """One adapter serving two slots of a component is one entry."""
+    unmet = unmet_requirements([_Bare()])
+
+    assert unmet[0].backends == ("MemoryLockAdapter",)
+
+
+@pytest.mark.usefixtures("_undeclared")
+async def test_undeclared_environment_counts_several_omitted_findings() -> None:
+    """Three findings report the first and count the other two."""
+    micro = Grelmicro(
+        uses=[
+            Coordination(lock=MemoryLockAdapter()),
+            Cache(MemoryCacheAdapter(), requires="cluster"),
+            RateLimiterComponent(
+                MemoryRateLimiterAdapter(), requires="cluster"
+            ),
+        ]
+    )
+
+    with pytest.warns(
+        GrelmicroConfigWarning, match="2 other bindings do not hold"
+    ):
+        await micro.__aenter__()
+
+    await micro.__aexit__(None, None, None)
+
+
+@pytest.mark.usefixtures("_undeclared")
+async def test_the_report_logs_straight_away_once_logging_is_configured(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An app opened after `Log` does not queue its report."""
+    flush_ignored_env_reports()
+    micro = Grelmicro(uses=[Coordination(lock=MemoryLockAdapter())])
+
+    with caplog.at_level(logging.WARNING, logger="grelmicro"):
+        with pytest.warns(GrelmicroConfigWarning):
+            await micro.__aenter__()
+        await micro.__aexit__(None, None, None)
+
+    assert "MemoryLockAdapter" in caplog.records[0].getMessage()

--- a/tests/test_backend_scope.py
+++ b/tests/test_backend_scope.py
@@ -391,3 +391,15 @@ async def test_a_bulkhead_checks_the_components_it_opens() -> None:
         with pytest.raises(BackendScopeError, match="MemoryLockAdapter"):
             async with bulkhead:
                 pass  # pragma: no cover
+
+
+def test_a_host_requirement_names_sqlite_as_a_fix() -> None:
+    """SQLite reaches far enough for `host`, so the message offers it."""
+    micro = Grelmicro(
+        uses=[Coordination(lock=MemoryLockAdapter(), requires="host")]
+    )
+
+    with pytest.raises(BackendScopeError, match="Use a SQLite,") as error:
+        micro.check_backends()
+
+    assert "provides scope 'process'" in str(error.value)

--- a/tests/test_backend_scope.py
+++ b/tests/test_backend_scope.py
@@ -19,7 +19,11 @@ from grelmicro.outbox import Outbox
 from grelmicro.outbox.memory import MemoryOutboxAdapter
 from grelmicro.providers.memory import MemoryProvider
 from grelmicro.providers.sqlite import SQLiteProvider
-from grelmicro.resilience import CircuitBreakerComponent, RateLimiterComponent
+from grelmicro.resilience import (
+    Bulkhead,
+    CircuitBreakerComponent,
+    RateLimiterComponent,
+)
 from grelmicro.resilience.circuitbreaker.memory import (
     MemoryCircuitBreakerAdapter,
 )
@@ -372,3 +376,18 @@ async def test_the_report_logs_straight_away_once_logging_is_configured(
         await micro.__aexit__(None, None, None)
 
     assert "MemoryLockAdapter" in caplog.records[0].getMessage()
+
+
+async def test_a_bulkhead_checks_the_components_it_opens() -> None:
+    """`Bulkhead(uses=[...])` is checked the first time the scope opens."""
+    bulkhead = Bulkhead(
+        "orders",
+        max_concurrent=1,
+        uses=[Coordination(lock=MemoryLockAdapter())],
+    )
+    micro = Grelmicro(environment="production")
+
+    async with micro:
+        with pytest.raises(BackendScopeError, match="MemoryLockAdapter"):
+            async with bulkhead:
+                pass  # pragma: no cover

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -17,7 +17,11 @@ from grelmicro.trace import (
     TraceExporterType,
     TraceSamplerType,
 )
-from grelmicro.trace._component import _exporter_kwargs, _resolve_exporter_type
+from grelmicro.trace._component import (
+    _declared_environment,
+    _exporter_kwargs,
+    _resolve_exporter_type,
+)
 from grelmicro.trace.errors import (
     TraceError,
     TraceSettingsValidationError,
@@ -505,3 +509,35 @@ def test_invalid_value_does_not_echo_the_credential() -> None:
         TraceConfig(sample_ratio=-1, endpoint="https://usr:s3cret@collector")
 
     assert "s3cret" not in str(excinfo.value)
+
+
+async def test_declared_environment_becomes_a_resource_attribute() -> None:
+    """The tier that gates the backend check names the tier in every span."""
+    micro = Grelmicro(
+        uses=[Trace(exporter=TraceExporterType.NONE)],
+        environment="staging",
+    )
+
+    async with micro:
+        resource = micro.trace.provider.resource
+        assert resource.attributes["deployment.environment.name"] == "staging"
+
+
+async def test_an_undeclared_environment_writes_no_attribute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no tier declared, the OTel env detector is left to answer."""
+    monkeypatch.delenv("GREL_ENVIRONMENT", raising=False)
+    micro = Grelmicro(uses=[Trace(exporter=TraceExporterType.NONE)])
+
+    async with micro:
+        resource = micro.trace.provider.resource
+        assert "deployment.environment.name" not in resource.attributes
+
+
+def test_the_environment_is_read_without_an_active_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `Trace` opened on its own still reads `GREL_ENVIRONMENT`."""
+    monkeypatch.setenv("GREL_ENVIRONMENT", "production")
+    assert _declared_environment() == "production"


### PR DESCRIPTION
Closes #683.

A `Lock` on a memory backend excludes nothing once a second replica runs, and nothing said so. Declare the tier with `GREL_ENVIRONMENT` or `Grelmicro(environment=...)` and grelmicro holds the wiring to it.

## The model

A backend **provides** a scope, a component **requires** one.

| Backend scope | Backends | State is shared by |
| --- | --- | --- |
| `process` | Memory | One process |
| `host` | SQLite | The processes on one host |
| `cluster` | Redis, Valkey, Postgres, Kubernetes | Every process that connects |

`Coordination` and `Outbox` require `cluster`, `Cache`, `RateLimiterComponent` and `CircuitBreakerComponent` require `process`. `requires=` moves the bar either way and takes no value meaning "off". An adapter that declares no `scope` is never reported, because a third-party author knows their reach and grelmicro does not.

```python
Coordination(memory, requires="process")      # a single-process deployment, declared
RateLimiterComponent(redis, requires="cluster")  # fails the day someone points it at memory
```

## Severity by tier

| `GREL_ENVIRONMENT` | A backend that cannot keep the promise |
| --- | --- |
| `production`, `staging` | `BackendScopeError` before the first connection opens |
| unset | Warning on both channels, once |
| `development`, `test` | Nothing |

A value naming no tier (`preprod`, `qa`) warns and reads as undeclared, so a fleet with its own tier names keeps booting and `prodution` is loud instead of silent.

The error teaches both words in one sentence:

```
BackendScopeError: Coordination('default') is bound to MemoryLockAdapter, which
provides scope 'process', but requires scope 'cluster' in environment 'production'.
```

## Before it deploys

`micro.check_backends()` answers for production from a process that declares something else, and raises naming every binding that does not hold.

## The tier earns its keep twice

It also sets the OpenTelemetry `deployment.environment.name` resource attribute, so it is not a name nothing consumes, which is what killed `FLASK_ENV`.

## Design notes

Every fork was researched and adversarially challenged before it was built.

- **`GREL_ENVIRONMENT` is read outside `GREL_ENV_LOAD`.** A safety check behind an opt-in flag is off in the deployments that need it. It is the second ungated `GREL_` name, alongside the flag itself, and neither fills a component field.
- **grelmicro never reads `OTEL_RESOURCE_ATTRIBUTES`.** The OTel Operator injects it fleet-wide from one `Instrumentation` CR, so a CI pod would inherit `production` and stop booting. No library hard-gates on that variable. The flow is one-way: grelmicro writes the attribute, never reads it.
- **Unset does not mean production.** Every surviving hard-fail precedent (Rails `secret_key_base`, Django `ALLOWED_HOSTS`, Spring `DataSource`) keys on an explicit act, and Django carves tests out entirely. The alternative was pytest sniffing, which pytest's own docs call a bad idea.
- **The escape hatch declares, it does not negate.** `requires="process"` states a falsifiable deployment fact a reviewer can check against the manifest, which is the `verify="/path/ca.pem"` half of the `requests` precedent, not the `verify=False` half.
- **`requires` over `scope`.** The most-encountered `scope=` in Python is `@pytest.fixture(scope="session")`, where it configures sharing. `requires` carries the packaging prior (`python_requires`) instead: a checked constraint that provisions nothing. `backend_scope` was ranked next and lost on the same axis CPython renamed `ssl_version` to `minimum_version` for: a property-named threshold becomes a false statement once the backend behind it changes.

## Testing

30 new tests in `tests/test_backend_scope.py`, plus three in `tests/tracing/test_component.py` for the resource attribute. The suite declares `GREL_ENVIRONMENT=test` in `conftest.py`, which is exactly what the docs ask of a user's test suite. Full `pre-commit run --all-files` passes, integration tier and the 100% coverage gate included.
