### PR TITLE
🐛 Validate a provider URL the same way whichever path it arrives on

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+* ✨ Add `ValkeyConfig`, which accepts Valkey's own URL schemes. `ValkeyProvider` reads `valkey://` in the constructor and in `VALKEY_URL`, but `from_config` took a `RedisConfig`, which refuses those schemes, so the one path that could not name the server was the config object. `from_config` still takes a `RedisConfig`. ([#718](https://github.com/grelinfo/grelmicro/issues/718))
+
+### Fixed
+
+* 🐛 Validate a URL passed to a provider exactly as one read from the environment. `RedisProvider("anything://host")` handed the string to redis-py and failed with its `ValueError`, while `REDIS_URL` was checked against the provider's own URL type and raised `RedisProviderConfigError`. Both paths now validate against one type, so they accept the same URLs and fail the same way, and `PostgresProvider` does too. A URL that a client library used to accept and the URL type refuses, such as a host-less authority, now raises at construction. ([#718](https://github.com/grelinfo/grelmicro/issues/718))
+* 🐛 Carry the Sentinel password through `ValkeyProvider.from_config`. It was dropped, so a Valkey Sentinel built from a config connected to the Sentinel servers unauthenticated while the same config on `RedisProvider` authenticated. ([#718](https://github.com/grelinfo/grelmicro/issues/718))
+
 ## 0.37.0 - 2026-08-11
 
 ### Breaking

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -167,6 +167,24 @@ RedisProvider.from_config(RedisConfig(...))  # from a config object
 RedisProvider.from_client(client)            # bring-your-own client
 ```
 
+## URL validation
+
+A URL reaches a provider from three places: the constructor, the
+environment, and a config object. All three check it against the same
+type, so a URL accepted in one is accepted in the others, and a URL
+refused in one is refused in all of them.
+
+A URL the provider cannot use is refused before any client is built:
+
+```python
+RedisProvider("anything://localhost:6379")
+# RedisProviderConfigError: Could not validate settings:
+# - url: URL scheme should be 'redis', 'rediss', 'unix', 'redis+sentinel' or 'redis+cluster'
+```
+
+`RedisProviderConfigError` and `PostgresProviderConfigError` are both
+`GrelmicroError`, so one `except` covers every way the URL arrives.
+
 ## Sentinel and Cluster
 
 `RedisProvider` switches topology from the URL scheme. The scheme rides
@@ -376,15 +394,18 @@ ValkeyProvider(host="x", port=6379, db=0)   # decomposed kwargs
 ValkeyProvider()                             # env-driven (VALKEY_*)
 ValkeyProvider(env_prefix="CACHE_VALKEY_")  # custom env prefix
 ValkeyProvider(env_load=False)              # kwargs only, no env
-ValkeyProvider.from_config(RedisConfig(...))  # from a config object
+ValkeyProvider.from_config(ValkeyConfig(...))  # from a config object
 ValkeyProvider.from_client(client)           # bring-your-own client
 ```
 
 `ValkeyProvider` also reads Valkey's own schemes, so a deployment can name
 the server it runs: `valkey://`, `valkeys://`, `valkey+sentinel://`, and
 `valkey+cluster://` work wherever the `redis` spellings do, in the
-constructor and in `VALKEY_URL` alike. `RedisProvider` keeps the `redis`
-schemes only.
+constructor, in `VALKEY_URL`, and in `ValkeyConfig`. `RedisProvider` and
+`RedisConfig` keep the `redis` schemes only.
+
+`ValkeyConfig` carries the same fields as `RedisConfig`, so
+`ValkeyProvider.from_config()` takes either one.
 
 `ValkeyProvider` reads the same `redis+sentinel://` and `redis+cluster://`
 schemes as `RedisProvider` and builds the Valkey Sentinel and Cluster

--- a/grelmicro/providers/_url.py
+++ b/grelmicro/providers/_url.py
@@ -1,0 +1,51 @@
+"""URL validation shared by the providers that take a URL."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from types import NoneType
+from typing import TYPE_CHECKING, Any, get_args
+
+from pydantic import ConfigDict, create_model
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+    from pydantic_settings import BaseSettings
+
+
+@lru_cache
+def _url_model(settings_cls: type[BaseSettings]) -> type[BaseModel]:
+    """Build a one-field model that validates a URL as `settings_cls` does.
+
+    The field type is read from the `url` field of the environment
+    settings, so every provider has exactly one URL type. The field is
+    optional there and required here, since a URL reaches this model only
+    once a caller has passed one.
+    """
+    annotation = settings_cls.model_fields["url"].annotation
+    arguments = get_args(annotation)
+    url_type: Any = (
+        next(argument for argument in arguments if argument is not NoneType)
+        if NoneType in arguments
+        else annotation
+    )
+    name = settings_cls.__name__.removeprefix("_").removesuffix("EnvSettings")
+    return create_model(
+        f"{name}Url",
+        __config__=ConfigDict(hide_input_in_errors=True),
+        url=(url_type, ...),
+    )
+
+
+def validate_url(url: str, *, settings_cls: type[BaseSettings]) -> str:
+    """Validate a URL against the type the environment path uses.
+
+    Returns the URL as pydantic writes it back: the scheme lowercased,
+    everything else as it was given.
+
+    Raises:
+        ValidationError: If the URL is malformed, or carries a scheme the
+            provider does not understand.
+    """
+    validated = _url_model(settings_cls).model_validate({"url": url})
+    return str(validated.model_dump()["url"].get_secret_value())

--- a/grelmicro/providers/_url.py
+++ b/grelmicro/providers/_url.py
@@ -48,4 +48,7 @@ def validate_url(url: str, *, settings_cls: type[BaseSettings]) -> str:
             provider does not understand.
     """
     validated = _url_model(settings_cls).model_validate({"url": url})
-    return str(validated.model_dump()["url"].get_secret_value())
+    # The model is built at runtime, so a static checker sees `BaseModel` and
+    # rejects `validated.url`. `model_dump()` hands back the same `SecretUrl`,
+    # since a python-mode dump keeps the wrapper.
+    return validated.model_dump()["url"].get_secret_value().unicode_string()

--- a/grelmicro/providers/postgres.py
+++ b/grelmicro/providers/postgres.py
@@ -19,6 +19,7 @@ from typing_extensions import Doc
 from grelmicro._redact import redact_url
 from grelmicro.errors import OutOfContextError, SettingsValidationError
 from grelmicro.providers._base import Provider
+from grelmicro.providers._url import validate_url
 from grelmicro.types import SecretUrl
 
 if TYPE_CHECKING:
@@ -472,13 +473,24 @@ def _resolve_url(
     env_prefix: str,
     env_load: bool,
 ) -> str:
-    """Resolve the connection URL from kwargs and (optionally) the environment."""
+    """Resolve the connection URL from kwargs and (optionally) the environment.
+
+    A URL passed here is validated against `_PostgresEnvSettings.url`, the same
+    type the environment path uses, so both accept the same URLs and fail the
+    same way.
+    """
     if url is not None and host is not None:
         msg = "pass either `url` or `host`, not both"
         raise PostgresProviderConfigError(msg)
 
     if url is not None:
-        return _normalize_scheme(str(url))
+        try:
+            validated = validate_url(
+                str(url), settings_cls=_PostgresEnvSettings
+            )
+        except ValidationError as error:
+            raise PostgresProviderConfigError(error) from None
+        return _normalize_scheme(validated)
 
     if host is not None:
         return _compose_url(

--- a/grelmicro/providers/redis.py
+++ b/grelmicro/providers/redis.py
@@ -21,6 +21,7 @@ from grelmicro.errors import (
     SettingsValidationError,
 )
 from grelmicro.providers._base import Provider
+from grelmicro.providers._url import validate_url
 from grelmicro.types import SecretUrl
 
 if TYPE_CHECKING:
@@ -583,16 +584,22 @@ def _resolve_url(
 ) -> tuple[str, str | None]:
     """Resolve the connection URL and Sentinel password from kwargs and env.
 
-    `settings_cls` decides which URL schemes the environment path accepts, so
-    `ValkeyProvider` reads `valkey://` where `RedisProvider` does not.
+    `settings_cls` carries the URL type both paths validate against, so
+    `ValkeyProvider` reads `valkey://` where `RedisProvider` does not, and a
+    URL passed to the constructor is accepted or refused exactly as the same
+    URL set in the environment.
     """
     if url is not None and host is not None:
         msg = "pass either `url` or `host`, not both"
         raise RedisProviderConfigError(msg)
 
     if url is not None:
+        try:
+            validated = validate_url(str(url), settings_cls=settings_cls)
+        except ValidationError as error:
+            raise RedisProviderConfigError(error) from None
         return (
-            _apply_password(str(url), password, source="`password`"),
+            _apply_password(validated, password, source="`password`"),
             sentinel_password,
         )
 

--- a/grelmicro/providers/valkey.py
+++ b/grelmicro/providers/valkey.py
@@ -63,6 +63,17 @@ deployment that names the server it runs should not have to say `redis`.
 """
 
 
+class ValkeyConfig(RedisConfig):
+    """Valkey connection settings.
+
+    The same fields as `RedisConfig`, with Valkey's own URL schemes
+    accepted alongside Redis's. Pass it to
+    `ValkeyProvider.from_config(cfg)`, which also takes a `RedisConfig`.
+    """
+
+    url: SecretUrl[ValkeyAnyDsn] | None = None
+
+
 class _ValkeyEnvSettings(_RedisEnvSettings):
     """Read Valkey settings from the environment, Valkey schemes included."""
 
@@ -89,7 +100,7 @@ class ValkeyProvider(RedisProvider):
     ValkeyProvider(host="x", port=6379, db=0)   # decomposed kwargs
     ValkeyProvider()                             # env-driven (VALKEY_*)
     ValkeyProvider(env_prefix="CACHE_VALKEY_")  # custom env prefix
-    ValkeyProvider.from_config(RedisConfig(...))  # from a config object
+    ValkeyProvider.from_config(ValkeyConfig(...))  # from a config object
     ValkeyProvider.from_client(client)           # bring-your-own client
     ```
 
@@ -228,12 +239,17 @@ class ValkeyProvider(RedisProvider):
         cls,
         config: Annotated[
             RedisConfig,
-            Doc("Pre-built `RedisConfig` carrying the connection settings."),
+            Doc(
+                """
+                Pre-built `ValkeyConfig` or `RedisConfig` carrying the
+                connection settings.
+                """
+            ),
         ],
         *,
         env_prefix: str = "VALKEY_",
     ) -> Self:
-        """Build a provider from a `RedisConfig` instance.
+        """Build a provider from a `ValkeyConfig` or `RedisConfig` instance.
 
         The config is treated as authoritative: no environment reads.
         """
@@ -248,6 +264,11 @@ class ValkeyProvider(RedisProvider):
             db=config.db,
             password=(
                 config.password.get_secret_value() if config.password else None
+            ),
+            sentinel_password=(
+                config.sentinel_password.get_secret_value()
+                if config.sentinel_password
+                else None
             ),
             env_prefix=env_prefix,
             env_load=False,

--- a/tests/providers/test_postgres_provider.py
+++ b/tests/providers/test_postgres_provider.py
@@ -595,6 +595,47 @@ class TestValidationErrors:
         assert "test_password" not in str(excinfo.value)
 
 
+BAD_URLS = [
+    "mysql://test_host:5432/test_db",
+    "redis://test_host:6379/0",
+    "postgresql://test_host:notaport/test_db",
+    "not a url",
+]
+
+
+class TestUrlValidationParity:
+    """The constructor, the environment, and the config accept one set."""
+
+    @pytest.mark.parametrize("url", BAD_URLS)
+    def test_constructor_refuses_what_the_environment_refuses(
+        self, url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both paths reject the same URL, and with the same error."""
+        monkeypatch.setenv("POSTGRES_URL", url)
+
+        with pytest.raises(PostgresProviderConfigError) as from_env:
+            PostgresProvider()
+        with pytest.raises(PostgresProviderConfigError) as from_kwarg:
+            PostgresProvider(url, env_load=False)
+
+        assert str(from_kwarg.value) == str(from_env.value)
+
+    @pytest.mark.parametrize("url", BAD_URLS)
+    def test_the_config_refuses_it_too(self, url: str) -> None:
+        """`PostgresConfig` rejects every URL the other two paths reject."""
+        with pytest.raises(ValidationError):
+            PostgresConfig(url=url)
+
+    def test_a_rejected_constructor_url_does_not_echo_the_password(
+        self,
+    ) -> None:
+        """A wrong scheme reports the failure without the credential."""
+        with pytest.raises(PostgresProviderConfigError) as excinfo:
+            PostgresProvider("mysql://usr:test_password@h/db", env_load=False)
+
+        assert "test_password" not in str(excinfo.value)
+
+
 DRIVER_SCHEMES = [
     "postgresql+asyncpg",
     "postgresql+pg8000",

--- a/tests/providers/test_redis_provider.py
+++ b/tests/providers/test_redis_provider.py
@@ -8,7 +8,7 @@ from redis.asyncio.client import Redis
 from redis.asyncio.cluster import RedisCluster
 from redis.asyncio.sentinel import Sentinel
 
-from grelmicro import Grelmicro, GrelmicroConfigWarning
+from grelmicro import Grelmicro, GrelmicroConfigWarning, GrelmicroError
 from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.coordination.redis import (
     RedisLockAdapter,
@@ -596,17 +596,25 @@ class TestSentinelUrl:
         )
         assert "secret" not in repr(provider)
 
-    def test_sentinel_url_skips_empty_authority_item(self) -> None:
-        """A trailing comma in the authority is ignored."""
-        provider = RedisProvider("redis+sentinel://h1:26379,/mymaster")
-
-        assert isinstance(provider._sentinel, Sentinel)
-        assert sum(1 for _ in provider._sentinel.sentinels) == 1
+    def test_sentinel_url_with_empty_authority_item_raises(self) -> None:
+        """A trailing comma in the authority leaves a host empty and raises."""
+        with pytest.raises(RedisProviderConfigError, match="empty host"):
+            RedisProvider("redis+sentinel://h1:26379,/mymaster")
 
     def test_cluster_url_with_no_hosts_raises(self) -> None:
         """An authority with only separators raises."""
-        with pytest.raises(RedisProviderConfigError, match="at least one host"):
+        with pytest.raises(RedisProviderConfigError, match="empty host"):
             RedisProvider("redis+cluster://,")
+
+    def test_sentinel_factory_without_hosts_raises(self) -> None:
+        """The factory composes a host-less URL, which the parser refuses."""
+        with pytest.raises(RedisProviderConfigError, match="at least one host"):
+            RedisProvider.sentinel(sentinels=[], service_name="mymaster")
+
+    def test_cluster_factory_with_an_empty_host_raises(self) -> None:
+        """A node with no host name is refused rather than silently dropped."""
+        with pytest.raises(RedisProviderConfigError, match="missing host"):
+            RedisProvider.cluster(nodes=[("", 6379)])
 
     async def test_sentinel_provider_closes_sentinels_on_exit(self) -> None:
         """Owned sentinel providers close every Sentinel connection on exit."""
@@ -823,13 +831,6 @@ class TestRedactUrlEdgeCases:
         ):
             assert redact_url(url) == url
 
-    def test_provider_repr_redacts_unparsable_url(self) -> None:
-        """A URL redis-py accepts but pydantic cannot parse still reprs safely."""
-        provider = RedisProvider("redis://user:hun,ter2@:6379/0")
-
-        assert "hun,ter2" not in repr(provider)
-        assert "***" in repr(provider)
-
 
 class TestValidationErrors:
     """A rejected value must never carry its credential into the error."""
@@ -847,6 +848,65 @@ class TestValidationErrors:
             RedisConfig(url="redis://usr:test_password@h:notaport/0")
 
         assert "test_password" not in str(excinfo.value)
+
+
+BAD_URLS = [
+    "anything://test_host:6379/0",
+    "https://test_host:6379/0",
+    "redis://test_host:notaport/0",
+    "not a url",
+    "redis+sentinel://h1:26379,/mymaster",
+]
+
+
+class TestUrlValidationParity:
+    """The constructor, the environment, and the config accept one set."""
+
+    @pytest.mark.parametrize("url", BAD_URLS)
+    def test_constructor_refuses_what_the_environment_refuses(
+        self, url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both paths reject the same URL, and with the same error."""
+        monkeypatch.setenv("REDIS_URL", url)
+
+        with pytest.raises(RedisProviderConfigError) as from_env:
+            RedisProvider()
+        with pytest.raises(RedisProviderConfigError) as from_kwarg:
+            RedisProvider(url, env_load=False)
+
+        assert str(from_kwarg.value) == str(from_env.value)
+
+    @pytest.mark.parametrize("url", BAD_URLS)
+    def test_the_config_refuses_it_too(self, url: str) -> None:
+        """`RedisConfig` rejects every URL the other two paths reject."""
+        with pytest.raises(ValidationError):
+            RedisConfig(url=url)
+
+    def test_a_rejected_constructor_url_is_a_grelmicro_error(self) -> None:
+        """The failure is catchable as `GrelmicroError`, not a client error."""
+        with pytest.raises(GrelmicroError):
+            RedisProvider("anything://test_host:6379/0", env_load=False)
+
+    def test_a_rejected_constructor_url_does_not_echo_the_password(
+        self,
+    ) -> None:
+        """A wrong scheme reports the failure without the credential."""
+        with pytest.raises(RedisProviderConfigError) as excinfo:
+            RedisProvider("https://usr:test_password@h/0", env_load=False)
+
+        assert "test_password" not in str(excinfo.value)
+
+    def test_an_uppercase_scheme_resolves_the_same_from_both_paths(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A scheme is case-insensitive, and both paths lowercase it."""
+        monkeypatch.setenv("REDIS_URL", "REDIS://test_host:6379/0")
+
+        assert RedisProvider().url == "redis://test_host:6379/0"
+        assert (
+            RedisProvider("REDIS://test_host:6379/0", env_load=False).url
+            == "redis://test_host:6379/0"
+        )
 
 
 class TestSentinelPassword:

--- a/tests/providers/test_valkey_provider.py
+++ b/tests/providers/test_valkey_provider.py
@@ -4,6 +4,7 @@ from importlib.metadata import entry_points
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from grelmicro.cache.redis import RedisCacheAdapter
 from grelmicro.coordination.redis import (
@@ -16,7 +17,7 @@ from grelmicro.providers.redis import (
     RedisProvider,
     RedisProviderConfigError,
 )
-from grelmicro.providers.valkey import ValkeyProvider
+from grelmicro.providers.valkey import ValkeyConfig, ValkeyProvider
 from grelmicro.resilience.circuitbreaker.redis import (
     RedisCircuitBreakerAdapter,
 )
@@ -183,6 +184,32 @@ class TestFromConfig:
         cfg = RedisConfig(host="cfg_host")
         provider = ValkeyProvider.from_config(cfg)
         assert provider.env_prefix == "VALKEY_"
+
+    def test_from_config_takes_a_valkey_url(self) -> None:
+        """`ValkeyConfig` carries the schemes the provider accepts."""
+        cfg = ValkeyConfig(url="valkey://cfg_host:6379/0")
+
+        provider = ValkeyProvider.from_config(cfg)
+
+        assert provider.url == "valkey://cfg_host:6379/0"
+
+    def test_a_redis_config_refuses_a_valkey_url(self) -> None:
+        """`RedisConfig` keeps the Redis schemes, so `ValkeyConfig` exists."""
+        with pytest.raises(ValidationError):
+            RedisConfig(url="valkey://cfg_host:6379/0")
+
+    def test_from_config_carries_the_sentinel_password(self) -> None:
+        """`from_config` is authoritative and must not drop it."""
+        provider = ValkeyProvider.from_config(
+            ValkeyConfig(
+                url="valkey+sentinel://a:26379,b:26379/mymaster/0",
+                sentinel_password="sentinel_password",
+            )
+        )
+
+        sentinel = provider._sentinel
+        assert sentinel is not None
+        assert sentinel.sentinel_kwargs == {"password": "sentinel_password"}
 
 
 class TestFromClient:
@@ -401,6 +428,7 @@ class TestValkeySchemes:
         provider = ValkeyProvider()
 
         assert provider.url == url
+        assert ValkeyProvider(url, env_load=False).url == url
 
     @pytest.mark.parametrize(
         "url",
@@ -422,11 +450,13 @@ class TestValkeySchemes:
     def test_redis_keeps_its_own_schemes(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """`RedisProvider` does not learn Valkey's schemes."""
+        """`RedisProvider` does not learn Valkey's schemes, on either path."""
         monkeypatch.setenv("REDIS_URL", "valkey://localhost:6379/0")
 
         with pytest.raises(RedisProviderConfigError):
             RedisProvider()
+        with pytest.raises(RedisProviderConfigError):
+            RedisProvider("valkey://localhost:6379/0", env_load=False)
 
     @pytest.mark.parametrize(
         "url",


### PR DESCRIPTION
Closes #718.

## The problem

A URL passed to a provider constructor and the same URL read from the environment were validated by different things.

The environment path validated against the provider's own DSN and raised `RedisProviderConfigError`. The constructor path validated nothing: `redis+sentinel://` and `redis+cluster://` reached grelmicro's parser, and every other scheme went straight to redis-py, valkey-py, or asyncpg. So `RedisProvider("anything://host:6379/0")` failed with a bare `ValueError` from a third-party package, and a caller wrapping construction in `except GrelmicroError` caught the environment case and missed the constructor case.

## The fix

New `grelmicro/providers/_url.py`. `validate_url(url, settings_cls=...)` reads the URL type from the `url` field of the environment settings class, strips the `| None`, and builds a cached one-field model from it. Both paths validate against that one declaration, so they accept the same set, fail the same way, and cannot drift apart again. The error keeps the `url` location, so the message reads the same whichever path produced it, and the input stays out of it so a mistyped URL never carries its password into the text.

`RedisProvider`, `ValkeyProvider`, and `PostgresProvider` all wrap the failure into their own config error, which is a `GrelmicroError`, and validation returns the URL pydantic writes back, so an uppercase scheme now resolves identically on both paths.

## Also fixed

Two more breaks of the same invariant, found while implementing it:

* `ValkeyConfig` is added. `ValkeyProvider` reads `valkey://` in the constructor and in `VALKEY_URL`, but `from_config` took a `RedisConfig`, which refuses those schemes, so the config object was the one path that could not name the server it runs. `from_config` still takes a `RedisConfig`.
* `ValkeyProvider.from_config` dropped `sentinel_password`, so a Valkey Sentinel built from a config connected to the Sentinel servers unauthenticated while the same config on `RedisProvider` authenticated.

## Behaviour change

A URL a client library used to accept and the URL type refuses now raises at construction. In practice that is a malformed authority: `redis+sentinel://h1:26379,/mymaster` (trailing comma) and `redis+cluster://,` both used to build a client and now raise. The `unix://` scheme and the sentinel and cluster spellings were already in the URL type, so nothing else in the accepted set moves.

Three tests changed with it. Two now assert the refusal, and the "a provider reprs an unparsable URL safely" test is gone, because a provider can no longer hold one. The factory paths still reach the parser's own host checks, and two new tests cover them through `RedisProvider.sentinel(sentinels=[])` and `RedisProvider.cluster(nodes=[("", 6379)])`.

## Tests

`TestUrlValidationParity` in the Redis and Postgres suites asserts that the constructor and the environment produce the same error string for each bad URL, that the config refuses the same set, that the failure is catchable as `GrelmicroError`, that nothing echoes the password, and that an uppercase scheme resolves the same on both paths. The Valkey suite covers the config schemes and the Sentinel password.

Unit tier green (4087 passed), ruff, ty, mypy, and `mkdocs build --strict` all pass. Redis and Postgres integration pass (248). The k3s tier does not start on this machine (`failed to find cpuset cgroup (v2)`), which is why coverage reports 99% locally, with `kubernetes.py` as the only file short. Nothing in this PR touches it.
