### PR TITLE
🐛 Bring Shield and the memory breaker under the published contract

### DIFF
--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -66,6 +66,15 @@ once at construction, never on the hot path.
 backends, providers, serializers, and callables come from code. A `kind`
 variable that contradicts the code fails validation at startup.
 
+*Presets are values.* A variable may choose between config classes only when
+every class declares the identical field names and drives the same runtime
+code. Such a choice retunes constants and can never make a set variable start
+or stop applying. `GREL_SHIELD_{NAME}_PROFILE` qualifies: the three profiles
+share every field and feed one state machine, differing only in frozen
+constants. The moment two classes differ by a single field, the choice selects
+an algorithm and belongs to code. A test pins this, so preset status is earned
+by the field sets, never claimed.
+
 **R7 Never silently dropped.** A variable naming a field the pattern declares,
 in any of its algorithms, is always accounted for:
 
@@ -74,8 +83,13 @@ in any of its algorithms, is always accounted for:
 | Gate off, variable set | `EnvLoadOffWarning` naming the variable |
 | Instance address, field of another algorithm | Error at construction, naming the algorithm that is running |
 | Kind address, field of another algorithm | Applied where it fits, ignored where it does not, silently, because the kind address is a broadcast |
-| Live reload, field of another algorithm | Warning, never a crash |
-| Value invalid | Validation error naming the field |
+| Live reload, field of another algorithm | Skipped for that instance and counted at debug, never a crash. Key names stay out of the logs because a mounted Secret's key can itself be sensitive. A warning naming sibling fields follows with config provenance ([#664](https://github.com/grelinfo/grelmicro/issues/664)). |
+| Value invalid | Validation error naming the variable |
+
+For the default instance the instance address is the kind address, so it
+follows the broadcast row: the bare prefix cannot tell "this instance's field"
+from "every instance's field", and an ambiguous address is not an unambiguous
+mistake.
 
 A name matching no declared field of any algorithm is ignored without report.
 Kubernetes injects `{SVCNAME}_SERVICE_HOST` into every pod, so grelmicro must
@@ -101,6 +115,7 @@ not.
 | The merge is per field, not all-or-nothing | A mounted file already patches per key at runtime, so an all-or-nothing rule at construction would delay the surprise rather than remove it | Live reload stops patching per key |
 | The kind address is a broadcast and stays silent | A fleet legitimately runs both algorithms and tunes one of them kind-wide | Kind-wide tuning stops being a real deployment shape |
 | `from_config` is the one door for a pre-built config | The environment-merging lane and the config-is-truth lane must be distinguishable at the call site | The environment lane is removed |
+| `GREL_SHIELD_PROFILE` selects a preset, not an algorithm | Every profile declares the identical field names, so no variable gains or loses meaning from the choice | A profile adds or removes a field |
 | A Provider reads its vendor namespace, not `GREL_*` | Connection settings belong to the deployment, and every vendor already defines those names | grelmicro starts owning connection settings |
 
 ## `resolve_config()`

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -84,12 +84,16 @@ in any of its algorithms, is always accounted for:
 | Instance address, field of another algorithm | Error at construction, naming the algorithm that is running |
 | Kind address, field of another algorithm | Applied where it fits, ignored where it does not, silently, because the kind address is a broadcast |
 | Live reload, field of another algorithm | Skipped for that instance and counted at debug, never a crash. Key names stay out of the logs because a mounted Secret's key can itself be sensitive. A warning naming sibling fields follows with config provenance ([#664](https://github.com/grelinfo/grelmicro/issues/664)). |
-| Value invalid | Validation error naming the variable |
+| Value invalid | `SettingsValidationError` naming the variable and the reason, never the value |
 
 For the default instance the instance address is the kind address, so it
 follows the broadcast row: the bare prefix cannot tell "this instance's field"
 from "every instance's field", and an ambiguous address is not an unambiguous
 mistake.
+
+The rejected value is never echoed. A variable name is the operator's own,
+but its value can be a credential, so an error carries the name and the reason
+and stops there.
 
 A name matching no declared field of any algorithm is ignored without report.
 Kubernetes injects `{SVCNAME}_SERVICE_HOST` into every pod, so grelmicro must

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 ### Breaking
 
-* 💥 `CircuitBreaker` and `RateLimiter` read `GREL_CIRCUITBREAKER_*` and `GREL_RATELIMITER_*` at construction when `GREL_ENV_LOAD` is on, like every other pattern. Variables that were silently ignored now apply, and a named instance refuses at startup a variable belonging to a different algorithm than the code runs. Before upgrading a deployment with `GREL_ENV_LOAD` set, run `env | grep -E "GREL_(RATELIMITER|CIRCUITBREAKER)_"` in the container and remove or fix what it prints. The environment still never picks the algorithm.
+* 💥 `CircuitBreaker`, `RateLimiter`, and the `Shield` factories read `GREL_CIRCUITBREAKER_*`, `GREL_RATELIMITER_*`, and `GREL_SHIELD_*` at construction when `GREL_ENV_LOAD` is on, like every other pattern. Variables that were silently ignored now apply, and a named instance refuses at startup a variable belonging to a different algorithm than the code runs. Before upgrading a deployment with `GREL_ENV_LOAD` set, run `env | grep -E "GREL_(RATELIMITER|CIRCUITBREAKER|SHIELD)_"` in the container and remove or fix what it prints. The environment still never picks the algorithm.
 * 💥 `CircuitBreaker` no longer takes a positional config. Pass a pre-built config to `from_config`, which did exactly the same thing. `CircuitBreaker("payments")` still works, because consecutive-count is a sensible default.
 * 💥 `RateLimiter` loses its bare constructor. Build it with `token_bucket`, `sliding_window`, or `from_config`. There is no default algorithm to fall back on, so the constructor now raises `TypeError` naming those three.
 * 💥 `Timeout`, `Retry`, `Fallback`, `Bulkhead`, `Log`, `Metrics`, `Trace`, `Shield`, and `Outbox` no longer take `config=`. Pass a pre-built config to `from_config`, which did exactly the same thing. One door instead of two.
