### PR TITLE
✨ Build the cache serializer from the type parameter

### DIFF
--- a/docs/cache/index.md
+++ b/docs/cache/index.md
@@ -131,7 +131,7 @@ await cache.clear()
 
 ### Serialization
 
-Backends store raw bytes. To cache Python objects, pass a serializer:
+Backends store raw bytes. To cache Python objects, name the type:
 
 === "Pydantic Model (recommended)"
 
@@ -140,16 +140,26 @@ Backends store raw bytes. To cache Python objects, pass a serializer:
     ```python
     from pydantic import BaseModel
 
-    from grelmicro.cache import PydanticSerializer, TTLCache
+    from grelmicro.cache import TTLCache
 
     class User(BaseModel):
         id: int
         name: str
 
-    cache = TTLCache[User](ttl=300, serializer=PydanticSerializer(User))
+    cache = TTLCache[User](ttl=300)
 
     await cache.set("user", User(id=1, name="Alice"))
     user = await cache.get("user")  # returns User instance
+    ```
+
+    The type parameter picks the serializer. Anything Pydantic can adapt
+    works, including a dataclass, a `TypedDict`, and `list[User]`.
+
+    Where there is no type parameter to read, such as the `Cache.ttl`
+    factory, pass the type itself:
+
+    ```python
+    cache = micro.cache.ttl(ttl=300, serializer=User)
     ```
 
 === "JSON"
@@ -182,7 +192,7 @@ Backends store raw bytes. To cache Python objects, pass a serializer:
     data = await cache.get("data")
     ```
 
-Without a serializer, only `bytes` values are accepted.
+With no type parameter and no serializer, only `bytes` values are accepted. `TTLCache[bytes]` also stores raw bytes.
 
 ### Per-Entry TTL
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+* ✨ Build the cache serializer from the type parameter. `TTLCache[User](ttl=300)` serializes with `PydanticSerializer(User)`, so the model is named once instead of twice. `TTLCache()` and `TTLCache[bytes]()` still store raw bytes, and so does a type parameter Pydantic cannot adapt. ([#684](https://github.com/grelinfo/grelmicro/issues/684))
+* ✨ Accept a type wherever a serializer is accepted. `micro.cache.ttl(ttl=300, serializer=User)` and `Idempotency("http", serializer=Response)` build the `PydanticSerializer`, which is the way in for a factory that has no type parameter to read. ([#684](https://github.com/grelinfo/grelmicro/issues/684))
+
+### Changed
+
+* ✨ `Idempotency[Response]` stores responses with `PydanticSerializer(Response)` and replays the model itself. It used to store JSON, which cannot even encode a Pydantic model, so the typed form raised on the first response it was given. `Idempotency("http")` without a type parameter still stores JSON. ([#684](https://github.com/grelinfo/grelmicro/issues/684))
+
 ## 0.37.2 - 2026-08-13
 
 ### Changed

--- a/docs/idempotency/index.md
+++ b/docs/idempotency/index.md
@@ -108,7 +108,18 @@ from grelmicro.idempotency import Idempotency
 idem = Idempotency("charge", ttl=3600, cache=TTLCache(ttl=3600))
 ```
 
-Responses serialize through the cache serializers. The default is `JsonSerializer`. Pass `serializer=PydanticSerializer(Model)` or `serializer=PickleSerializer()` to store richer types.
+Responses serialize through the cache serializers. Name the response type and the store roundtrips it, so a replay returns the model and not a dict:
+
+```python
+class ChargeResponse(BaseModel):
+    id: str
+    amount: int
+
+
+idem = Idempotency[ChargeResponse]("charge", ttl=3600)
+```
+
+Without a type parameter, responses store as JSON. Pass `serializer=ChargeResponse` where there is no parameter to read, or `serializer=PickleSerializer()` for a type Pydantic cannot adapt.
 
 ## Single-flight duplicates
 

--- a/grelmicro/cache/_component.py
+++ b/grelmicro/cache/_component.py
@@ -128,7 +128,7 @@ class Cache:
         *,
         ttl: float = 60,
         maxsize: int = 0,
