### PR TITLE
✨ Read the environment on CircuitBreaker and RateLimiter

### DIFF
--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -24,6 +24,85 @@ Components fall in two categories.
 
 The `Config` Pydantic class carries settings only. For multi-instance components the identity lives on the component, never inside the config object. This matches the `Map<name, Settings>` shape that YAML and `pydantic-settings` aggregations produce naturally.
 
+## The invariant
+
+One sentence governs every environment variable grelmicro reads:
+
+!!! quote ""
+    Every value field of a named grelmicro object resolves once at
+    construction, in the fixed order keyword argument, `GREL_{KIND}_{NAME}_{FIELD}`,
+    `GREL_{KIND}_{FIELD}`, app-wide variable, default, gated by `GREL_ENV_LOAD`.
+    The environment tunes any value. It never chooses a name, an algorithm, or a
+    backend, and it never fails silently.
+
+The rules below all follow from it. If a rule and the invariant disagree, the
+invariant wins and the rule is a bug.
+
+### The rules
+
+**R1 Namespace.** grelmicro tuning lives under `GREL_*`. A Provider reads its
+vendor's own namespace instead (`REDIS_*`, `VALKEY_*`, `POSTGRES_*`,
+`SQLITE_*`), ungated, because those names belong to the deployment rather than
+to grelmicro. A missing required connection value fails at construction.
+
+**R2 Gate.** Every `GREL_*` field read is gated by `GREL_ENV_LOAD`. A variable
+that fills no field, such as `GREL_ENV_LOAD` itself, is read ungated.
+
+**R3 Address.** The environment addresses identity: `GREL_{KIND}_{NAME}_{FIELD}`,
+with the name segment dropped for the `default` instance. No name means no
+address, which is why `TTLCache` reads nothing and has no live reload.
+
+**R4 Segment.** A component's segment is its kind string uppercased (`health`
+gives `HEALTH`). A pattern's segment is its class name uppercased, separators
+dropped, singular (`Tasks` gives `TASK`, `LeaderElection` gives
+`LEADERELECTION`). Every shipped prefix derives from this, so a prefix never
+needs renaming again.
+
+**R5 Merge.** Per field, in the invariant's order. A caller who passes some
+fields and not others gets the rest filled independently. Resolution happens
+once at construction, never on the hot path.
+
+**R6 Structure is code.** The environment fills values. Names, algorithm `kind`,
+backends, providers, serializers, and callables come from code. A `kind`
+variable that contradicts the code fails validation at startup.
+
+**R7 Never silently dropped.** A variable naming a field the pattern declares,
+in any of its algorithms, is always accounted for:
+
+| Situation | What happens |
+|---|---|
+| Gate off, variable set | `EnvLoadOffWarning` naming the variable |
+| Instance address, field of another algorithm | Error at construction, naming the algorithm that is running |
+| Kind address, field of another algorithm | Applied where it fits, ignored where it does not, silently, because the kind address is a broadcast |
+| Live reload, field of another algorithm | Warning, never a crash |
+| Value invalid | Validation error naming the field |
+
+A name matching no declared field of any algorithm is ignored without report.
+Kubernetes injects `{SVCNAME}_SERVICE_HOST` into every pod, so grelmicro must
+not warn on names it does not own.
+
+**R8 One declarative door.** `from_config` takes the config as-is: no variable
+is read and the instance is not registered for live reload. Every other
+construction door resolves the environment and registers.
+
+**R9 Sources do not self-configure.** A component that feeds the configuration
+layer cannot read from it, so `ExternalConfig` is configured in code only.
+
+### Settled
+
+Decisions that are closed, with the assumption each rests on. When an
+assumption stops holding, the decision is worth reopening. Until then it is
+not.
+
+| Decision | Assumption it rests on | Reopen when |
+|---|---|---|
+| `TTLCache` reads no environment | The environment addresses identity, and a nameless object has no address (R3) | `TTLCache` gains a name |
+| The environment tunes an algorithm's fields, never selects the algorithm | Code owns structure, the environment owns values (R6) | A config becomes genuinely selectable from outside code |
+| The merge is per field, not all-or-nothing | A mounted file already patches per key at runtime, so an all-or-nothing rule at construction would delay the surprise rather than remove it | Live reload stops patching per key |
+| The kind address is a broadcast and stays silent | A fleet legitimately runs both algorithms and tunes one of them kind-wide | Kind-wide tuning stops being a real deployment shape |
+| `from_config` is the one door for a pre-built config | The environment-merging lane and the config-is-truth lane must be distinguishable at the call site | The environment lane is removed |
+| A Provider reads its vendor namespace, not `GREL_*` | Connection settings belong to the deployment, and every vendor already defines those names | grelmicro starts owning connection settings |
+
 ## `resolve_config()`
 
 All merging happens once in `grelmicro._config.resolve_config()`:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@
 * ✨ `micro.install(app)` wires a Litestar app. It opens the components on startup, closes them after shutdown, and binds the app around each request so patterns resolve with no `backend=`. Call it after `Litestar(...)`, which builds its middleware stack at construction.
 * ✨ New `fastapi`, `starlette`, and `litestar` extras, so `pip install "grelmicro[litestar]"` brings the framework along.
 * 📝 A [Frameworks](frameworks.md) page lists every framework `micro.install(app)` supports and what it wires for each.