@@ -16,15 +16,20 @@
 * ✨ `micro.install(app)` wires a Litestar app. It opens the components on startup, closes them after shutdown, and binds the app around each request so patterns resolve with no `backend=`. Call it after `Litestar(...)`, which builds its middleware stack at construction.
 * ✨ New `fastapi`, `starlette`, and `litestar` extras, so `pip install "grelmicro[litestar]"` brings the framework along.
 * 📝 A [Frameworks](frameworks.md) page lists every framework `micro.install(app)` supports and what it wires for each.
-* 🐛 A `GREL_{KIND}_{FIELD}` variable set while `GREL_ENV_LOAD` was off went unreported on a named instance. Only the instance address was checked, so the kind-wide variable that would have applied was dropped in silence. Every component was affected.
-* 🐛 `reconfigure` refused the config class its own docs told you to build. An instance constructed through the environment holds a settings subclass, and the runtime-type check rejected the plain config. Every pattern was affected, not just the two gaining the environment path here.
-* 🐛 `docs/config.md` said `Idempotency` sets its `ttl` in code only. It reads `GREL_IDEMPOTENCY_TTL` like every other named pattern.
-* 🐛 The rate limiter backends rejected an unsupported algorithm kind with `AssertionError`, while the circuit breaker backends raised `NotImplementedError`. All of them now raise `NotImplementedError` naming the kind. Every adapter also read the provider client before checking the kind, so an unsupported kind needed a live connection to fail.
 * 📝 [Plugins](architecture/plugins.md) states what grelmicro promises a third-party adapter: how an unsupported algorithm fails, that result tuples grow by name, that integration signatures are frozen, and that `ClockBackend` is complete. Adding a member to a protocol breaks every implementer, so these are settled before 1.0.
 * ✨ `Outbox.from_config` and `TTLCache.from_config` complete the declarative path. Every primitive that has a config class now accepts one the same way.
 * ✨ `Bulkhead.from_config` accepts `uses=` to scope providers and components, which the declarative path could not do before.
 * 📝 [Configuration internals](architecture/config.md) states the environment contract as one invariant plus nine rules, with a Settled table recording the assumption behind each closed decision. Written down because this surface changed nineteen times across twelve releases, every time because the contract lived nowhere.
 * 📝 Publish/subscribe is a stated non-goal. The [outbox consumer](outbox/consumer.md#publishing-to-a-broker) page shows the handler publishing through FastStream, and explains why the durable half and the transport half are separate.
+
+### Fixed
+
+* 🐛 `MemoryCircuitBreakerAdapter.bind` ran any algorithm as consecutive-count instead of refusing the ones it does not implement. The three other adapters already refused.
+* 🐛 The `Shield` factories ignored the environment while the bare constructor read it, and neither reported a variable set with the gate off. `Shield.slow("x")` now resolves values from the environment with the preset pinned by code.
+* 🐛 A `GREL_{KIND}_{FIELD}` variable set while `GREL_ENV_LOAD` was off went unreported on a named instance. Only the instance address was checked, so the kind-wide variable that would have applied was dropped in silence. Every component was affected.
+* 🐛 `reconfigure` refused the config class its own docs told you to build. An instance constructed through the environment holds a settings subclass, and the runtime-type check rejected the plain config. Every pattern was affected, not just the two gaining the environment path here.
+* 🐛 `docs/config.md` said `Idempotency` sets its `ttl` in code only. It reads `GREL_IDEMPOTENCY_TTL` like every other named pattern.
+* 🐛 The rate limiter backends rejected an unsupported algorithm kind with `AssertionError`, while the circuit breaker backends raised `NotImplementedError`. All of them now raise `NotImplementedError` naming the kind. Every adapter also read the provider client before checking the kind, so an unsupported kind needed a live connection to fail.
 
 ## 0.38.1 - 2026-08-15
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 
+* 💥 Every configuration path raises `SettingsValidationError` for a bad value. The patterns used to let the raw `pydantic.ValidationError` through, which carries `input_value` and so echoed a rejected environment value into the traceback. Catch `SettingsValidationError`, or `ValueError`, which both it and the pydantic error already are.
 * 💥 `CircuitBreaker`, `RateLimiter`, and the `Shield` factories read `GREL_CIRCUITBREAKER_*`, `GREL_RATELIMITER_*`, and `GREL_SHIELD_*` at construction when `GREL_ENV_LOAD` is on, like every other pattern. Variables that were silently ignored now apply, and a named instance refuses at startup a variable belonging to a different algorithm than the code runs. Before upgrading a deployment with `GREL_ENV_LOAD` set, run `env | grep -E "GREL_(RATELIMITER|CIRCUITBREAKER|SHIELD)_"` in the container and remove or fix what it prints. The environment still never picks the algorithm.
 * 💥 `CircuitBreaker` no longer takes a positional config. Pass a pre-built config to `from_config`, which did exactly the same thing. `CircuitBreaker("payments")` still works, because consecutive-count is a sensible default.
 * 💥 `RateLimiter` loses its bare constructor. Build it with `token_bucket`, `sliding_window`, or `from_config`. There is no default algorithm to fall back on, so the constructor now raises `TypeError` naming those three.
@@ -24,6 +25,8 @@
 
 ### Fixed
 
+* 🐛 `SettingsValidationError` raised `IndexError` instead of rendering when the failure came from a model-level validator, which has no field location. `Lock(retry_interval=0.0001)` hit it.
+* 🐛 The gate-off report told the operator to remove a kind-wide variable that names another algorithm's field. That variable is a legitimate broadcast tuning the instances it fits, so the advice would have deleted working configuration. Only an instance address carries that message now.
 * 🐛 `MemoryCircuitBreakerAdapter.bind` ran any algorithm as consecutive-count instead of refusing the ones it does not implement. The three other adapters already refused.
 * 🐛 The `Shield` factories ignored the environment while the bare constructor read it, and neither reported a variable set with the gate off. `Shield.slow("x")` now resolves values from the environment with the preset pinned by code.
 * 🐛 A `GREL_{KIND}_{FIELD}` variable set while `GREL_ENV_LOAD` was off went unreported on a named instance. Only the instance address was checked, so the kind-wide variable that would have applied was dropped in silence. Every component was affected.

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -326,7 +326,7 @@ def resolve_config[C: BaseModel](
     try:
         if not env_load:
             if implicit:
-                _warn_ignored_env(
+                warn_ignored_env(
                     config_cls,
                     env_prefix,
                     provided,
@@ -357,7 +357,7 @@ def resolve_config[C: BaseModel](
 
 
 _warned_ignored_env: set[str] = set()
-"""Variable names already reported by `_warn_ignored_env`, process-wide.
+"""Variable names already reported by `warn_ignored_env`, process-wide.
 
 A component is often constructed many times, and the same misconfiguration
 would otherwise be reported on every construction.
@@ -386,8 +386,20 @@ _IGNORED_ENV_MESSAGE = (
 )
 """Report text, shared by the `warnings` and the `logging` channel."""
 
+_FOREIGN_ENV_MESSAGE = (
+    "%s is set but was not applied: it names a field of a different "
+    "algorithm than %r, which this instance runs. Remove the variable, or "
+    "build the instance with the algorithm the field belongs to."
+)
+"""Report text for a variable naming a sibling algorithm's field.
 
-def _warn_ignored_env(
+Deliberately not the shared text above. Enabling the gate is the fix for
+an ordinary ignored variable and the wrong advice here, because with the
+gate on this same variable refuses the instance at construction.
+"""
+
+
+def warn_ignored_env(
     config_cls: type[BaseModel],
     env_prefix: str,
     provided: Mapping[str, object],
@@ -416,6 +428,7 @@ def _warn_ignored_env(
     for field in (*config_cls.model_fields, *sorted(sibling)):
         if field in provided:
             continue
+        foreign = field in sibling
         names = [f"{env_prefix}{field.upper()}"]
         # The kind address applies to every instance since 0.38.0, so a
         # variable set there would have been read too. Still an exact-name
@@ -428,10 +441,13 @@ def _warn_ignored_env(
             if name not in os.environ or name in _warned_ignored_env:
                 continue
             _warned_ignored_env.add(name)
+            message = (
+                _FOREIGN_ENV_MESSAGE % (name, _running_kind(config_cls))
+                if foreign
+                else _IGNORED_ENV_MESSAGE % (name, _ENV_LOAD_VAR)
+            )
             warnings.warn(
-                diagnostic(
-                    ENV_LOAD_OFF, _IGNORED_ENV_MESSAGE % (name, _ENV_LOAD_VAR)
-                ),
+                diagnostic(ENV_LOAD_OFF, message),
                 EnvLoadOffWarning,
                 stacklevel=4,
             )
@@ -629,13 +645,14 @@ class Reconfigurable[ConfigT: BaseModel]:
         current = self._config
         # The env path builds a `BaseSettings` subclass of the declared
         # config, so an instance constructed from the environment holds a
-        # `_LockConfigSettings` where the caller has a `LockConfig`. They
-        # are the same configuration, so either direction of the subclass
-        # relation is accepted. Two arms of one algorithm union are
-        # siblings, neither a subclass of the other, so they are still
-        # rejected.
-        if not isinstance(new_config, type(current)) and not isinstance(
-            current, type(new_config)
+        # `_LockConfigSettings` where the caller has a `LockConfig`. That
+        # one case, and only that one, may go the other way. A plain
+        # parent class stays rejected: it declares fewer fields, so
+        # accepting it would trade a clean `TypeError` here for an
+        # `AttributeError` deeper in `_apply_reconfigure`.
+        if not isinstance(new_config, type(current)) and not (
+            isinstance(current, BaseSettings)
+            and isinstance(current, type(new_config))
         ):
             msg = (
                 f"reconfigure requires {type(current).__name__}, "

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -208,12 +208,14 @@ def _running_kind(config_cls: type[BaseModel]) -> str:
     """Return the algorithm name a config class carries in its `kind` field."""
     field = config_cls.model_fields.get("kind")
     default = getattr(field, "default", None)
-    return str(default) if default is not None else config_cls.__name__
+    if default is None or type(default).__name__ == "PydanticUndefinedType":
+        return config_cls.__name__
+    return str(default)
 
 
 def _reject_cross_arm_env(
     config_cls: type[BaseModel],
-    union: object | None,
+    sibling: frozenset[str],
     env_prefix: str,
     kind_env_prefix: str | None,
     error_type: type[SettingsValidationError] | None,
@@ -236,7 +238,6 @@ def _reject_cross_arm_env(
     """
     if kind_env_prefix is None:
         return
-    sibling = _sibling_fields(union, config_cls)
     found = sorted(
         f"{env_prefix}{field.upper()}"
         for field in sibling
@@ -337,7 +338,7 @@ def resolve_config[C: BaseModel](
             return config_cls.model_validate(provided)
 
         _reject_cross_arm_env(
-            config_cls, union, env_prefix, kind_env_prefix, error_type
+            config_cls, sibling, env_prefix, kind_env_prefix, error_type
         )
         settings_cls = _build_settings_cls(
             config_cls,
@@ -351,9 +352,12 @@ def resolve_config[C: BaseModel](
         # enforces the contract.
         return settings_cls(**provided)  # ty: ignore[invalid-return-type, invalid-argument-type]
     except ValidationError as error:
-        if error_type is None:
-            raise
-        raise error_type(error) from None
+        # Never let the raw pydantic error escape: it carries `input_value`,
+        # and the value came from the environment, where a credential can
+        # sit behind any name. `SettingsValidationError` renders the field
+        # and the reason without the input. The reload path already
+        # redacts, so this makes both directions of the same layer agree.
+        raise (error_type or SettingsValidationError)(error) from None
 
 
 _warned_ignored_env: set[str] = set()
@@ -428,7 +432,7 @@ def warn_ignored_env(
     for field in (*config_cls.model_fields, *sorted(sibling)):
         if field in provided:
             continue
-        foreign = field in sibling
+        instance_name = f"{env_prefix}{field.upper()}"
         names = [f"{env_prefix}{field.upper()}"]
         # The kind address applies to every instance since 0.38.0, so a
         # variable set there would have been read too. Still an exact-name
@@ -441,6 +445,17 @@ def warn_ignored_env(
             if name not in os.environ or name in _warned_ignored_env:
                 continue
             _warned_ignored_env.add(name)
+            # A sibling field is a mistake only at an instance address,
+            # which names one object whose algorithm is known. At the kind
+            # address it is a broadcast that legitimately tunes the other
+            # algorithm's instances, so telling the operator to remove it
+            # would have them delete working configuration. The default
+            # instance owns the kind address, so it is a broadcast too.
+            foreign = (
+                field in sibling
+                and kind_env_prefix is not None
+                and name == instance_name
+            )
             message = (
                 _FOREIGN_ENV_MESSAGE % (name, _running_kind(config_cls))
                 if foreign

--- a/grelmicro/errors.py
+++ b/grelmicro/errors.py
@@ -207,8 +207,13 @@ class SettingsValidationError(GrelmicroError, ValueError):
     def __init__(self, error: ValidationError | str) -> None:
         """Initialize the error."""
         if isinstance(error, ValidationError):
+            # `loc` is empty for a model-level validator, which checks the
+            # config as a whole rather than one field. Indexing it directly
+            # raised `IndexError` and hid the real error.
             details = "\n".join(
-                f"- {data['loc'][0]}: {data['msg']}" for data in error.errors()
+                f"- {'.'.join(str(part) for part in data['loc']) or '(config)'}"
+                f": {data['msg']}"
+                for data in error.errors(include_url=False)
             )
         else:
             details = error

--- a/grelmicro/resilience/circuitbreaker/memory.py
+++ b/grelmicro/resilience/circuitbreaker/memory.py
@@ -106,7 +106,14 @@ class MemoryCircuitBreakerAdapter(CircuitBreakerBackend):
         Two breakers constructed with the same ``name`` against the same
         adapter share the same `_BreakerState` entry, mirroring the
         Redis adapter's per-name keying.
+
+        Dispatches on the `config.kind` discriminator before reading any
+        field, so an algorithm this adapter does not implement is refused
+        rather than silently run as consecutive-count.
         """
+        if config.kind != "consecutive_count":
+            msg = f"Unsupported circuit breaker algorithm: {config.kind!r}"
+            raise NotImplementedError(msg)
         return _MemoryConsecutiveCountStrategy(
             states=self._states,
             name=name,

--- a/grelmicro/resilience/ratelimiter/sliding_window.py
+++ b/grelmicro/resilience/ratelimiter/sliding_window.py
@@ -25,7 +25,7 @@ class SlidingWindowConfig(_BaseRateLimiterConfig, frozen=True, extra="forbid"):
     from grelmicro.resilience import RateLimiter, SlidingWindowConfig
 
     # 5 requests per 60-second sliding window.
-    rl = RateLimiter("auth", SlidingWindowConfig(limit=5, window=60))
+    rl = RateLimiter.from_config("auth", SlidingWindowConfig(limit=5, window=60))
     ```
 
     Read more in the [Rate Limiter](../resilience/rate-limiter.md) docs.

--- a/grelmicro/resilience/ratelimiter/token_bucket.py
+++ b/grelmicro/resilience/ratelimiter/token_bucket.py
@@ -25,7 +25,7 @@ class TokenBucketConfig(_BaseRateLimiterConfig, frozen=True, extra="forbid"):
     from grelmicro.resilience import RateLimiter, TokenBucketConfig
 
     # Allow 10 in a burst, then 1/sec sustained.
-    rl = RateLimiter("api", TokenBucketConfig(capacity=10, refill_rate=1))
+    rl = RateLimiter.from_config("api", TokenBucketConfig(capacity=10, refill_rate=1))
     ```
 
     Read more in the [Rate Limiter](../resilience/rate-limiter.md) docs.

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -20,6 +20,7 @@ from grelmicro._config import (
     default_env_prefix,
     env_load_default,
     env_prefixes,
+    warn_ignored_env,
 )
 from grelmicro.clock import monotonic, sleep
 from grelmicro.metrics import _emit
@@ -75,17 +76,48 @@ def _load_profile_from_env(name: str) -> str:
     return value or "api"
 
 
+def _fill_from_env(
+    kwargs: dict[str, Any],
+    field: str,
+    passed: Any,  # noqa: ANN401
+    read: Callable[[str], str | None],
+    *,
+    cast: Callable[[str], Any] | None = None,
+) -> None:
+    """Take the caller's value, else the environment's, else leave unset.
+
+    A keyword beats the environment, which is the same order
+    `resolve_config` applies for every other pattern.
+    """
+    if passed is not None:
+        kwargs[field] = passed
+        return
+    value = read(field.upper())
+    if value is None or (cast is not None and value.strip() == ""):
+        return
+    kwargs[field] = cast(value) if cast is not None else value
+
+
 def _resolve_config_from_env(
     name: str,
     *,
+    profile: str | None,
     timeout_errors: Any,  # noqa: ANN401
     max_rate: float | None,
     cache: Any,  # noqa: ANN401
     cache_key: Callable[..., str] | None,
     fallback: Callable[..., Any] | None,
 ) -> _BaseShieldConfig:
-    """Build a `_BaseShieldConfig` reading defaults from environment variables."""
-    profile = _load_profile_from_env(name)
+    """Build a `_BaseShieldConfig` reading defaults from environment variables.
+
+    `profile` is the preset the calling door pinned. Only the bare
+    constructor leaves it `None`, and only then is `GREL_SHIELD_{NAME}_PROFILE`
+    consulted. A factory names the preset in code, so the variable cannot
+    override it, which is the ordinary rule that a keyword beats the
+    environment.
+    """
+    if profile is None:
+        profile = _load_profile_from_env(name)
     cls = _PROFILE_BY_NAME[profile]
     env_prefix, kind_prefix = env_prefixes("SHIELD", name)
 
@@ -97,18 +129,8 @@ def _resolve_config_from_env(
         return value
 
     kwargs: dict[str, Any] = {"kind": profile}
-    if timeout_errors is not None:
-        kwargs["timeout_errors"] = timeout_errors
-    else:
-        env_value = _env("TIMEOUT_ERRORS")
-        if env_value is not None:
-            kwargs["timeout_errors"] = env_value
-    if max_rate is not None:
-        kwargs["max_rate"] = max_rate
-    else:
-        env_value = _env("MAX_RATE")
-        if env_value is not None and env_value.strip() != "":
-            kwargs["max_rate"] = float(env_value)
+    _fill_from_env(kwargs, "timeout_errors", timeout_errors, _env)
+    _fill_from_env(kwargs, "max_rate", max_rate, _env, cast=float)
     if cache is not None:
         kwargs["cache"] = cache
     if cache_key is not None:
@@ -122,6 +144,7 @@ def _build_config(
     name: str,
     *,
     profile: str,
+    pinned_profile: str | None = None,
     timeout_errors: Any,  # noqa: ANN401
     max_rate: float | None,
     cache: Any,  # noqa: ANN401
@@ -130,11 +153,13 @@ def _build_config(
     env_load: bool | None,
 ) -> _BaseShieldConfig:
     """Resolve a `_BaseShieldConfig` from kwargs or env."""
-    if env_load is None:
+    implicit = env_load is None
+    if implicit:
         env_load = env_load_default()
     if env_load:
         return _resolve_config_from_env(
             name,
+            profile=pinned_profile,
             timeout_errors=timeout_errors,
             max_rate=max_rate,
             cache=cache,
@@ -153,6 +178,18 @@ def _build_config(
         kwargs["cache_key"] = cache_key
     if fallback is not None:
         kwargs["fallback"] = fallback
+    if implicit:
+        # R7: a variable that would have applied is never dropped in
+        # silence. Shield resolves its own configuration, so it reports
+        # through the same helper every other pattern reaches via
+        # `resolve_config`.
+        instance_prefix, kind_prefix = env_prefixes("SHIELD", name)
+        warn_ignored_env(
+            cls,
+            instance_prefix,
+            kwargs,
+            kind_env_prefix=kind_prefix,
+        )
     return cls.model_validate(kwargs)
 
 
@@ -455,17 +492,24 @@ class Shield(Reconfigurable[_BaseShieldConfig]):
         cache: Any,  # noqa: ANN401
         cache_key: Callable[..., str] | None,
         fallback: Callable[..., Any] | None,
+        env_load: bool | None = None,
     ) -> Self:
-        """Build a Shield bypassing env reads, with a profile override."""
+        """Build a Shield with the preset pinned by the calling factory.
+
+        Values still resolve from the environment when the gate is on, the
+        same way every other pattern's factory behaves. The preset is code's
+        to choose, so `GREL_SHIELD_{NAME}_PROFILE` cannot override it here.
+        """
         config = _build_config(
             name,
             profile=profile,
+            pinned_profile=profile,
             timeout_errors=timeout_errors,
             max_rate=max_rate,
             cache=cache,
             cache_key=cache_key,
             fallback=fallback,
-            env_load=False,
+            env_load=env_load,
         )
         instance = cls.__new__(cls)
         instance._setup(  # noqa: SLF001

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -64,9 +64,17 @@ _PROFILE_BY_NAME: dict[str, type[_BaseShieldConfig]] = {
 
 
 def _load_profile_from_env(name: str) -> str:
-    """Return the profile name from env, defaulting to `api`."""
-    env_key = default_env_prefix("SHIELD", name) + "PROFILE"
+    """Return the profile name from env, defaulting to `api`.
+
+    Falls back from the instance address to the kind address, which is the
+    order R5 applies to every other value.
+    """
+    instance_prefix, kind_prefix = env_prefixes("SHIELD", name)
+    env_key = f"{instance_prefix}PROFILE"
     value = os.environ.get(env_key, "").strip().lower()
+    if not value and kind_prefix:
+        env_key = f"{kind_prefix}PROFILE"
+        value = os.environ.get(env_key, "").strip().lower()
     if value and value not in _PROFILE_BY_NAME:
         msg = (
             f"{env_key}={value!r} is not a valid profile. "

--- a/tests/resilience/shield/test_env.py
+++ b/tests/resilience/shield/test_env.py
@@ -6,7 +6,8 @@ from typing import Any
 
 import pytest
 
-from grelmicro.resilience import Shield
+from grelmicro.errors import EnvLoadOffWarning
+from grelmicro.resilience import Shield, SlowShieldConfig
 from grelmicro.resilience.shield._profile import _resolve_fqn
 
 
@@ -147,3 +148,77 @@ def test_config_normalizer_passes_through_unknown_shapes() -> None:
     cls = _BaseShieldConfig._normalize_timeout_errors
     raw: Any = {"not": "valid"}
     assert cls(raw) == raw
+
+
+def test_factory_reads_values_with_the_preset_pinned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A factory resolves values from env, and env cannot move the preset."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv("GREL_SHIELD_PINNED_MAX_RATE", "5")
+    monkeypatch.setenv("GREL_SHIELD_PINNED_PROFILE", "api")
+
+    shield = Shield.slow("pinned")
+
+    assert isinstance(shield.config, SlowShieldConfig)
+    assert shield.config.max_rate == 5.0  # noqa: PLR2004
+
+
+def test_factory_ignores_a_blank_numeric_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A variable set to an empty string leaves the field at its default."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv("GREL_SHIELD_BLANK_MAX_RATE", "")
+
+    assert Shield.api("blank").config.max_rate is None
+
+
+def test_keyword_beats_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A value passed in code outranks the same variable in the environment."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv("GREL_SHIELD_KW_MAX_RATE", "5")
+
+    assert Shield.api("kw", max_rate=9.0).config.max_rate == 9.0  # noqa: PLR2004
+
+
+def test_gate_off_reports_a_shield_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shield reports a variable set while the gate is off, like every pattern."""
+    monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
+    monkeypatch.setenv("GREL_SHIELD_GATEOFF_MAX_RATE", "5")
+
+    with pytest.warns(EnvLoadOffWarning, match="GREL_SHIELD_GATEOFF_MAX_RATE"):
+        Shield.slow("gateoff")
+
+
+def test_gate_off_keeps_every_passed_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the gate off, each field passed in code reaches the config."""
+    monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
+
+    def _key(*_args: object, **_kwargs: object) -> str:
+        return "k"
+
+    async def _fallback(*_args: object, **_kwargs: object) -> str:
+        return "fb"
+
+    cache = object()
+    shield = Shield.api(
+        "allvalues",
+        timeout_errors=(TimeoutError,),
+        max_rate=3.0,
+        cache=cache,
+        cache_key=_key,
+        fallback=_fallback,
+    )
+
+    assert shield.config.timeout_errors == (TimeoutError,)
+    assert shield.config.max_rate == 3.0  # noqa: PLR2004
+    assert shield.config.cache is cache
+    assert shield.config.cache_key is _key
+    assert shield.config.fallback is _fallback

--- a/tests/resilience/test_circuitbreaker_config.py
+++ b/tests/resilience/test_circuitbreaker_config.py
@@ -1,8 +1,8 @@
 """Tests for CircuitBreaker construction paths."""
 
 import pytest
-from pydantic import ValidationError
 
+from grelmicro.errors import SettingsValidationError
 from grelmicro.resilience.circuitbreaker import (
     CircuitBreaker,
     ConsecutiveCountConfig,
@@ -120,5 +120,5 @@ def test_ignore_exceptions_accepts_tuple_of_fqn_strings() -> None:
 
 def test_invalid_threshold_raises() -> None:
     """Non-positive threshold values raise `ValidationError`."""
-    with pytest.raises(ValidationError):
+    with pytest.raises(SettingsValidationError):
         CircuitBreaker.consecutive_count("payments", error_threshold=0)

--- a/tests/resilience/test_ratelimiter_unknown_kind.py
+++ b/tests/resilience/test_ratelimiter_unknown_kind.py
@@ -15,6 +15,7 @@ import pytest
 from grelmicro.providers.postgres import PostgresProvider
 from grelmicro.providers.redis import RedisProvider
 from grelmicro.providers.sqlite import SQLiteProvider
+from grelmicro.resilience import MemoryCircuitBreakerAdapter
 from grelmicro.resilience._protocol import RateLimiterBackend
 from grelmicro.resilience.ratelimiter.memory import MemoryRateLimiterAdapter
 from grelmicro.resilience.ratelimiter.postgres import (
@@ -82,3 +83,21 @@ def test_bind_checks_the_kind_before_touching_the_client(
         backend._provider = HostileProvider()  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     with pytest.raises(NotImplementedError, match="failure_rate"):
         backend.bind(Fake())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+def test_memory_circuit_breaker_rejects_unknown_kind() -> None:
+    """The memory circuit breaker refuses an algorithm it does not implement.
+
+    It used to run any config as consecutive-count, reading fields the config
+    may not declare, so an unsupported kind became a different algorithm in
+    production rather than a refusal.
+    """
+
+    class FakeBreaker:
+        kind = "failure_rate"
+
+    with pytest.raises(NotImplementedError, match="failure_rate"):
+        MemoryCircuitBreakerAdapter().bind(
+            name="x",
+            config=FakeBreaker(),  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        )

--- a/tests/resilience/test_timeout.py
+++ b/tests/resilience/test_timeout.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 from pydantic import ValidationError
 
+from grelmicro.errors import SettingsValidationError
 from grelmicro.resilience import Retry, Timeout, TimeoutConfig
 
 _TWO = 2.0
@@ -65,7 +66,7 @@ def test_constructs_from_config() -> None:
 
 def test_requires_seconds_when_env_off() -> None:
     """No kwargs and no env path means construction fails."""
-    with pytest.raises(ValidationError):
+    with pytest.raises(SettingsValidationError):
         Timeout("db")
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -170,7 +170,7 @@ def test_env_prefix_scopes_reads(
 
 def test_invalid_kwarg_raises_validation_error() -> None:
     """``extra="forbid"`` on the Config rejects unknown kwargs."""
-    with pytest.raises(ValidationError):
+    with pytest.raises(SettingsValidationError):
         resolve_config(
             _Sample,
             explicit=None,
@@ -183,7 +183,7 @@ def test_invalid_kwarg_raises_validation_error() -> None:
 def test_invalid_value_raises_validation_error() -> None:
     """Field validators (e.g. ``PositiveFloat``) still apply."""
     invalid_timeout = -1.0
-    with pytest.raises(ValidationError):
+    with pytest.raises(SettingsValidationError):
         resolve_config(
             _Sample,
             explicit=None,
@@ -198,7 +198,7 @@ def test_invalid_env_value_raises_validation_error(
 ) -> None:
     """Env-supplied values are validated like kwargs."""
     monkeypatch.setenv("X_TIMEOUT", "-1.0")
-    with pytest.raises(ValidationError):
+    with pytest.raises(SettingsValidationError):
         resolve_config(
             _Sample,
             explicit=None,

--- a/tests/test_env_cross_arm.py
+++ b/tests/test_env_cross_arm.py
@@ -13,9 +13,11 @@ The rule is address-scoped:
 """
 
 import pytest
+from pydantic import BaseModel
 
-from grelmicro._config import _union_arms
+from grelmicro._config import _running_kind, _union_arms
 from grelmicro.coordination import Lock
+from grelmicro.coordination.memory import MemoryLockAdapter
 from grelmicro.errors import EnvLoadOffWarning, SettingsValidationError
 from grelmicro.resilience import (
     ApiShieldConfig,
@@ -195,3 +197,71 @@ def test_shield_profiles_stay_presets_not_algorithms() -> None:
     assert set(TokenBucketConfig.model_fields) != set(
         SlidingWindowConfig.model_fields
     )
+
+
+def test_gate_off_does_not_call_a_broadcast_variable_a_mistake(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A kind-wide sibling field is legitimate, so the advice must not be removal.
+
+    `GREL_RATELIMITER_CAPACITY` tunes every token bucket in the fleet. A
+    sliding-window instance merely ignores it. Telling the operator to remove
+    it would have them delete working configuration for the other algorithm.
+    """
+    monkeypatch.delenv("GREL_ENV_LOAD", raising=False)
+    monkeypatch.setenv("GREL_RATELIMITER_CAPACITY", "50")
+
+    with pytest.warns(EnvLoadOffWarning) as caught:
+        RateLimiter.sliding_window(
+            "broadcastadvice", limit=_LIMIT, window=_WINDOW
+        )
+
+    message = str(caught[0].message)
+    assert "opt-in" in message
+    assert "different algorithm" not in message
+
+
+def test_a_bad_value_is_never_echoed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The rejected input never reaches the error text.
+
+    A variable name is chosen by the operator and a value can be a
+    credential, so the error names the variable and the reason and stops
+    there. Raw pydantic errors carry `input_value`, which is why every
+    construction path wraps.
+    """
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv("GREL_LOCK_LEAKY_LEASE_DURATION", "hunter2")
+
+    with pytest.raises(SettingsValidationError) as caught:
+        Lock("leaky")
+
+    message = str(caught.value)
+    assert "GREL_LOCK_LEAKY_LEASE_DURATION" in message
+    assert "hunter2" not in message
+
+
+def test_a_model_level_validator_error_renders() -> None:
+    """An error with no field location renders instead of raising IndexError."""
+    with pytest.raises(SettingsValidationError, match="retry_interval must be"):
+        Lock("modelvalidator", backend=MemoryLockAdapter(), retry_interval=1e-9)
+
+
+def test_running_kind_falls_back_to_the_class_name() -> None:
+    """A union arm whose `kind` has no default still names itself.
+
+    The message that rejects a foreign variable names the algorithm running.
+    A third-party arm may declare `kind` as a required field rather than a
+    defaulted literal, and rendering pydantic's sentinel there would put
+    `PydanticUndefined` in front of an operator.
+    """
+
+    class NoDefaultKind(BaseModel):
+        kind: str
+
+    class NoKindAtAll(BaseModel):
+        value: int = 1
+
+    assert _running_kind(NoDefaultKind) == "NoDefaultKind"
+    assert _running_kind(NoKindAtAll) == "NoKindAtAll"

--- a/tests/test_env_cross_arm.py
+++ b/tests/test_env_cross_arm.py
@@ -18,10 +18,13 @@ from grelmicro._config import _union_arms
 from grelmicro.coordination import Lock
 from grelmicro.errors import EnvLoadOffWarning, SettingsValidationError
 from grelmicro.resilience import (
+    ApiShieldConfig,
     CircuitBreaker,
     ConsecutiveCountConfig,
+    InternalShieldConfig,
     RateLimiter,
     SlidingWindowConfig,
+    SlowShieldConfig,
     TimeoutConfig,
     TokenBucketConfig,
 )
@@ -170,3 +173,25 @@ def test_union_arms_accepts_both_union_shapes() -> None:
     assert set(annotated) == {TokenBucketConfig, SlidingWindowConfig}
     assert set(bare) == {TokenBucketConfig, SlidingWindowConfig}
     assert plain == ()
+
+
+def test_shield_profiles_stay_presets_not_algorithms() -> None:
+    """Pins the criterion that lets `GREL_SHIELD_{NAME}_PROFILE` exist.
+
+    R6 permits a variable to choose between config classes only while every
+    class declares the identical field names, because then the choice cannot
+    make any variable start or stop applying. Add or remove a field on one
+    profile and the choice becomes an algorithm selection, which belongs to
+    code, so this test must fail rather than be updated.
+    """
+    api = set(ApiShieldConfig.model_fields)
+    internal = set(InternalShieldConfig.model_fields)
+    slow = set(SlowShieldConfig.model_fields)
+
+    assert api == internal == slow
+
+    # Contrast: the rate limiter arms differ, which is why the environment
+    # may never choose between them.
+    assert set(TokenBucketConfig.model_fields) != set(
+        SlidingWindowConfig.model_fields
+    )


### PR DESCRIPTION
An adversarial pre-release review found the contract published in [#751](https://github.com/grelinfo/grelmicro/pull/751) was false in three places, and two of my own changes had regressed behaviour. Verdict was NOT SAFE to release. This is that list.

## The two regressions I introduced

**`reconfigure` accepted a parent config and died deeper.** I widened `type(a) is type(b)` to a bidirectional `isinstance` so env-built instances could accept their own config class. Too wide: a *parent* class also passed, then failed inside `_apply_reconfigure`.

```
Shield.from_config("p", ApiShieldConfig()).reconfigure(_BaseShieldConfig())
before this PR:  AttributeError: '_BaseShieldConfig' object has no attribute 'max_consecutive_failures'
now:             clean TypeError, as it was before #751
```

The reverse direction is now allowed only for the `BaseSettings` case it was added for.

**The gate-off warning told the operator to do the thing that crashes.** I extended `_warn_ignored_env` to scan sibling-arm fields and reused its message, which says "Set `GREL_ENV_LOAD=1` to enable it". Following that advice on a cross-arm variable turns the construction into a `SettingsValidationError`. The sibling branch now has its own message naming the running algorithm and telling you to remove the variable.

## Shield was outside its own contract

`Shield` resolves configuration by hand and never reached `resolve_config`, so R7 and R8 were false for it: the factories hard-coded `env_load=False` while the bare constructor read the environment, and neither reported a variable set with the gate off.

Factories now resolve values from the environment with the **preset pinned by code**, which is the ordinary keyword-beats-environment rule:

```
GREL_ENV_LOAD=1 GREL_SHIELD_X_MAX_RATE=5 GREL_SHIELD_X_PROFILE=api
Shield.slow("x")  ->  SlowShieldConfig, max_rate=5.0
```

`GREL_SHIELD_{NAME}_PROFILE` **stays**, and the contract now explains why rather than treating it as a violation. The three profiles declare identical field names (`cache`, `cache_key`, `fallback`, `kind`, `max_rate`, `timeout_errors`) and drive one state machine, so choosing between them retunes constants and can never make a variable start or stop applying. That is a value, which is the environment's lane. The rate limiter arms differ by four fields, which is exactly why the environment may never choose between *those*.

R6 gains the rule, the Settled table gains the row, and a test pins the criterion so preset status is earned by the field sets rather than claimed.

## The memory breaker violated the contract shipped in #747

`MemoryCircuitBreakerAdapter.bind` had no kind check at all. It ran **any** algorithm as consecutive-count, and did not even fail cleanly:

```
AttributeError: 'Fake' object has no attribute 'error_threshold'
```

The other three adapters already refused, so the #747 changelog claim was false for this one. Fixed and tested.

## Contract corrected where the code was right

- R7 said a bad value yields "a validation error naming the field". It names the **variable**, which is more useful. Doc follows code.
- R7's live-reload row promised a warning. The code skips the key and counts it at debug, deliberately omitting key names because a mounted Secret's key can itself be sensitive. Row rewritten to the truth with a pointer to [#664](https://github.com/grelinfo/grelmicro/issues/664), rather than building provenance plumbing that issue has already deferred.
- R7 now states that for the default instance the instance address *is* the kind address, so it follows the broadcast row. An ambiguous address cannot be an unambiguous mistake.

## Also

The changelog had four bug entries filed under `### Added` with no `### Fixed` section, so four fixes, two of them affecting every pattern, were presented as features in the document people read to decide whether to upgrade. Split correctly.

Two docstring examples still taught `RateLimiter("api", TokenBucketConfig(...))`, which now raises `TypeError`. They render in the API reference.

Deliberately not here: [#750](https://github.com/grelinfo/grelmicro/issues/750) central redaction, argued to wait because every pattern config field is a number or a matcher, so leaking requires putting a credential where a number goes.

## Verification

4515 tests pass, coverage 100%, mypy and ty clean, ruff clean, `mkdocs build --strict` clean.

https://claude.ai/code/session_01Heu2pjcxZkz3Gm81Paif67