-        serializer: CacheSerializer[T] | None = None,
+        serializer: CacheSerializer[T] | type[T] | None = None,
     ) -> TTLCache[T]:
         """Construct a `TTLCache` bound to this component's backend.
 
@@ -138,7 +138,8 @@ class Cache:
         Args:
             ttl: Default TTL in seconds for cached entries.
             maxsize: Maximum local cache entries (`0` means unlimited).
-            serializer: Serialization strategy. Defaults to raw bytes.
+            serializer: Serialization strategy, or a type to serialize with
+                `PydanticSerializer`. Defaults to raw bytes.
         """
         return TTLCache(
             maxsize=maxsize,

--- a/grelmicro/cache/serializers.py
+++ b/grelmicro/cache/serializers.py
@@ -14,8 +14,8 @@ Example::
     # JSON (orjson when available)
     cache = TTLCache(ttl=300, serializer=JsonSerializer())
 
-    # Pydantic model (TypeAdapter, fastest)
-    cache = TTLCache[User](ttl=300, serializer=PydanticSerializer(User))
+    # Pydantic model (TypeAdapter, fastest, inferred from `TTLCache[User]`)
+    cache = TTLCache[User](ttl=300)
 
     # Pickle (supports any Python object)
     cache = TTLCache(ttl=300, serializer=PickleSerializer())
@@ -24,9 +24,18 @@ Example::
 from __future__ import annotations
 
 import pickle
-from typing import Any, Generic, Protocol, runtime_checkable
+from typing import (
+    Any,
+    Generic,
+    Protocol,
+    cast,
+    get_args,
+    get_origin,
+    runtime_checkable,
+)
 
 from pydantic import TypeAdapter
+from pydantic.errors import PydanticSchemaGenerationError
 from typing_extensions import TypeVar
 
 from grelmicro._json import (
@@ -134,3 +143,74 @@ class PydanticSerializer(Generic[T]):
     def loads(self, data: bytes) -> T:
         """Deserialize JSON bytes to a typed value via TypeAdapter."""
         return self._adapter.validate_json(data)
+
+
+def _looks_like_serializer(obj: object) -> bool:
+    """Check whether an object carries the `dumps` and `loads` pair."""
+    return callable(getattr(obj, "dumps", None)) and callable(
+        getattr(obj, "loads", None)
+    )
+
+
+def _resolve_serializer(
+    serializer: CacheSerializer[T] | type[T],
+) -> CacheSerializer[T]:
+    """Return the serializer for a serializer instance or a model type.
+
+    A serializer instance passes through. Anything else is treated as a
+    type and wrapped in a `PydanticSerializer`.
+
+    Raises:
+        TypeError: If a serializer class is passed instead of an instance.
+    """
+    if _looks_like_serializer(serializer):
+        if isinstance(serializer, type):
+            name = serializer.__name__
+            msg = f"{name} is a serializer class, pass an instance: {name}()."
+            raise TypeError(msg)
+        return serializer
+    return PydanticSerializer(cast("type[T]", serializer))
+
+
+def _infer_serializer(annotation: object) -> CacheSerializer[Any] | None:
+    """Return a `PydanticSerializer` for a type parameter, or None.
+
+    Returns None for `bytes`, for `Any`, for an unbound type variable, and
+    for any type Pydantic cannot build a schema for. The caller keeps
+    storing raw bytes in those cases.
+    """
+    if (
+        annotation is Any
+        or annotation is bytes
+        or isinstance(annotation, TypeVar)
+    ):
+        return None
+    try:
+        return PydanticSerializer(cast("type[Any]", annotation))
+    except (PydanticSchemaGenerationError, TypeError):
+        return None
+
+
+def _infer_serializer_from_instance(obj: object) -> CacheSerializer[Any] | None:
+    """Return a serializer for the type parameter of `Klass[Model](...)`.
+
+    Python sets `__orig_class__` after `__init__` returns, so this reads
+    the parameter from the first call that needs a serializer.
+    """
+    args = get_args(getattr(obj, "__orig_class__", None))
+    return _infer_serializer(args[0]) if args else None
+
+
+def _infer_serializer_from_class(
+    cls: type, generic: type
+) -> CacheSerializer[Any] | None:
+    """Return a serializer for the parameter of `class Sub(Generic[Model])`.
+
+    Unlike the `Klass[Model](...)` form, a subclass carries its parameter
+    from the moment the class is defined.
+    """
+    for base in getattr(cls, "__orig_bases__", ()):
+        origin = get_origin(base)
+        if isinstance(origin, type) and issubclass(origin, generic):
+            return _infer_serializer(get_args(base)[0])
+    return None

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -16,6 +16,11 @@ from grelmicro.cache._stampede import (
     AsyncStampedeGuard,
     compute_with_stampede,
 )
+from grelmicro.cache.serializers import (
+    _infer_serializer_from_class,
+    _infer_serializer_from_instance,
+    _resolve_serializer,
+)
 from grelmicro.metrics import _emit
 
 if TYPE_CHECKING:
@@ -103,8 +108,11 @@ class TTLCache(Generic[T]):
 
     The type parameter ``T`` represents the cached value type.
     Defaults to ``Any`` when unspecified (``TTLCache()``).
-    Use ``TTLCache[User](serializer=PydanticSerializer(User))``
-    for typed caching.
+
+    ``TTLCache[User]()`` serializes with ``PydanticSerializer(User)``
+    unless a ``serializer`` is given. ``TTLCache()`` and
+    ``TTLCache[bytes]()`` store raw bytes, and so does any type
+    parameter Pydantic cannot build a schema for.
 
     Raises:
         pydantic.ValidationError: If `maxsize` is negative or `ttl` is not
@@ -143,7 +151,7 @@ class TTLCache(Generic[T]):
             ),
         ] = None,
         serializer: Annotated[
-            CacheSerializer[T] | None,
+            CacheSerializer[T] | type[T] | None,
             Doc(
                 """
                 Serialization strategy for cached values.
@@ -153,11 +161,12 @@ class TTLCache(Generic[T]):
 
                 Built-in options:
 
-                - ``PydanticSerializer(Model)``: Type-safe Pydantic roundtrips.
+                - ``Model``: A type, wrapped in ``PydanticSerializer``.
                 - ``JsonSerializer()``: JSON-native types (dict, list, etc.).
                 - ``PickleSerializer()``: Any picklable object. Trusted
                   backends only: deserialization can execute arbitrary code.
-                - ``None``: Raw bytes only (no serialization).
+                - ``None``: The type parameter of ``TTLCache[T]`` when it
+                  is one Pydantic can adapt, raw bytes otherwise.
                 """,
             ),
         ] = None,
