### PR TITLE
📝 Return a typed value in every example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ api_limiter = RateLimiter.sliding_window(
 
 
 @app.get("/ping")
-async def ping() -> dict[str, str]:
+async def ping() -> str:
     try:
         await api_limiter.acquire_or_raise()
     except RateLimitExceededError:
-        return {"status": "throttled"}
-    return {"status": "ok"}
+        return "throttled"
+    return "ok"
 ```
 
 That is the whole thing. Pick a primitive, name it, give it a backend, call it. The memory backend says per-process on purpose. [Make it fleet-wide](#fastapi-with-one-provider) when you need to.
@@ -142,12 +142,12 @@ micro.install(app)
 
 
 @app.get("/ping")
-async def ping() -> dict[str, str]:
+async def ping() -> str:
     try:
         await api_limiter.acquire_or_raise()
     except RateLimitExceededError:
-        return {"status": "throttled"}
-    return {"status": "ok"}
+        return "throttled"
+    return "ok"
 ```
 
 Adding more primitives is the same shape: they resolve through the same provider. `micro.install(app)` opens the app on startup, closes it on shutdown, and lets request handlers resolve backends without passing `backend=`.
@@ -161,9 +161,10 @@ import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
 
 from grelmicro import Grelmicro
-from grelmicro.cache import JsonSerializer, TTLCache, cached
+from grelmicro.cache import TTLCache, cached
 from grelmicro.clientip import TrustedProxies, resolve_client_address
 from grelmicro.health import HealthChecks
 from grelmicro.log import configure as configure_logging
@@ -190,8 +191,13 @@ tasks.add_task(leader)
 
 micro = Grelmicro(uses=[redis, tasks, health])
 
+class User(BaseModel):
+    id: int
+    name: str
+
+
 # === Patterns declared once at module load, no backend wiring ===
-ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer())
+ttl_cache = TTLCache[User](ttl=300)
 lock = Lock("shared-resource")
 cb = CircuitBreaker("my-service")
 api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
@@ -210,20 +216,20 @@ micro.install(app)
 
 # --- Cache: avoid redundant database queries ---
 @cached(ttl_cache)
-async def get_user(user_id: int) -> dict:
-    return {"id": user_id, "name": "Alice"}
+async def get_user(user_id: int) -> User:
+    return User(id=user_id, name="Alice")
 
 
 @app.get("/users/{user_id}")
-async def read_user(user_id: int):
+async def read_user(user_id: int) -> User:
     return await get_user(user_id)
 
 
 # --- Circuit Breaker: protect calls to an unreliable service ---
 @app.get("/")
-async def read_root():
+async def read_root() -> str:
     async with cb:
-        return {"Hello": "World"}
+        return "Hello World"
 
 
 # --- Rate Limiter: protect endpoints from overload ---
@@ -239,7 +245,7 @@ def client_key(request: Request) -> str:
 
 
 @app.get("/api")
-async def api_endpoint(request: Request):
+async def api_endpoint(request: Request) -> str:
     try:
         await api_limiter.acquire_or_raise(key=client_key(request))
     except RateLimitExceededError as exc:
@@ -248,14 +254,14 @@ async def api_endpoint(request: Request):
             detail="Too many requests",
             headers={"Retry-After": str(int(exc.retry_after))},
         )
-    return {"status": "ok"}
+    return "ok"
 
 
 # --- Distributed Lock: synchronize access to a shared resource ---
 @app.get("/protected")
-async def protected():
+async def protected() -> str:
     async with lock:
-        return {"status": "ok"}
+        return "ok"
 
 
 # --- Interval Task: run locally on every worker ---

--- a/docs/cache/cached.md
+++ b/docs/cache/cached.md
@@ -8,19 +8,19 @@ For the plain "memoize this function for N seconds" case, pass `ttl=` and nothin
 from grelmicro.cache import cached
 
 @cached(ttl=30)
-async def get_rates() -> dict:
+async def get_rates() -> Rates:
     return await fetch_rates()
 ```
 
 That private cache lives only in this process and is never shared across replicas. To share results across replicas, invalidate by tag, or reuse one store across functions, pass a [`TTLCache`](index.md#ttlcache) instead:
 
 ```python
-from grelmicro.cache import JsonSerializer, TTLCache, cached
+from grelmicro.cache import TTLCache, cached
 
-cache = TTLCache(ttl=300, serializer=JsonSerializer())
+cache = TTLCache[User](ttl=300)
 
 @cached(cache)
-async def get_user(user_id: int) -> dict:
+async def get_user(user_id: int) -> User:
     return await db.fetch_user(user_id)
 ```
 
@@ -32,7 +32,7 @@ By default `@cached` derives the key from the `repr()` of the arguments. Pass `k
 
 ```python
 @cached(cache, key="user:{user_id}")
-async def get_user(user_id: int) -> dict:
+async def get_user(user_id: int) -> User:
     return await db.fetch_user(user_id)
 ```
 
