### PR TITLE
🔖 Prepare the 0.39.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.39.0 - 2026-08-16
 
 ### Breaking
 


### PR DESCRIPTION
Moves `## Unreleased` to `## 0.39.0 - 2026-08-16`. No code changes.

## Why 0.39.0 and not 0.38.2

Decided from this project's own history rather than semver doctrine. Across 75 releases:

- Patch releases containing a `### Breaking` section: **none, ever**.
- Minor releases containing one: **25**, including 0.38.0, 0.37.0, 0.36.0, 0.35.0, 0.34.0.

This release has six breaking entries, so it is a minor bump.

## What is in it

Five merged PRs that make the configuration surface consistent and write down the contract it follows.

**Breaking.** `from_config` is now the only door for a pre-built config, across every class that has one. `CircuitBreaker` loses its positional config and `RateLimiter` loses its bare constructor, because both were exact duplicates of `from_config`. `CircuitBreaker`, `RateLimiter`, and the `Shield` factories read the environment at construction like every other pattern. Every configuration path now raises `SettingsValidationError`, so a rejected value is never echoed back.

**Fixed**, all pre-existing and none reported by a user, found by writing the contract down and then checking the code against it:

- `reconfigure` refused the config class its own docs told you to build, for any instance built from the environment. Every pattern was affected.
- A `GREL_{KIND}_{FIELD}` variable set with the gate off was silently dropped on every named instance.
- The rate limiter backends rejected an unsupported algorithm with `AssertionError` while the circuit breakers raised `NotImplementedError`, and `MemoryCircuitBreakerAdapter` did not check at all, running any algorithm as consecutive-count.
- Every rate limiter adapter read the provider client before checking the algorithm, so an unsupported kind needed a live connection to fail.
- `SettingsValidationError` raised `IndexError` instead of rendering when the failure came from a model-level validator.
- `docs/config.md` said `Idempotency` reads no environment. It does.

**Documented.** [Configuration internals](https://grelmicro.grel.info/architecture/config/) now carries one invariant, nine rules, and a Settled table recording the assumption behind each closed decision. [Plugins](https://grelmicro.grel.info/architecture/plugins/) states what grelmicro promises a third-party adapter, since adding a member to a protocol breaks every implementer and that has to be settled before 1.0.

## Verification

4519 tests, coverage 100%, mypy and ty clean, ruff clean, `mkdocs build --strict` clean. `tools/changelog.py check 0.39.0` passes.

`just release-check 0.39.0` runs after this merges, from `origin/main`, because that is what would actually be tagged. It adds the full slow tier and the whole Python matrix that PR CI skips. That matrix step is not ceremony: 0.34.0 passed every other check and still failed its release on Python 3.14, and a tag is immutable, so the version was burned.

https://claude.ai/code/session_01Heu2pjcxZkz3Gm81Paif67