### PR TITLE
💥 Make from_config the only door for a pre-built config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It is built for any Python application that coordinates work across processes, w
 - **Backend-agnostic**: each primitive is a protocol. Swap Redis for PostgreSQL or SQLite without touching application code.
 - **Railguarded**: fully tested, type-checked, and validated. Pre-1.0 the API may change on a minor release. `1.x` follows standard semver.
 
-grelmicro is **not** a task queue (reach for Celery, Dramatiq, or taskiq) and **not** a web framework (it plugs into FastAPI, Starlette, Litestar, and FastStream). It fills the gap between the web framework you picked and the infrastructure you run.
+grelmicro is **not** a task queue (reach for Celery, Dramatiq, or taskiq), **not** a message broker client (reach for FastStream to publish and subscribe over Kafka, RabbitMQ, NATS, or Redis), and **not** a web framework (it plugs into FastAPI, Starlette, Litestar, and FastStream). It fills the gap between the web framework you picked and the infrastructure you run.
 
 Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? See the [comparison page](https://grelmicro.grel.info/comparison/) for a per-domain breakdown.
 

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -85,9 +85,11 @@ Build a config object, then construct via `from_config`:
 The config object is a frozen Pydantic model. Field names match the kwargs from
 the programmatic path. `from_config` skips the env layer entirely.
 
-Every primitive takes the same path. Some accept the config as a `config=`
-keyword instead of `from_config`, because their config type also selects the
-algorithm:
+Every primitive takes the same path, and `from_config` is the only door for a
+pre-built config. It reads as what it does: the config you hand over is the
+whole truth, so the env layer is skipped and the instance is not registered for
+live reload. The kwargs on the constructor are the other lane, where env fills
+whatever you left out.
 
 === "Retry"
     ```python

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 `Timeout`, `Retry`, `Fallback`, `Bulkhead`, `Log`, `Metrics`, `Trace`, `Shield`, and `Outbox` no longer take `config=`. Pass a pre-built config to `from_config`, which did exactly the same thing. One door instead of two.
 * 💥 `grelmicro.clientip` moved to `grelmicro.security`. Import `TrustedProxies`, `ClientAddress`, `ClientAddressReason`, `ClientAddressMiddleware`, and `resolve_client_address` from there. The logger is renamed to `grelmicro.security.clientip`, so a filter or a level set on the old name stops matching.
 
 ### Added
@@ -12,6 +13,9 @@
 * ✨ `micro.install(app)` wires a Litestar app. It opens the components on startup, closes them after shutdown, and binds the app around each request so patterns resolve with no `backend=`. Call it after `Litestar(...)`, which builds its middleware stack at construction.
 * ✨ New `fastapi`, `starlette`, and `litestar` extras, so `pip install "grelmicro[litestar]"` brings the framework along.
 * 📝 A [Frameworks](frameworks.md) page lists every framework `micro.install(app)` supports and what it wires for each.
+* ✨ `Outbox.from_config` and `TTLCache.from_config` complete the declarative path. Every primitive that has a config class now accepts one the same way.
+* ✨ `Bulkhead.from_config` accepts `uses=` to scope providers and components, which the declarative path could not do before.
+* 📝 Publish/subscribe is a stated non-goal. The [outbox consumer](outbox/consumer.md#publishing-to-a-broker) page shows the handler publishing through FastStream, and explains why the durable half and the transport half are separate.
 
 ## 0.38.1 - 2026-08-15
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -169,7 +169,7 @@ A few categories the comparison page does not cover, because grelmicro does not 
 |---|---|
 | HTTP framework | [FastAPI](https://fastapi.tiangolo.com/), [Starlette](https://www.starlette.io/), [Litestar](https://litestar.dev/) |
 | Embedded server | [Uvicorn](https://www.uvicorn.org/), [Hypercorn](https://github.com/pgjones/hypercorn), [Granian](https://github.com/emmett-framework/granian) |
-| Message broker abstraction | [FastStream](https://faststream.airt.ai/), [aio_pika](https://github.com/mosquito/aio-pika) |
+| Publish/subscribe and message brokers | [FastStream](https://faststream.airt.ai/), [aio_pika](https://github.com/mosquito/aio-pika) |
 | Background workers (queues) | [Celery](https://docs.celeryq.dev/), [dramatiq](https://github.com/Bogdanp/dramatiq), [taskiq](https://github.com/taskiq-python/taskiq) |
 | ORM | [SQLAlchemy](https://www.sqlalchemy.org/), [SQLModel](https://sqlmodel.tiangolo.com/), [tortoise-orm](https://tortoise.github.io/) |
 | Auth | [Authlib](https://authlib.org/), [authx](https://github.com/yezz123/authx), [fastapi-users](https://github.com/fastapi-users/fastapi-users) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ It is built for any Python application that coordinates work across processes, w
 - **Backend-agnostic**: each primitive is a protocol. Swap Redis for PostgreSQL or SQLite without touching application code.
 - **Railguarded**: fully tested, type-checked, and validated. Pre-1.0 the API may change on a minor release. `1.x` follows standard semver.
 
-grelmicro is **not** a task queue (reach for Celery, Dramatiq, or taskiq) and **not** a web framework (it plugs into FastAPI, Starlette, Litestar, and FastStream). It fills the gap between the web framework you picked and the infrastructure you run.
+grelmicro is **not** a task queue (reach for Celery, Dramatiq, or taskiq), **not** a message broker client (reach for FastStream to publish and subscribe over Kafka, RabbitMQ, NATS, or Redis), and **not** a web framework (it plugs into FastAPI, Starlette, Litestar, and FastStream). It fills the gap between the web framework you picked and the infrastructure you run.
 
 Already using `aiocache`, `slowapi`, `pybreaker`, `tenacity`, or `aioredlock`? See the [comparison page](https://grelmicro.grel.info/comparison/) for a per-domain breakdown.
 

--- a/docs/outbox/consumer.md
+++ b/docs/outbox/consumer.md
@@ -23,6 +23,25 @@ async def send_welcome(message: Message[WelcomeEmail]) -> None:
 Delivery is at least once, so a handler must be idempotent. See
 [Delivery semantics](index.md#delivery-semantics).
 
+## Publishing to a broker
+
+grelmicro has no publish/subscribe primitive and talks to no broker. Reach for [FastStream](https://faststream.airt.ai/), which covers Kafka, RabbitMQ, NATS, Redis, and MQTT. The two fit together in the handler:
+
+```python
+from faststream.kafka import KafkaBroker
+
+broker = KafkaBroker("localhost:9092")
+
+
+@outbox.handler(OrderPlaced)
+async def emit_order_placed(message: Message[OrderPlaced]) -> None:
+    await broker.publish(message.data, topic="orders", key=message.key)
+```
+
+The split is the point. The outbox makes the intent to publish durable, committed in the same transaction as the business write, so a crash can neither lose the event nor emit one for a rollback. FastStream carries the message to the broker. Neither half does the other's job on its own.
+
+Both sides deliver at least once, so consumers downstream stay idempotent. `message.id` is stable across retries, which makes it the key to deduplicate on.
+
 ## Controlling retries from the handler
 
 Any exception retries the message with backoff. Raise `Retry` to reschedule on your own terms, or `Cancel` to dead-letter it now without burning the remaining attempts:

--- a/docs/snippets/resilience/fallback_declarative.py
+++ b/docs/snippets/resilience/fallback_declarative.py
@@ -6,4 +6,4 @@ config = FallbackConfig(
     when=Match.exception(httpx.HTTPError),
     default=[],
 )
-policy = Fallback("recs", config=config)
+policy = Fallback.from_config("recs", config)

--- a/docs/snippets/resilience/retry_declarative.py
+++ b/docs/snippets/resilience/retry_declarative.py
@@ -12,4 +12,4 @@ config = RetryConfig(
     when=Match.exception(httpx.HTTPError),
     backoff=ExponentialBackoff(base_delay=0.2, max_delay=10.0, jitter="full"),
 )
-policy = Retry("payments", config=config)
+policy = Retry.from_config("payments", config)

--- a/docs/snippets/resilience/shield_declarative.py
+++ b/docs/snippets/resilience/shield_declarative.py
@@ -6,4 +6,4 @@ config = ApiShieldConfig(
     timeout_errors=(httpx.TimeoutException, httpx.ConnectError),
     max_rate=20.0,
 )
-github = Shield("github", config=config)
+github = Shield.from_config("github", config)

--- a/docs/snippets/resilience/timeout_declarative.py
+++ b/docs/snippets/resilience/timeout_declarative.py
@@ -1,4 +1,4 @@
 from grelmicro.resilience import Timeout, TimeoutConfig
 
 config = TimeoutConfig(seconds=2.0)
-db_timeout = Timeout("db", config=config)
+db_timeout = Timeout.from_config("db", config)

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Annotated, Any, Generic, cast
+from typing import TYPE_CHECKING, Annotated, Any, Generic, Self, cast
 
 from pydantic import BaseModel, NonNegativeInt, PositiveFloat
 from typing_extensions import Doc, TypeVar
@@ -197,6 +197,35 @@ class TTLCache(Generic[T]):
         self._keys: OrderedDict[str, None] = OrderedDict()
         # Per-key in-process locks for get_or_set stampede protection.
         self._stampede = AsyncStampedeGuard()
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Annotated[
+            TTLCacheConfig,
+            Doc("The pre-built cache configuration."),
+        ],
+        *,
+        backend: Annotated[
+            CacheBackend | None,
+            Doc("The cache storage backend."),
+        ] = None,
+        serializer: Annotated[
+            CacheSerializer[T] | type[T] | None,
+            Doc("Serialization strategy for cached values."),
+        ] = None,
+    ) -> Self:
+        """Construct a `TTLCache` from a pre-built `TTLCacheConfig`.
+
+        `TTLCache` reads no environment variable, so this differs from the
+        constructor only in taking the settings as one object.
+        """
+        return cls(
+            config.maxsize,
+            config.ttl,
+            backend=backend,
+            serializer=serializer,
+        )
 
     @property
     def config(self) -> TTLCacheConfig:

--- a/grelmicro/log/_component.py
+++ b/grelmicro/log/_component.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import TYPE_CHECKING, Annotated, ClassVar, Self
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Self
 
 from typing_extensions import Doc
 
@@ -78,15 +78,6 @@ class Log:
                 """
             ),
         ] = "default",
-        config: Annotated[
-            LogConfig | None,
-            Doc(
-                """
-                Pre-built configuration. When provided, individual kwargs
-                must be `None`. The env path is bypassed.
-                """
-            ),
-        ] = None,
         backend: Annotated[
             LogBackendType | None,
             Doc("Logging backend (`stdlib`, `loguru`, `structlog`)."),
@@ -120,17 +111,33 @@ class Log:
         ] = None,
     ) -> None:
         """Initialize the component (defer configuration until `__aenter__`)."""
+        self._setup(
+            name=name,
+            config=None,
+            kwargs={
+                "backend": backend,
+                "level": level,
+                "format": format,
+                "timezone": timezone,
+                "json_serializer": json_serializer,
+                "caller_enabled": caller_enabled,
+                "otel_enabled": otel_enabled,
+            },
+            env_load=env_load,
+        )
+
+    def _setup(
+        self,
+        *,
+        name: str,
+        config: LogConfig | None,
+        kwargs: dict[str, Any],
+        env_load: bool | None,
+    ) -> None:
+        """Wire the deferred configuration onto the instance."""
         self._name = name
         self._explicit_config = config
-        self._kwargs = {
-            "backend": backend,
-            "level": level,
-            "format": format,
-            "timezone": timezone,
-            "json_serializer": json_serializer,
-            "caller_enabled": caller_enabled,
-            "otel_enabled": otel_enabled,
-        }
+        self._kwargs = kwargs
         self._env_load = env_load
         self._resolved: LogConfig | None = None
         self._snapshot_handlers: list[logging.Handler] | None = None
@@ -160,7 +167,11 @@ class Log:
         ] = "default",
     ) -> Self:
         """Construct a `Log` from a pre-built `LogConfig`."""
-        return cls(name=name, config=config)
+        instance = cls.__new__(cls)
+        instance._setup(  # noqa: SLF001
+            name=name, config=config, kwargs={}, env_load=None
+        )
+        return instance
 
     @property
     def name(self) -> str:

--- a/grelmicro/metrics/_component.py
+++ b/grelmicro/metrics/_component.py
@@ -90,15 +90,6 @@ class Metrics:
                 """
             ),
         ] = "default",
-        config: Annotated[
-            MetricsConfig | None,
-            Doc(
-                """
-                Pre-built configuration. When provided, individual kwargs
-                must be `None`. The env path is bypassed.
-                """
-            ),
-        ] = None,
         service_name: Annotated[
             str | None, Doc("Service name resource attribute.")
         ] = None,
@@ -153,20 +144,36 @@ class Metrics:
         if basic_auth is not None and len(basic_auth) != 2:  # noqa: PLR2004
             msg = "basic_auth must be a (username, password) tuple."
             raise TypeError(msg)
+        self._setup(
+            name=name,
+            config=None,
+            kwargs={
+                "service_name": service_name,
+                "exporter": exporter,
+                "endpoint": endpoint,
+                "headers": headers,
+                "basic_auth_username": basic_auth[0] if basic_auth else None,
+                "basic_auth_password": basic_auth[1] if basic_auth else None,
+                "export_interval": export_interval,
+                "export_timeout": export_timeout,
+                "resource_attributes": resource_attributes,
+                "shutdown_timeout": shutdown_timeout,
+            },
+            env_load=env_load,
+        )
+
+    def _setup(
+        self,
+        *,
+        name: str,
+        config: MetricsConfig | None,
+        kwargs: dict[str, Any],
+        env_load: bool | None,
+    ) -> None:
+        """Wire the deferred configuration onto the instance."""
         self._name = name
         self._explicit_config = config
-        self._kwargs = {
-            "service_name": service_name,
-            "exporter": exporter,
-            "endpoint": endpoint,
-            "headers": headers,
-            "basic_auth_username": basic_auth[0] if basic_auth else None,
-            "basic_auth_password": basic_auth[1] if basic_auth else None,
-            "export_interval": export_interval,
-            "export_timeout": export_timeout,
-            "resource_attributes": resource_attributes,
-            "shutdown_timeout": shutdown_timeout,
-        }
+        self._kwargs = kwargs
         self._env_load = env_load
         self._resolved: MetricsConfig | None = None
         self._entered: bool = False
@@ -198,7 +205,11 @@ class Metrics:
         ] = "default",
     ) -> Self:
         """Construct a `Metrics` from a pre-built `MetricsConfig`."""
-        return cls(name=name, config=config)
+        instance = cls.__new__(cls)
+        instance._setup(  # noqa: SLF001
+            name=name, config=config, kwargs={}, env_load=None
+        )
+        return instance
 
     @property
     def name(self) -> str:

--- a/grelmicro/outbox/_component.py
+++ b/grelmicro/outbox/_component.py
@@ -90,10 +90,6 @@ class Outbox:
             ),
         ] = None,
         name: Annotated[str, Doc("Registration name.")] = "default",
-        config: Annotated[
-            OutboxConfig | None,
-            Doc("A pre-built `OutboxConfig`. Mutually exclusive with kwargs."),
-        ] = None,
         relay: Annotated[
             bool | None, Doc("Run the relay on this replica.")
         ] = None,
@@ -146,33 +142,51 @@ class Outbox:
         ] = 30.0,
     ) -> None:
         """Initialize the component and resolve its config and backend."""
+        instance_prefix, kind_prefix = env_prefixes("OUTBOX", name)
+        self._setup(
+            source,
+            resolve_config(
+                OutboxConfig,
+                explicit=None,
+                kwargs={
+                    "relay": relay,
+                    "table": table,
+                    "poll_interval": poll_interval,
+                    "batch_size": batch_size,
+                    "lease_duration": lease_duration,
+                    "max_attempts": max_attempts,
+                    "retry_base": retry_base,
+                    "retry_max": retry_max,
+                    "retry_jitter": retry_jitter,
+                    "concurrency": concurrency,
+                    "dead_letter": dead_letter,
+                    "keep_delivered": keep_delivered,
+                    "auto_migrate": auto_migrate,
+                    "notify": notify,
+                },
+                env_prefix=instance_prefix,
+                kind_env_prefix=kind_prefix,
+                env_load=env_load,
+                error_type=OutboxSettingsValidationError,
+            ),
+            requires=requires,
+            name=name,
+            shutdown_timeout=shutdown_timeout,
+        )
+
+    def _setup(
+        self,
+        source: Provider | OutboxBackend | type[Provider | OutboxBackend],
+        config: OutboxConfig,
+        *,
+        requires: BackendScope | None,
+        name: str,
+        shutdown_timeout: float,
+    ) -> None:
+        """Wire the resolved config, backend, and registry onto the instance."""
         self._name = name
         self._requires: BackendScope = requires or self.default_requires
-        instance_prefix, kind_prefix = env_prefixes("OUTBOX", name)
-        self._config = resolve_config(
-            OutboxConfig,
-            explicit=config,
-            kwargs={
-                "relay": relay,
-                "table": table,
-                "poll_interval": poll_interval,
-                "batch_size": batch_size,
-                "lease_duration": lease_duration,
-                "max_attempts": max_attempts,
-                "retry_base": retry_base,
-                "retry_max": retry_max,
-                "retry_jitter": retry_jitter,
-                "concurrency": concurrency,
-                "dead_letter": dead_letter,
-                "keep_delivered": keep_delivered,
-                "auto_migrate": auto_migrate,
-                "notify": notify,
-            },
-            env_prefix=instance_prefix,
-            kind_env_prefix=kind_prefix,
-            env_load=env_load,
-            error_type=OutboxSettingsValidationError,
-        )
+        self._config = config
         resolved = cast(
             "Provider | OutboxBackend",
             instantiate_if_class(source),
@@ -188,6 +202,43 @@ class Outbox:
         self._registry = OutboxRegistry()
         self._relay: Relay | None = None
         self._shutdown_timeout = shutdown_timeout
+
+    @classmethod
+    def from_config(
+        cls,
+        source: Annotated[
+            Provider | OutboxBackend | type[Provider | OutboxBackend],
+            Doc(
+                "A `Provider` (e.g. `PostgresProvider`) or an `OutboxBackend`."
+            ),
+        ],
+        config: Annotated[
+            OutboxConfig,
+            Doc("The pre-built outbox configuration."),
+        ],
+        *,
+        requires: Annotated[
+            BackendScope | None,
+            Doc("The smallest backend scope this component accepts."),
+        ] = None,
+        name: Annotated[str, Doc("Registration name.")] = "default",
+        shutdown_timeout: Annotated[
+            float, Doc("Seconds to let in-flight handlers drain on shutdown.")
+        ] = 30.0,
+    ) -> Self:
+        """Construct an `Outbox` from a source and a pre-built `OutboxConfig`.
+
+        The config is taken as-is, so no environment variable is read.
+        """
+        instance = cls.__new__(cls)
+        instance._setup(  # noqa: SLF001
+            source,
+            config,
+            requires=requires,
+            name=name,
+            shutdown_timeout=shutdown_timeout,
+        )
+        return instance
 
     @property
     def name(self) -> str:

--- a/grelmicro/resilience/bulkhead.py
+++ b/grelmicro/resilience/bulkhead.py
@@ -153,13 +153,6 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
                 """
             ),
         ] = (),
-        config: Annotated[
-            BulkheadConfig | None,
-            Doc(
-                "A pre-built [`BulkheadConfig`][grelmicro.resilience.BulkheadConfig]. "
-                "Mutually exclusive with the per-field kwargs."
-            ),
-        ] = None,
         env_load: Annotated[
             bool | None,
             Doc(
@@ -171,24 +164,35 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
         ] = None,
     ) -> None:
         """Initialize the bulkhead."""
-        self._name = name
         env_prefix, kind_prefix = env_prefixes("BULKHEAD", name)
-        resolved = resolve_config(
-            BulkheadConfig,
-            explicit=config,
-            kwargs={
-                "max_concurrent": max_concurrent,
-                "max_wait": max_wait,
-                "max_workers": max_workers,
-            },
-            env_prefix=env_prefix,
-            kind_env_prefix=kind_prefix,
-            env_load=env_load,
+        self._setup(
+            name,
+            resolve_config(
+                BulkheadConfig,
+                explicit=None,
+                kwargs={
+                    "max_concurrent": max_concurrent,
+                    "max_wait": max_wait,
+                    "max_workers": max_workers,
+                },
+                env_prefix=env_prefix,
+                kind_env_prefix=kind_prefix,
+                env_load=env_load,
+            ),
+            uses,
         )
-        self._config = resolved
-        self._state = _State(
-            config=resolved, semaphore=_build_semaphore(resolved)
-        )
+        self._track_reconfigure(env_prefix)
+
+    def _setup(
+        self,
+        name: str,
+        config: BulkheadConfig,
+        uses: Iterable[Usable | None],
+    ) -> None:
+        """Wire the validated config and runtime state onto the instance."""
+        self._name = name
+        self._config = config
+        self._state = _State(config=config, semaphore=_build_semaphore(config))
         self._reconfigure_lock = asyncio.Lock()
         self._executor: ThreadPoolExecutor | None = None
         self._uses = tuple(
@@ -205,8 +209,6 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
             asyncio.Task[Any],
             list[tuple[asyncio.Semaphore | None, Token[Any] | None]],
         ] = {}
-        if config is None:
-            self._track_reconfigure(env_prefix)
 
     @property
     def name(self) -> str:
@@ -221,9 +223,23 @@ class Bulkhead(Reconfigurable[BulkheadConfig]):
             BulkheadConfig,
             Doc("The pre-built bulkhead configuration."),
         ],
+        *,
+        uses: Annotated[
+            Iterable[Usable | None],
+            Doc(
+                "Providers and Components scoped to this bulkhead, in "
+                "the same shape as on the constructor."
+            ),
+        ] = (),
     ) -> Self:
-        """Construct a `Bulkhead` from a name and a pre-built `BulkheadConfig`."""
-        return cls(name, config=config)
+        """Construct a `Bulkhead` from a name and a pre-built `BulkheadConfig`.
+
+        The config is taken as-is: no environment variable is read, and
+        the instance is not registered for live reconfiguration.
+        """
+        instance = cls.__new__(cls)
+        instance._setup(name, config, uses)  # noqa: SLF001
+        return instance
 
     async def __aenter__(self) -> Self:
         """Admit the current task, waiting up to `max_wait` for a permit."""

--- a/grelmicro/resilience/fallback.py
+++ b/grelmicro/resilience/fallback.py
@@ -199,24 +199,14 @@ def _resolve_config(
     when: WhenInput | None,
     default: Any,  # noqa: ANN401
     factory: Callable[[BaseException], Any] | None,
-    config: FallbackConfig | None,
     env_load: bool | None,
 ) -> FallbackConfig:
-    """Build a `FallbackConfig` from kwargs, an explicit config, or env.
+    """Build a `FallbackConfig` from kwargs or env.
 
     Mirrors :func:`grelmicro._config.resolve_config` but treats
     ``default`` with the ``_UNSET`` sentinel so that ``default=None``
     is preserved as a valid value.
     """
-    explicit_kwargs = (
-        when is not None or factory is not None or default is not _UNSET
-    )
-    if config is not None:
-        if explicit_kwargs:
-            msg = "pass a pre-built config OR individual kwargs, not both"
-            raise TypeError(msg)
-        return config
-
     kwargs: dict[str, Any] = {}
     if when is not None:
         kwargs["when"] = when
@@ -374,7 +364,7 @@ class Fallback(Reconfigurable[FallbackConfig]):
                 "Exception filter that engages the fallback. Pass a "
                 "[`Match`][grelmicro.resilience.Match] or a shorthand "
                 "(class, tuple of classes, callable). Required unless "
-                "``config=`` is given or the value comes from env."
+                "the value comes from env."
             ),
         ] = None,
         default: Annotated[  # noqa: ANN401
@@ -391,13 +381,6 @@ class Fallback(Reconfigurable[FallbackConfig]):
                 "matched exception. Mutually exclusive with ``default``."
             ),
         ] = None,
-        config: Annotated[
-            FallbackConfig | None,
-            Doc(
-                "A pre-built [`FallbackConfig`][grelmicro.resilience.FallbackConfig]. "
-                "Mutually exclusive with the per-field kwargs."
-            ),
-        ] = None,
         env_load: Annotated[
             bool | None,
             Doc(
@@ -409,20 +392,24 @@ class Fallback(Reconfigurable[FallbackConfig]):
         ] = None,
     ) -> None:
         """Initialize the fallback policy."""
-        self._name = name
-        resolved = _resolve_config(
+        self._setup(
             name,
-            when=when,
-            default=default,
-            factory=factory,
-            config=config,
-            env_load=env_load,
+            _resolve_config(
+                name,
+                when=when,
+                default=default,
+                factory=factory,
+                env_load=env_load,
+            ),
         )
-        self._config = resolved
-        self._state = _State(config=resolved, matcher=resolved.when)
+        self._track_reconfigure(default_env_prefix("FALLBACK", name))
+
+    def _setup(self, name: str, config: FallbackConfig) -> None:
+        """Wire the validated config and runtime state onto the instance."""
+        self._name = name
+        self._config = config
+        self._state = _State(config=config, matcher=config.when)
         self._reconfigure_lock = asyncio.Lock()
-        if config is None:
-            self._track_reconfigure(default_env_prefix("FALLBACK", name))
 
     @property
     def name(self) -> str:
@@ -438,8 +425,14 @@ class Fallback(Reconfigurable[FallbackConfig]):
             Doc("The pre-built fallback configuration."),
         ],
     ) -> Self:
-        """Construct a `Fallback` from a name and a pre-built `FallbackConfig`."""
-        return cls(name, config=config)
+        """Construct a `Fallback` from a name and a pre-built `FallbackConfig`.
+
+        The config is taken as-is: no environment variable is read, and
+        the instance is not registered for live reconfiguration.
+        """
+        instance = cls.__new__(cls)
+        instance._setup(name, config)  # noqa: SLF001
+        return instance
 
     @overload
     def __call__[**P, R](

--- a/grelmicro/resilience/retry.py
+++ b/grelmicro/resilience/retry.py
@@ -584,7 +584,7 @@ class Retry(Reconfigurable[RetryConfig]):
                 "Outcome filter that engages the retry. Pass a "
                 "[`Match`][grelmicro.resilience.Match] or one of the "
                 "shorthand forms (exception class, tuple, callable). "
-                "Required unless ``config=`` is given."
+                "Required unless the value comes from env."
             ),
         ] = None,
         attempts: Annotated[
@@ -599,13 +599,6 @@ class Retry(Reconfigurable[RetryConfig]):
                 "whichever comes first. Default no time limit."
             ),
         ] = None,
-        config: Annotated[
-            RetryConfig | None,
-            Doc(
-                "A pre-built [`RetryConfig`][grelmicro.resilience.RetryConfig]. "
-                "Mutually exclusive with the per-field kwargs."
-            ),
-        ] = None,
         env_load: Annotated[
             bool | None,
             Doc(
@@ -617,7 +610,6 @@ class Retry(Reconfigurable[RetryConfig]):
         ] = None,
     ) -> None:
         """Initialize the retry policy."""
-        self._name = name
         env_prefix, kind_prefix = env_prefixes("RETRY", name)
         kwargs: dict[str, object | None] = {
             "attempts": attempts,
@@ -625,19 +617,25 @@ class Retry(Reconfigurable[RetryConfig]):
             "when": when,
             "backoff": backoff,
         }
-        resolved = resolve_config(
-            RetryConfig,
-            explicit=config,
-            kwargs=kwargs,
-            env_prefix=env_prefix,
-            kind_env_prefix=kind_prefix,
-            env_load=env_load,
+        self._setup(
+            name,
+            resolve_config(
+                RetryConfig,
+                explicit=None,
+                kwargs=kwargs,
+                env_prefix=env_prefix,
+                kind_env_prefix=kind_prefix,
+                env_load=env_load,
+            ),
         )
-        self._config = resolved
-        self._state = _State(config=resolved, matcher=resolved.when)
+        self._track_reconfigure(env_prefix)
+
+    def _setup(self, name: str, config: RetryConfig) -> None:
+        """Wire the validated config and runtime state onto the instance."""
+        self._name = name
+        self._config = config
+        self._state = _State(config=config, matcher=config.when)
         self._reconfigure_lock = asyncio.Lock()
-        if config is None:
-            self._track_reconfigure(env_prefix)
 
     @property
     def name(self) -> str:
@@ -664,8 +662,14 @@ class Retry(Reconfigurable[RetryConfig]):
             ),
         ],
     ) -> Self:
-        """Construct a `Retry` from a name and a pre-built `RetryConfig`."""
-        return cls(name, config=config)
+        """Construct a `Retry` from a name and a pre-built `RetryConfig`.
+
+        The config is taken as-is: no environment variable is read, and
+        the instance is not registered for live reconfiguration.
+        """
+        instance = cls.__new__(cls)
+        instance._setup(name, config)  # noqa: SLF001
+        return instance
 
     @classmethod
     def exponential(

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -121,7 +121,6 @@ def _resolve_config_from_env(
 def _build_config(
     name: str,
     *,
-    config: _BaseShieldConfig | None,
     profile: str,
     timeout_errors: Any,  # noqa: ANN401
     max_rate: float | None,
@@ -130,22 +129,7 @@ def _build_config(
     fallback: Callable[..., Any] | None,
     env_load: bool | None,
 ) -> _BaseShieldConfig:
-    """Resolve a `_BaseShieldConfig` from kwargs, an explicit config, or env."""
-    explicit_kwargs = any(
-        value is not None
-        for value in (
-            timeout_errors,
-            max_rate,
-            cache,
-            cache_key,
-            fallback,
-        )
-    )
-    if config is not None:
-        if explicit_kwargs:
-            msg = "pass a pre-built config OR individual kwargs, not both"
-            raise TypeError(msg)
-        return config
+    """Resolve a `_BaseShieldConfig` from kwargs or env."""
     if env_load is None:
         env_load = env_load_default()
     if env_load:
@@ -261,16 +245,6 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
                 "logs, metrics, and PEP 678 notes attached on give-up."
             ),
         ],
-        config: Annotated[
-            _BaseShieldConfig | None,
-            Doc(
-                "A pre-built profile config "
-                "([`InternalShieldConfig`][grelmicro.resilience.InternalShieldConfig], "
-                "[`ApiShieldConfig`][grelmicro.resilience.ApiShieldConfig], "
-                "[`SlowShieldConfig`][grelmicro.resilience.SlowShieldConfig]). "
-                "Mutually exclusive with the per-field kwargs."
-            ),
-        ] = None,
         *,
         timeout_errors: Annotated[
             tuple[type[BaseException], ...] | None,
@@ -335,7 +309,6 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
             name=name,
             config=_build_config(
                 name,
-                config=config,
                 profile="api",
                 timeout_errors=timeout_errors,
                 max_rate=max_rate,
@@ -346,7 +319,7 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
             ),
             time_source=time_source,
             random_source=random_source,
-            register=config is None,
+            register=True,
         )
 
     def _setup(
@@ -486,7 +459,6 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
         """Build a Shield bypassing env reads, with a profile override."""
         config = _build_config(
             name,
-            config=None,
             profile=profile,
             timeout_errors=timeout_errors,
             max_rate=max_rate,

--- a/grelmicro/resilience/timeout.py
+++ b/grelmicro/resilience/timeout.py
@@ -85,15 +85,7 @@ class Timeout(Reconfigurable[TimeoutConfig]):
         seconds: Annotated[
             PositiveFloat | None,
             Doc(
-                "Deadline in seconds. Required unless ``config=`` is "
-                "given or the value comes from env."
-            ),
-        ] = None,
-        config: Annotated[
-            TimeoutConfig | None,
-            Doc(
-                "A pre-built [`TimeoutConfig`][grelmicro.resilience.TimeoutConfig]. "
-                "Mutually exclusive with the per-field kwargs."
+                "Deadline in seconds. Required unless the value comes from env."
             ),
         ] = None,
         env_load: Annotated[
@@ -107,22 +99,27 @@ class Timeout(Reconfigurable[TimeoutConfig]):
         ] = None,
     ) -> None:
         """Initialize the timeout policy."""
-        self._name = name
         env_prefix, kind_prefix = env_prefixes("TIMEOUT", name)
-        resolved = resolve_config(
-            TimeoutConfig,
-            explicit=config,
-            kwargs={"seconds": seconds},
-            env_prefix=env_prefix,
-            kind_env_prefix=kind_prefix,
-            env_load=env_load,
+        self._setup(
+            name,
+            resolve_config(
+                TimeoutConfig,
+                explicit=None,
+                kwargs={"seconds": seconds},
+                env_prefix=env_prefix,
+                kind_env_prefix=kind_prefix,
+                env_load=env_load,
+            ),
         )
-        self._config = resolved
-        self._state = _State(config=resolved)
+        self._track_reconfigure(env_prefix)
+
+    def _setup(self, name: str, config: TimeoutConfig) -> None:
+        """Wire the validated config and runtime state onto the instance."""
+        self._name = name
+        self._config = config
+        self._state = _State(config=config)
         self._reconfigure_lock = asyncio.Lock()
         self._scopes: dict[asyncio.Task[Any], list[asyncio.Timeout]] = {}
-        if config is None:
-            self._track_reconfigure(env_prefix)
 
     @property
     def name(self) -> str:
@@ -138,8 +135,14 @@ class Timeout(Reconfigurable[TimeoutConfig]):
             Doc("The pre-built timeout configuration."),
         ],
     ) -> Self:
-        """Construct a `Timeout` from a name and a pre-built `TimeoutConfig`."""
-        return cls(name, config=config)
+        """Construct a `Timeout` from a name and a pre-built `TimeoutConfig`.
+
+        The config is taken as-is: no environment variable is read, and
+        the instance is not registered for live reconfiguration.
+        """
+        instance = cls.__new__(cls)
+        instance._setup(name, config)  # noqa: SLF001
+        return instance
 
     async def __aenter__(self) -> Self:
         """Open a fresh deadline scope for the current task."""

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -83,15 +83,6 @@ class Trace:
                 """
             ),
         ] = "default",
-        config: Annotated[
-            TraceConfig | None,
-            Doc(
-                """
-                Pre-built configuration. When provided, individual kwargs
-                must be `None`. The env path is bypassed.
-                """
-            ),
-        ] = None,
         service_name: Annotated[
             str | None, Doc("Service name resource attribute.")
         ] = None,
@@ -167,21 +158,39 @@ class Trace:
         if basic_auth is not None and len(basic_auth) != 2:  # noqa: PLR2004
             msg = "basic_auth must be a (username, password) tuple."
             raise TypeError(msg)
+        self._setup(
+            name=name,
+            config=None,
+            kwargs={
+                "service_name": service_name,
+                "exporter": exporter,
+                "endpoint": endpoint,
+                "headers": headers,
+                "basic_auth_username": basic_auth[0] if basic_auth else None,
+                "basic_auth_password": basic_auth[1] if basic_auth else None,
+                "processor": processor,
+                "sampler": sampler,
+                "sample_ratio": sample_ratio,
+                "resource_attributes": resource_attributes,
+                "shutdown_timeout": shutdown_timeout,
+            },
+            env_load=env_load,
+            instrument=instrument,
+        )
+
+    def _setup(
+        self,
+        *,
+        name: str,
+        config: TraceConfig | None,
+        kwargs: dict[str, Any],
+        env_load: bool | None,
+        instrument: InstrumentDirective,
+    ) -> None:
+        """Wire the deferred configuration onto the instance."""
         self._name = name
         self._explicit_config = config
-        self._kwargs = {
-            "service_name": service_name,
-            "exporter": exporter,
-            "endpoint": endpoint,
-            "headers": headers,
-            "basic_auth_username": basic_auth[0] if basic_auth else None,
-            "basic_auth_password": basic_auth[1] if basic_auth else None,
-            "processor": processor,
-            "sampler": sampler,
-            "sample_ratio": sample_ratio,
-            "resource_attributes": resource_attributes,
-            "shutdown_timeout": shutdown_timeout,
-        }
+        self._kwargs = kwargs
         self._env_load = env_load
         self._instrument = instrument
         self._resolved: TraceConfig | None = None
@@ -211,7 +220,15 @@ class Trace:
         ] = "default",
     ) -> Self:
         """Construct a `Trace` from a pre-built `TraceConfig`."""
-        return cls(name=name, config=config)
+        instance = cls.__new__(cls)
+        instance._setup(  # noqa: SLF001
+            name=name,
+            config=config,
+            kwargs={},
+            env_load=None,
+            instrument=True,
+        )
+        return instance
 
     @property
     def name(self) -> str:

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -80,7 +80,8 @@
       "()": "(model)"
     },
     "TTLCache": {
-      "()": "(maxsize=..., ttl=..., *, backend=..., serializer=...)"
+      "()": "(maxsize=..., ttl=..., *, backend=..., serializer=...)",
+      ".from_config": "(config, *, backend=..., serializer=...)"
     },
     "TTLCacheConfig": {
       "()": "(*, maxsize=..., ttl=...)"
@@ -335,7 +336,7 @@
     "ErrorDict": null,
     "JSONRecordDict": null,
     "Log": {
-      "()": "(*, name=..., config=..., backend=..., level=..., format=..., timezone=..., json_serializer=..., caller_enabled=..., otel_enabled=..., env_load=...)",
+      "()": "(*, name=..., backend=..., level=..., format=..., timezone=..., json_serializer=..., caller_enabled=..., otel_enabled=..., env_load=...)",
       ".from_config": "(config, *, name=...)"
     },
     "LogBackendType": {
@@ -376,7 +377,7 @@
   },
   "grelmicro.metrics": {
     "Metrics": {
-      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., basic_auth=..., export_interval=..., export_timeout=..., resource_attributes=..., shutdown_timeout=..., env_load=...)",
+      "()": "(*, name=..., service_name=..., exporter=..., endpoint=..., headers=..., basic_auth=..., export_interval=..., export_timeout=..., resource_attributes=..., shutdown_timeout=..., env_load=...)",
       ".from_config": "(config, *, name=...)"
     },
     "MetricsConfig": {
@@ -406,8 +407,8 @@
       "()": "(*, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=..., kind=...)"
     },
     "Bulkhead": {
-      "()": "(name, *, max_concurrent=..., max_wait=..., max_workers=..., uses=..., config=..., env_load=...)",
-      ".from_config": "(name, config)"
+      "()": "(name, *, max_concurrent=..., max_wait=..., max_workers=..., uses=..., env_load=...)",
+      ".from_config": "(name, config, *, uses=...)"
     },
     "BulkheadConfig": {
       "()": "(*, max_concurrent=..., max_wait=..., max_workers=...)"
@@ -457,7 +458,7 @@
       "()": "(*, kind=..., base_delay=..., max_delay=..., jitter=...)"
     },
     "Fallback": {
-      "()": "(name, *, when=..., default=..., factory=..., config=..., env_load=...)",
+      "()": "(name, *, when=..., default=..., factory=..., env_load=...)",
       ".from_config": "(name, config)"
     },
     "FallbackConfig": {
@@ -550,7 +551,7 @@
       "()": "(error)"
     },
     "Retry": {
-      "()": "(name, backoff=..., *, when=..., attempts=..., max_seconds=..., config=..., env_load=...)",
+      "()": "(name, backoff=..., *, when=..., attempts=..., max_seconds=..., env_load=...)",
       ".constant": "(name, *, when, attempts=..., max_seconds=..., delay=..., env_load=...)",
       ".exponential": "(name, *, when, attempts=..., max_seconds=..., base_delay=..., max_delay=..., jitter=..., env_load=...)",
       ".from_config": "(name, config)"
@@ -574,7 +575,7 @@
       "()": "(*, provider=..., env_prefix=..., prefix=..., table_name=..., auto_migrate=...)"
     },
     "Shield": {
-      "()": "(name, config=..., *, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=..., env_load=..., time_source=..., random_source=...)",
+      "()": "(name, *, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=..., env_load=..., time_source=..., random_source=...)",
       ".api": "(name, *, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=...)",
       ".from_config": "(name, config)",
       ".internal": "(name, *, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=...)",
@@ -590,7 +591,7 @@
       "()": "(*, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=..., kind=...)"
     },
     "Timeout": {
-      "()": "(name, *, seconds=..., config=..., env_load=...)",
+      "()": "(name, *, seconds=..., env_load=...)",
       ".from_config": "(name, config)"
     },
     "TimeoutConfig": {
@@ -685,7 +686,7 @@
       "()": "(*, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=..., kind=...)"
     },
     "Shield": {
-      "()": "(name, config=..., *, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=..., env_load=..., time_source=..., random_source=...)",
+      "()": "(name, *, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=..., env_load=..., time_source=..., random_source=...)",
       ".api": "(name, *, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=...)",
       ".from_config": "(name, config)",
       ".internal": "(name, *, timeout_errors=..., max_rate=..., cache=..., cache_key=..., fallback=...)",
@@ -771,7 +772,7 @@
   },
   "grelmicro.trace": {
     "Trace": {
-      "()": "(*, name=..., config=..., service_name=..., exporter=..., endpoint=..., headers=..., basic_auth=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., instrument=..., shutdown_timeout=..., env_load=...)",
+      "()": "(*, name=..., service_name=..., exporter=..., endpoint=..., headers=..., basic_auth=..., processor=..., sampler=..., sample_ratio=..., resource_attributes=..., instrument=..., shutdown_timeout=..., env_load=...)",
       ".from_config": "(config, *, name=...)"
     },
     "TraceConfig": {

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -86,6 +86,17 @@ class TestInit:
         with pytest.raises(ValidationError, match="ttl"):
             TTLCache(maxsize=10, ttl=-1, backend=backend)
 
+    def test_from_config(self, backend: MemoryCacheAdapter) -> None:
+        """Test that `from_config` builds a cache from a pre-built config."""
+        # Arrange
+        config = TTLCacheConfig(maxsize=50, ttl=30)
+
+        # Act
+        cache = TTLCache.from_config(config, backend=backend)
+
+        # Assert
+        assert cache.config == config
+
     def test_config_property(self, backend: MemoryCacheAdapter) -> None:
         """Test that `config` exposes the frozen `TTLCacheConfig`."""
         # Arrange / Act

--- a/tests/logging/test_component.py
+++ b/tests/logging/test_component.py
@@ -57,15 +57,15 @@ async def test_log_resolves_config_on_enter(
 
 
 async def test_log_accepts_prebuilt_config(reset_stdlib: None) -> None:  # noqa: ARG001
-    """`Log(config=...)` uses the pre-built `LogConfig` as-is."""
+    """`Log.from_config(...)` uses the pre-built `LogConfig` as-is."""
     config = LogConfig(level=LogLevelType.WARNING)
-    micro = Grelmicro(uses=[Log(config=config)])
+    micro = Grelmicro(uses=[Log.from_config(config)])
     async with micro:
         assert micro.log.config is config
 
 
-def test_log_from_config_matches_config_kwarg() -> None:
-    """`Log.from_config(cfg)` matches `Log(config=cfg)`."""
+def test_log_from_config_keeps_config_and_default_name() -> None:
+    """`Log.from_config(cfg)` keeps the config and defaults the name."""
     config = LogConfig(level=LogLevelType.WARNING)
     log = Log.from_config(config)
     assert log._explicit_config is config

--- a/tests/metrics/test_component.py
+++ b/tests/metrics/test_component.py
@@ -123,17 +123,17 @@ async def test_metrics_installs_provider_on_enter() -> None:
 
 
 async def test_metrics_accepts_prebuilt_config() -> None:
-    """`Metrics(config=...)` uses the pre-built `MetricsConfig` as-is."""
+    """`Metrics.from_config(...)` uses the pre-built `MetricsConfig` as-is."""
     config = MetricsConfig(
         exporter=MetricsExporterType.NONE, service_name="payments"
     )
-    micro = Grelmicro(uses=[Metrics(config=config)])
+    micro = Grelmicro(uses=[Metrics.from_config(config)])
     async with micro:
         assert micro.metrics.config is config
 
 
-def test_metrics_from_config_matches_config_kwarg() -> None:
-    """`Metrics.from_config(cfg)` matches `Metrics(config=cfg)`."""
+def test_metrics_from_config_keeps_config_and_default_name() -> None:
+    """`Metrics.from_config(cfg)` keeps the config and defaults the name."""
     config = MetricsConfig(
         exporter=MetricsExporterType.NONE, service_name="payments"
     )

--- a/tests/metrics/test_config.py
+++ b/tests/metrics/test_config.py
@@ -57,15 +57,6 @@ async def test_kwargs_win_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
         assert micro.metrics.config.service_name == "explicit"
 
 
-async def test_prebuilt_config_rejects_kwargs() -> None:
-    """Passing both a pre-built config and kwargs raises on enter."""
-    config = MetricsConfig(exporter=MetricsExporterType.NONE)
-    micro = Grelmicro(uses=[Metrics(config=config, service_name="x")])
-    with pytest.raises(TypeError, match="pre-built config OR"):
-        async with micro:
-            pass
-
-
 def test_endpoint_repr_redacts_embedded_credentials() -> None:
     """An endpoint carrying userinfo credentials is displayed redacted."""
     config = MetricsConfig(endpoint="https://usr:s3cret@otlp.example.com/v1")

--- a/tests/outbox/test_config.py
+++ b/tests/outbox/test_config.py
@@ -63,21 +63,23 @@ def test_kwargs_win_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_explicit_config() -> None:
     """A pre-built config is used as-is."""
-    outbox = Outbox(
+    outbox = Outbox.from_config(
         MemoryOutboxAdapter(),
-        config=OutboxConfig(max_attempts=CONFIG_ATTEMPTS),
+        OutboxConfig(max_attempts=CONFIG_ATTEMPTS),
     )
     assert outbox.config.max_attempts == CONFIG_ATTEMPTS
 
 
-def test_explicit_config_and_kwargs_conflict() -> None:
-    """Passing both a config and kwargs raises."""
-    with pytest.raises(TypeError):
-        Outbox(
-            MemoryOutboxAdapter(),
-            config=OutboxConfig(),
-            max_attempts=KWARG_ATTEMPTS,
-        )
+def test_from_config_ignores_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`from_config` takes the config as-is, so env never fills a field."""
+    monkeypatch.setenv("GREL_OUTBOX_MAX_ATTEMPTS", str(ENV_ATTEMPTS))
+    outbox = Outbox.from_config(
+        MemoryOutboxAdapter(),
+        OutboxConfig(max_attempts=CONFIG_ATTEMPTS),
+    )
+    assert outbox.config.max_attempts == CONFIG_ATTEMPTS
 
 
 def test_invalid_value_raises() -> None:

--- a/tests/resilience/shield/test_env.py
+++ b/tests/resilience/shield/test_env.py
@@ -109,21 +109,12 @@ def test_constructor_with_max_rate_no_env() -> None:
     assert s.config.max_rate == 3.0  # noqa: PLR2004
 
 
-def test_constructor_rejects_config_and_kwargs_together() -> None:
-    """Passing `config=` with kwargs raises."""
-    from grelmicro.resilience import ApiShieldConfig  # noqa: PLC0415
-
-    cfg = ApiShieldConfig(max_rate=2.0)
-    with pytest.raises(TypeError, match="pre-built"):
-        Shield("dup", config=cfg, max_rate=3.0)
-
-
-def test_constructor_accepts_config() -> None:
+def test_from_config_accepts_config() -> None:
     """The pre-built config path works."""
     from grelmicro.resilience import ApiShieldConfig  # noqa: PLC0415
 
     cfg = ApiShieldConfig(max_rate=2.0)
-    s = Shield("dup", config=cfg)
+    s = Shield.from_config("dup", cfg)
     assert s.config is cfg
 
 

--- a/tests/resilience/test_fallback.py
+++ b/tests/resilience/test_fallback.py
@@ -479,13 +479,3 @@ def test_class_form_decorator_reraises_unmatched_sync() -> None:
 
     with pytest.raises(KeyError, match="nope"):
         fn()
-
-
-# --- Mutual exclusion: pre-built config + kwargs --------------------------
-
-
-def test_config_and_kwargs_are_mutually_exclusive() -> None:
-    """Passing both `config=` and per-field kwargs raises `TypeError`."""
-    cfg = FallbackConfig(when=Match.exception(ValueError), default=1)
-    with pytest.raises(TypeError, match="pre-built config OR"):
-        Fallback("x", when=ValueError, config=cfg)

--- a/tests/resilience/test_fallback_mutants.py
+++ b/tests/resilience/test_fallback_mutants.py
@@ -16,13 +16,6 @@ from grelmicro.resilience import (
 )
 
 
-def test_config_and_default_only_kwarg_conflict() -> None:
-    """Passing `config=` together with only `default=` is rejected."""
-    cfg = FallbackConfig(when=Match.exception(ValueError), default=1)
-    with pytest.raises(TypeError, match="not both"):
-        Fallback("conflict", default=2, config=cfg)
-
-
 def test_from_config_keeps_the_name() -> None:
     """`Fallback.from_config` keeps the given name, not None."""
     cfg = FallbackConfig(when=Match.exception(ValueError), default=1)

--- a/tests/resilience/test_timeout.py
+++ b/tests/resilience/test_timeout.py
@@ -63,16 +63,6 @@ def test_constructs_from_config() -> None:
     assert policy.config is cfg
 
 
-def test_rejects_seconds_and_config_together() -> None:
-    """Mixing kwargs with a pre-built config is rejected."""
-    with pytest.raises(TypeError):
-        Timeout(
-            "db",
-            seconds=1.0,
-            config=TimeoutConfig(seconds=2.0),
-        )
-
-
 def test_requires_seconds_when_env_off() -> None:
     """No kwargs and no env path means construction fails."""
     with pytest.raises(ValidationError):

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -105,17 +105,17 @@ async def test_trace_installs_provider_on_enter() -> None:
 
 
 async def test_trace_accepts_prebuilt_config() -> None:
-    """`Trace(config=...)` uses the pre-built `TraceConfig` as-is."""
+    """`Trace.from_config(...)` uses the pre-built `TraceConfig` as-is."""
     config = TraceConfig(
         exporter=TraceExporterType.NONE, service_name="payments"
     )
-    micro = Grelmicro(uses=[Trace(config=config)])
+    micro = Grelmicro(uses=[Trace.from_config(config)])
     async with micro:
         assert micro.trace.config is config
 
 
-def test_trace_from_config_matches_config_kwarg() -> None:
-    """`Trace.from_config(cfg)` matches `Trace(config=cfg)`."""
+def test_trace_from_config_keeps_config_and_default_name() -> None:
+    """`Trace.from_config(cfg)` keeps the config and defaults the name."""
     config = TraceConfig(
         exporter=TraceExporterType.NONE, service_name="payments"
     )


### PR DESCRIPTION
## Why

Passing a pre-built config had four different shapes across the library, and two of them were the same thing wearing different names. Verified before changing anything:

```
GREL_ENV_LOAD=1 GREL_BULKHEAD_DB_MAX_WAIT=77

Bulkhead("db", max_concurrent=3)                             -> max_wait=77.0   (env fills the rest)
Bulkhead("db", config=BulkheadConfig(max_concurrent=3))      -> max_wait=None
Bulkhead.from_config("db", BulkheadConfig(max_concurrent=3)) -> max_wait=None
```

`config=` and `from_config` were byte-identical, and `from_config` was literally `return cls(name, config=config)`. Two doors to one room, while the kwarg path next to them looks the same at the call site and behaves differently.

`docs/advanced/config.md` had a section titled "The hazard in step 2" explaining the split to users. The docs were apologising for the API.

## What changed

`from_config` is now the only door for a pre-built config, on every primitive that has a config class.

**Breaking.** `config=` removed from `Timeout`, `Retry`, `Fallback`, `Bulkhead`, `Log`, `Metrics`, `Trace`, `Shield`, and `Outbox`. The contract is now readable at the call site:

- `from_config(...)` takes the config as-is, skips env, stays static.
- The constructor is the live lane, where env fills what you left out.

**Added.** `Outbox.from_config` and `TTLCache.from_config` complete the path, and `Bulkhead.from_config` gained `uses=`, which the declarative path could not do at all before.

Mechanism is the pattern `Lock` and `Shield` already used: `cls.__new__(cls)` plus a private `_setup()`. A private `_config=` parameter was rejected because `_symbol_surface` in `tests/test_public_api.py` snapshots parameters (it filters underscore-prefixed *attributes*, not parameters), so it would have leaked into the public surface.

## Fallout worth reviewing

Removing the parameter made the runtime "pre-built config OR kwargs, not both" guard unreachable in `Fallback._resolve_config` and `Shield._build_config`. Both are deleted, along with four tests asserting a `TypeError` that can no longer happen. Three of those tests were passing for the wrong reason: they caught the unexpected-keyword `TypeError` instead of the guard's. `ty` found the last one, pytest did not.

`Log` was missing an `Any` import that only surfaced once `_setup` was extracted.

## Consistency check

An audit over every public class with a matching `*Config` now reports two remaining, both deliberate:

```
CircuitBreaker     still exposes a `config` parameter
RateLimiter        still exposes a `config` parameter
```

Those two are algorithm selectors rather than settings carriers, so they keep a positional config. Renaming that parameter to `algorithm` is the next change, not this one.

## Verification

- 4492 tests pass, coverage 100%, gate held
- mypy and ty clean over the whole tree
- ruff check and format clean
- `mkdocs build --strict` clean
- Public API snapshot diff is exactly the intended signature changes

Also included: a docs-only first commit stating publish/subscribe as a non-goal and showing the FastStream pairing in the outbox handler.

https://claude.ai/code/session_01Heu2pjcxZkz3Gm81Paif67