### PR TITLE
🔖 Prepare the 0.37.2 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.37.2 - 2026-08-13
 
 ### Changed
 


### PR DESCRIPTION
Flips `## Unreleased` to `## 0.37.2 - 2026-08-13` in the changelog.

A patch release: the changes are documentation and test infrastructure, with no change to the public API.

- Split the six longest guide pages into sections, with the top-level URLs unchanged (#681, #725)
- Move Redis connection settings onto the providers page and the logging benchmark table onto the benchmarks page (#681)
- Fail the docs build on a link whose anchor no longer exists (#681)
- Render the snippets no page included, delete the superseded ones, and fail a test on any future orphan (#681)