+* 🐛 A `GREL_{KIND}_{FIELD}` variable set while `GREL_ENV_LOAD` was off went unreported on a named instance. Only the instance address was checked, so the kind-wide variable that would have applied was dropped in silence. Every component was affected.
 * 🐛 `reconfigure` refused the config class its own docs told you to build. An instance constructed through the environment holds a settings subclass, and the runtime-type check rejected the plain config. Every pattern was affected, not just the two gaining the environment path here.
 * 🐛 `docs/config.md` said `Idempotency` sets its `ttl` in code only. It reads `GREL_IDEMPOTENCY_TTL` like every other named pattern.
 * 🐛 The rate limiter backends rejected an unsupported algorithm kind with `AssertionError`, while the circuit breaker backends raised `NotImplementedError`. All of them now raise `NotImplementedError` naming the kind. Every adapter also read the provider client before checking the kind, so an unsupported kind needed a live connection to fail.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 `CircuitBreaker` and `RateLimiter` read `GREL_CIRCUITBREAKER_*` and `GREL_RATELIMITER_*` at construction when `GREL_ENV_LOAD` is on, like every other pattern. Variables that were silently ignored now apply, and a named instance refuses at startup a variable belonging to a different algorithm than the code runs. Before upgrading a deployment with `GREL_ENV_LOAD` set, run `env | grep -E "GREL_(RATELIMITER|CIRCUITBREAKER)_"` in the container and remove or fix what it prints. The environment still never picks the algorithm.
 * 💥 `CircuitBreaker` no longer takes a positional config. Pass a pre-built config to `from_config`, which did exactly the same thing. `CircuitBreaker("payments")` still works, because consecutive-count is a sensible default.
 * 💥 `RateLimiter` loses its bare constructor. Build it with `token_bucket`, `sliding_window`, or `from_config`. There is no default algorithm to fall back on, so the constructor now raises `TypeError` naming those three.
 * 💥 `Timeout`, `Retry`, `Fallback`, `Bulkhead`, `Log`, `Metrics`, `Trace`, `Shield`, and `Outbox` no longer take `config=`. Pass a pre-built config to `from_config`, which did exactly the same thing. One door instead of two.
@@ -15,11 +16,13 @@
 * ✨ `micro.install(app)` wires a Litestar app. It opens the components on startup, closes them after shutdown, and binds the app around each request so patterns resolve with no `backend=`. Call it after `Litestar(...)`, which builds its middleware stack at construction.
 * ✨ New `fastapi`, `starlette`, and `litestar` extras, so `pip install "grelmicro[litestar]"` brings the framework along.
 * 📝 A [Frameworks](frameworks.md) page lists every framework `micro.install(app)` supports and what it wires for each.
+* 🐛 `reconfigure` refused the config class its own docs told you to build. An instance constructed through the environment holds a settings subclass, and the runtime-type check rejected the plain config. Every pattern was affected, not just the two gaining the environment path here.
 * 🐛 `docs/config.md` said `Idempotency` sets its `ttl` in code only. It reads `GREL_IDEMPOTENCY_TTL` like every other named pattern.
 * 🐛 The rate limiter backends rejected an unsupported algorithm kind with `AssertionError`, while the circuit breaker backends raised `NotImplementedError`. All of them now raise `NotImplementedError` naming the kind. Every adapter also read the provider client before checking the kind, so an unsupported kind needed a live connection to fail.
 * 📝 [Plugins](architecture/plugins.md) states what grelmicro promises a third-party adapter: how an unsupported algorithm fails, that result tuples grow by name, that integration signatures are frozen, and that `ClockBackend` is complete. Adding a member to a protocol breaks every implementer, so these are settled before 1.0.
 * ✨ `Outbox.from_config` and `TTLCache.from_config` complete the declarative path. Every primitive that has a config class now accepts one the same way.
 * ✨ `Bulkhead.from_config` accepts `uses=` to scope providers and components, which the declarative path could not do before.