@@ -170,7 +179,17 @@ class TTLCache(Generic[T]):
         self._maxsize = self._config.maxsize
         self._ttl = self._config.ttl
         self._backend = backend
-        self._serializer = serializer
+        if serializer is not None:
+            self._serializer: CacheSerializer[T] | None = _resolve_serializer(
+                serializer
+            )
+            self._serializer_bound = True
+        else:
+            self._serializer = cast(
+                "CacheSerializer[T] | None",
+                _infer_serializer_from_class(type(self), TTLCache),
+            )
+            self._serializer_bound = self._serializer is not None
         self._hits = 0
         self._misses = 0
         self._evictions = 0
@@ -219,10 +238,27 @@ class TTLCache(Generic[T]):
             raise OutOfContextError(msg) from None
         return cache.backend
 
+    def _bind_serializer(self) -> CacheSerializer[T] | None:
+        """Resolve the serializer from the type parameter, once.
+
+        Python sets ``__orig_class__`` after ``__init__`` returns, so the
+        parameter of ``TTLCache[User](...)`` is first readable here.
+        """
+        self._serializer_bound = True
+        self._serializer = cast(
+            "CacheSerializer[T] | None", _infer_serializer_from_instance(self)
+        )
+        return self._serializer
+
     def _serialize(self, value: T) -> bytes:
         """Serialize a value to bytes for storage."""
