### PR TITLE
🔖 Prepare the 0.37.3 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.37.3 - 2026-08-14
 
 ### Added
 


### PR DESCRIPTION
Stamps the `Unreleased` changelog section as 0.37.3, dated today.

Contents: the cache serializer inferred from the type parameter (#684) and the typed-example sweep across the docs, the README, and the demo app (#679).