### PR TITLE
✨ Read Valkey's own URL schemes wherever a Redis scheme works

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -359,7 +359,7 @@ pip install "grelmicro[valkey]"
 from grelmicro import Grelmicro
 from grelmicro.providers.valkey import ValkeyProvider
 
-valkey = ValkeyProvider("redis://localhost:6379/0")
+valkey = ValkeyProvider("valkey://localhost:6379/0")
 
 micro = Grelmicro(uses=[valkey])
 ```
@@ -379,6 +379,12 @@ ValkeyProvider(env_load=False)              # kwargs only, no env
 ValkeyProvider.from_config(RedisConfig(...))  # from a config object
 ValkeyProvider.from_client(client)           # bring-your-own client
 ```
+
+`ValkeyProvider` also reads Valkey's own schemes, so a deployment can name
+the server it runs: `valkey://`, `valkeys://`, `valkey+sentinel://`, and
+`valkey+cluster://` work wherever the `redis` spellings do, in the
+constructor and in `VALKEY_URL` alike. `RedisProvider` keeps the `redis`
+schemes only.
 
 `ValkeyProvider` reads the same `redis+sentinel://` and `redis+cluster://`
 schemes as `RedisProvider` and builds the Valkey Sentinel and Cluster

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -736,8 +736,11 @@ def _compose_url(*, host: str, port: int, db: int, password: str | None) -> str:
 _SENTINEL_SCHEME = "redis+sentinel"
 _CLUSTER_SCHEME = "redis+cluster"
 
-_SENTINEL_SUFFIX = "+sentinel"
-_CLUSTER_SUFFIX = "+cluster"
+_SENTINEL_SCHEMES = frozenset({_SENTINEL_SCHEME, "valkey+sentinel"})
+"""Every scheme naming a Sentinel URL, across both vendors."""
+
+_CLUSTER_SCHEMES = frozenset({_CLUSTER_SCHEME, "valkey+cluster"})
+"""Every scheme naming a Cluster URL, across both vendors."""
 
 
 def _is_sentinel(scheme: str) -> bool:
@@ -746,12 +749,12 @@ def _is_sentinel(scheme: str) -> bool:
     `ValkeyProvider` accepts `valkey+sentinel://` alongside
     `redis+sentinel://`, and both reach the same Sentinel client.
     """
-    return scheme.endswith(_SENTINEL_SUFFIX)
+    return scheme in _SENTINEL_SCHEMES
 
 
 def _is_cluster(scheme: str) -> bool:
     """Return whether `scheme` names a Cluster URL, whichever vendor wrote it."""
-    return scheme.endswith(_CLUSTER_SUFFIX)
+    return scheme in _CLUSTER_SCHEMES
 
 
 _DEFAULT_SENTINEL_PORT = 26379

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -216,7 +216,7 @@ class RedisProvider(Provider):
         proxy. `redis+cluster://` opens a `RedisCluster`.
         """
         scheme = url.split("://", 1)[0].lower() if "://" in url else ""
-        if scheme == _SENTINEL_SCHEME:
+        if _is_sentinel(scheme):
             parts = _parse_multihost_url(url)
             self._sentinel = self._sentinel_class(
                 parts.hosts,
@@ -232,7 +232,7 @@ class RedisProvider(Provider):
                 username=parts.username,
                 password=parts.password,
             )
