### PR TITLE
🔖 Prepare the 0.38.1 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,24 +1,24 @@
 # Changelog
 
-## Unreleased
+## 0.38.1 - 2026-08-15
 
 ### Added
 
-* ✨ `grelmicro.describe` exposes the report models `Grelmicro.describe()` returns, so a caller can annotate a report without reaching into a private module. `import grelmicro` still does not pay for them.
-* ✨ `micro.health`, `micro.metrics`, `micro.outbox`, `micro.ratelimiter`, and `micro.circuitbreaker` are typed properties. Every first-party kind now keeps its type through lookup instead of resolving as `Any`.
-* ✨ Export the names public signatures already required: `LockConfig` and `TaskLockConfig` (needed by `from_config`), `Task` (accepted by `Tasks(tasks=...)` and `TaskRouter.add_task`), and the four `Log*Type` enums (accepted by `configure`).
-* ✨ `Metrics.provider`, `Metrics.prometheus_registry`, and `Trace.provider` return their OpenTelemetry and Prometheus types instead of `Any`.
+* ✨ `grelmicro.describe` exposes the report models `Grelmicro.describe()` returns, so a caller can annotate a report without reaching into a private module. `import grelmicro` still does not pay for them. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
+* ✨ `micro.health`, `micro.metrics`, `micro.outbox`, `micro.ratelimiter`, and `micro.circuitbreaker` are typed properties. Every first-party kind now keeps its type through lookup instead of resolving as `Any`. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
+* ✨ Export the names public signatures already required: `LockConfig` and `TaskLockConfig` (needed by `from_config`), `Task` (accepted by `Tasks(tasks=...)` and `TaskRouter.add_task`), and the four `Log*Type` enums (accepted by `configure`). ([#734](https://github.com/grelinfo/grelmicro/pull/734))
+* ✨ `Metrics.provider`, `Metrics.prometheus_registry`, and `Trace.provider` return their OpenTelemetry and Prometheus types instead of `Any`. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
 
 ### Fixed
 
-* 🐛 `HealthChecks` never registered for live reload, so `ExternalConfig` could not retune it from a mounted ConfigMap. It inherited the reconfiguration machinery like every other component but was the only one that did not track itself.
-* 🐛 `TTLCache.get_or_set` and `Idempotency.run` awaited only coroutines, so a factory returning any other awaitable, such as a `Future`, had that awaitable stored as the cached value or the idempotent response.
-* 🐛 `TrustedProxies` accepted `max_entries=0`, which slices as `entries[-0:]` and returns the whole list, so the cap silently allowed everything it was meant to bound. Zero and negative values now raise, and `max_hops=0` stays valid.
-* 🐛 The singleton guard only inspected the incoming component, so a plain component of a singleton kind could register after the singleton. Either side declaring the kind is now enough.
-* 🐛 `CallLog.count(name=None)` matched calls that never passed `name`, because an absent key read as `None`.
-* 🐛 `ExternalConfig(reload_interval=0)` polled without pause. The interval must now be positive.
-* 🐛 `@idempotent` accepted a synchronous function that then failed at runtime, and erased the decorated return type. It now requires a coroutine function and preserves the type.
-* 🐛 The `CircuitBreaker.consecutive_count` docstring claimed the bare constructor reads environment variables. No circuit breaker path does.
+* 🐛 `HealthChecks` never registered for live reload, so `ExternalConfig` could not retune it from a mounted ConfigMap. It inherited the reconfiguration machinery like every other component but was the only one that did not track itself. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
+* 🐛 `TTLCache.get_or_set` and `Idempotency.run` awaited only coroutines, so a factory returning any other awaitable, such as a `Future`, had that awaitable stored as the cached value or the idempotent response. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
+* 🐛 `TrustedProxies` accepted `max_entries=0`, which slices as `entries[-0:]` and returns the whole list, so the cap silently allowed everything it was meant to bound. Zero and negative values now raise, and `max_hops=0` stays valid. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
+* 🐛 The singleton guard only inspected the incoming component, so a plain component of a singleton kind could register after the singleton. Either side declaring the kind is now enough. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
+* 🐛 `CallLog.count(name=None)` matched calls that never passed `name`, because an absent key read as `None`. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
+* 🐛 `ExternalConfig(reload_interval=0)` polled without pause. The interval must now be positive. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
+* 🐛 `@idempotent` accepted a synchronous function that then failed at runtime, and erased the decorated return type. It now requires a coroutine function and preserves the type. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
+* 🐛 The `CircuitBreaker.consecutive_count` docstring claimed the bare constructor reads environment variables. No circuit breaker path does. ([#734](https://github.com/grelinfo/grelmicro/pull/734))
 
 ## 0.38.0 - 2026-08-15
 


### PR DESCRIPTION
Cuts 0.38.1 from the API review follow-ups merged in #734.

Patch rather than minor: the release is bug fixes plus additive exports, with no breaking change. Matches 0.37.3, which also carried an `### Added` section on a patch bump.

## Fixed

- `HealthChecks` never registered for live reload, so `ExternalConfig` could not retune it from a mounted ConfigMap. It was the only reconfigurable component that did not track itself.
- `TTLCache.get_or_set` and `Idempotency.run` awaited only coroutines while their annotations promise `Awaitable`, so a factory returning a `Future` had the awaitable itself stored as the cached value or the idempotent response.
- `TrustedProxies` accepted `max_entries=0`, which slices as `entries[-0:]` and returns the whole list, so a cap meaning "allow nothing" silently allowed everything.
- The singleton guard inspected only the incoming component, so a plain component of a singleton kind could register after the singleton.
- `CallLog.count(name=None)` matched calls that never passed `name`.
- `ExternalConfig(reload_interval=0)` polled without pause.
- `@idempotent` accepted a synchronous function that failed at runtime, and erased the decorated return type.

## Added

- `grelmicro.describe` gives the `describe()` report models a public home, without adding to `import grelmicro` cost.
- Typed properties for `health`, `metrics`, `outbox`, `ratelimiter`, and `circuitbreaker`.
- `LockConfig`, `TaskLockConfig`, `Task`, and the four `Log*Type` enums, all of which public signatures already required.
- Real OpenTelemetry and Prometheus types on `Metrics.provider`, `Metrics.prometheus_registry`, and `Trace.provider`.

## Verification

Full tier green before cutting: 4487 unit plus 296 integration and slow tests, 100% coverage, ruff, ty, mypy, and `mkdocs build --strict`.