-        if self._serializer is not None:
-            return self._serializer.dumps(value)
+        serializer = self._serializer
+        if serializer is not None:
+            return serializer.dumps(value)
+        if not self._serializer_bound:
+            serializer = self._bind_serializer()
+            if serializer is not None:
+                return serializer.dumps(value)
         if isinstance(value, bytes):
             return value
         msg = (
@@ -233,8 +269,13 @@ class TTLCache(Generic[T]):
 
     def _deserialize(self, raw: bytes) -> T:
         """Deserialize bytes from storage."""
-        if self._serializer is not None:
-            return self._serializer.loads(raw)
+        serializer = self._serializer
+        if serializer is not None:
+            return serializer.loads(raw)
+        if not self._serializer_bound:
+            serializer = self._bind_serializer()
+            if serializer is not None:
+                return serializer.loads(raw)
         return cast("T", raw)
 
     async def get(

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -306,6 +306,10 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
 
     The type parameter `T` represents the stored response type. Defaults
     to `Any` when unspecified.
+
+    `Idempotency[Response]` stores responses with
+    `PydanticSerializer(Response)` unless a `cache` or a `serializer` is
+    given. Without a type parameter, responses store as JSON.
     """
 
     _IDEMPOTENCY_PREFIX = "idempotency"
@@ -364,14 +368,16 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
             ),
         ] = None,
         serializer: Annotated[
-            CacheSerializer[T] | None,
+            CacheSerializer[T] | type[T] | None,
             Doc(
                 """
-                Serialization strategy for stored responses.
+                Serialization strategy for stored responses, or a type to
+                serialize with `PydanticSerializer`.
 
                 Ignored when an explicit `cache` is given. Otherwise
                 passed to the internally composed `TTLCache`. Defaults to
-                `JsonSerializer`.
+                the type parameter of `Idempotency[T]` when it is one
+                Pydantic can adapt, and to `JsonSerializer` otherwise.
                 """,
             ),
         ] = None,
@@ -448,8 +454,11 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
             Doc("The `TTLCache` used to store responses."),
         ] = None,
         serializer: Annotated[
-            CacheSerializer[T] | None,
-            Doc("Serialization strategy for stored responses."),
+            CacheSerializer[T] | type[T] | None,
+            Doc(
+                "Serialization strategy for stored responses, or a type to"
+                " serialize with `PydanticSerializer`."
+            ),
         ] = None,
     ) -> Self:
         """Construct an `Idempotency` from a name and a pre-built config."""
@@ -463,28 +472,50 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
         config: IdempotencyConfig,
         fingerprint: str | None,
         cache: TTLCache[T] | None,
-        serializer: CacheSerializer[T] | None,
+        serializer: CacheSerializer[T] | type[T] | None,
     ) -> None:
         """Wire the validated config and runtime deps onto the instance."""
         import asyncio  # noqa: PLC0415
-
-        from grelmicro.cache.serializers import JsonSerializer  # noqa: PLC0415
 
         self._name = name
         self._config = config
         self._reconfigure_lock = asyncio.Lock()
         self._fingerprint = fingerprint
         self._guard = AsyncStampedeGuard()
+        self._serializer = serializer
+        self._cache: TTLCache[T] | None = cache
+
+    def _get_cache(self) -> TTLCache[T]:
+        """Return the response store, composing it on first use.
+
+        Python sets `__orig_class__` after `__init__` returns, so the
+        type parameter of `Idempotency[Model]` is first readable here.
+        """
+        cache = self._cache
         if cache is not None:
-            self._cache: TTLCache[T] = cache
+            return cache
+        from grelmicro.cache.serializers import (  # noqa: PLC0415
+            JsonSerializer,
+            _infer_serializer_from_class,
+            _infer_serializer_from_instance,
+            _resolve_serializer,
+        )
+
+        serializer: CacheSerializer[Any] | None
+        if self._serializer is not None:
+            serializer = _resolve_serializer(self._serializer)
         else:
-            resolved_serializer: CacheSerializer[Any] = (
-                serializer if serializer is not None else JsonSerializer()
-            )
-            self._cache = cast(
-                "TTLCache[T]",
-                TTLCache(ttl=config.ttl, serializer=resolved_serializer),
-            )
+            serializer = _infer_serializer_from_instance(
+                self
+            ) or _infer_serializer_from_class(type(self), Idempotency)
+        if serializer is None:
+            serializer = JsonSerializer()
+        cache = cast(
+            "TTLCache[T]",
+            TTLCache(ttl=self._config.ttl, serializer=serializer),
+        )
+        self._cache = cache
+        return cache
 
     @property
     def name(self) -> str:
@@ -607,11 +638,12 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
         the stored fingerprint differs.
         """
         scoped = self._scoped(key)
-        stored = await self._cache.get(scoped, cast("T", _SENTINEL))
+        cache = self._get_cache()
+        stored = await cache.get(scoped, cast("T", _SENTINEL))
         if stored is _SENTINEL:
             return _SENTINEL
         if fingerprint is not None:
-            saved = await self._cache._get_backend().get(  # noqa: SLF001
+            saved = await cache._get_backend().get(  # noqa: SLF001
                 key=f"{_CACHE_PREFIX}:{scoped}{_FINGERPRINT_SUFFIX}"
             )
             if saved is not None and saved.decode() != fingerprint:
@@ -624,11 +656,12 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
         """Store the response and the optional fingerprint under `ttl`."""
         scoped = self._scoped(key)
         ttl = self._config.ttl
+        cache = self._get_cache()
         if fingerprint is not None:
             # Store the guard first so a response never outlives its check.
-            await self._cache._get_backend().set(  # noqa: SLF001
+            await cache._get_backend().set(  # noqa: SLF001
                 key=f"{_CACHE_PREFIX}:{scoped}{_FINGERPRINT_SUFFIX}",
                 value=fingerprint.encode(),
                 ttl=ttl + 1,
             )
-        await self._cache.set(scoped, response, ttl)
+        await cache.set(scoped, response, ttl)

--- a/tests/cache/test_serializers.py
+++ b/tests/cache/test_serializers.py
@@ -3,22 +3,29 @@
 from __future__ import annotations
 
 import pickle
+from typing import Any
 
 import pytest
 from pydantic import BaseModel
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, TypeVar
 
 from grelmicro.cache.serializers import (
     CacheSerializer,
     JsonSerializer,
     PickleSerializer,
     PydanticSerializer,
+    _infer_serializer,
+    _infer_serializer_from_class,
+    _infer_serializer_from_instance,
+    _resolve_serializer,
 )
 
 pytestmark = [pytest.mark.timeout(10)]
 
 
 EXPECTED_USER_ID = 42
+
+T = TypeVar("T")
 
 
 class _User(BaseModel):
@@ -167,3 +174,87 @@ class TestPydanticSerializer:
         result = serializer.loads(serializer.dumps(item))
 
         assert result == item
+
+
+class TestResolveSerializer:
+    """Tests for `_resolve_serializer`."""
+
+    def test_serializer_instance_passes_through(self) -> None:
+        """Test that a serializer instance is returned unchanged."""
+        serializer = JsonSerializer()
+
+        assert _resolve_serializer(serializer) is serializer
+
+    def test_model_becomes_pydantic_serializer(self) -> None:
+        """Test that a model type is wrapped in a PydanticSerializer."""
+        serializer = _resolve_serializer(_User)
+
+        assert isinstance(serializer, PydanticSerializer)
+        assert serializer.loads(b'{"id": 1, "name": "Alice"}').name == "Alice"
+
+    def test_generic_alias_becomes_pydantic_serializer(self) -> None:
+        """Test that a parameterized type is wrapped too."""
+        serializer = _resolve_serializer(list[_User])
+
+        assert serializer.loads(b'[{"id": 1, "name": "Alice"}]') == [
+            _User(id=1, name="Alice")
+        ]
+
+    def test_serializer_class_names_the_fix(self) -> None:
+        """Test that a serializer class raises and asks for an instance."""
+        with pytest.raises(
+            TypeError, match=r"pass an instance: JsonSerializer\(\)"
+        ):
+            _resolve_serializer(JsonSerializer)
+
+
+class TestInferSerializer:
+    """Tests for `_infer_serializer` and its two readers."""
+
+    def test_model_infers_pydantic_serializer(self) -> None:
+        """Test that a model type infers a PydanticSerializer."""
+        assert isinstance(_infer_serializer(_User), PydanticSerializer)
+
+    @pytest.mark.parametrize("annotation", [bytes, Any, T])
+    def test_raw_bytes_annotations_infer_nothing(
+        self, annotation: object
+    ) -> None:
+        """Test that `bytes`, `Any`, and a type variable infer nothing."""
+        assert _infer_serializer(annotation) is None
+
+    def test_unsupported_type_infers_nothing(self) -> None:
+        """Test that a type Pydantic cannot adapt infers nothing."""
+
+        class Opaque:
+            def __init__(self, value: object) -> None:
+                self.value = value
+
+        assert _infer_serializer(Opaque) is None
+
+    def test_instance_without_type_parameter_infers_nothing(self) -> None:
+        """Test that an unparameterized instance infers nothing."""
+        assert _infer_serializer_from_instance(object()) is None
+
+    def test_instance_type_parameter_is_read(self) -> None:
+        """Test that `Klass[Model](...)` exposes its parameter."""
+        assert isinstance(
+            _infer_serializer_from_instance(PydanticSerializer[_User](_User)),
+            PydanticSerializer,
+        )
+
+    def test_class_without_matching_base_infers_nothing(self) -> None:
+        """Test that a subclass of another generic infers nothing."""
+        assert (
+            _infer_serializer_from_class(list[int], PydanticSerializer) is None
+        )
+
+    def test_class_type_parameter_is_read(self) -> None:
+        """Test that `class Sub(Klass[Model])` exposes its parameter."""
+
+        class UserSerializer(PydanticSerializer[_User]):
+            pass
+
+        assert isinstance(
+            _infer_serializer_from_class(UserSerializer, PydanticSerializer),
+            PydanticSerializer,
+        )

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -7,7 +7,7 @@ from time import monotonic
 from unittest.mock import patch
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from grelmicro import Grelmicro
 from grelmicro.cache import Cache, TTLCacheConfig
@@ -26,6 +26,11 @@ pytestmark = [pytest.mark.timeout(10)]
 EXPECTED_HITS_2 = 2
 EXPECTED_OVERWRITE_VALUE = 10
 EXPECTED_UNLIMITED_COUNT = 1000
+
+
+class _User(BaseModel):
+    id: int
+    name: str
 
 
 @pytest.fixture
@@ -1009,3 +1014,130 @@ class TestStaleReserve:
             pytest.raises(RuntimeError, match="down"),
         ):
             await cache.get_or_set("k", boom, stale_ttl=100)
+
+
+class TestSerializerInference:
+    """Test the serializer inferred from the type parameter."""
+
+    async def test_type_parameter_infers_pydantic_serializer(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that `TTLCache[Model]` roundtrips the model without a serializer."""
+        # Arrange
+        cache = TTLCache[_User](ttl=60, backend=backend)
+
+        # Act
+        await cache.set("user", _User(id=1, name="Alice"))
+
+        # Assert
+        assert await cache.get("user") == _User(id=1, name="Alice")
+
+    async def test_subclass_parameter_infers_pydantic_serializer(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that `class Sub(TTLCache[Model])` infers the same serializer."""
+
+        # Arrange
+        class UserCache(TTLCache[_User]):
+            pass
+
+        cache = UserCache(ttl=60, backend=backend)
+
+        # Act
+        await cache.set("user", _User(id=1, name="Alice"))
+
+        # Assert
+        assert await cache.get("user") == _User(id=1, name="Alice")
+
+    async def test_explicit_serializer_wins_over_type_parameter(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that an explicit serializer is kept for a parameterized cache."""
+        # Arrange
+        cache = TTLCache[_User](
+            ttl=60, backend=backend, serializer=PickleSerializer()
+        )
+
+        # Act
+        await cache.set("user", _User(id=1, name="Alice"))
+
+        # Assert: pickle writes its own framing, not JSON
+        stored = await backend.get(key=f"{_CACHE_PREFIX}:user")
+        assert stored is not None
+        assert not stored.startswith(b"{")
+
+    async def test_model_as_serializer(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that a type passed as `serializer` builds the serializer."""
+        # Arrange
+        cache = TTLCache(ttl=60, backend=backend, serializer=_User)
+
+        # Act
+        await cache.set("user", _User(id=1, name="Alice"))
+
+        # Assert
+        assert await cache.get("user") == _User(id=1, name="Alice")
+
+    async def test_bytes_parameter_stays_raw(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that `TTLCache[bytes]` still stores raw bytes."""
+        # Arrange
+        cache = TTLCache[bytes](ttl=60, backend=backend)
+
+        # Act
+        await cache.set("raw", b"value")
+
+        # Assert
+        assert await cache.get("raw") == b"value"
+
+    async def test_unparameterized_cache_stays_raw(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that `TTLCache()` still refuses a non-bytes value."""
+        # Arrange
+        cache = TTLCache(ttl=60, backend=backend)
+
+        # Act / Assert
+        with pytest.raises(TypeError, match="without a serializer"):
+            await cache.set("user", _User(id=1, name="Alice"))
+
+    async def test_unsupported_parameter_stays_raw(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that a type Pydantic cannot adapt keeps raw bytes."""
+
+        # Arrange
+        class _Opaque:
+            def __init__(self, value: object) -> None:
+                self.value = value
+
+        cache = TTLCache[_Opaque](ttl=60, backend=backend)
+
+        # Act / Assert
+        with pytest.raises(TypeError, match="without a serializer"):
+            await cache.set("opaque", _Opaque(1))
+
+    async def test_read_before_write_infers_the_serializer(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that a `get` on a fresh cache resolves the type parameter."""
+        # Arrange
+        writer = TTLCache[_User](ttl=60, backend=backend)
+        await writer.set("user", _User(id=1, name="Alice"))
+        reader = TTLCache[_User](ttl=60, backend=backend)
+
+        # Act
+        user = await reader.get("user")
+
+        # Assert
+        assert user == _User(id=1, name="Alice")
+
+    async def test_serializer_class_names_the_fix(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that a serializer class raises and asks for an instance."""
+        # Act / Assert
+        with pytest.raises(TypeError, match=r"pass an instance"):
+            TTLCache(ttl=60, backend=backend, serializer=PickleSerializer)

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -17,8 +18,8 @@ from grelmicro import Grelmicro
 from grelmicro._config import reconfigurable_instances, reconfigure_all
 from grelmicro.cache import Cache
 from grelmicro.cache.memory import MemoryCacheAdapter
-from grelmicro.cache.serializers import JsonSerializer
-from grelmicro.cache.ttl import TTLCache
+from grelmicro.cache.serializers import JsonSerializer, PickleSerializer
+from grelmicro.cache.ttl import _CACHE_PREFIX, TTLCache
 from grelmicro.coordination import Coordination
 from grelmicro.coordination.memory import MemoryLockAdapter
 from grelmicro.errors import OutOfContextError, SettingsValidationError
@@ -35,6 +36,11 @@ from grelmicro.idempotency import (
 pytestmark = [pytest.mark.timeout(10)]
 
 EXPECTED_CALLS_2 = 2
+
+
+class _Response(BaseModel):
+    id: int
+    ok: bool
 
 
 @pytest.fixture
@@ -745,3 +751,97 @@ async def test_idempotency_run_waits_out_the_timeout() -> None:
 
     # Assert
     assert result == {"ok": True}
+
+
+class TestSerializerInference:
+    """Test the serializer the internal store is composed with."""
+
+    async def test_type_parameter_infers_pydantic_serializer(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that `Idempotency[Model]` replays the model itself."""
+        # Arrange
+        micro = Grelmicro(uses=[Cache(backend)])
+        idem = Idempotency[_Response]("http", ttl=60)
+
+        # Act
+        async with micro:
+            first = await idem.run("k", lambda: _Response(id=1, ok=True))
+            replay = await idem.run("k", lambda: _Response(id=2, ok=False))
+
+        # Assert
+        assert first == replay == _Response(id=1, ok=True)
+
+    async def test_model_as_serializer(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that a type passed as `serializer` builds the serializer."""
+        # Arrange
+        micro = Grelmicro(uses=[Cache(backend)])
+        idem = Idempotency("http", ttl=60, serializer=_Response)
+
+        # Act
+        async with micro:
+            await idem.run("k", lambda: _Response(id=1, ok=True))
+            replay = await idem.run("k", lambda: _Response(id=2, ok=False))
+
+        # Assert
+        assert replay == _Response(id=1, ok=True)
+
+    async def test_subclass_parameter_infers_pydantic_serializer(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that `class Sub(Idempotency[Model])` infers the same serializer."""
+
+        # Arrange
+        class ResponseIdempotency(Idempotency[_Response]):
+            pass
+
+        micro = Grelmicro(uses=[Cache(backend)])
+        idem = ResponseIdempotency("http", ttl=60)
+
+        # Act
+        async with micro:
+            replay = await idem.run("k", lambda: _Response(id=1, ok=True))
+
+        # Assert
+        assert replay == _Response(id=1, ok=True)
+
+    async def test_unparameterized_stores_json(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that `Idempotency(...)` keeps storing JSON."""
+        # Arrange
+        micro = Grelmicro(uses=[Cache(backend)])
+        idem: Idempotency = Idempotency("http", ttl=60)
+
+        # Act
+        async with micro:
+            await idem.run("k", lambda: {"ok": True})
+            replay = await idem.run("k", lambda: {"ok": False})
+
+        # Assert
+        assert replay == {"ok": True}
+
+    async def test_explicit_cache_wins_over_type_parameter(
+        self, backend: MemoryCacheAdapter
+    ) -> None:
+        """Test that an explicit cache is used as given."""
+        # Arrange
+        micro = Grelmicro(uses=[Cache(backend)])
+        store = TTLCache[_Response](
+            ttl=60, backend=backend, serializer=PickleSerializer()
+        )
+        idem = Idempotency[_Response]("http", ttl=60, cache=store)
+
+        # Act
+        async with micro:
+            replay = await idem.run("k", lambda: _Response(id=1, ok=True))
+            stored = await backend.get(
+                key=f"{_CACHE_PREFIX}:idempotency:http:k"
+            )
+
+        # Assert: the given cache pickled the response, JSON was never used
+        assert replay == _Response(id=1, ok=True)
+        assert stored is not None
+        assert not stored.startswith(b"{")

--- a/tests/typing/test_cache_generics.py
+++ b/tests/typing/test_cache_generics.py
@@ -13,8 +13,9 @@ from typing import assert_type
 
 from pydantic import BaseModel
 
+from grelmicro import Grelmicro
 from grelmicro._json import JSONDecodable
-from grelmicro.cache import serializers
+from grelmicro.cache import Cache, serializers
 from grelmicro.cache.memory import MemoryCacheAdapter
 from grelmicro.cache.ttl import TTLCache
 
@@ -66,3 +67,29 @@ async def test_default_serializer_get_returns_bytes_or_none() -> None:
     await cache.set("k", b"raw")
     value = await cache.get("k")
     assert_type(value, bytes | None)
+
+
+async def test_type_parameter_alone_preserves_t() -> None:
+    """`TTLCache[User]` with no serializer keeps `User | None` on get."""
+    cache = TTLCache[_User](ttl=60, backend=MemoryCacheAdapter())
+    await cache.set("k", _User(id=1, name="alice"))
+    value = await cache.get("k")
+    assert_type(value, _User | None)
+
+
+async def test_model_as_serializer_binds_t() -> None:
+    """A model passed as `serializer` binds `T` to that model."""
+    cache = TTLCache(ttl=60, serializer=_User, backend=MemoryCacheAdapter())
+    await cache.set("k", _User(id=1, name="alice"))
+    value = await cache.get("k")
+    assert_type(value, _User | None)
+
+
+async def test_component_factory_model_binds_t() -> None:
+    """`micro.cache.ttl(serializer=User)` yields a `TTLCache[User]`."""
+    micro = Grelmicro(uses=[Cache(MemoryCacheAdapter())])
+    cache = micro.cache.ttl(ttl=60, serializer=_User)
+    assert_type(cache, TTLCache[_User])
+    async with micro:
+        await cache.set("k", _User(id=1, name="alice"))
+        assert_type(await cache.get("k"), _User | None)


### PR DESCRIPTION
Closes #684.

The model was named twice: `TTLCache[User](ttl=300, serializer=PydanticSerializer(User))`. Now the type parameter picks the serializer.

## Two ways in

```python
cache = TTLCache[User](ttl=300)                    # type parameter
cache = micro.cache.ttl(ttl=300, serializer=User)  # a type, where there is no parameter to read
```

`serializer=` accepts `CacheSerializer[T] | type[T]` everywhere it appears: `TTLCache`, `Cache.ttl`, and `Idempotency`. A serializer class passed by mistake (`serializer=PickleSerializer`) raises a `TypeError` naming the fix.

Inference covers anything Pydantic can adapt, including a dataclass, a `TypedDict`, and `list[User]`. `TTLCache()` and `TTLCache[bytes]()` keep storing raw bytes, and so does a type parameter Pydantic cannot build a schema for.

## Idempotency

`Idempotency[Response]` now stores responses with `PydanticSerializer(Response)` and replays the model itself. It used to default to `JsonSerializer`, which cannot encode a Pydantic model at all, so the typed form raised on the first response it was given. `Idempotency("http")` without a type parameter still stores JSON.

The internal `TTLCache` composes on first use instead of in `_setup`, because Python sets `__orig_class__` only after `__init__` returns.

## Outbox

Already infers from the payload model through `_codec`, so nothing is named twice there. No change.

## Hot path

The fast path in `_serialize` and `_deserialize` is unchanged: `if serializer is not None` still hits first, and the resolve branch sits only on the raw-bytes path. The subclass form `class UserCache(TTLCache[User])` binds at construction.

## Checks

`pre-commit run --all-files` passes every hook, including the integration tier, the 100% coverage gate, `ty`, `mypy`, and `mkdocs build --strict`. New tests cover the resolver, both inference readers, the six `TTLCache` forms, the `Idempotency` forms, and three `assert_type` cases.
