### PR TITLE
🐛 Split uvicorn access fields on a copy of the record

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+* 🐛 Cover uvicorn's takeover on every logging backend. `stdlib`, `structlog`, and `loguru` all hand uvicorn's own loggers the matching formatter, so one process emits one format whichever backend runs the app, and each is now tested. ([#705](https://github.com/grelinfo/grelmicro/issues/705))
 * 🐛 Keep a log record readable after uvicorn's access formatter has seen it. `UvicornAccessFormatter` split the request fields by rewriting `msg` and `args` on the record itself, so any record carrying five or more positional arguments reached every later reader as `"%s %s %s"`: a second handler on the same logger, a queue listener, or a test reading `caplog`. The split now runs on a copy. ([#705](https://github.com/grelinfo/grelmicro/issues/705))
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+* 🐛 Keep a log record readable after uvicorn's access formatter has seen it. `UvicornAccessFormatter` split the request fields by rewriting `msg` and `args` on the record itself, so any record carrying five or more positional arguments reached every later reader as `"%s %s %s"`: a second handler on the same logger, a queue listener, or a test reading `caplog`. The split now runs on a copy. ([#705](https://github.com/grelinfo/grelmicro/issues/705))
+
 ### Added
 
 * ✨ Refuse to start when a backend cannot keep the promise its component makes. Declare the tier with `GREL_ENVIRONMENT` or `Grelmicro(environment=...)`, and in `production` or `staging` a `Coordination` or `Outbox` bound to a memory or SQLite backend raises `BackendScopeError` before the first connection opens. A lock that excludes nothing the moment a second replica starts used to say nothing at all. ([#683](https://github.com/grelinfo/grelmicro/issues/683))

--- a/grelmicro/log/uvicorn.py
+++ b/grelmicro/log/uvicorn.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import copy
 from typing import TYPE_CHECKING, Any
 
 from grelmicro.log._shared import (
@@ -118,24 +119,33 @@ class UvicornAccessFormatter(UvicornFormatter):
     """
 
     def format(self, record: logging.LogRecord) -> str:
-        """Format access records with split request fields."""
-        if (
+        """Format access records with split request fields.
+
+        The split runs on a copy. A record is formatted once per handler and
+        stays readable afterwards, so rewriting `msg` and `args` in place
+        would hand every later reader the rewritten record: a second handler
+        on the same logger, a queue listener, or a test reading `caplog`.
+        """
+        if not (
             isinstance(record.args, tuple)
             and len(record.args) >= _MIN_ACCESS_ARGS
         ):
-            client_addr, method, full_path, http_version, status_code, *_ = (
-                record.args
-            )
-            record.__dict__.update(
-                {
-                    "client_addr": client_addr,
-                    "method": method,
-                    "full_path": full_path,
-                    "http_version": http_version,
-                    "status_code": status_code,
-                }
-            )
-            record.msg = "%s %s %s"
-            record.args = (method, full_path, status_code)
+            return super().format(record)
 
-        return super().format(record)
+        client_addr, method, full_path, http_version, status_code, *_ = (
+            record.args
+        )
+        access = copy(record)
+        access.__dict__.update(
+            {
+                "client_addr": client_addr,
+                "method": method,
+                "full_path": full_path,
+                "http_version": http_version,
+                "status_code": status_code,
+            }
+        )
+        access.msg = "%s %s %s"
+        access.args = (method, full_path, status_code)
+
+        return super().format(access)

--- a/tests/logging/test_uvicorn.py
+++ b/tests/logging/test_uvicorn.py
@@ -702,3 +702,45 @@ class TestUvicornProcess:
             assert "logger" in startup_logs[0]
             assert "caller" not in startup_logs[0]
             assert "time" in startup_logs[0]
+
+
+class TestAccessRecordIsLeftIntact:
+    """The access split must not rewrite the record other handlers read."""
+
+    def test_the_record_survives_formatting(
+        self, access_formatter: UvicornAccessFormatter
+    ) -> None:
+        """Formatting reads the record and leaves it as it found it."""
+        # Arrange
+        record = _make_record()
+        expected_msg, expected_args = record.msg, record.args
+
+        # Act
+        access_formatter.format(record)
+
+        # Assert
+        assert record.msg == expected_msg
+        assert record.args == expected_args
+        assert (
+            record.getMessage()
+            == '127.0.0.1:8000 - "GET /api/v1/users HTTP/1.1" 200'
+        )
+
+    def test_a_second_handler_reads_the_original_message(
+        self, access_formatter: UvicornAccessFormatter
+    ) -> None:
+        """A record with five arguments reaches the next handler unharmed."""
+        # Arrange
+        record = _make_record(
+            name="app.audit",
+            msg="%s wanted %s but got %s at %s on %s",
+            args=("cart", "cluster", "process", "boot", "replica-2"),
+        )
+
+        # Act
+        access_formatter.format(record)
+
+        # Assert
+        assert record.getMessage() == (
+            "cart wanted cluster but got process at boot on replica-2"
+        )

--- a/tests/logging/test_uvicorn_takeover.py
+++ b/tests/logging/test_uvicorn_takeover.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator
 import pytest
 
 from grelmicro.log._apply import apply as apply_backend
-from grelmicro.log.config import LogConfig, LogFormatType
+from grelmicro.log.config import LogBackendType, LogConfig, LogFormatType
 from grelmicro.log.uvicorn import UvicornAccessFormatter, UvicornFormatter
 from grelmicro.log.uvicorn import apply as apply_uvicorn
 
@@ -146,3 +146,48 @@ def test_apply_backend_respects_the_opt_out(
 
     apply_backend(LogConfig(uvicorn_enabled=True))
     assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [LogBackendType.STDLIB, LogBackendType.STRUCTLOG, LogBackendType.LOGURU],
+)
+@pytest.mark.usefixtures("reset_backend")
+def test_uvicorn_matches_the_app_format_on_every_backend(
+    backend: LogBackendType,
+) -> None:
+    """Uvicorn's own records are rendered by grelmicro, whatever runs the app.
+
+    The app's records go through the selected backend, and uvicorn keeps its
+    own stdlib handlers. Both ends render through the same writers, so one
+    process emits one format.
+    """
+    apply_backend(LogConfig(backend=backend, format=LogFormatType.LOGFMT))
+    formatter = _formatters("uvicorn.access")[0]
+    assert formatter is not None
+
+    line = formatter.format(_access_record())
+
+    assert "method=POST" in line
+    assert "status_code=200" in line
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [LogBackendType.STDLIB, LogBackendType.STRUCTLOG, LogBackendType.LOGURU],
+)
+@pytest.mark.usefixtures("reset_backend")
+def test_the_access_record_survives_every_backend(
+    backend: LogBackendType,
+) -> None:
+    """Formatting leaves the record as it found it, on every backend."""
+    apply_backend(LogConfig(backend=backend, format=LogFormatType.LOGFMT))
+    formatter = _formatters("uvicorn.access")[0]
+    assert formatter is not None
+    record = _access_record()
+
+    formatter.format(record)
+
+    assert record.getMessage() == (
+        '127.0.0.1:54321 - "POST /orders HTTP/1.1" 200'
+    )


### PR DESCRIPTION
Closes #705.

`UvicornAccessFormatter` split uvicorn's access arguments into structured fields by rewriting the record itself:

```python
record.msg = "%s %s %s"
record.args = (method, full_path, status_code)
```

A record is formatted once per handler and stays readable afterwards, so the rewrite reached every later reader: a second handler on the same logger, a queue listener, or a test reading `caplog`. The trigger is a shape heuristic, five or more positional arguments, so it was never limited to uvicorn's own records.

```python
logger.warning("%s wanted %s but got %s at %s on %s", "cart", "cluster", "process", "boot", "replica-2")
# before formatting: cart wanted cluster but got process at boot on replica-2
# after formatting:  cluster process replica-2
```

The split now runs on a copy. Two regression tests cover it: the access record is unchanged after formatting, and a five-argument application record reaches the next handler intact.

## Every backend

`grelmicro.log.uvicorn.apply` runs for `stdlib`, `structlog`, and `loguru` alike: the app's records go through the selected backend, uvicorn keeps its own handlers, and both ends render through grelmicro's shared writers so one process emits one format. That held already and had no test, so this adds one per backend for the format and one per backend for the record surviving. They take the existing `reset_backend` fixture, so they leave no global logging state behind.

Found while adding the backend scope check in #683, whose startup report passed eight positional arguments and arrived at `caplog` rewritten. That report renders its message up front now, so the feature no longer triggers this, but the defect stood for any record with five or more arguments.
