### PR TITLE
🔖 Prepare the 0.37.4 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.37.4 - 2026-08-14
+
+### Fixed
+
+* 🐛 Drop the generic parameter from the `asyncpg.Connection` annotations in the Postgres outbox adapter. `asyncpg.Connection` is not generic, so `typing.get_type_hints` on `PostgresOutboxAdapter` raised `TypeError: type 'Connection' is not subscriptable`. Only deferred annotation evaluation kept it from raising at import. ([#731](https://github.com/grelinfo/grelmicro/pull/731))
 
 ### Docs
 


### PR DESCRIPTION
Stamps the unreleased section as 0.37.4, dated today, and adds the missing entry for the `asyncpg.Connection` annotation fix that shipped in #731.

That fix is user-visible after all: `typing.get_type_hints(PostgresOutboxAdapter...)` raised `TypeError: type 'Connection' is not subscriptable`, since `asyncpg.Connection` is not generic. Only deferred annotation evaluation kept it from raising at import.

Also in this release: `DEMO_PORT` for the demo stack (#730).