@@ -51,7 +51,7 @@ Each tag is a template filled in from the call's arguments, so one decorator tag
 
 ```python
 @cached(cache, tags=["users", "user:{user_id}"])
-async def get_user(user_id: int) -> dict:
+async def get_user(user_id: int) -> User:
     return await db.fetch_user(user_id)
 
 
@@ -69,7 +69,7 @@ A method must name its key. Decorating one without `key=` or `key_maker=` raises
 ```python
 class Repo:
     @cached(cache, key="repo:{user_id}")
-    async def load(self, user_id: int) -> dict:
+    async def load(self, user_id: int) -> User:
         return await self.db.fetch_user(user_id)
 ```
 
@@ -80,7 +80,7 @@ Only you know what identifies the entry, so the decorator asks rather than guess
 ```python
 class Repo:
     @cached(cache, key="repo:{self.region}:{user_id}")
-    async def load(self, user_id: int) -> dict: ...
+    async def load(self, user_id: int) -> User: ...
 ```
 
 A `staticmethod` and a `classmethod` are untouched. Neither receives an instance, and a class `repr()` is stable, so their default key is sound.
@@ -103,7 +103,7 @@ Use it where a caller asks for fresh data, such as an endpoint honouring `Cache-
 
 ```python
 @app.post("/reports/{user_id}")
-async def report(user_id: int, cache_control: Annotated[str, Header()] = "") -> dict:
+async def report(user_id: int, cache_control: Annotated[str, Header()] = "") -> Report:
     if "no-cache" in cache_control:
         return await get_report.refresh(user_id)
     return await get_report(user_id)
@@ -174,17 +174,17 @@ A cache stampede (or "dog-pile") happens when many callers miss the same key at 
 
 ```python
 @cached(cache)                  # default: in-process stampede folding
-async def get_user(user_id: int) -> dict:
+async def get_user(user_id: int) -> User:
     return await db.fetch_user(user_id)
 
 
 @cached(cache, lock=True)       # fold misses, across replicas if a lock backend is set
-async def get_billing(user_id: int) -> dict:
+async def get_billing(user_id: int) -> Billing:
     return await billing.fetch(user_id)
 
 
 @cached(cache, early=0.1)       # refresh hot keys before they expire
-async def get_homepage_feed() -> dict:
+async def get_homepage_feed() -> Feed:
     return await build_feed()
 ```
 
@@ -201,10 +201,10 @@ async def get_homepage_feed() -> dict:
 Set `stale_ttl` to keep serving the last good value when a recompute fails. Each result is also kept as a fallback copy for `ttl + stale_ttl` seconds. After the TTL, the next miss recomputes as usual, but if that recompute raises, the most recent value is served instead of propagating the error, for up to `stale_ttl` seconds past the TTL.
 
 ```python
-cache = TTLCache(ttl=60)
+cache = TTLCache[Rates](ttl=60)
 
 @cached(cache, stale_ttl=600)
-async def get_exchange_rates() -> dict:
+async def get_exchange_rates() -> Rates:
     return await rates_api.fetch()   # a flaky external call
 ```
 

--- a/docs/cache/index.md
+++ b/docs/cache/index.md
@@ -11,17 +11,17 @@ Cache an async function's result with `@cached`. One provider line says where th
 
 ```python
 from grelmicro import Grelmicro
-from grelmicro.cache import JsonSerializer, TTLCache, cached
+from grelmicro.cache import TTLCache, cached
 from grelmicro.providers.redis import RedisProvider
 
 redis = RedisProvider("redis://localhost:6379/0")
 micro = Grelmicro(uses=[redis])
 
-cache = TTLCache(ttl=300, serializer=JsonSerializer())
+cache = TTLCache[User](ttl=300)
 
 
 @cached(cache)
