### PR TITLE
🐛 Adopt a Provider borrowed only by a read-write lock backend

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+* 🐛 Adopt a Provider that only a read-write lock backend borrows. `Grelmicro` walks a `Coordination` to find the Providers its backends borrow, and the read-write lock was missing from that walk, so `Coordination(rwlock=...)` with a Provider left out of `uses=` started clean and then raised `OutOfContextError` on first use. Pool sharing and open-ordering missed it the same way. ([#707](https://github.com/grelinfo/grelmicro/issues/707))
 * 🐛 Cover uvicorn's takeover on every logging backend. `stdlib`, `structlog`, and `loguru` all hand uvicorn's own loggers the matching formatter, so one process emits one format whichever backend runs the app, and each is now tested. ([#705](https://github.com/grelinfo/grelmicro/issues/705))
 * 🐛 Keep a log record readable after uvicorn's access formatter has seen it. `UvicornAccessFormatter` split the request fields by rewriting `msg` and `args` on the record itself, so any record carrying five or more positional arguments reached every later reader as `"%s %s %s"`: a second handler on the same logger, a queue listener, or a test reading `caplog`. The split now runs on a copy. ([#705](https://github.com/grelinfo/grelmicro/issues/705))
 

--- a/grelmicro/_app.py
+++ b/grelmicro/_app.py
@@ -1149,13 +1149,18 @@ def _iter_provider_backends(item: object) -> list[object]:
     """Return the provider-holding backends to inspect for `item`.
 
     Most components expose one backend via `backend`. A `Coordination`
-    component holds a lock backend, an election backend, and a schedule
-    backend, any of which may own a Provider, so all present ones are
-    returned. A plain item with no backend is inspected directly.
+    component holds a lock, a read-write lock, an election, and a schedule
+    backend, any of which may own or borrow a Provider, so all present ones
+    are returned. A plain item with no backend is inspected directly.
     """
     backends = [
         getattr(item, name, None)
-        for name in ("_lock_backend", "_election_backend", "_schedule_backend")
+        for name in (
+            "_lock_backend",
+            "_rwlock_backend",
+            "_election_backend",
+            "_schedule_backend",
+        )
     ]
     if any(backend is not None for backend in backends):
         return [backend for backend in backends if backend is not None]

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -11,7 +11,11 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from types import TracebackType
 
-    from grelmicro.coordination._protocol import LeaderRecord
+    from grelmicro.coordination._protocol import (
+        LeaderRecord,
+        ReadWriteLockState,
+        WriteGrant,
+    )
 
 from grelmicro import (
     Component,
@@ -182,13 +186,76 @@ class _RecordingScheduleAdapter:
         raise NotImplementedError
 
 
+class _RecordingReadWriteLockAdapter:
+    """A `ReadWriteLockBackend` that borrows a provider it does not own.
+
+    Only the lifecycle hooks run in these tests. The read-write lock methods
+    are stubs present to satisfy the `ReadWriteLockBackend` protocol.
+    """
+
+    def __init__(self, provider: _RecordingProvider) -> None:
+        self._provider = provider
+        self._owns_provider = False
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def __aenter__(self) -> Self:
+        self._loop = asyncio.get_running_loop()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def acquire_read(
+        self, *, name: str, token: str, duration: float
+    ) -> bool:
+        raise NotImplementedError
+
+    async def release_read(self, *, name: str, token: str) -> bool:
+        raise NotImplementedError
+
+    async def acquire_write(
+        self,
+        *,
+        name: str,
+        token: str,
+        duration: float,
+        intent: bool = True,
+    ) -> WriteGrant | None:
+        raise NotImplementedError
+
+    async def release_write(self, *, name: str, token: str) -> bool:
+        raise NotImplementedError
+
+    async def cancel_intent(self, *, name: str, token: str) -> bool:
+        raise NotImplementedError
+
+    async def downgrade(
+        self, *, name: str, token: str, duration: float
+    ) -> int | None:
+        raise NotImplementedError
+
+    async def state(self, *, name: str) -> ReadWriteLockState:
+        raise NotImplementedError
+
+    async def owned_read(self, *, name: str, token: str) -> bool:
+        raise NotImplementedError
+
+    async def owned_write(self, *, name: str, token: str) -> bool:
+        raise NotImplementedError
+
+
 class _RecordingProvider(Provider):
     """A Provider that records its enter/exit lifecycle for discovery tests.
 
-    `Coordination(provider)` asks for a lock backend, an election backend,
-    and a schedule backend, so this Provider ships all three. The adapters
-    borrow the same Provider instance, so discovery walks every backend and
-    still adopts the Provider exactly once.
+    `Coordination(provider)` asks for a lock backend, a read-write lock
+    backend, an election backend, and a schedule backend, so this Provider
+    ships all four. The adapters borrow the same Provider instance, so
+    discovery walks every backend and still adopts the Provider exactly once.
     """
 
     short_name: ClassVar[str] = "rec"
@@ -199,6 +266,12 @@ class _RecordingProvider(Provider):
 
     def lock(self, **kwargs: object) -> _RecordingLockAdapter:  # noqa: ARG002
         return _RecordingLockAdapter(self)
+
+    def readwritelock(
+        self,
+        **kwargs: object,  # noqa: ARG002
+    ) -> _RecordingReadWriteLockAdapter:
+        return _RecordingReadWriteLockAdapter(self)
 
     def leaderelection(
         self,
@@ -810,6 +883,21 @@ async def test_discovers_the_provider_of_a_schedule_backend() -> None:
     """A `Coordination` holding only a schedule backend adopts its provider."""
     provider = _RecordingProvider()
     micro = Grelmicro(uses=[Coordination(schedule=provider)])
+    async with micro:
+        pass
+
+    assert provider.entered == 1
+    assert provider.exited == 1
+
+
+async def test_discovers_the_provider_of_a_read_write_lock_backend() -> None:
+    """A `Coordination` holding only a read-write lock adopts its provider.
+
+    The read-write lock is the fourth coordination backend, and it borrows a
+    Provider the same way the other three do.
+    """
+    provider = _RecordingProvider()
+    micro = Grelmicro(uses=[Coordination(rwlock=provider)])
     async with micro:
         pass
 

--- a/tests/test_grelmicro_app.py
+++ b/tests/test_grelmicro_app.py
@@ -212,7 +212,7 @@ class _RecordingReadWriteLockAdapter:
 
     async def acquire_read(
         self, *, name: str, token: str, duration: float
-    ) -> bool:
+    ) -> int | None:
         raise NotImplementedError
 
     async def release_read(self, *, name: str, token: str) -> bool:


### PR DESCRIPTION
Closes #707.

`Grelmicro` adopts a Provider that a Component borrows but `uses=` does not list, so listing the Provider stays optional (#665). That walk missed the read-write lock.

`_iter_provider_backends` inspected `_lock_backend`, `_election_backend` and `_schedule_backend`. `Coordination` has held a fourth backend since the read-write lock shipped (#696), so a Provider borrowed only by that backend was never adopted:

```python
provider = SQLiteProvider(path="/tmp/app.db")
micro = Grelmicro(uses=[Coordination(rwlock=SQLiteReadWriteLockAdapter(provider=provider))])

async with micro:  # starts clean
    ...
# OutOfContextError: Could not call SQLiteProvider.client outside of the context manager
```

The same wiring with `lock=` worked, because that backend was on the list.

Three behaviours read that helper, so all three skipped the read-write lock: Provider adoption, connection-pool sharing between adapters holding the same `(class, env_prefix)`, and the reordering that opens a Provider before the Component borrowing it. One line fixes all three.

`_RecordingProvider`, the test double for these paths, shipped three of the four coordination adapters and its docstring said so. It now ships the read-write lock too, which is what makes the regression test possible: the test fails with `entered == 0` before the fix and passes after.

Found while reviewing the backend scope check in #683, whose own walk lists all four backends.