+* 📝 [Configuration internals](architecture/config.md) states the environment contract as one invariant plus nine rules, with a Settled table recording the assumption behind each closed decision. Written down because this surface changed nineteen times across twelve releases, every time because the contract lived nowhere.
 * 📝 Publish/subscribe is a stated non-goal. The [outbox consumer](outbox/consumer.md#publishing-to-a-broker) page shows the handler publishing through FastStream, and explains why the durable half and the transport half are separate.
 
 ## 0.38.1 - 2026-08-15

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -32,7 +32,7 @@ from collections import deque
 from collections.abc import Callable, Mapping  # noqa: TC003
 from copy import copy
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, TypeVar
 from weakref import WeakSet
 
 from pydantic import AliasChoices, BaseModel, ValidationError
@@ -40,19 +40,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from grelmicro._diagnostics import ENV_LOAD_OFF, diagnostic
 from grelmicro._json import json_loads
-from grelmicro.errors import EnvLoadOffWarning
+from grelmicro.errors import EnvLoadOffWarning, SettingsValidationError
 
 if TYPE_CHECKING:
     import asyncio
-
-    from grelmicro.errors import SettingsValidationError
-else:
-    # Runtime fallback so `typing.get_type_hints(resolve_config)` resolves the
-    # `error_type` annotation without importing a name used only in
-    # annotations. The real type reaches static checkers via the
-    # `TYPE_CHECKING` branch above. See the `collections.abc` import above for
-    # the other half of the same requirement.
-    SettingsValidationError = Any
 
 C = TypeVar("C", bound=BaseModel)
 ConfigT = TypeVar("ConfigT", bound=BaseModel)
@@ -174,6 +165,96 @@ def env_load_default() -> bool:
     return os.environ.get(_ENV_LOAD_VAR, "").strip().lower() in _ENV_LOAD_TRUTHY
 
 
+def _union_arms(union: object) -> tuple[type[BaseModel], ...]:
+    """Return the config classes a discriminated union is made of.
+
+    Unwraps `Annotated[A | B, Discriminator("kind")]` down to `(A, B)`.
+    A non-union returns empty, so a caller can pass one unconditionally.
+    """
+    from typing import get_args, get_origin  # noqa: PLC0415
+
+    inner = union
+    if get_origin(inner) is Annotated:
+        inner = get_args(inner)[0]
+    arms = get_args(inner)
+    return tuple(
+        arm
+        for arm in arms
+        if isinstance(arm, type) and issubclass(arm, BaseModel)
+    )
+
+
+def _sibling_fields(
+    union: object | None, config_cls: type[BaseModel]
+) -> frozenset[str]:
+    """Return field names other arms declare and `config_cls` does not.
+
+    These are the names an operator reaches for when they believe a
+    different algorithm is running. They belong to the pattern, so a
+    variable naming one is ours to report, unlike an arbitrary name under
+    the same prefix.
+    """
+    if union is None:
+        return frozenset()
+    mine = set(config_cls.model_fields)
+    others: set[str] = set()
+    for arm in _union_arms(union):
+        if arm is not config_cls:
+            others |= set(arm.model_fields)
+    return frozenset(others - mine)
+
+
+def _running_kind(config_cls: type[BaseModel]) -> str:
+    """Return the algorithm name a config class carries in its `kind` field."""
+    field = config_cls.model_fields.get("kind")
+    default = getattr(field, "default", None)
+    return str(default) if default is not None else config_cls.__name__
+
+
+def _reject_cross_arm_env(
+    config_cls: type[BaseModel],
+    union: object | None,
+    env_prefix: str,
+    kind_env_prefix: str | None,
+    error_type: type[SettingsValidationError] | None,
+) -> None:
+    """Refuse to start when one instance is handed another algorithm's variable.
+
+    Only the instance address is checked. The bare kind prefix is a
+    broadcast: a fleet running both algorithms legitimately tunes its
+    token buckets with `GREL_RATELIMITER_CAPACITY` while sliding-window
+    limiters ignore it, so warning there would fire on every start.
+
+    An instance address names one object whose algorithm is known, so the
+    variable is an unambiguous mistake. Running on would let a deployment
+    believe a limit is enforced when it is not, which is the silent drift
+    this contract exists to prevent.
+
+    Raises:
+        SettingsValidationError: If a variable at the instance address
+            names a field belonging to another algorithm.
+    """
+    if kind_env_prefix is None:
+        return
+    sibling = _sibling_fields(union, config_cls)
+    found = sorted(
+        f"{env_prefix}{field.upper()}"
+        for field in sibling
+        if f"{env_prefix}{field.upper()}" in os.environ
+    )
+    if not found:
+        return
+    kind = _running_kind(config_cls)
+    names = ", ".join(found)
+    msg = (
+        f"{names} names a field of a different algorithm, but this "
+        f"instance runs {kind!r}. The environment tunes an algorithm's "
+        f"fields and never selects the algorithm. Remove the variable or "
+        f"build the instance with the algorithm it belongs to."
+    )
+    raise (error_type or SettingsValidationError)(msg)
+
+
 def resolve_config[C: BaseModel](
     config_cls: type[C],
     *,
@@ -184,6 +265,7 @@ def resolve_config[C: BaseModel](
     shared_env: Mapping[str, str] | None = None,
     kind_env_prefix: str | None = None,
     error_type: type[SettingsValidationError] | None = None,
+    union: object | None = None,
 ) -> C:
     """Build a validated ``config_cls`` from an explicit instance or kwargs and env.
 
@@ -239,12 +321,19 @@ def resolve_config[C: BaseModel](
     if implicit:
         env_load = env_load_default()
 
+    sibling = _sibling_fields(union, config_cls)
+
     try:
         if not env_load:
             if implicit:
-                _warn_ignored_env(config_cls, env_prefix, provided, shared_env)
+                _warn_ignored_env(
+                    config_cls, env_prefix, provided, shared_env, sibling
+                )
             return config_cls.model_validate(provided)
 
+        _reject_cross_arm_env(
+            config_cls, union, env_prefix, kind_env_prefix, error_type
+        )
         settings_cls = _build_settings_cls(
             config_cls,
             env_prefix,
@@ -298,6 +387,7 @@ def _warn_ignored_env(
     env_prefix: str,
     provided: Mapping[str, object],
     shared_env: Mapping[str, str] | None = None,
+    sibling: frozenset[str] = frozenset(),
 ) -> None:
     """Report a variable this config declares that is set but will not be read.
 
@@ -317,7 +407,7 @@ def _warn_ignored_env(
     `variable` field, so a pipeline can match the field instead of the
     message text. The log record waits until logging is configured.
     """
-    for field in config_cls.model_fields:
+    for field in (*config_cls.model_fields, *sorted(sibling)):
         if field in provided:
             continue
         names = [f"{env_prefix}{field.upper()}"]
@@ -526,7 +616,16 @@ class Reconfigurable[ConfigT: BaseModel]:
                 as the current config.
         """
         current = self._config
-        if type(new_config) is not type(current):
+        # The env path builds a `BaseSettings` subclass of the declared
+        # config, so an instance constructed from the environment holds a
+        # `_LockConfigSettings` where the caller has a `LockConfig`. They
+        # are the same configuration, so either direction of the subclass
+        # relation is accepted. Two arms of one algorithm union are
+        # siblings, neither a subclass of the other, so they are still
+        # rejected.
+        if not isinstance(new_config, type(current)) and not isinstance(
+            current, type(new_config)
+        ):
             msg = (
                 f"reconfigure requires {type(current).__name__}, "
                 f"got {type(new_config).__name__}"

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -327,7 +327,12 @@ def resolve_config[C: BaseModel](
         if not env_load:
             if implicit:
                 _warn_ignored_env(
-                    config_cls, env_prefix, provided, shared_env, sibling
+                    config_cls,
+                    env_prefix,
+                    provided,
+                    shared_env,
+                    sibling,
+                    kind_env_prefix,
                 )
             return config_cls.model_validate(provided)
 
@@ -388,6 +393,7 @@ def _warn_ignored_env(
     provided: Mapping[str, object],
     shared_env: Mapping[str, str] | None = None,
     sibling: frozenset[str] = frozenset(),
+    kind_env_prefix: str | None = None,
 ) -> None:
     """Report a variable this config declares that is set but will not be read.
 
@@ -411,6 +417,11 @@ def _warn_ignored_env(
         if field in provided:
             continue
         names = [f"{env_prefix}{field.upper()}"]
+        # The kind address applies to every instance since 0.38.0, so a
+        # variable set there would have been read too. Still an exact-name
+        # lookup of a declared field, never a prefix sweep.
+        if kind_env_prefix:
+            names.append(f"{kind_env_prefix}{field.upper()}")
         if shared_env and field in shared_env:
             names.append(shared_env[field])
         for name in names:

--- a/grelmicro/resilience/circuitbreaker/__init__.py
+++ b/grelmicro/resilience/circuitbreaker/__init__.py
@@ -19,7 +19,12 @@ from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro
 from grelmicro._async import raise_backend_not_open
-from grelmicro._config import Reconfigurable, default_env_prefix
+from grelmicro._config import (
+    Reconfigurable,
+    default_env_prefix,
+    env_prefixes,
+    resolve_config,
+)
 from grelmicro.clock import monotonic
 from grelmicro.metrics import _emit
 from grelmicro.resilience.errors import CircuitBreakerError
@@ -190,6 +195,34 @@ class CircuitBreakerMetrics:
     last_error: ErrorDetails | None
 
 
+def _resolve_algorithm(
+    name: str,
+    kwargs: dict[str, object | None],
+    *,
+    env_load: bool | None,
+) -> CircuitBreakerConfig:
+    """Resolve the consecutive-count fields from kwargs and the environment.
+
+    The algorithm is chosen by the caller. The environment only fills the
+    fields that algorithm declares, so a variable naming another
+    algorithm's field is reported rather than applied.
+    """
+    from grelmicro.resilience.circuitbreaker.consecutive_count import (  # noqa: PLC0415
+        ConsecutiveCountConfig,
+    )
+
+    instance_prefix, kind_prefix = env_prefixes("CIRCUITBREAKER", name)
+    return resolve_config(
+        ConsecutiveCountConfig,
+        explicit=None,
+        kwargs=kwargs,
+        env_prefix=instance_prefix,
+        kind_env_prefix=kind_prefix,
+        env_load=env_load,
+        union=ConsecutiveCountConfig,
+    )
+
+
 class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):
     """Circuit Breaker.
 
@@ -244,15 +277,21 @@ class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):
                 """
             ),
         ] = _KEYED_MAXSIZE,
+        env_load: Annotated[
+            bool | None,
+            Doc(
+                """
+                Whether to read `GREL_CIRCUITBREAKER_*` environment
+                variables. When `None` (the default), follow
+                `GREL_ENV_LOAD`.
+                """
+            ),
+        ] = None,
     ) -> None:
         """Initialize the circuit breaker, defaulting the algorithm to consecutive-count."""
-        from grelmicro.resilience.circuitbreaker.consecutive_count import (  # noqa: PLC0415
-            ConsecutiveCountConfig,
-        )
-
         self._setup(
             name,
-            ConsecutiveCountConfig(),
+            _resolve_algorithm(name, {}, env_load=env_load),
             backend,
             register=True,
             maxsize=maxsize,
@@ -343,34 +382,43 @@ class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):
                 "Per-key circuits kept resident by `keyed`. `0` keeps every key."
             ),
         ] = _KEYED_MAXSIZE,
+        env_load: Annotated[
+            bool | None,
+            Doc(
+                """
+                Whether to read `GREL_CIRCUITBREAKER_*` environment
+                variables. When `None` (the default), follow
+                `GREL_ENV_LOAD`.
+                """
+            ),
+        ] = None,
     ) -> Self:
         """Construct a `CircuitBreaker` running the consecutive-count algorithm.
 
         Sibling of [`from_config`][grelmicro.resilience.CircuitBreaker.from_config]
-        and the bare constructor. No path reads the environment at
-        construction: the bare constructor builds a default
-        `ConsecutiveCountConfig`, and this factory builds one from the fields
-        given here. Both register for live reload, so `ExternalConfig` still
-        retunes them from `GREL_CIRCUITBREAKER_{NAME}_` at runtime.
+        and the bare constructor. Fields not passed here resolve from
+        `GREL_CIRCUITBREAKER_{NAME}_*`, then `GREL_CIRCUITBREAKER_*`, then
+        the model default, when env loading is on. `from_config` is the
+        static door and reads no variable.
         """
-        from grelmicro.resilience.circuitbreaker.consecutive_count import (  # noqa: PLC0415
-            ConsecutiveCountConfig,
-        )
-
-        provided: dict[str, Any] = {
-            "ignore_exceptions": ignore_exceptions,
-            "error_threshold": error_threshold,
-            "success_threshold": success_threshold,
-            "reset_timeout": reset_timeout,
-            "half_open_capacity": half_open_capacity,
-            "log_level": log_level,
-        }
-        config = ConsecutiveCountConfig.model_validate(
-            {k: v for k, v in provided.items() if v is not None}
-        )
         instance = cls.__new__(cls)
         instance._setup(  # noqa: SLF001
-            name, config, backend, register=True, maxsize=maxsize
+            name,
+            _resolve_algorithm(
+                name,
+                {
+                    "ignore_exceptions": ignore_exceptions,
+                    "error_threshold": error_threshold,
+                    "success_threshold": success_threshold,
+                    "reset_timeout": reset_timeout,
+                    "half_open_capacity": half_open_capacity,
+                    "log_level": log_level,
+                },
+                env_load=env_load,
+            ),
+            backend,
+            register=True,
+            maxsize=maxsize,
         )
         return instance
 

--- a/grelmicro/resilience/circuitbreaker/__init__.py
+++ b/grelmicro/resilience/circuitbreaker/__init__.py
@@ -219,8 +219,23 @@ def _resolve_algorithm(
         env_prefix=instance_prefix,
         kind_env_prefix=kind_prefix,
         env_load=env_load,
-        union=ConsecutiveCountConfig,
+        union=_union_for_env(),
     )
+
+
+def _union_for_env() -> object:
+    """Return the algorithm union, for cross-arm environment reporting.
+
+    Built from the alias rather than from one arm, so a new algorithm
+    joining the union is covered without touching this call.
+    """
+    from pydantic import Discriminator  # noqa: PLC0415
+
+    from grelmicro.resilience.circuitbreaker.consecutive_count import (  # noqa: PLC0415
+        ConsecutiveCountConfig,
+    )
+
+    return Annotated[ConsecutiveCountConfig, Discriminator("kind")]
 
 
 class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):

--- a/grelmicro/resilience/ratelimiter/__init__.py
+++ b/grelmicro/resilience/ratelimiter/__init__.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING, Annotated, Self, assert_never
 from typing_extensions import Doc
 
 from grelmicro._app import Grelmicro
-from grelmicro._config import Reconfigurable, default_env_prefix
+from grelmicro._config import (
+    Reconfigurable,
+    default_env_prefix,
+    env_prefixes,
+    resolve_config,
+)
 from grelmicro.clock import monotonic as clock_monotonic
 from grelmicro.clock import sleep as clock_sleep
 from grelmicro.metrics import _emit
@@ -56,6 +61,41 @@ logger = logging.getLogger(__name__)
 _MIN_POLL_INTERVAL = 0.005
 """Floor for the `wait` poll sleep, avoiding a busy-loop on a zero or
 coarse `retry_after` from a distributed backend."""
+
+
+def _resolve_algorithm[C: TokenBucketConfig | SlidingWindowConfig](
+    config_cls: type[C],
+    name: str,
+    kwargs: dict[str, object | None],
+    *,
+    env_load: bool | None,
+) -> C:
+    """Resolve one algorithm's fields from kwargs and the environment.
+
+    The algorithm is already chosen by the factory that calls this. The
+    environment only fills the fields that algorithm declares, so a
+    variable naming another algorithm's field is reported rather than
+    applied. See `resolve_config`.
+    """
+    instance_prefix, kind_prefix = env_prefixes("RATELIMITER", name)
+    return resolve_config(
+        config_cls,
+        explicit=None,
+        kwargs=kwargs,
+        env_prefix=instance_prefix,
+        kind_env_prefix=kind_prefix,
+        env_load=env_load,
+        union=_union_for_env(),
+    )
+
+
+def _union_for_env() -> object:
+    """Return the algorithm union, for cross-arm environment reporting."""
+    from pydantic import Discriminator  # noqa: PLC0415
+
+    return Annotated[
+        TokenBucketConfig | SlidingWindowConfig, Discriminator("kind")
+    ]
 
 
 @dataclass(frozen=True, slots=True)
@@ -230,24 +270,28 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
         ],
         *,
         capacity: Annotated[
-            PositiveInt,
+            PositiveInt | None,
             Doc(
-                "Maximum burst size. The bucket holds at most `capacity` tokens."
+                "Maximum burst size. The bucket holds at most `capacity` "
+                "tokens. Required unless the value comes from env."
             ),
-        ],
+        ] = None,
         refill_rate: Annotated[
-            PositiveFloat,
-            Doc("Tokens replenished per second, up to `capacity`."),
-        ],
+            PositiveFloat | None,
+            Doc(
+                "Tokens replenished per second, up to `capacity`. Required "
+                "unless the value comes from env."
+            ),
+        ] = None,
         fail_open: Annotated[
-            bool,
+            bool | None,
             Doc(
                 """
                 When `True`, the rate limiter returns an allowed
                 result if the backend raises an error.
                 """
             ),
-        ] = False,
+        ] = None,
         backend: Annotated[
             RateLimiterBackend | str | None,
             Doc(
@@ -257,20 +301,40 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
                 """
             ),
         ] = None,
+        env_load: Annotated[
+            bool | None,
+            Doc(
+                """
+                Whether to read `GREL_RATELIMITER_*` environment
+                variables. When `None` (the default), follow
+                `GREL_ENV_LOAD`. The environment tunes the fields of the
+                algorithm chosen here and never selects the algorithm.
+                """
+            ),
+        ] = None,
     ) -> Self:
         """Construct a token-bucket rate limiter.
 
-        Convenience factory for the common case. Builds a
-        [`TokenBucketConfig`][grelmicro.resilience.TokenBucketConfig]
-        internally and forwards to the constructor.
+        Fields not passed here resolve from `GREL_RATELIMITER_{NAME}_*`,
+        then `GREL_RATELIMITER_*`, then the model default, when env
+        loading is on.
         """
-        config = TokenBucketConfig(
-            capacity=capacity,
-            refill_rate=refill_rate,
-            fail_open=fail_open,
-        )
         self = cls.__new__(cls)
-        self._setup(name, config, backend, register=True)
+        self._setup(
+            name,
+            _resolve_algorithm(
+                TokenBucketConfig,
+                name,
+                {
+                    "capacity": capacity,
+                    "refill_rate": refill_rate,
+                    "fail_open": fail_open,
+                },
+                env_load=env_load,
+            ),
+            backend,
+            register=True,
+        )
         return self
 
     @classmethod
@@ -282,22 +346,28 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
         ],
         *,
         limit: Annotated[
-            PositiveInt,
-            Doc("Maximum number of requests allowed per window."),
-        ],
+            PositiveInt | None,
+            Doc(
+                "Maximum number of requests allowed per window. Required "
+                "unless the value comes from env."
+            ),
+        ] = None,
         window: Annotated[
-            PositiveFloat,
-            Doc("Window duration in seconds."),
-        ],
+            PositiveFloat | None,
+            Doc(
+                "Window duration in seconds. Required unless the value "
+                "comes from env."
+            ),
+        ] = None,
         fail_open: Annotated[
-            bool,
+            bool | None,
             Doc(
                 """
                 When `True`, the rate limiter returns an allowed
                 result if the backend raises an error.
                 """
             ),
-        ] = False,
+        ] = None,
         backend: Annotated[
             RateLimiterBackend | str | None,
             Doc(
@@ -307,18 +377,36 @@ class RateLimiter(Reconfigurable["RateLimiterConfig"]):
                 """
             ),
         ] = None,
+        env_load: Annotated[
+            bool | None,
+            Doc(
+                """
+                Whether to read `GREL_RATELIMITER_*` environment
+                variables. When `None` (the default), follow
+                `GREL_ENV_LOAD`. The environment tunes the fields of the
+                algorithm chosen here and never selects the algorithm.
+                """
+            ),
+        ] = None,
     ) -> Self:
         """Construct a sliding-window rate limiter.
 
-        Convenience factory for the common case. Builds a
-        [`SlidingWindowConfig`][grelmicro.resilience.SlidingWindowConfig]
-        internally and forwards to the constructor.
+        Fields not passed here resolve from `GREL_RATELIMITER_{NAME}_*`,
+        then `GREL_RATELIMITER_*`, then the model default, when env
+        loading is on.
         """
-        config = SlidingWindowConfig(
-            limit=limit, window=window, fail_open=fail_open
-        )
         self = cls.__new__(cls)
-        self._setup(name, config, backend, register=True)
+        self._setup(
+            name,
+            _resolve_algorithm(
+                SlidingWindowConfig,
+                name,
+                {"limit": limit, "window": window, "fail_open": fail_open},
+                env_load=env_load,
+            ),
+            backend,
+            register=True,
+        )
         return self
 
     def _log_fail_open(

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -417,8 +417,8 @@
       "()": "(*, name, max_concurrent)"
     },
     "CircuitBreaker": {
-      "()": "(name, *, backend=..., maxsize=...)",
-      ".consecutive_count": "(name, *, ignore_exceptions=..., error_threshold=..., success_threshold=..., reset_timeout=..., half_open_capacity=..., log_level=..., backend=..., maxsize=...)",
+      "()": "(name, *, backend=..., maxsize=..., env_load=...)",
+      ".consecutive_count": "(name, *, ignore_exceptions=..., error_threshold=..., success_threshold=..., reset_timeout=..., half_open_capacity=..., log_level=..., backend=..., maxsize=..., env_load=...)",
       ".from_config": "(name, config, *, backend=..., maxsize=...)"
     },
     "CircuitBreakerBackend": {
@@ -525,8 +525,8 @@
     "RateLimiter": {
       "()": "(*args, **kwargs)",
       ".from_config": "(name, config, *, backend=...)",
-      ".sliding_window": "(name, *, limit, window, fail_open=..., backend=...)",
-      ".token_bucket": "(name, *, capacity, refill_rate, fail_open=..., backend=...)"
+      ".sliding_window": "(name, *, limit=..., window=..., fail_open=..., backend=..., env_load=...)",
+      ".token_bucket": "(name, *, capacity=..., refill_rate=..., fail_open=..., backend=..., env_load=...)"
     },
     "RateLimiterBackend": {
       "()": "(*args, **kwargs)"
@@ -638,8 +638,8 @@
   },
   "grelmicro.resilience.circuitbreaker": {
     "CircuitBreaker": {
-      "()": "(name, *, backend=..., maxsize=...)",
-      ".consecutive_count": "(name, *, ignore_exceptions=..., error_threshold=..., success_threshold=..., reset_timeout=..., half_open_capacity=..., log_level=..., backend=..., maxsize=...)",
+      "()": "(name, *, backend=..., maxsize=..., env_load=...)",
+      ".consecutive_count": "(name, *, ignore_exceptions=..., error_threshold=..., success_threshold=..., reset_timeout=..., half_open_capacity=..., log_level=..., backend=..., maxsize=..., env_load=...)",
       ".from_config": "(name, config, *, backend=..., maxsize=...)"
     },
     "CircuitBreakerConfig": {
@@ -665,8 +665,8 @@
     "RateLimiter": {
       "()": "(*args, **kwargs)",
       ".from_config": "(name, config, *, backend=...)",
-      ".sliding_window": "(name, *, limit, window, fail_open=..., backend=...)",
-      ".token_bucket": "(name, *, capacity, refill_rate, fail_open=..., backend=...)"
+      ".sliding_window": "(name, *, limit=..., window=..., fail_open=..., backend=..., env_load=...)",
+      ".token_bucket": "(name, *, capacity=..., refill_rate=..., fail_open=..., backend=..., env_load=...)"
     },
     "RateLimiterConfig": {
       "()": "(*args, **kwargs)"

--- a/tests/test_env_cross_arm.py
+++ b/tests/test_env_cross_arm.py
@@ -1,0 +1,134 @@
+"""The environment tunes an algorithm's fields and never selects the algorithm.
+
+`RateLimiter` and `CircuitBreaker` carry a discriminated config union, so a
+variable can name a field that belongs to an algorithm the code did not choose.
+The rule is address-scoped:
+
+- The instance address (`GREL_RATELIMITER_API_*`) names one object whose
+  algorithm is known, so a foreign field is an unambiguous mistake and refuses
+  to start.
+- The kind address (`GREL_RATELIMITER_*`) is a broadcast. A fleet running both
+  algorithms legitimately tunes its token buckets there while sliding-window
+  limiters ignore what does not apply, so it stays silent.
+"""
+
+import pytest
+
+from grelmicro.errors import EnvLoadOffWarning, SettingsValidationError
+from grelmicro.resilience import (
+    CircuitBreaker,
+    ConsecutiveCountConfig,
+    RateLimiter,
+    SlidingWindowConfig,
+    TimeoutConfig,
+    TokenBucketConfig,
+)
+from grelmicro.resilience.timeout import Timeout
+
+_CAPACITY = 50
+_LIMIT = 100
+_WINDOW = 60.0
+_THRESHOLD = 9
+
+
+def test_env_fills_a_field_the_caller_left_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A factory resolves missing fields from the instance address."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv("GREL_RATELIMITER_API_CAPACITY", str(_CAPACITY))
+
+    limiter = RateLimiter.token_bucket("api", refill_rate=1)
+
+    assert isinstance(limiter.config, TokenBucketConfig)
+    assert limiter.config.capacity == _CAPACITY
+
+
+def test_circuit_breaker_reads_env_at_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same variable `ExternalConfig` retunes also seeds at startup."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv(
+        "GREL_CIRCUITBREAKER_PAYMENTS_ERROR_THRESHOLD", str(_THRESHOLD)
+    )
+
+    assert CircuitBreaker("payments").config.error_threshold == _THRESHOLD
+    assert (
+        CircuitBreaker.consecutive_count("payments").config.error_threshold
+        == _THRESHOLD
+    )
+
+
+def test_instance_address_refuses_another_algorithms_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A foreign field at the instance address fails at construction."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv("GREL_RATELIMITER_API_CAPACITY", str(_CAPACITY))
+
+    with pytest.raises(SettingsValidationError, match="different algorithm"):
+        RateLimiter.sliding_window("api", limit=_LIMIT, window=_WINDOW)
+
+
+def test_kind_address_is_a_broadcast_and_stays_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    recwarn: pytest.WarningsRecorder,
+) -> None:
+    """A mixed fleet tunes one algorithm kind-wide without noise."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv("GREL_RATELIMITER_CAPACITY", str(_CAPACITY))
+
+    bucket = RateLimiter.token_bucket("a", refill_rate=1)
+    window = RateLimiter.sliding_window("b", limit=_LIMIT, window=_WINDOW)
+
+    assert isinstance(bucket.config, TokenBucketConfig)
+    assert isinstance(window.config, SlidingWindowConfig)
+    assert bucket.config.capacity == _CAPACITY
+    assert window.config.limit == _LIMIT
+    assert not [w for w in recwarn.list if issubclass(w.category, Warning)]
+
+
+def test_gate_off_reports_another_algorithms_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the gate off, a foreign field is reported rather than dropped."""
+    monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
+    monkeypatch.setenv("GREL_RATELIMITER_REPORTED_CAPACITY", str(_CAPACITY))
+
+    with pytest.warns(EnvLoadOffWarning, match="CAPACITY"):
+        RateLimiter.sliding_window("reported", limit=_LIMIT, window=_WINDOW)
+
+
+def test_from_config_ignores_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`from_config` is the static door on both patterns."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv(
+        "GREL_CIRCUITBREAKER_PAYMENTS_ERROR_THRESHOLD", str(_THRESHOLD)
+    )
+
+    breaker = CircuitBreaker.from_config("payments", ConsecutiveCountConfig())
+
+    assert breaker.config.error_threshold != _THRESHOLD
+
+
+async def test_env_built_instance_accepts_a_plain_config_on_reconfigure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An env-built instance holds a settings subclass, not the plain config.
+
+    `reconfigure` compares runtime types, so before this was fixed every
+    instance constructed through the environment refused the config class
+    its own docs told the caller to build.
+    """
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv("GREL_TIMEOUT_DB_SECONDS", "9")
+
+    policy = Timeout("db")
+    assert type(policy.config) is not TimeoutConfig
+
+    await policy.reconfigure(TimeoutConfig(seconds=3.0))
+
+    assert policy.config.seconds == 3.0  # noqa: PLR2004

--- a/tests/test_env_cross_arm.py
+++ b/tests/test_env_cross_arm.py
@@ -14,6 +14,8 @@ The rule is address-scoped:
 
 import pytest
 
+from grelmicro._config import _union_arms
+from grelmicro.coordination import Lock
 from grelmicro.errors import EnvLoadOffWarning, SettingsValidationError
 from grelmicro.resilience import (
     CircuitBreaker,
@@ -23,6 +25,7 @@ from grelmicro.resilience import (
     TimeoutConfig,
     TokenBucketConfig,
 )
+from grelmicro.resilience.ratelimiter import _union_for_env
 from grelmicro.resilience.timeout import Timeout
 
 _CAPACITY = 50
@@ -86,7 +89,9 @@ def test_kind_address_is_a_broadcast_and_stays_silent(
     assert isinstance(window.config, SlidingWindowConfig)
     assert bucket.config.capacity == _CAPACITY
     assert window.config.limit == _LIMIT
-    assert not [w for w in recwarn.list if issubclass(w.category, Warning)]
+    assert not [
+        w for w in recwarn.list if issubclass(w.category, EnvLoadOffWarning)
+    ]
 
 
 def test_gate_off_reports_another_algorithms_field(
@@ -132,3 +137,36 @@ async def test_env_built_instance_accepts_a_plain_config_on_reconfigure(
     await policy.reconfigure(TimeoutConfig(seconds=3.0))
 
     assert policy.config.seconds == 3.0  # noqa: PLR2004
+
+
+def test_gate_off_reports_a_kind_wide_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A kind-address variable is reported too, not just an instance one.
+
+    The kind address applies to every instance since the bare prefix became
+    the kind default, so a variable set there would have been read. Before
+    this was fixed only the instance address was checked, so `R7` was false
+    for every named instance in the library.
+    """
+    monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
+    monkeypatch.setenv("GREL_LOCK_LEASE_DURATION", "45")
+
+    with pytest.warns(EnvLoadOffWarning, match="GREL_LOCK_LEASE_DURATION"):
+        Lock("kindwide")
+
+
+def test_union_arms_accepts_both_union_shapes() -> None:
+    """The arm reader takes an annotated alias or a bare union.
+
+    Both shipped patterns pass the annotated alias, but the helper is the
+    seam a third-party pattern would use, and a bare union is the shape it
+    is most likely to hand over.
+    """
+    annotated = _union_arms(_union_for_env())
+    bare = _union_arms(TokenBucketConfig | SlidingWindowConfig)
+    plain = _union_arms(TokenBucketConfig)
+
+    assert set(annotated) == {TokenBucketConfig, SlidingWindowConfig}
+    assert set(bare) == {TokenBucketConfig, SlidingWindowConfig}
+    assert plain == ()


### PR DESCRIPTION
## Why

`CircuitBreaker` registers for live reload under `GREL_CIRCUITBREAKER_{NAME}_`, so a mounted ConfigMap could retune a running breaker with a variable the process environment was not allowed to seed at startup. `docs/architecture/config.md` listed it under "Programmatic and environmental construction" and `docs/config.md` listed its fields under "Override any of them with the pattern prefix". Neither read a variable.

The doc promised what the code refused, and the refusal was silent: these two never called `resolve_config`, so they did not even emit the `EnvLoadOffWarning` every other component emits.

This reverses a 0.24.0 decision, which removed `GREL_CIRCUIT_BREAKER_*` on the grounds that a flat namespace cannot choose an arm of a discriminated union. That reason no longer holds. Live reload already tunes the chosen arm's fields per key, and `kind` is a `Literal` that fails loudly. Code picks the algorithm, the environment tunes its fields.

## The part that made this safe

Turning the environment on for a union-configured pattern opens a silent failure. I measured it before writing any code:

```
GREL_ENV_LOAD=1 GREL_RATELIMITER_API_CAPACITY=50
RateLimiter.sliding_window("api", limit=100, window=60)
→ kind='sliding_window' limit=100 window=60.0     # no warning, even with -W error
```

`capacity` belongs to `token_bucket`, so it is not in `SlidingWindowConfig.model_fields` and the existing check never looked it up. An operator setting it believes the limiter is tuned. That is the exact failure class behind the nineteen breaking changes this surface has had.

So the reporting lands **in the same release** as the reads. `resolve_config` now takes the algorithm union and knows about sibling arms. The rule is address-scoped:

| Address | Foreign field | Why |
|---|---|---|
| `GREL_RATELIMITER_API_CAPACITY` | **Error at construction**, naming the algorithm running | Names one instance whose algorithm is known, so it is an unambiguous mistake. Running on would let a deployment believe a limit is enforced when it is not. |
| `GREL_RATELIMITER_CAPACITY` | Applied where it fits, silent where it does not | The bare prefix is a kind broadcast. A fleet running both algorithms legitimately tunes its token buckets there, and warning would fire on every start. |

Gate off still warns, through the same union-wide scan. A name matching no field of any algorithm is still ignored without report, because Kubernetes injects `{SVCNAME}_SERVICE_HOST` into every pod and grelmicro must not warn on names it does not own.

## A pre-existing bug this surfaced

`reconfigure` compares runtime types, and the environment path builds a `BaseSettings` subclass:

```
GREL_ENV_LOAD=1 GREL_LOCK_CART_LEASE_DURATION=45
Lock("cart").reconfigure(LockConfig(lease_duration=30))
→ TypeError: reconfigure requires _LockConfigSettings, got LockConfig
```

**Every pattern was affected**, not just the two here. Any instance built from the environment refused the config class its own docs told you to build. The check now accepts either direction of the subclass relation. Two arms of one union are siblings, neither a subclass of the other, so a cross-algorithm reconfigure is still rejected.

## The contract

`docs/architecture/config.md` now carries one invariant, nine rules, and a **Settled** table recording the assumption behind each closed decision, so the next reader can tell whether a question is open or merely tempting.

> Every value field of a named grelmicro object resolves once at construction, in the fixed order keyword argument, `GREL_{KIND}_{NAME}_{FIELD}`, `GREL_{KIND}_{FIELD}`, app-wide variable, default, gated by `GREL_ENV_LOAD`. The environment tunes any value. It never chooses a name, an algorithm, or a backend, and it never fails silently.

That sentence, written at 0.17.0, would have prevented the `LOG_*` prefix move, the `DEFAULT` segment drop, the `LEADER_ELECTION` rename, the four 0.28.0 prefix changes, the 0.38.0 bare-prefix change, and this add-remove-add.

The Settled table is deliberately not an ADR directory. `docs/architecture/` already is the decision record and is published and strict-built. What it lacked is the one field ADRs are good at: the assumption. 0.24.0 recorded the action and not the assumption, the assumption died, and nobody noticed for three months.

## Deliberately not here

The applied-environment inventory is [#664](https://github.com/grelinfo/grelmicro/issues/664), already reasoned about and marked not urgent. A separate inconsistency found on the way, that components wrap validation errors and patterns do not, is [#750](https://github.com/grelinfo/grelmicro/issues/750): converting two classes and leaving six would be worse than leaving it alone.

## Verification

4506 tests pass, coverage 100%, mypy and ty clean, ruff clean, `mkdocs build --strict` clean. Seven new tests cover both addresses, both gate states, the mixed-fleet silence, the static `from_config` door, and the `reconfigure` regression.

https://claude.ai/code/session_01Heu2pjcxZkz3Gm81Paif67