-        if scheme == _CLUSTER_SCHEME:
+        if _is_cluster(scheme):
             import importlib  # noqa: PLC0415
 
             cluster_node = importlib.import_module(
@@ -579,8 +579,13 @@ def _resolve_url(
     sentinel_password: str | None,
     env_prefix: str,
     env_load: bool,
+    settings_cls: type[_RedisEnvSettings] = _RedisEnvSettings,
 ) -> tuple[str, str | None]:
-    """Resolve the connection URL and Sentinel password from kwargs and env."""
+    """Resolve the connection URL and Sentinel password from kwargs and env.
+
+    `settings_cls` decides which URL schemes the environment path accepts, so
+    `ValkeyProvider` reads `valkey://` where `RedisProvider` does not.
+    """
     if url is not None and host is not None:
         msg = "pass either `url` or `host`, not both"
         raise RedisProviderConfigError(msg)
@@ -607,7 +612,7 @@ def _resolve_url(
         # `_env_prefix` is a pydantic-settings runtime kwarg that overrides
         # `model_config["env_prefix"]` per call. The stubs do not expose it,
         # so static checkers reject it even though the runtime accepts it.
-        settings = _RedisEnvSettings(_env_prefix=env_prefix)
+        settings = settings_cls(_env_prefix=env_prefix)
     except ValidationError as error:
         raise RedisProviderConfigError(error) from None
 
@@ -671,7 +676,7 @@ def _sentinel_kwargs(
     if sentinel_password is None:
         return None
     scheme = url.split("://", 1)[0].lower() if "://" in url else ""
-    if scheme != _SENTINEL_SCHEME:
+    if not _is_sentinel(scheme):
         import warnings  # noqa: PLC0415
 
         msg = (
@@ -730,6 +735,25 @@ def _compose_url(*, host: str, port: int, db: int, password: str | None) -> str:
 
 _SENTINEL_SCHEME = "redis+sentinel"
 _CLUSTER_SCHEME = "redis+cluster"
+
+_SENTINEL_SUFFIX = "+sentinel"
+_CLUSTER_SUFFIX = "+cluster"
+
+
+def _is_sentinel(scheme: str) -> bool:
+    """Return whether `scheme` names a Sentinel URL, whichever vendor wrote it.
+
+    `ValkeyProvider` accepts `valkey+sentinel://` alongside
+    `redis+sentinel://`, and both reach the same Sentinel client.
+    """
+    return scheme.endswith(_SENTINEL_SUFFIX)
+
+
+def _is_cluster(scheme: str) -> bool:
+    """Return whether `scheme` names a Cluster URL, whichever vendor wrote it."""
+    return scheme.endswith(_CLUSTER_SUFFIX)
+
+
 _DEFAULT_SENTINEL_PORT = 26379
 _DEFAULT_REDIS_PORT = 6379
 
@@ -768,9 +792,7 @@ def _parse_multihost_url(url: str) -> _MultiHostUrl:
     scheme, _, rest = url.partition("://")
     scheme = scheme.lower()
     default_port = (
-        _DEFAULT_SENTINEL_PORT
-        if scheme == _SENTINEL_SCHEME
-        else _DEFAULT_REDIS_PORT
+        _DEFAULT_SENTINEL_PORT if _is_sentinel(scheme) else _DEFAULT_REDIS_PORT
     )
 
     authority, _, path = rest.partition("/")
@@ -798,7 +820,7 @@ def _parse_multihost_url(url: str) -> _MultiHostUrl:
 
     service_name = ""
     db = 0
-    if scheme == _SENTINEL_SCHEME:
+    if _is_sentinel(scheme):
         segments = [seg for seg in path.split("/") if seg]
         if not segments:
             msg = "redis+sentinel URL must name the master service"

--- a/grelmicro/providers/valkey.py
+++ b/grelmicro/providers/valkey.py
@@ -4,14 +4,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
 
+from pydantic import UrlConstraints
+from pydantic_core import MultiHostUrl
 from typing_extensions import Doc
 
 from grelmicro.providers.redis import (
     RedisConfig,
     RedisProvider,
+    _RedisEnvSettings,
     _resolve_url,
     _sentinel_kwargs,
 )
+
+# Runtime import: pydantic resolves the annotation on `_ValkeyEnvSettings.url`
+# from module globals when it builds the model.
+from grelmicro.types import SecretUrl  # noqa: TC001
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -33,6 +40,35 @@ if TYPE_CHECKING:
     )
 
 
+ValkeyAnyDsn = Annotated[
+    MultiHostUrl,
+    UrlConstraints(
+        allowed_schemes=[
+            "valkey",
+            "valkeys",
+            "valkey+sentinel",
+            "valkey+cluster",
+            "redis",
+            "rediss",
+            "unix",
+            "redis+sentinel",
+            "redis+cluster",
+        ]
+    ),
+]
+"""Every URL scheme `ValkeyProvider` understands.
+
+Valkey's own schemes and Redis's, because `valkey-py` reads both and a
+deployment that names the server it runs should not have to say `redis`.
+"""
+
+
+class _ValkeyEnvSettings(_RedisEnvSettings):
+    """Read Valkey settings from the environment, Valkey schemes included."""
+
+    url: SecretUrl[ValkeyAnyDsn] | None = None
+
+
 class ValkeyProvider(RedisProvider):
     """Valkey connection provider.
 
@@ -48,8 +84,8 @@ class ValkeyProvider(RedisProvider):
     Construction forms (FastStream-style):
 
     ```python
-    ValkeyProvider("redis://localhost:6379")     # positional URL
-    ValkeyProvider(url="redis://...")            # keyword URL
+    ValkeyProvider("valkey://localhost:6379")    # positional URL
+    ValkeyProvider(url="redis://...")            # either vendor's scheme
     ValkeyProvider(host="x", port=6379, db=0)   # decomposed kwargs
     ValkeyProvider()                             # env-driven (VALKEY_*)
     ValkeyProvider(env_prefix="CACHE_VALKEY_")  # custom env prefix
@@ -121,6 +157,7 @@ class ValkeyProvider(RedisProvider):
         self._bind_valkey_classes()
         self._env_prefix = env_prefix
         self._url, resolved_sentinel_password = _resolve_url(
+            settings_cls=_ValkeyEnvSettings,
             url=url,
             host=host,
             port=port,

--- a/tests/providers/test_valkey_provider.py
+++ b/tests/providers/test_valkey_provider.py
@@ -427,3 +427,19 @@ class TestValkeySchemes:
 
         with pytest.raises(RedisProviderConfigError):
             RedisProvider()
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "foo+sentinel://a:26379,b:26379/mymaster/0",
+            "foo+cluster://a:6379,b:6379",
+        ],
+    )
+    def test_an_unknown_vendor_prefix_is_not_a_sentinel_or_cluster_url(
+        self, url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only the two vendors' spellings reach the Sentinel and Cluster clients."""
+        monkeypatch.setenv("VALKEY_URL", url)
+
+        with pytest.raises(RedisProviderConfigError):
+            ValkeyProvider()

--- a/tests/providers/test_valkey_provider.py
+++ b/tests/providers/test_valkey_provider.py
@@ -11,7 +11,11 @@ from grelmicro.coordination.redis import (
     RedisLockAdapter,
     RedisScheduleAdapter,
 )
-from grelmicro.providers.redis import RedisConfig, RedisProviderConfigError
+from grelmicro.providers.redis import (
+    RedisConfig,
+    RedisProvider,
+    RedisProviderConfigError,
+)
 from grelmicro.providers.valkey import ValkeyProvider
 from grelmicro.resilience.circuitbreaker.redis import (
     RedisCircuitBreakerAdapter,
@@ -369,3 +373,57 @@ class TestEntryPoint:
         assert "valkey" in names
         loaded = names["valkey"].load()
         assert loaded is ValkeyProvider
+
+
+class TestValkeySchemes:
+    """`valkey://` is what a Valkey deployment writes, so it is accepted."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "valkey://localhost:6379/0",
+            "valkeys://localhost:6379/0",
+            "redis://localhost:6379/0",
+            "rediss://localhost:6379/0",
+        ],
+    )
+    def test_both_vendors_schemes_are_read_from_the_environment(
+        self, url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The env path accepts every scheme the constructor accepts.
+
+        A URL that builds a client when passed in code has to build one when
+        it arrives as `VALKEY_URL`, or the deployment path fails on the value
+        the development path took.
+        """
+        monkeypatch.setenv("VALKEY_URL", url)
+
+        provider = ValkeyProvider()
+
+        assert provider.url == url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "valkey+sentinel://a:26379,b:26379/mymaster/0",
+            "valkey+cluster://a:6379,b:6379",
+        ],
+    )
+    def test_valkey_sentinel_and_cluster_schemes_build_their_clients(
+        self, url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Valkey spellings reach the same clients as the Redis ones."""
+        monkeypatch.setenv("VALKEY_URL", url)
+
+        provider = ValkeyProvider()
+
+        assert provider.client is not None
+
+    def test_redis_keeps_its_own_schemes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`RedisProvider` does not learn Valkey's schemes."""
+        monkeypatch.setenv("REDIS_URL", "valkey://localhost:6379/0")
+
+        with pytest.raises(RedisProviderConfigError):
+            RedisProvider()


### PR DESCRIPTION
Closes #716.

`ValkeyProvider` accepted a `valkey://` URL in the constructor and rejected the same URL from the environment:

```python
ValkeyProvider("valkey://localhost:6379/0")   # builds a Valkey client
```
```bash
VALKEY_URL=valkey://localhost:6379/0
# RedisProviderConfigError: URL scheme should be 'redis', 'rediss', 'unix', ...
```

The constructor never validated a string URL, so it reached `valkey-py`, which reads `valkey://` and `valkeys://` natively. The environment path validated against `RedisAnyDsn`, which lists the Redis schemes only. Same value, two paths, opposite verdicts, and the failing one is the deployment path the docs teach.

## What changed

`ValkeyAnyDsn` adds Valkey's four spellings to the Redis ones, and `_ValkeyEnvSettings` validates `VALKEY_URL` against it, so `valkey://`, `valkeys://`, `valkey+sentinel://` and `valkey+cluster://` work wherever the `redis` ones do. `RedisProvider` keeps the `redis` schemes only, and a test holds it to that.

The Sentinel and Cluster branches compared the scheme literally against `redis+sentinel` and `redis+cluster`. They now ask whether the scheme ends in `+sentinel` or `+cluster`, so both vendors' spellings reach the same clients, and the URL keeps the scheme the user wrote rather than being rewritten behind their back.

## Why this and not a normalisation

Rewriting `valkey://` to `redis://` on the way in would have been fewer lines, but then `provider.url` reports a scheme the user never typed, and every log line and error message about that provider would name the wrong server. Accepting the vendor's spelling costs one DSN type and keeps what the deployment wrote.
