### PR TITLE
🐛 Publish the demo on a port nothing else holds

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Docs
+
+* 📝 Let the demo publish a port other than 8000 with `DEMO_PORT`. `just demo-smoke` now picks a free port on its own, and `just demo` refuses to start when the port is taken. A local port-forward on 8000 used to answer the probes in the demo's place, because it binds the loopback address while the container runtime binds the wildcard, so both start and neither reports a conflict.
+
 ## 0.37.3 - 2026-08-14
 
 ### Added

--- a/examples/fastapi-demo/README.md
+++ b/examples/fastapi-demo/README.md
@@ -12,11 +12,13 @@ open http://localhost:8000/docs
 
 `up --wait` blocks until Redis, Postgres, and the app are all healthy. From the repo root you can also run `just demo`, which refuses to start when something already holds the port.
 
-Set `DEMO_PORT` to publish somewhere other than 8000, then use that port in the calls below:
+Set `DEMO_PORT` to publish somewhere other than 8000:
 
 ```bash
 DEMO_PORT=8001 docker compose up --wait
 ```
+
+Every command below uses 8000. Replace it with the port you chose.
 
 ## Hit the endpoints
 

--- a/examples/fastapi-demo/README.md
+++ b/examples/fastapi-demo/README.md
@@ -10,7 +10,13 @@ docker compose up --wait
 open http://localhost:8000/docs
 ```
 
-`up --wait` blocks until Redis, Postgres, and the app are all healthy. From the repo root you can also run `just demo`.
+`up --wait` blocks until Redis, Postgres, and the app are all healthy. From the repo root you can also run `just demo`, which refuses to start when something already holds the port.
+
+Set `DEMO_PORT` to publish somewhere other than 8000, then use that port in the calls below:
+
+```bash
+DEMO_PORT=8001 docker compose up --wait
+```
 
 ## Hit the endpoints
 

--- a/examples/fastapi-demo/compose.yml
+++ b/examples/fastapi-demo/compose.yml
@@ -28,7 +28,9 @@ services:
       REDIS_URL: redis://redis:6379/0
       POSTGRES_URL: postgresql://demo:demo@postgres:5432/demo
     ports:
-      - "8000:8000"
+      # `DEMO_PORT` moves the published port off 8000 when something else
+      # already holds it. The container port never changes.
+      - "${DEMO_PORT:-8000}:8000"
     depends_on:
       redis:
         condition: service_healthy

--- a/justfile
+++ b/justfile
@@ -6,10 +6,17 @@ docs-build:
 docs-serve:
     uv run mkdocs serve
 
-# Run the FastAPI demo (Redis + Postgres + app) via Docker Compose
+# Run the FastAPI demo (Redis + Postgres + app) via Docker Compose.
+# Refuses to start when the port is taken, because the demo would come up
+# healthy while another service answers on the URL this prints.
 demo:
-    docker compose -f examples/fastapi-demo/compose.yml up --build --wait
-    @echo "Demo running: open http://localhost:8000/docs"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    port="${DEMO_PORT:-8000}"
+    uv run --no-project -- python tools/demo_port.py --check "$port"
+    DEMO_PORT="$port" docker compose -f examples/fastapi-demo/compose.yml \
+        up --build --wait
+    echo "Demo running: open http://127.0.0.1:${port}/docs"
 
 # Stop and clean up the demo stack
 demo-down:
@@ -43,17 +50,23 @@ test-full:
     uv run coverage report --fail-under=100
 
 # Bring the demo stack up, probe it the way CI does, and tear it down.
+# Publishes a free port rather than 8000, so a port-forward or another
+# local service never answers the probes in the demo's place.
 [doc("Bring the demo stack up, probe it the way CI does, tear it down")]
 demo-smoke:
     #!/usr/bin/env bash
     set -euo pipefail
     compose="examples/fastapi-demo/compose.yml"
+    export DEMO_PORT="${DEMO_PORT:-$(uv run --no-project -- python tools/demo_port.py)}"
     trap 'docker compose -f "$compose" down -v >/dev/null 2>&1 || true' EXIT
     docker compose -f "$compose" up --build --wait --wait-timeout 240
-    curl -fsS http://localhost:8000/livez > /dev/null
-    curl -fsS http://localhost:8000/readyz > /dev/null
-    curl -fsS http://localhost:8000/healthz > /dev/null
-    echo "demo smoke passed"
+    for path in livez readyz healthz; do
+        curl -fsS "http://127.0.0.1:${DEMO_PORT}/${path}" > /dev/null
+    done
+    # The demo is the only service serving this path, so a probe that
+    # reached something else fails here instead of reporting a pass.
+    curl -fsS "http://127.0.0.1:${DEMO_PORT}/product/42" | grep -q '"Product 42"'
+    echo "demo smoke passed on port ${DEMO_PORT}"
 
 # Run the unit and integration tiers on every Python the release matrix uses.
 # The version list comes from the workflow, so this cannot drift away from

--- a/tools/demo_port.py
+++ b/tools/demo_port.py
@@ -21,11 +21,24 @@ import socket
 import sys
 
 
-def free_port() -> int:
-    """Return a port the kernel reports as free right now."""
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
+def free_port(attempts: int = 20) -> int:
+    """Return a port free on both loopback families right now.
+
+    The kernel hands out an ephemeral port for one family at a time, and a
+    port free on `127.0.0.1` can be taken on `::1`. Each candidate is
+    checked against both before it is returned.
+
+    Raises:
+        SystemExit: If no candidate came back free within `attempts`.
+    """
+    for _ in range(attempts):
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = int(sock.getsockname()[1])
+        if is_free(port):
+            return port
+    msg = f"found no port free on both loopback families in {attempts} tries"
+    raise SystemExit(msg)
 
 
 def is_free(port: int) -> bool:

--- a/tools/demo_port.py
+++ b/tools/demo_port.py
@@ -1,0 +1,68 @@
+"""Pick the host port the demo stack publishes.
+
+`just demo-smoke` probes the demo over a published port. Anything else
+already listening on that port answers the probes instead, and the smoke
+check then passes or fails against the wrong service. A local
+`kubectl port-forward` or `oc port-forward` on 8000 is enough to do it,
+and it does not even collide visibly: it binds `127.0.0.1` while the
+container runtime binds the wildcard address, so both start and the
+probes reach the port-forward.
+
+With no arguments, print a free ephemeral port. With `--check PORT`,
+exit non-zero when that port is already taken.
+
+Run via `just demo` and `just demo-smoke`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import sys
+
+
+def free_port() -> int:
+    """Return a port the kernel reports as free right now."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def is_free(port: int) -> bool:
+    """Return whether a port can be bound on both loopback families."""
+    for family, address in (
+        (socket.AF_INET, "127.0.0.1"),
+        (socket.AF_INET6, "::1"),
+    ):
+        try:
+            with socket.socket(family) as sock:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                sock.bind((address, port))
+        except OSError:
+            return False
+    return True
+
+
+def main() -> int:
+    """Print a free port, or check the one given."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", type=int, default=None)
+    args = parser.parse_args()
+
+    if args.check is None:
+        print(free_port())
+        return 0
+
+    if is_free(args.check):
+        return 0
+    print(
+        f"port {args.check} is already in use, "
+        f"so the demo would not be the service answering there. "
+        f"Free it, or pick another: DEMO_PORT=8001 just demo",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`just demo-smoke` failed locally against a healthy demo stack. The probes were answered by an `oc port-forward` holding `127.0.0.1:8000`, not by the demo.

Nothing reports the conflict, which is what makes it worth fixing rather than remembering. The port-forward binds the loopback address and the container runtime binds the wildcard, so both bind successfully, `docker compose up --wait` reports every container healthy, and `curl localhost:8000/livez` reaches the port-forward. The result was a 404 that reads like a broken demo.

## Changes

- `compose.yml` publishes `${DEMO_PORT:-8000}`, so the host port moves while the container port stays put.
- `just demo-smoke` picks a free ephemeral port through `tools/demo_port.py` and probes `127.0.0.1` explicitly. It also asserts `/product/42` carries `"Product 42"`, so a probe that somehow reached another service fails instead of passing.
- `just demo` checks the port first and refuses to start when it is taken, naming the fix (`DEMO_PORT=8001 just demo`). It used to print a URL that belonged to whatever already held 8000.
- `tools/demo_port.py` prints a free port, or checks one with `--check`. It tries both loopback families, since binding only one is exactly how the collision hid.
- The demo README documents `DEMO_PORT`.

CI is untouched: `reusable-tests.yml` runs on a clean runner where 8000 is free, and its rate-limit check across two workers is more than the local recipe does.

## Checks

`just demo-smoke` passes with the `oc port-forward` still holding 8000, on port 58748. `pre-commit run --all-files` passes every hook.