-async def get_user(user_id: int) -> dict:
+async def get_user(user_id: int) -> User:
     return await db.fetch_user(user_id)
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@
 
 * ✨ `Idempotency[Response]` stores responses with `PydanticSerializer(Response)` and replays the model itself. It used to store JSON, which cannot even encode a Pydantic model, so the typed form raised on the first response it was given. `Idempotency("http")` without a type parameter still stores JSON. ([#684](https://github.com/grelinfo/grelmicro/issues/684))
 
+### Docs
+
+* 📝 Return a typed value in every example. The README, the guides, the snippets, and the demo app returned `dict`, which read as untyped scripting rather than a type-safe library. Each one now returns a Pydantic model, a plain `str`, or an `int`, whichever is shortest for the point it makes. ([#679](https://github.com/grelinfo/grelmicro/issues/679))
+
 ## 0.37.2 - 2026-08-13
 
 ### Changed

--- a/docs/clientip.md
+++ b/docs/clientip.md
@@ -44,7 +44,7 @@ Keying on a spoofable value means a caller sends a different
 attacker can spoof *your* address and get you throttled.
 
 ```python
-async def api(request: Request) -> dict:
+async def api(request: Request) -> str:
     client = resolve_client_address(request.scope, trusted)
     await limiter.acquire_or_raise(key=client.key if client else "unknown")
     ...

--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -73,7 +73,7 @@ Decorators take the same keyword arguments:
 from grelmicro.cache import cached
 
 @cached(ttl=30)
-async def get_user(user_id: int) -> dict:
+async def get_user(user_id: int) -> User:
     ...
 ```
 

--- a/docs/idempotency/index.md
+++ b/docs/idempotency/index.md
@@ -16,6 +16,8 @@ A FastAPI handler reads the key from the `Idempotency-Key` header and wraps the 
 from typing import Annotated
 
 from fastapi import FastAPI, Header
+from pydantic import BaseModel
+
 from grelmicro import Grelmicro
 from grelmicro.idempotency import Idempotency
 from grelmicro.providers.redis import RedisProvider
@@ -26,14 +28,20 @@ micro = Grelmicro(uses=[redis])
 app = FastAPI()
 micro.install(app)
 
-idem = Idempotency("charge", ttl=3600)
+
+class ChargeResponse(BaseModel):
+    id: str
+    amount: int
+
+
+idem = Idempotency[ChargeResponse]("charge", ttl=3600)
 
 
 @app.post("/charge")
 async def charge(
     amount: int,
     key: Annotated[str, Header(alias="Idempotency-Key")],
-) -> dict:
+) -> ChargeResponse:
     async with idem(key) as op:
         if op.replayed:
             return op.result()
@@ -91,7 +99,7 @@ from grelmicro.idempotency import idempotent
 
 
 @idempotent(idem, key=lambda **kw: kw["idempotency_key"])
-async def charge(*, amount: int, idempotency_key: str) -> dict:
+async def charge(*, amount: int, idempotency_key: str) -> ChargeResponse:
     return await do_charge(amount)
 ```
 
@@ -108,14 +116,9 @@ from grelmicro.idempotency import Idempotency
 idem = Idempotency("charge", ttl=3600, cache=TTLCache(ttl=3600))
 ```
 
-Responses serialize through the cache serializers. Name the response type and the store roundtrips it, so a replay returns the model and not a dict:
+Responses serialize through the cache serializers. Name the response type and the store roundtrips it, so a replay returns the model itself:
 
 ```python
-class ChargeResponse(BaseModel):
-    id: str
-    amount: int
-
-
 idem = Idempotency[ChargeResponse]("charge", ttl=3600)
 ```
 

--- a/docs/img/demo/app.py
+++ b/docs/img/demo/app.py
@@ -16,8 +16,8 @@ limiter = RateLimiter.token_bucket(
 
 
 @app.get("/quote")
-async def quote() -> dict[str, str]:
+async def quote() -> str:
     """Serve a quote, rate limited to a 5-burst then 1 per second."""
     if not await limiter.allow():
-        return {"status": "slow down"}
-    return {"quote": "one toolkit, many patterns"}
+        return "slow down"
+    return "one toolkit, many patterns"

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,12 +111,12 @@ api_limiter = RateLimiter.sliding_window(
 
 
 @app.get("/ping")
-async def ping() -> dict[str, str]:
+async def ping() -> str:
     try:
         await api_limiter.acquire_or_raise()
     except RateLimitExceededError:
-        return {"status": "throttled"}
-    return {"status": "ok"}
+        return "throttled"
+    return "ok"
 ```
 
 That is the whole thing. Pick a primitive, name it, give it a backend, call it. The memory backend says per-process on purpose. [Make it fleet-wide](#fastapi-with-one-provider) when you need to.
@@ -142,12 +142,12 @@ micro.install(app)
 
 
 @app.get("/ping")
-async def ping() -> dict[str, str]:
+async def ping() -> str:
     try:
         await api_limiter.acquire_or_raise()
     except RateLimitExceededError:
-        return {"status": "throttled"}
-    return {"status": "ok"}
+        return "throttled"
+    return "ok"
 ```
 
 Adding more primitives is the same shape: they resolve through the same provider. `micro.install(app)` opens the app on startup, closes it on shutdown, and lets request handlers resolve backends without passing `backend=`.
@@ -161,9 +161,10 @@ import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
 
 from grelmicro import Grelmicro
-from grelmicro.cache import JsonSerializer, TTLCache, cached
+from grelmicro.cache import TTLCache, cached
 from grelmicro.clientip import TrustedProxies, resolve_client_address
 from grelmicro.health import HealthChecks
 from grelmicro.log import configure as configure_logging
@@ -190,8 +191,13 @@ tasks.add_task(leader)
 
 micro = Grelmicro(uses=[redis, tasks, health])
 
+class User(BaseModel):
+    id: int
+    name: str
+
+
 # === Patterns declared once at module load, no backend wiring ===
-ttl_cache = TTLCache(ttl=300, serializer=JsonSerializer())
+ttl_cache = TTLCache[User](ttl=300)
 lock = Lock("shared-resource")
 cb = CircuitBreaker("my-service")
 api_limiter = RateLimiter.sliding_window("api", limit=100, window=60)
@@ -210,20 +216,20 @@ micro.install(app)
 
 # --- Cache: avoid redundant database queries ---
 @cached(ttl_cache)
-async def get_user(user_id: int) -> dict:
-    return {"id": user_id, "name": "Alice"}
+async def get_user(user_id: int) -> User:
+    return User(id=user_id, name="Alice")
 
 
 @app.get("/users/{user_id}")
-async def read_user(user_id: int):
+async def read_user(user_id: int) -> User:
     return await get_user(user_id)
 
 
 # --- Circuit Breaker: protect calls to an unreliable service ---
 @app.get("/")
-async def read_root():
+async def read_root() -> str:
     async with cb:
-        return {"Hello": "World"}
+        return "Hello World"
 
 
 # --- Rate Limiter: protect endpoints from overload ---
@@ -239,7 +245,7 @@ def client_key(request: Request) -> str:
 
 
 @app.get("/api")
-async def api_endpoint(request: Request):
+async def api_endpoint(request: Request) -> str:
     try:
         await api_limiter.acquire_or_raise(key=client_key(request))
     except RateLimitExceededError as exc:
@@ -248,14 +254,14 @@ async def api_endpoint(request: Request):
             detail="Too many requests",
             headers={"Retry-After": str(int(exc.retry_after))},
         )
-    return {"status": "ok"}
+    return "ok"
 
 
 # --- Distributed Lock: synchronize access to a shared resource ---
 @app.get("/protected")
-async def protected():
+async def protected() -> str:
     async with lock:
-        return {"status": "ok"}
+        return "ok"
 
 
 # --- Interval Task: run locally on every worker ---

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -152,20 +152,20 @@ Name what identifies the entry and leave `self` out:
 # Before
 class Repo:
     @cached(cache)
-    async def load(self, user_id: int) -> dict: ...
+    async def load(self, user_id: int) -> User: ...
 
 
 # After
 class Repo:
     @cached(cache, key="repo:{user_id}")
-    async def load(self, user_id: int) -> dict: ...
+    async def load(self, user_id: int) -> User: ...
 ```
 
 When the result does depend on instance state, fold that state into the key:
 
 ```python
 @cached(cache, key="repo:{self.region}:{user_id}")
-async def load(self, user_id: int) -> dict: ...
+async def load(self, user_id: int) -> User: ...
 ```
 
 A `staticmethod` and a `classmethod` are untouched. Neither receives an

--- a/docs/snippets/cache/key.py
+++ b/docs/snippets/cache/key.py
@@ -1,16 +1,24 @@
+from pydantic import BaseModel
+
 from grelmicro import Grelmicro
-from grelmicro.cache import JsonSerializer, cached
+from grelmicro.cache import cached
 from grelmicro.providers.redis import RedisProvider
 
 redis = RedisProvider("redis://localhost:6379/0")
 micro = Grelmicro(uses=[redis])
 
-ttl_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
+
+class User(BaseModel):
+    id: int
+    name: str
+
+
+ttl_cache = micro.cache.ttl(ttl=300, serializer=User)
 
 
 @cached(ttl_cache, key="user:{user_id}")
-async def get_user(user_id: int) -> dict:
-    return {"id": user_id, "name": "Alice"}
+async def get_user(user_id: int) -> User:
+    return User(id=user_id, name="Alice")
 
 
 async def main() -> None:

--- a/docs/snippets/cache/refresh.py
+++ b/docs/snippets/cache/refresh.py
@@ -1,16 +1,23 @@
+from pydantic import BaseModel
+
 from grelmicro import Grelmicro
-from grelmicro.cache import JsonSerializer, TTLCache, cached
+from grelmicro.cache import TTLCache, cached
 from grelmicro.providers.redis import RedisProvider
 
 redis = RedisProvider("redis://localhost:6379/0")
 micro = Grelmicro(uses=[redis])
 
-cache = TTLCache(ttl=300, serializer=JsonSerializer())
+
+class Report(BaseModel):
+    user_id: int
+
+
+cache = TTLCache[Report](ttl=300)
 
 
 @cached(cache, key="report:{user_id}")
-async def get_report(user_id: int) -> dict:
-    return {"user_id": user_id}
+async def get_report(user_id: int) -> Report:
+    return Report(user_id=user_id)
 
 
 async def main() -> None:

--- a/docs/snippets/cache/tags.py
+++ b/docs/snippets/cache/tags.py
@@ -1,16 +1,24 @@
+from pydantic import BaseModel
+
 from grelmicro import Grelmicro
-from grelmicro.cache import JsonSerializer, cached
+from grelmicro.cache import cached
 from grelmicro.providers.redis import RedisProvider
 
 redis = RedisProvider("redis://localhost:6379/0")
 micro = Grelmicro(uses=[redis])
 
-ttl_cache = micro.cache.ttl(ttl=300, serializer=JsonSerializer())
+
+class User(BaseModel):
+    id: int
+    name: str
+
+
+ttl_cache = micro.cache.ttl(ttl=300, serializer=User)
 
 
 @cached(ttl_cache, tags=["users", "user:{user_id}"])
-async def get_user(user_id: int) -> dict:
-    return {"id": user_id, "name": "Alice"}
+async def get_user(user_id: int) -> User:
+    return User(id=user_id, name="Alice")
 
 
 async def update_user(user_id: int) -> None:

--- a/docs/snippets/clientip/clientip.py
+++ b/docs/snippets/clientip/clientip.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Request
+from pydantic import BaseModel
 
 from grelmicro.clientip import TrustedProxies, resolve_client_address
 
@@ -8,10 +9,15 @@ app = FastAPI()
 trusted = TrustedProxies(["10.0.0.0/8"])
 
 
+class Who(BaseModel):
+    client: str
+    reason: str | None = None
+
+
 @app.get("/whoami")
-async def whoami(request: Request) -> dict[str, str]:
+async def whoami(request: Request) -> Who:
     client = resolve_client_address(request.scope, trusted)
     if client is None:
-        return {"client": "unknown"}
+        return Who(client="unknown")
     # `key` is safe to store or to use as a rate limiter bucket.
-    return {"client": client.key, "reason": client.reason}
+    return Who(client=client.key, reason=client.reason)

--- a/docs/snippets/idempotency/middleware.py
+++ b/docs/snippets/idempotency/middleware.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
 
 from grelmicro import Grelmicro
 from grelmicro.idempotency import Idempotency
@@ -15,7 +16,11 @@ app.add_middleware(
 )
 
 
+class Charge(BaseModel):
+    amount: int
+
+
 @app.post("/charge")
-async def charge(amount: int) -> dict[str, int]:
+async def charge(amount: int) -> Charge:
     # A retry carrying the same Idempotency-Key replays this response.
-    return {"amount": amount}
+    return Charge(amount=amount)

--- a/docs/snippets/idempotency/run.py
+++ b/docs/snippets/idempotency/run.py
@@ -1,3 +1,5 @@
+from pydantic import BaseModel
+
 from grelmicro import Grelmicro
 from grelmicro.idempotency import Idempotency
 from grelmicro.providers.redis import RedisProvider
@@ -5,11 +7,16 @@ from grelmicro.providers.redis import RedisProvider
 redis = RedisProvider("redis://localhost:6379/0")
 micro = Grelmicro(uses=[redis])
 
-idem = Idempotency("charge", ttl=3600)
+
+class Charge(BaseModel):
+    amount: int
 
 
-async def do_charge(amount: int) -> dict:
-    return {"amount": amount}
+idem = Idempotency[Charge]("charge", ttl=3600)
+
+
+async def do_charge(amount: int) -> Charge:
+    return Charge(amount=amount)
 
 
 async def main() -> None:

--- a/docs/snippets/resilience/fallback.py
+++ b/docs/snippets/resilience/fallback.py
@@ -6,7 +6,7 @@ from grelmicro.resilience import fallback
 @fallback(when=httpx.HTTPError, default=[])
 async def get_recommendations(
     client: httpx.AsyncClient, user_id: str
-) -> list[dict]:
+) -> list[str]:
     response = await client.get(f"/recs/{user_id}")
     response.raise_for_status()
     return response.json()

--- a/docs/snippets/resilience/fallback_block.py
+++ b/docs/snippets/resilience/fallback_block.py
@@ -5,7 +5,7 @@ from grelmicro.resilience import falling_back
 
 async def get_recommendations(
     client: httpx.AsyncClient, user_id: str
-) -> list[dict]:
+) -> list[str]:
     async with falling_back(when=httpx.HTTPError, default=[]) as result:
         response = await client.get(f"/recs/{user_id}")
         response.raise_for_status()

--- a/docs/snippets/resilience/fallback_composition.py
+++ b/docs/snippets/resilience/fallback_composition.py
@@ -11,7 +11,7 @@ retrier = Retry.exponential("recs", when=httpx.HTTPError, attempts=3)
 @breaker
 async def get_recommendations(
     client: httpx.AsyncClient, user_id: str
-) -> list[dict]:
+) -> list[str]:
     response = await client.get(f"/recs/{user_id}")
     response.raise_for_status()
     return response.json()

--- a/docs/snippets/resilience/fallback_factory.py
+++ b/docs/snippets/resilience/fallback_factory.py
@@ -3,7 +3,7 @@ import httpx
 from grelmicro.resilience import fallback
 
 
-def _cached_recommendations(exc: BaseException) -> list[dict]:
+def _cached_recommendations(exc: BaseException) -> list[str]:
     # Read from a local cache shared by the process.
     return []
 
@@ -11,7 +11,7 @@ def _cached_recommendations(exc: BaseException) -> list[dict]:
 @fallback(when=httpx.HTTPError, factory=_cached_recommendations)
 async def get_recommendations(
     client: httpx.AsyncClient, user_id: str
-) -> list[dict]:
+) -> list[str]:
     response = await client.get(f"/recs/{user_id}")
     response.raise_for_status()
     return response.json()

--- a/docs/snippets/resilience/fallback_programmatic.py
+++ b/docs/snippets/resilience/fallback_programmatic.py
@@ -8,7 +8,7 @@ policy = Fallback("recs", when=httpx.HTTPError, default=[])
 @policy
 async def get_recommendations(
     client: httpx.AsyncClient, user_id: str
-) -> list[dict]:
+) -> list[str]:
     response = await client.get(f"/recs/{user_id}")
     response.raise_for_status()
     return response.json()

--- a/docs/snippets/resilience/faststream.py
+++ b/docs/snippets/resilience/faststream.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 
 from faststream import ContextRepo, FastStream
 from faststream.redis import RedisBroker
+from pydantic import BaseModel
 
 from grelmicro import Grelmicro
 from grelmicro.coordination import Lock
@@ -19,6 +20,10 @@ redis = RedisProvider("redis://localhost:6379/0")
 micro = Grelmicro(uses=[redis])
 
 per_user_limiter = RateLimiter.sliding_window("messages", limit=10, window=60)
+
+
+class UserEvent(BaseModel):
+    user_id: int
 
 
 @asynccontextmanager
@@ -32,9 +37,9 @@ app = FastStream(broker, lifespan=lifespan)
 
 
 @broker.subscriber("user-events")
-async def handle_user_event(message: dict) -> None:
+async def handle_user_event(message: UserEvent) -> None:
     """Process a user event under a per-user lock and a fleet rate limit."""
-    user_id = message["user_id"]
+    user_id = message.user_id
 
     try:
         await per_user_limiter.acquire_or_raise(key=str(user_id))
@@ -49,5 +54,5 @@ async def handle_user_event(message: dict) -> None:
         await _process(message)
 
 
-async def _process(message: dict) -> None:
+async def _process(message: UserEvent) -> None:
     print("processing:", message)

--- a/docs/snippets/resilience/retry_block.py
+++ b/docs/snippets/resilience/retry_block.py
@@ -1,17 +1,29 @@
 import httpx
+from pydantic import BaseModel
 
 from grelmicro.resilience import retrying
 
 
-async def submit(client: httpx.AsyncClient, url: str, payload: dict) -> dict:
+class Payment(BaseModel):
+    amount: int
+
+
+class Receipt(BaseModel):
+    id: str
+
+
+async def submit(
+    client: httpx.AsyncClient, url: str, payment: Payment
+) -> Receipt:
     async for attempt in retrying(when=httpx.HTTPError, attempts=3):
         async with attempt:
-            response = await client.post(url, json=payload)
+            response = await client.post(url, json=payment.model_dump())
             response.raise_for_status()
-            return response.json()
-    return {}
+            return Receipt.model_validate(response.json())
+    msg = "retrying returns or raises, never falls through"
+    raise AssertionError(msg)
 
 
-async def main() -> dict:
+async def main() -> Receipt:
     async with httpx.AsyncClient() as client:
-        return await submit(client, "https://example.com", {"k": "v"})
+        return await submit(client, "https://example.com", Payment(amount=100))

--- a/docs/snippets/resilience/retry_composition.py
+++ b/docs/snippets/resilience/retry_composition.py
@@ -1,8 +1,17 @@
 import httpx
+from pydantic import BaseModel
 
 from grelmicro.resilience import CircuitBreaker, retry
 
 cb = CircuitBreaker("payments")
+
+
+class Payment(BaseModel):
+    amount: int
+
+
+class Receipt(BaseModel):
+    id: str
 
 
 # A narrow allowlist that excludes CircuitBreakerError. When the
@@ -10,14 +19,16 @@ cb = CircuitBreaker("payments")
 # `on`, so the retry loop aborts immediately.
 @retry(when=(httpx.ConnectError, httpx.TimeoutException), attempts=3)
 async def call_payments(
-    client: httpx.AsyncClient, url: str, payload: dict
-) -> dict:
+    client: httpx.AsyncClient, url: str, payment: Payment
+) -> Receipt:
     async with cb:
-        response = await client.post(url, json=payload)
+        response = await client.post(url, json=payment.model_dump())
         response.raise_for_status()
-        return response.json()
+        return Receipt.model_validate(response.json())
 
 
-async def main() -> dict:
+async def main() -> Receipt:
     async with httpx.AsyncClient() as client:
-        return await call_payments(client, "https://example.com", {"k": "v"})
+        return await call_payments(
+            client, "https://example.com", Payment(amount=100)
+        )

--- a/docs/snippets/resilience/retry_match.py
+++ b/docs/snippets/resilience/retry_match.py
@@ -1,6 +1,11 @@
 import httpx
+from pydantic import BaseModel
 
 from grelmicro.resilience import Match, retry
+
+
+class Job(BaseModel):
+    status: str
 
 
 # Compose exception and result matchers with `|`.
@@ -17,7 +22,7 @@ async def fetch(client: httpx.AsyncClient, url: str) -> httpx.Response:
 
 # Polling-style: retry until the result is no longer ``None``.
 @retry(when=Match.result(None), attempts=20)
-async def poll_job(client: httpx.AsyncClient, job_id: str) -> dict | None:
+async def poll_job(client: httpx.AsyncClient, job_id: str) -> Job | None:
     response = await client.get(f"/jobs/{job_id}")
-    payload = response.json()
-    return payload if payload["status"] == "ready" else None
+    job = Job.model_validate(response.json())
+    return job if job.status == "ready" else None

--- a/docs/snippets/resilience/shield_class.py
+++ b/docs/snippets/resilience/shield_class.py
@@ -1,4 +1,5 @@
 import httpx
+from pydantic import BaseModel
 
 from grelmicro.resilience import Shield
 
@@ -8,11 +9,15 @@ github = Shield.api(
 )
 
 
+class Repo(BaseModel):
+    name: str
+
+
 @github
-async def list_repos() -> list[dict]:
+async def list_repos() -> list[Repo]:
     return []
 
 
 @github
-async def get_repo() -> dict:
-    return {}
+async def get_repo() -> Repo:
+    return Repo(name="grelmicro")

--- a/docs/snippets/resilience/timeout.py
+++ b/docs/snippets/resilience/timeout.py
@@ -1,8 +1,14 @@
+from pydantic import BaseModel
+
 from grelmicro.resilience import Timeout
 
 db_timeout = Timeout("db", seconds=2.0)
 
 
-async def fetch_rows(db) -> list[dict]:
+class Account(BaseModel):
+    id: int
+
+
+async def fetch_rows(db) -> list[Account]:
     async with db_timeout:
         return await db.fetch_all("SELECT * FROM accounts")

--- a/docs/snippets/resilience/timeout_composition.py
+++ b/docs/snippets/resilience/timeout_composition.py
@@ -13,7 +13,7 @@ call_timeout = Timeout("recs", seconds=1.0)
 @call_timeout
 async def get_recommendations(
     client: httpx.AsyncClient, user_id: str
-) -> list[dict]:
+) -> list[str]:
     response = await client.get(f"/recs/{user_id}")
     response.raise_for_status()
     return response.json()

--- a/docs/snippets/resilience/timeout_decorator.py
+++ b/docs/snippets/resilience/timeout_decorator.py
@@ -1,8 +1,14 @@
+from pydantic import BaseModel
+
 from grelmicro.resilience import Timeout
 
 db_timeout = Timeout("db", seconds=2.0)
 
 
+class Account(BaseModel):
+    id: int
+
+
 @db_timeout
-async def fetch_rows(db) -> list[dict]:
+async def fetch_rows(db) -> list[Account]:
     return await db.fetch_all("SELECT * FROM accounts")

--- a/docs/snippets/wiring/provider_client.py
+++ b/docs/snippets/wiring/provider_client.py
@@ -1,4 +1,4 @@
-from typing import Any
+from pydantic import BaseModel
 
 from grelmicro import Grelmicro
 from grelmicro.providers.redis import RedisProvider
@@ -8,9 +8,13 @@ redis = RedisProvider("redis://localhost:6379/0")
 micro = Grelmicro(uses=[redis])
 
 
+class Order(BaseModel):
+    total: str
+
+
 async def save_order(order_id: str, total: str) -> None:
     await redis.client.hset(f"order:{order_id}", mapping={"total": total})
 
 
-async def load_order(order_id: str) -> dict[str, Any]:
-    return await redis.client.hgetall(f"order:{order_id}")
+async def load_order(order_id: str) -> Order:
+    return Order.model_validate(await redis.client.hgetall(f"order:{order_id}"))

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -174,7 +174,7 @@ micro.install(app)
 
 
 @broker.subscriber("orders")
-async def handle(order: dict) -> None:
+async def handle(order: Order) -> None:
     async with Lock("orders"):
         ...
 ```

--- a/examples/fastapi-demo/app.py
+++ b/examples/fastapi-demo/app.py
@@ -10,11 +10,11 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 
 from grelmicro import Grelmicro
 from grelmicro.cache import TTLCache
 from grelmicro.cache.cached import cached
-from grelmicro.cache.serializers import JsonSerializer
 from grelmicro.coordination import LeaderElection, Lock
 from grelmicro.health import HealthChecks
 from grelmicro.integrations.fastapi import GrelmicroMiddleware, health_router
@@ -79,14 +79,21 @@ app.include_router(health_router(health))  # GET /livez, /readyz, /healthz
 
 
 # --- Cache: @cached over the Cache backend, with stampede protection ---
-catalog = TTLCache(ttl=30, serializer=JsonSerializer())
+class Product(BaseModel):
+    """A catalog product."""
+
+    id: int
+    name: str
+
+
+catalog = TTLCache[Product](ttl=30)
 
 
 @app.get("/product/{product_id}")
 @cached(catalog, lock=True)
-async def get_product(product_id: int) -> dict:
+async def get_product(product_id: int) -> Product:
     # Cache Pattern: the second call within the TTL skips this body.
-    return {"id": product_id, "name": f"Product {product_id}"}
+    return Product(id=product_id, name=f"Product {product_id}")
 
 
 # --- Rate limiter: token bucket per client ---
@@ -94,12 +101,12 @@ api_limiter = RateLimiter.token_bucket("api", capacity=5, refill_rate=1)
 
 
 @app.get("/quote")
-async def quote(client: str = "anon") -> dict:
+async def quote(client: str = "anon") -> str:
     # Rate-limiter Pattern: 5 burst, then 1 per second per client.
     result = await api_limiter.acquire(key=client)
     if not result.allowed:
         raise HTTPException(status_code=429, detail="slow down")
-    return {"quote": "the cost of a thing is the life you exchange for it"}
+    return "the cost of a thing is the life you exchange for it"
 
 
 # --- Circuit breaker: trips after repeated failures to a flaky service ---
@@ -107,14 +114,14 @@ breaker = CircuitBreaker("flaky-service")
 
 
 @app.get("/flaky")
-async def flaky(fail: bool = False) -> dict:
+async def flaky(fail: bool = False) -> str:
     # Circuit-breaker Pattern: opens after the failure threshold.
     try:
         async with breaker:
             if fail:
                 msg = "upstream failed"
                 raise RuntimeError(msg)
-            return {"status": "ok"}
+            return "ok"
     except CircuitBreakerError as exc:
         raise HTTPException(status_code=503, detail="circuit open") from exc
 
@@ -124,10 +131,10 @@ ledger_lock = Lock("ledger")
 
 
 @app.post("/ledger")
-async def update_ledger(amount: int) -> dict:
+async def update_ledger(amount: int) -> int:
     # Distributed-lock Pattern: only one replica updates at a time.
     async with ledger_lock:
-        return {"applied": amount}
+        return amount
 
 
 # --- Leader-gated task: only the elected leader runs the sweep ---

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -477,12 +477,20 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
         """Wire the validated config and runtime deps onto the instance."""
         import asyncio  # noqa: PLC0415
 
+        from grelmicro.cache.serializers import (  # noqa: PLC0415
+            _resolve_serializer,
+        )
+
         self._name = name
         self._config = config
         self._reconfigure_lock = asyncio.Lock()
         self._fingerprint = fingerprint
         self._guard = AsyncStampedeGuard()
-        self._serializer = serializer
+        # Resolved here rather than with the cache below so a serializer
+        # class passed instead of an instance raises at construction.
+        self._serializer: CacheSerializer[T] | None = (
+            _resolve_serializer(serializer) if serializer is not None else None
+        )
         self._cache: TTLCache[T] | None = cache
 
     def _get_cache(self) -> TTLCache[T]:
@@ -498,13 +506,10 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
             JsonSerializer,
             _infer_serializer_from_class,
             _infer_serializer_from_instance,
-            _resolve_serializer,
         )
 
-        serializer: CacheSerializer[Any] | None
-        if self._serializer is not None:
-            serializer = _resolve_serializer(self._serializer)
-        else:
+        serializer: CacheSerializer[Any] | None = self._serializer
+        if serializer is None:
             serializer = _infer_serializer_from_instance(
                 self
             ) or _infer_serializer_from_class(type(self), Idempotency)

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -845,3 +845,9 @@ class TestSerializerInference:
         assert replay == _Response(id=1, ok=True)
         assert stored is not None
         assert not stored.startswith(b"{")
+
+    def test_serializer_class_raises_at_construction(self) -> None:
+        """Test that a serializer class is refused where it is passed."""
+        # Act / Assert
+        with pytest.raises(TypeError, match=r"pass an instance"):
+            Idempotency("http", ttl=60, serializer=PickleSerializer)


### PR DESCRIPTION
Closes #679.

Examples across the docs, the README, and the demo app returned `dict[str, str]`. That read as untyped scripting rather than the type-safe library grelmicro is. Every example now returns a typed value: a Pydantic model, a plain `str`, or an `int`, whichever is shortest for the point it makes.

## Snippets

Cache, idempotency, clientip, and wiring snippets define a model and return it. The cache ones also drop `JsonSerializer` in favour of the inferred `TTLCache[User]` and `serializer=User` forms from #684, which is required rather than cosmetic: a `JsonSerializer` cache cannot encode a Pydantic model.

Resilience: `list[dict]` recommendations became `list[str]` ids, the retry snippets gained `Payment` and `Receipt`, `poll_job` returns `Job | None`, the shield example gained `Repo`, the timeout examples gained `Account`, and the FastStream consumer takes a `UserEvent` model instead of indexing `message["user_id"]`.

## README and guides

Both `/ping` handlers return `str`. The full FastAPI example gained a `User` model with `TTLCache[User](ttl=300)`, and `read_root`, `api_endpoint`, and `protected` return `str` instead of unannotated dict literals. Same sweep through `cache/index.md`, `cache/cached.md`, `idempotency/index.md`, `clientip.md`, `first-steps.md`, `migration.md`, and `wiring.md`.

## Demo apps

`examples/fastapi-demo/app.py` gained a `Product` model, `/quote` and `/flaky` return `str`, and `/ledger` returns `int`. The demo smoke check in CI asserts status codes only, so the response shapes are free to change.

## Left as is

`HealthDetails` is the library's own `dict[str, JSONEncodable]` contract, the outbox "topic string and a dict" path is the documented untyped API, and `docs/img/logo/build_logo.py` is a build tool rather than an example.

## Also in this branch

Reviewing the unreleased range surfaced one defect from #684: `Idempotency("http", serializer=PickleSerializer)`, passing the class instead of an instance, constructed fine and only raised at the first request, while `TTLCache` raises the same mistake at construction. The explicit serializer now resolves in `_setup`, so both fail where they are written. Type-parameter inference stays lazy, since `__orig_class__` does not exist yet at that point. Covered by a new test.

## Checks

`pre-commit run --all-files` passes every hook, including the integration tier, the 100% coverage gate, `ty`, `mypy`, and `mkdocs build --strict`.
