### PR TITLE
💥 Raise one SettingsValidationError for every bad configuration value

### DIFF
--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -86,6 +86,13 @@ in any of its algorithms, is always accounted for:
 | Live reload, field of another algorithm | Skipped for that instance and counted at debug, never a crash. Key names stay out of the logs because a mounted Secret's key can itself be sensitive. A warning naming sibling fields follows with config provenance ([#664](https://github.com/grelinfo/grelmicro/issues/664)). |
 | Value invalid | `SettingsValidationError` naming the variable and the reason, never the value |
 
+Every class raises that one error, whichever pattern or component it is. There
+is no per-module subclass to remember: a bad value is a startup crash, and the
+message already names the exact variable, which locates the problem better than
+a class name can. A config class you build yourself, such as `RetryConfig(...)`
+or `ExponentialBackoff(...)`, raises pydantic's `ValidationError` like any
+pydantic model.
+
 For the default instance the instance address is the kind address, so it
 follows the broadcast row: the bare prefix cannot tell "this instance's field"
 from "every instance's field", and an ambiguous address is not an unambiguous
@@ -94,6 +101,13 @@ mistake.
 The rejected value is never echoed. A variable name is the operator's own,
 but its value can be a credential, so an error carries the name and the reason
 and stops there.
+
+Pydantic attaches the rejected input to every error it raises, for every field,
+whether or not anyone reviewed that field for secrets. Wrapping into
+`SettingsValidationError` is what removes it. A validator may still name a
+value on purpose where the field's domain is a public closed set and the value
+is the whole diagnostic, as an unknown timezone name does. That is a per-field
+decision, never the default.
 
 A name matching no declared field of any algorithm is ignored without report.
 Kubernetes injects `{SVCNAME}_SERVICE_HOST` into every pod, so grelmicro must
@@ -121,6 +135,7 @@ not.
 | `from_config` is the one door for a pre-built config | The environment-merging lane and the config-is-truth lane must be distinguishable at the call site | The environment lane is removed |
 | `GREL_SHIELD_PROFILE` selects a preset, not an algorithm | Every profile declares the identical field names, so no variable gains or loses meaning from the choice | A profile adds or removes a field |
 | A Provider reads its vendor namespace, not `GREL_*` | Connection settings belong to the deployment, and every vendor already defines those names | grelmicro starts owning connection settings |
+| One `SettingsValidationError` for every class, no per-module subclass | No caller reacts differently to a bad value by module, and the message names the variable | A caller needs to branch on the module a config error came from |
 
 ## `resolve_config()`
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,27 @@
 # Changelog
 
+## Unreleased
+
+### Breaking
+
+* 💥 A bad configuration value raises `SettingsValidationError`, whichever pattern or component you built. The ten per-module subclasses are removed: `CacheSettingsValidationError`, `CoordinationSettingsValidationError`, `HealthSettingsValidationError`, `IdempotencySettingsValidationError`, `LogSettingsValidationError`, `MetricsSettingsValidationError`, `OutboxSettingsValidationError`, `ResilienceSettingsValidationError`, `TaskSettingsValidationError`, and `TraceSettingsValidationError`. Catch the base error, which every one of them already subclassed. No caller ever reacted differently by module, and the message names the exact variable. ([#750](https://github.com/grelinfo/grelmicro/issues/750))
+* 💥 `Fallback`, `Shield`, and `TTLCache` raise `SettingsValidationError` for a bad value instead of letting `pydantic.ValidationError` through. Both are `ValueError`, so an `except ValueError` keeps working. ([#750](https://github.com/grelinfo/grelmicro/issues/750))
+
+### Fixed
+
+* 🔒 `Fallback`, `Shield`, and `TTLCache` echoed the rejected value into the error. Pydantic attaches the input to every error it raises, so `GREL_FALLBACK_{NAME}_WHEN` reached the traceback verbatim, and `GREL_SHIELD_{NAME}_MAX_RATE` failed with a bare `ValueError` from `float()` carrying the same string. 0.39.0 said every configuration path raised `SettingsValidationError`. These three did not. ([#750](https://github.com/grelinfo/grelmicro/issues/750))
+* 🔒 A validator that names the value it rejected leaked it through the wrapper, which strips only pydantic's own copy of the input. The `when=` and `timeout_errors` entries on `Retry`, `Fallback`, and `Shield` reported the module path and the attribute instead of the raw entry. ([#750](https://github.com/grelinfo/grelmicro/issues/750))
+
+### Added
+
+* 📝 An [Errors](reference/errors.md) reference page. `SettingsValidationError` is now the one configuration error, and it had no documented home.
+* ✅ The public API snapshot covers `grelmicro.outbox` and `grelmicro.types`. Both were documented in the API reference while their exports went unguarded, so a rename could have shipped unnoticed. A test now reads the reference pages, so documenting a module guards it.
+
 ## 0.39.0 - 2026-08-16
 
 ### Breaking
 
-* 💥 Every configuration path raises `SettingsValidationError` for a bad value. The patterns used to let the raw `pydantic.ValidationError` through, which carries `input_value` and so echoed a rejected environment value into the traceback. Catch `SettingsValidationError`, or `ValueError`, which both it and the pydantic error already are.
+* 💥 Every configuration path that goes through `resolve_config` raises `SettingsValidationError` for a bad value. The patterns used to let the raw `pydantic.ValidationError` through, which carries `input_value` and so echoed a rejected environment value into the traceback. Catch `SettingsValidationError`, or `ValueError`, which both it and the pydantic error already are. (`Fallback`, `Shield`, and `TTLCache` resolve their own configuration and were missed here, fixed in the next release.)
 * 💥 `CircuitBreaker`, `RateLimiter`, and the `Shield` factories read `GREL_CIRCUITBREAKER_*`, `GREL_RATELIMITER_*`, and `GREL_SHIELD_*` at construction when `GREL_ENV_LOAD` is on, like every other pattern. Variables that were silently ignored now apply, and a named instance refuses at startup a variable belonging to a different algorithm than the code runs. Before upgrading a deployment with `GREL_ENV_LOAD` set, run `env | grep -E "GREL_(RATELIMITER|CIRCUITBREAKER|SHIELD)_"` in the container and remove or fix what it prints. The environment still never picks the algorithm.
 * 💥 `CircuitBreaker` no longer takes a positional config. Pass a pre-built config to `from_config`, which did exactly the same thing. `CircuitBreaker("payments")` still works, because consecutive-count is a sensible default.
 * 💥 `RateLimiter` loses its bare constructor. Build it with `token_bucket`, `sliding_window`, or `from_config`. There is no default algorithm to fall back on, so the constructor now raises `TypeError` naming those three.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,8 @@
 ### Fixed
 
 * 🔒 `Fallback`, `Shield`, and `TTLCache` echoed the rejected value into the error. Pydantic attaches the input to every error it raises, so `GREL_FALLBACK_{NAME}_WHEN` reached the traceback verbatim, and `GREL_SHIELD_{NAME}_MAX_RATE` failed with a bare `ValueError` from `float()` carrying the same string. 0.39.0 said every configuration path raised `SettingsValidationError`. These three did not. ([#750](https://github.com/grelinfo/grelmicro/issues/750))
-* 🔒 A validator that names the value it rejected leaked it through the wrapper, which strips only pydantic's own copy of the input. The `when=` and `timeout_errors` entries on `Retry`, `Fallback`, and `Shield` reported the module path and the attribute instead of the raw entry. ([#750](https://github.com/grelinfo/grelmicro/issues/750))
+* 🔒 A validator that names the value it rejected leaked it through the wrapper, which strips only pydantic's own copy of the input. The `when=` and `timeout_errors` entries on `Retry`, `Fallback`, and `Shield` no longer report any part of the rejected entry. ([#750](https://github.com/grelinfo/grelmicro/issues/750))
+* 🐛 A `when=` or `timeout_errors` entry that resolved to something other than an exception class raised `TypeError`, which escaped `except SettingsValidationError` and `except ValueError` alike, because pydantic converts only `ValueError` and `AssertionError` into a validation error. `GREL_RETRY_{NAME}_WHEN=os.getcwd` hit it. ([#750](https://github.com/grelinfo/grelmicro/issues/750))
 
 ### Added
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -22,17 +22,62 @@ that a client library used to accept.
 | A password or URL reads back as `SecretStr(...)` or `***` | 0.31, 0.32 | [Call `.get_secret_value()`](#0-31-secret-credentials) |
 | Metrics stopped arriving after upgrading, with no error | 0.31 | [Set an endpoint](#0-31-metrics-auto-exporter) |
 | `TypeError` on a SQLite adapter, either `unexpected keyword argument 'path'` or `takes 1 positional argument` | 0.32 | [Pass `provider=`](#0-32-sqlite-provider) |
-| `SettingsValidationError` where you caught `CoordinationSettingsValidationError` | 0.32 | [Catch the base error](#0-32-sqlite-provider) |
 | An open circuit closed once, just after upgrading | 0.32.2 | [Expected, happens once](#0-32-2-circuit-breaker-state) |
 | `TypeError: @cached on ... needs an explicit key=` | 0.34 | [Name the key](#0-34-cached-method-key) |
 | Task run totals jumped after upgrading, with no new failures | 0.34 | [Filter on `outcome`](#0-34-task-run-outcomes) |
 | `ImportError: cannot import name 'LogTimeZoneType'` | 0.36 | [Use `TimeZoneName`](#0-36-timezone-type) |
-| `LogSettingsValidationError: unknown timezone name 'CEST'` | 0.36 | [Name the zone](#0-36-timezone-abbreviation) |
+| `SettingsValidationError: unknown timezone name 'CEST'` | 0.36 | [Name the zone](#0-36-timezone-abbreviation) |
 | `ImportError: cannot import name 'RateLimiterRegistry'` or `ImportError: cannot import name 'CircuitBreakerRegistry'` | 0.37 | [Rename to `Component`](#0-37-registry-renamed) |
 | `TypeError: health_router() got an unexpected keyword argument 'registry'` | 0.37 | [Pass `component=`](#0-37-registry-renamed) |
 | `RedisProviderConfigError` or `PostgresProviderConfigError` on a URL that used to connect | 0.37.1 | [Fix the URL](#0-37-1-url-validation) |
 | `ModuleNotFoundError: No module named 'grelmicro.clientip'` | 0.39 | [Import from `grelmicro.security`](#0-39-clientip-moved) |
 | A logging filter or level set on `grelmicro.clientip` stopped matching | 0.39 | [Rename the logger](#0-39-clientip-moved) |
+| `ImportError: cannot import name 'LogSettingsValidationError'`, or any other `*SettingsValidationError` | 0.40 | [Catch the base error](#0-40-one-settings-error) |
+| `SettingsValidationError` where you caught `pydantic.ValidationError` from `Fallback`, `Shield`, or `TTLCache` | 0.40 | [Catch the base error](#0-40-one-settings-error) |
+
+## 0.40
+
+### One error for every bad configuration value {#0-40-one-settings-error}
+
+A bad configuration value raises `SettingsValidationError`, whichever pattern
+or component you built. The ten per-module subclasses are gone:
+`CacheSettingsValidationError`, `CoordinationSettingsValidationError`,
+`HealthSettingsValidationError`, `IdempotencySettingsValidationError`,
+`LogSettingsValidationError`, `MetricsSettingsValidationError`,
+`OutboxSettingsValidationError`, `ResilienceSettingsValidationError`,
+`TaskSettingsValidationError`, and `TraceSettingsValidationError`.
+
+Catch the base error, which every one of them already subclassed:
+
+```python
+# Before
+from grelmicro.log import LogSettingsValidationError
+
+try:
+    Log(level="NOPE")
+except LogSettingsValidationError:
+    ...
+
+# After
+from grelmicro import SettingsValidationError
+
+try:
+    Log(level="NOPE")
+except SettingsValidationError:
+    ...
+```
+
+`except ValueError` and `except GrelmicroError` keep working unchanged.
+
+`Fallback`, `Shield`, and `TTLCache` used to let pydantic's `ValidationError`
+through instead, so they now raise `SettingsValidationError` too. If you catch
+`ValidationError` around one of those, catch `SettingsValidationError`. It
+subclasses `ValueError`, which `ValidationError` also is, so an
+`except ValueError` around either keeps working.
+
+That change closes a leak: pydantic attaches the rejected input to its error,
+so an invalid value read from the environment used to reach the traceback.
+Errors now carry the variable name and the reason, never the value.
 
 ## 0.39
 
@@ -139,7 +184,7 @@ from grelmicro.types import TimeZoneName
 ### A timezone abbreviation no longer validates {#0-36-timezone-abbreviation}
 
 `GREL_LOG_TIMEZONE=CEST` used to validate and then fail later, because
-`zoneinfo` has no such zone. It now raises `LogSettingsValidationError:
+`zoneinfo` has no such zone. It now raises `SettingsValidationError:
 unknown timezone name 'CEST'` where the value is read. Abbreviations such as
 `CEST`, `PST`, `PDT`, `EDT`, `BST`, and `JST` are daylight saving variants,
 not zones, and pinning one would freeze the offset year-round. Name the zone
@@ -222,9 +267,8 @@ micro = Grelmicro(uses=[Coordination(sqlite)])
 That also shares one connection across every component on the same file,
 where the old form opened its own.
 
-A missing path now raises `SettingsValidationError` instead of
-`CoordinationSettingsValidationError`. If you catch the latter, catch the
-base error.
+A missing path raises `SettingsValidationError`, as every configuration
+failure does since 0.40.
 
 ### URL and header fields hide their credentials {#0-32-secret-urls}
 

--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -12,7 +12,6 @@
         - CacheError
         - CacheInfo
         - CacheSerializer
-        - CacheSettingsValidationError
         - CachedFunction
         - CachedStream
         - JsonSerializer

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,0 +1,27 @@
+# Errors
+
+- **Start here**: [Configuration](../config.md)
+- **The contract**: [Configuration internals](../architecture/config.md)
+
+Every grelmicro error subclasses `GrelmicroError`, so one `except` catches any
+of them. A bad configuration value always raises `SettingsValidationError`,
+whichever pattern or component you built.
+
+::: grelmicro
+    options:
+      members:
+        - GrelmicroError
+        - SettingsValidationError
+        - AdmissionError
+        - BackendScopeError
+        - DependencyNotFoundError
+        - MultipleActiveAppsError
+        - OutOfContextError
+        - AdapterNotRegisteredError
+        - ProviderNotRegisteredError
+        - GrelmicroConfigWarning
+        - EnvLoadOffWarning
+        - BackendScopeWarning
+        - AmbientBindingWarning
+        - SentinelPasswordWarning
+        - UnknownEnvironmentWarning

--- a/docs/reference/health.md
+++ b/docs/reference/health.md
@@ -15,4 +15,3 @@
         - HealthChecksConfig
         - HealthReport
         - HealthStatus
-        - HealthSettingsValidationError

--- a/docs/reference/idempotency.md
+++ b/docs/reference/idempotency.md
@@ -12,7 +12,6 @@
         - IdempotencyConfig
         - IdempotencyConflictError
         - IdempotencyError
-        - IdempotencySettingsValidationError
         - IdempotencyStateError
         - IdempotencyWaitTimeoutError
         - Operation

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -14,7 +14,6 @@
         - Log
         - LogConfig
         - LogError
-        - LogSettingsValidationError
         - RateLimitFilter
         - RateLimitFilterConfig
         - configure

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -11,6 +11,5 @@
         - MetricsConfig
         - MetricsError
         - MetricsExporterType
-        - MetricsSettingsValidationError
         - measure
         - metrics_router

--- a/docs/reference/resilience.md
+++ b/docs/reference/resilience.md
@@ -51,7 +51,6 @@
         - ApiShieldConfig
         - InternalShieldConfig
         - ResilienceError
-        - ResilienceSettingsValidationError
         - Retry
         - RetryAttempt
         - RetryBackoffConfig

--- a/docs/reference/trace.md
+++ b/docs/reference/trace.md
@@ -13,7 +13,6 @@
         - TraceExporterType
         - TraceProcessorType
         - TraceSamplerType
-        - TraceSettingsValidationError
         - add_context
         - get_context
         - instrument

--- a/grelmicro/_config.py
+++ b/grelmicro/_config.py
@@ -218,7 +218,6 @@ def _reject_cross_arm_env(
     sibling: frozenset[str],
     env_prefix: str,
     kind_env_prefix: str | None,
-    error_type: type[SettingsValidationError] | None,
 ) -> None:
     """Refuse to start when one instance is handed another algorithm's variable.
 
@@ -253,7 +252,7 @@ def _reject_cross_arm_env(
         f"fields and never selects the algorithm. Remove the variable or "
         f"build the instance with the algorithm it belongs to."
     )
-    raise (error_type or SettingsValidationError)(msg)
+    raise SettingsValidationError(msg)
 
 
 def resolve_config[C: BaseModel](
@@ -265,7 +264,6 @@ def resolve_config[C: BaseModel](
     env_load: bool | None = None,
     shared_env: Mapping[str, str] | None = None,
     kind_env_prefix: str | None = None,
-    error_type: type[SettingsValidationError] | None = None,
     union: object | None = None,
 ) -> C:
     """Build a validated ``config_cls`` from an explicit instance or kwargs and env.
@@ -299,9 +297,8 @@ def resolve_config[C: BaseModel](
     ``env_prefixes``, which returns ``None`` for the default instance and
     for a caller-supplied prefix.
 
-    Pass ``error_type`` to wrap a ``pydantic.ValidationError`` into a
-    component-specific ``SettingsValidationError``. Without it, the
-    raw ``pydantic.ValidationError`` propagates.
+    A value the model rejects raises ``SettingsValidationError``, never
+    the raw ``pydantic.ValidationError``, which carries the input.
 
     See `docs/architecture/config.md` for the full contract,
     including the name-as-namespace convention used to derive
@@ -337,9 +334,7 @@ def resolve_config[C: BaseModel](
                 )
             return config_cls.model_validate(provided)
 
-        _reject_cross_arm_env(
-            config_cls, sibling, env_prefix, kind_env_prefix, error_type
-        )
+        _reject_cross_arm_env(config_cls, sibling, env_prefix, kind_env_prefix)
         settings_cls = _build_settings_cls(
             config_cls,
             env_prefix,
@@ -357,7 +352,7 @@ def resolve_config[C: BaseModel](
         # sit behind any name. `SettingsValidationError` renders the field
         # and the reason without the input. The reload path already
         # redacts, so this makes both directions of the same layer agree.
-        raise (error_type or SettingsValidationError)(error) from None
+        raise SettingsValidationError(error) from None
 
 
 _warned_ignored_env: set[str] = set()
@@ -715,7 +710,6 @@ def resolve_config_from_mapping[C: BaseModel](
     env_prefix: str,
     mapping: Mapping[str, str],
     immutable_fields: frozenset[str] = frozenset(),
-    error_type: type[SettingsValidationError] | None = None,
 ) -> C:
     """Patch `current` with values from a flat env-style `mapping`.
 
@@ -732,13 +726,12 @@ def resolve_config_from_mapping[C: BaseModel](
     from the environment. Returns `current` unchanged when the mapping
     carries nothing for this prefix.
 
-    Pass `error_type` to wrap a `pydantic.ValidationError` into a
-    component-specific `SettingsValidationError`. Without it, the raw
-    `pydantic.ValidationError` propagates.
+    The raw `pydantic.ValidationError` propagates. This is the reload
+    path, whose caller `reconfigure_all` logs a redacted summary and
+    keeps the running config, so the error is never raised at a caller.
 
     Raises:
-        pydantic.ValidationError: If a present value fails validation
-            and no `error_type` is given.
+        pydantic.ValidationError: If a present value fails validation.
     """
     cls = type(current)
     fields = cls.model_fields
@@ -769,12 +762,7 @@ def resolve_config_from_mapping[C: BaseModel](
         )
     if not overrides:
         return current
-    try:
-        return cls.model_validate({**current.model_dump(), **overrides})
-    except ValidationError as error:
-        if error_type is None:
-            raise
-        raise error_type(error) from None
+    return cls.model_validate({**current.model_dump(), **overrides})
 
 
 _warned_immutable_skipped: set[str] = set()

--- a/grelmicro/cache/__init__.py
+++ b/grelmicro/cache/__init__.py
@@ -3,7 +3,7 @@
 from grelmicro.cache._component import Cache
 from grelmicro.cache._protocol import CacheBackend
 from grelmicro.cache.cached import CachedFunction, CachedStream, cached
-from grelmicro.cache.errors import CacheError, CacheSettingsValidationError
+from grelmicro.cache.errors import CacheError
 from grelmicro.cache.serializers import (
     CacheSerializer,
     JsonSerializer,
@@ -18,7 +18,6 @@ __all__ = [
     "CacheError",
     "CacheInfo",
     "CacheSerializer",
-    "CacheSettingsValidationError",
     "CachedFunction",
     "CachedStream",
     "JsonSerializer",

--- a/grelmicro/cache/errors.py
+++ b/grelmicro/cache/errors.py
@@ -1,11 +1,7 @@
 """Cache Errors."""
 
-from grelmicro.errors import GrelmicroError, SettingsValidationError
+from grelmicro.errors import GrelmicroError
 
 
 class CacheError(GrelmicroError):
     """Base cache error."""
-
-
-class CacheSettingsValidationError(CacheError, SettingsValidationError):
-    """Cache Settings Validation Error."""

--- a/grelmicro/cache/ttl.py
+++ b/grelmicro/cache/ttl.py
@@ -7,7 +7,12 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Self, cast
 
-from pydantic import BaseModel, NonNegativeInt, PositiveFloat
+from pydantic import (
+    BaseModel,
+    NonNegativeInt,
+    PositiveFloat,
+    ValidationError,
+)
 from typing_extensions import Doc, TypeVar
 
 from grelmicro._app import Grelmicro
@@ -21,6 +26,7 @@ from grelmicro.cache.serializers import (
     _infer_serializer_from_instance,
     _resolve_serializer,
 )
+from grelmicro.errors import SettingsValidationError
 from grelmicro.metrics import _emit
 
 if TYPE_CHECKING:
@@ -115,9 +121,9 @@ class TTLCache(Generic[T]):
     parameter Pydantic cannot build a schema for.
 
     Raises:
-        pydantic.ValidationError: If `maxsize` is negative or `ttl` is not
-            positive. `ValidationError` is a subclass of `ValueError`, so
-            existing `except ValueError:` blocks still catch it.
+        SettingsValidationError: If `maxsize` is negative or `ttl` is not
+            positive. It subclasses `ValueError`, so an existing
+            `except ValueError:` block still catches it.
     """
 
     def __init__(
@@ -172,7 +178,10 @@ class TTLCache(Generic[T]):
         ] = None,
     ) -> None:
         """Initialize the cache."""
-        self._config = TTLCacheConfig(maxsize=maxsize, ttl=ttl)
+        try:
+            self._config = TTLCacheConfig(maxsize=maxsize, ttl=ttl)
+        except ValidationError as error:
+            raise SettingsValidationError(error) from None
         # Snapshot the validated config to instance attributes so the
         # hot path (`get`, `set`) reads a single attribute instead of
         # walking through `self._config.<field>`.

--- a/grelmicro/coordination/__init__.py
+++ b/grelmicro/coordination/__init__.py
@@ -16,7 +16,6 @@ from grelmicro.coordination._protocol import (
 from grelmicro.coordination.errors import (
     CoordinationBackendError,
     CoordinationError,
-    CoordinationSettingsValidationError,
     LockAcquireError,
     LockBackendError,
     LockLockedCheckError,
@@ -42,7 +41,6 @@ __all__ = [
     "Coordination",
     "CoordinationBackendError",
     "CoordinationError",
-    "CoordinationSettingsValidationError",
     "LeaderElection",
     "LeaderElectionBackend",
     "LeaderElectionConfig",

--- a/grelmicro/coordination/_base.py
+++ b/grelmicro/coordination/_base.py
@@ -11,7 +11,7 @@ from typing_extensions import Doc
 from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination._protocol import LockPrimitive
 from grelmicro.coordination._tokens import generate_worker_id
-from grelmicro.coordination.errors import CoordinationSettingsValidationError
+from grelmicro.errors import SettingsValidationError
 
 # Seam for randomness in retry jitter. Tests pin it to a fixed value.
 _random = random.random
@@ -54,7 +54,7 @@ def assert_worker_unchanged(
             f"({current.worker!r} -> {new.worker!r}). "
             f"Reuse the existing worker on the new config."
         )
-        raise CoordinationSettingsValidationError(msg)
+        raise SettingsValidationError(msg)
 
 
 class BaseLock(LockPrimitive, Protocol):

--- a/grelmicro/coordination/errors.py
+++ b/grelmicro/coordination/errors.py
@@ -2,14 +2,12 @@
 
 from grelmicro.errors import (
     GrelmicroError,
-    SettingsValidationError,
     WouldBlockError,
 )
 
 __all__ = [
     "CoordinationBackendError",
     "CoordinationError",
-    "CoordinationSettingsValidationError",
     "LockAcquireError",
     "LockBackendError",
     "LockLockedCheckError",
@@ -132,9 +130,3 @@ class LockNotOwnedError(LockReleaseError):
     def __init__(self, *, name: str) -> None:
         """Initialize the error."""
         super().__init__(name=name, reason="lock not owned")
-
-
-class CoordinationSettingsValidationError(
-    CoordinationError, SettingsValidationError
-):
-    """Coordination Settings Validation Error."""

--- a/grelmicro/coordination/kubernetes.py
+++ b/grelmicro/coordination/kubernetes.py
@@ -26,8 +26,7 @@ from grelmicro.coordination._protocol import (
     ReadWriteLockState,
     WriteGrant,
 )
-from grelmicro.coordination.errors import CoordinationSettingsValidationError
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import OutOfContextError, SettingsValidationError
 from grelmicro.types import BackendScope
 
 _LABEL_MANAGED_BY = "app.kubernetes.io/managed-by"
@@ -48,7 +47,7 @@ def _get_kube_namespace() -> str:
     """Get the Kubernetes namespace from the environment variables.
 
     Raises:
-        CoordinationSettingsValidationError: If KUBE_NAMESPACE is not set.
+        SettingsValidationError: If KUBE_NAMESPACE is not set.
     """
     settings = _KubernetesSettings()
 
@@ -56,7 +55,7 @@ def _get_kube_namespace() -> str:
         return settings.KUBE_NAMESPACE
 
     msg = "KUBE_NAMESPACE must be set"
-    raise CoordinationSettingsValidationError(msg)
+    raise SettingsValidationError(msg)
 
 
 def _sanitize_lease_name(name: str) -> str:

--- a/grelmicro/errors.py
+++ b/grelmicro/errors.py
@@ -194,7 +194,15 @@ class AdapterNotRegisteredError(GrelmicroError, LookupError):
 
 
 class SettingsValidationError(GrelmicroError, ValueError):
-    """Settings Validation Error.
+    """Raised when a configuration value fails validation.
+
+    Every grelmicro class raises this one error, whichever pattern or
+    component it is, so one `except` covers the whole library. A config
+    class you build yourself, such as `RetryConfig(...)`, raises
+    pydantic's `ValidationError` like any pydantic model.
+
+    Subclasses `ValueError`, which `pydantic.ValidationError` also is, so
+    an `except ValueError` catches either.
 
     Pydantic ValidationError messages already describe the failure shape
     ("Input should be a valid string", "Input should be greater than 0",

--- a/grelmicro/health/__init__.py
+++ b/grelmicro/health/__init__.py
@@ -7,7 +7,7 @@ from grelmicro.health._models import (
     HealthStatus,
 )
 from grelmicro.health._types import HealthCheckFunc, HealthDetails
-from grelmicro.health.errors import HealthError, HealthSettingsValidationError
+from grelmicro.health.errors import HealthError
 
 __all__ = [
     "CheckResult",
@@ -17,6 +17,5 @@ __all__ = [
     "HealthDetails",
     "HealthError",
     "HealthReport",
-    "HealthSettingsValidationError",
     "HealthStatus",
 ]

--- a/grelmicro/health/_checks.py
+++ b/grelmicro/health/_checks.py
@@ -30,7 +30,6 @@ from grelmicro.health._types import (
 )
 from grelmicro.health.errors import (
     HealthError,
-    HealthSettingsValidationError,
 )
 from grelmicro.metrics import _emit
 
@@ -213,7 +212,6 @@ class HealthChecks(Reconfigurable[HealthChecksConfig]):
             kwargs={"timeout": timeout, "cache_ttl": cache_ttl},
             env_prefix=resolved_env_prefix,
             env_load=env_load,
-            error_type=HealthSettingsValidationError,
         )
         self._setup(config, name=name, auto_health=auto_health)
         # Registers for external reload under `GREL_HEALTH_`. Only this path

--- a/grelmicro/health/errors.py
+++ b/grelmicro/health/errors.py
@@ -1,8 +1,6 @@
 """Health Errors."""
 
-from pydantic import ValidationError
-
-from grelmicro.errors import GrelmicroError, SettingsValidationError
+from grelmicro.errors import GrelmicroError
 from grelmicro.health._types import HealthDetails
 
 
@@ -23,12 +21,3 @@ class HealthError(GrelmicroError):
         """Initialize with a message and optional details dict."""
         super().__init__(message)
         self.details = details
-
-
-class HealthSettingsValidationError(HealthError, SettingsValidationError):
-    """Health Settings Validation Error."""
-
-    def __init__(self, error: ValidationError | str) -> None:
-        """Initialize from a Pydantic validation error."""
-        SettingsValidationError.__init__(self, error)
-        self.details = None

--- a/grelmicro/idempotency/__init__.py
+++ b/grelmicro/idempotency/__init__.py
@@ -18,7 +18,6 @@ from grelmicro.idempotency.errors import (
     IdempotencyConflictError,
     IdempotencyError,
     IdempotencyKeyMakerError,
-    IdempotencySettingsValidationError,
     IdempotencyStateError,
     IdempotencyWaitTimeoutError,
 )
@@ -29,7 +28,6 @@ __all__ = [
     "IdempotencyConflictError",
     "IdempotencyError",
     "IdempotencyKeyMakerError",
-    "IdempotencySettingsValidationError",
     "IdempotencyStateError",
     "IdempotencyWaitTimeoutError",
     "Operation",

--- a/grelmicro/idempotency/_idempotency.py
+++ b/grelmicro/idempotency/_idempotency.py
@@ -21,7 +21,6 @@ from grelmicro.coordination.lock import Lock
 from grelmicro.idempotency.config import IdempotencyConfig
 from grelmicro.idempotency.errors import (
     IdempotencyConflictError,
-    IdempotencySettingsValidationError,
     IdempotencyStateError,
     IdempotencyWaitTimeoutError,
 )
@@ -421,7 +420,6 @@ class Idempotency(Reconfigurable[IdempotencyConfig], Generic[T]):
             env_prefix=resolved_env_prefix,
             kind_env_prefix=kind_prefix,
             env_load=env_load,
-            error_type=IdempotencySettingsValidationError,
         )
         self._setup(name, config, fingerprint, cache, serializer)
         self._track_reconfigure(resolved_env_prefix)

--- a/grelmicro/idempotency/errors.py
+++ b/grelmicro/idempotency/errors.py
@@ -1,16 +1,10 @@
 """Idempotency Errors."""
 
-from grelmicro.errors import GrelmicroError, SettingsValidationError
+from grelmicro.errors import GrelmicroError
 
 
 class IdempotencyError(GrelmicroError):
     """Base idempotency error."""
-
-
-class IdempotencySettingsValidationError(
-    IdempotencyError, SettingsValidationError
-):
-    """Idempotency Settings Validation Error."""
 
 
 class IdempotencyKeyMakerError(IdempotencyError, ValueError):

--- a/grelmicro/log/__init__.py
+++ b/grelmicro/log/__init__.py
@@ -21,7 +21,7 @@ from grelmicro.log.config import (
     LogLevelType,
     LogSerializerType,
 )
-from grelmicro.log.errors import LogError, LogSettingsValidationError
+from grelmicro.log.errors import LogError
 from grelmicro.log.types import ErrorDict, JSONRecordDict
 from grelmicro.types import TimeZoneName
 
@@ -104,7 +104,7 @@ def configure(
 
     Raises:
         DependencyNotFoundError: If the selected backend module is not installed.
-        LogSettingsValidationError: If configuration is invalid.
+        SettingsValidationError: If configuration is invalid.
     """
     config = resolve_config(
         LogConfig,
@@ -122,7 +122,6 @@ def configure(
         env_prefix="GREL_LOG_",
         shared_env=SHARED_TIMEZONE_ENV,
         env_load=env_load,
-        error_type=LogSettingsValidationError,
     )
     _apply(config)
     return config
@@ -163,7 +162,6 @@ __all__ = [
     "LogFormatType",
     "LogLevelType",
     "LogSerializerType",
-    "LogSettingsValidationError",
     "ProbeFilter",
     "RateLimitFilter",
     "RateLimitFilterConfig",

--- a/grelmicro/log/_component.py
+++ b/grelmicro/log/_component.py
@@ -22,7 +22,6 @@ from grelmicro.log.config import (
     LogLevelType,
     LogSerializerType,
 )
-from grelmicro.log.errors import LogSettingsValidationError
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -204,7 +203,6 @@ class Log:
                 env_prefix="GREL_LOG_",
                 shared_env=SHARED_TIMEZONE_ENV,
                 env_load=self._env_load,
-                error_type=LogSettingsValidationError,
             )
             _apply(self._resolved)
         return self

--- a/grelmicro/log/_dedup.py
+++ b/grelmicro/log/_dedup.py
@@ -17,7 +17,6 @@ from typing_extensions import Doc
 
 from grelmicro._config import env_prefixes, resolve_config
 from grelmicro.log._shared import KeyMode
-from grelmicro.log.errors import LogSettingsValidationError
 
 
 class DuplicateFilterConfig(BaseModel, frozen=True, extra="forbid"):
@@ -242,7 +241,6 @@ class DuplicateFilter(Filter):
             env_prefix=instance_prefix,
             kind_env_prefix=kind_prefix,
             env_load=env_load,
-            error_type=LogSettingsValidationError,
         )
         Filter.__init__(self)
         self._setup(config, key)

--- a/grelmicro/log/_loguru.py
+++ b/grelmicro/log/_loguru.py
@@ -250,7 +250,7 @@ def configure(config: LogConfig | None = None) -> None:
 
     Raises:
         DependencyNotFoundError: If OpenTelemetry is enabled but not installed.
-        pydantic.ValidationError: If environment variables are invalid.
+        SettingsValidationError: If environment variables are invalid.
     """
     settings, timezone, resolved_format, json_dumps, colors = load_settings(
         config

--- a/grelmicro/log/_ratelimit.py
+++ b/grelmicro/log/_ratelimit.py
@@ -15,7 +15,6 @@ from typing_extensions import Doc
 
 from grelmicro._config import env_prefixes, resolve_config
 from grelmicro.log._shared import KeyMode
-from grelmicro.log.errors import LogSettingsValidationError
 from grelmicro.resilience import MemoryTokenBucket
 
 
@@ -245,7 +244,6 @@ class RateLimitFilter(Filter):
             env_prefix=instance_prefix,
             kind_env_prefix=kind_prefix,
             env_load=env_load,
-            error_type=LogSettingsValidationError,
         )
         Filter.__init__(self)
         self._setup(config, key)

--- a/grelmicro/log/_shared.py
+++ b/grelmicro/log/_shared.py
@@ -16,7 +16,6 @@ from grelmicro.log.config import (
     LogFormatType,
     LogSerializerType,
 )
-from grelmicro.log.errors import LogSettingsValidationError
 
 try:
     from opentelemetry import trace
@@ -385,7 +384,7 @@ def load_settings(settings: LogConfig | None = None) -> LoadedSettings:
 
     Raises:
         DependencyNotFoundError: If orjson or OpenTelemetry is enabled but not installed.
-        LogSettingsValidationError: If environment variables are invalid.
+        SettingsValidationError: If environment variables are invalid.
     """
     if settings is None:
         settings = resolve_config(
@@ -394,7 +393,6 @@ def load_settings(settings: LogConfig | None = None) -> LoadedSettings:
             kwargs={},
             env_prefix="GREL_LOG_",
             shared_env=SHARED_TIMEZONE_ENV,
-            error_type=LogSettingsValidationError,
         )
 
     json_dumps: Callable[[Mapping[str, Any]], str]

--- a/grelmicro/log/_stdlib.py
+++ b/grelmicro/log/_stdlib.py
@@ -217,7 +217,7 @@ def configure(config: LogConfig | None = None) -> None:
 
     Raises:
         DependencyNotFoundError: If OpenTelemetry is enabled but not installed.
-        pydantic.ValidationError: If environment variables are invalid.
+        SettingsValidationError: If environment variables are invalid.
     """
     settings, timezone, resolved_format, json_dumps, colors = load_settings(
         config

--- a/grelmicro/log/_structlog.py
+++ b/grelmicro/log/_structlog.py
@@ -208,7 +208,7 @@ def configure(config: LogConfig | None = None) -> None:
 
     Raises:
         DependencyNotFoundError: If OpenTelemetry is enabled but not installed.
-        pydantic.ValidationError: If environment variables are invalid.
+        SettingsValidationError: If environment variables are invalid.
     """
     settings, timezone, resolved_format, _, colors = load_settings(config)
     caller = settings.caller_enabled

--- a/grelmicro/log/errors.py
+++ b/grelmicro/log/errors.py
@@ -1,11 +1,7 @@
 """Logging Errors."""
 
-from grelmicro.errors import GrelmicroError, SettingsValidationError
+from grelmicro.errors import GrelmicroError
 
 
 class LogError(GrelmicroError):
     """Base log error."""
-
-
-class LogSettingsValidationError(LogError, SettingsValidationError):
-    """Log Settings Validation Error."""

--- a/grelmicro/metrics/__init__.py
+++ b/grelmicro/metrics/__init__.py
@@ -13,7 +13,6 @@ from grelmicro.metrics.config import (
 )
 from grelmicro.metrics.errors import (
     MetricsError,
-    MetricsSettingsValidationError,
 )
 from grelmicro.metrics.fastapi import metrics_router
 
@@ -22,7 +21,6 @@ __all__ = [
     "MetricsConfig",
     "MetricsError",
     "MetricsExporterType",
-    "MetricsSettingsValidationError",
     "measure",
     "metrics_router",
 ]

--- a/grelmicro/metrics/_component.py
+++ b/grelmicro/metrics/_component.py
@@ -19,7 +19,6 @@ from grelmicro.metrics.config import (
 )
 from grelmicro.metrics.errors import (
     MetricsError,
-    MetricsSettingsValidationError,
 )
 
 if TYPE_CHECKING:
@@ -280,7 +279,6 @@ class Metrics:
                 kwargs=self._kwargs,
                 env_prefix="GREL_METRICS_",
                 env_load=self._env_load,
-                error_type=MetricsSettingsValidationError,
             )
         return self._resolved
 

--- a/grelmicro/metrics/errors.py
+++ b/grelmicro/metrics/errors.py
@@ -1,11 +1,7 @@
 """Metrics Errors."""
 
-from grelmicro.errors import GrelmicroError, SettingsValidationError
+from grelmicro.errors import GrelmicroError
 
 
 class MetricsError(GrelmicroError):
     """Base metrics error."""
-
-
-class MetricsSettingsValidationError(MetricsError, SettingsValidationError):
-    """Raised when the metrics configuration fails validation."""

--- a/grelmicro/outbox/__init__.py
+++ b/grelmicro/outbox/__init__.py
@@ -15,7 +15,6 @@ from grelmicro.outbox.errors import (
     HandlerNotFoundError,
     OutboxError,
     OutboxHandleError,
-    OutboxSettingsValidationError,
     OutboxTransactionError,
 )
 
@@ -30,7 +29,6 @@ __all__ = [
     "OutboxError",
     "OutboxHandleError",
     "OutboxRecord",
-    "OutboxSettingsValidationError",
     "OutboxTransactionError",
     "Retry",
 ]

--- a/grelmicro/outbox/_component.py
+++ b/grelmicro/outbox/_component.py
@@ -17,7 +17,6 @@ from grelmicro.outbox._otel import inject_trace_context
 from grelmicro.outbox._registry import OutboxRegistry, derive_topic
 from grelmicro.outbox._relay import Relay
 from grelmicro.outbox._uuid import uuid7
-from grelmicro.outbox.errors import OutboxSettingsValidationError
 from grelmicro.providers._base import Provider
 
 if TYPE_CHECKING:
@@ -167,7 +166,6 @@ class Outbox:
                 env_prefix=instance_prefix,
                 kind_env_prefix=kind_prefix,
                 env_load=env_load,
-                error_type=OutboxSettingsValidationError,
             ),
             requires=requires,
             name=name,

--- a/grelmicro/outbox/errors.py
+++ b/grelmicro/outbox/errors.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-from grelmicro.errors import GrelmicroError, SettingsValidationError
+from grelmicro.errors import GrelmicroError
 
 
 class OutboxError(GrelmicroError):
     """Base outbox error."""
-
-
-class OutboxSettingsValidationError(OutboxError, SettingsValidationError):
-    """Outbox Settings Validation Error."""
 
 
 class OutboxTransactionError(OutboxError, RuntimeError):

--- a/grelmicro/resilience/__init__.py
+++ b/grelmicro/resilience/__init__.py
@@ -77,7 +77,6 @@ from grelmicro.resilience.errors import (
     CircuitBreakerError,
     RateLimitExceededError,
     ResilienceError,
-    ResilienceSettingsValidationError,
 )
 
 # Same shadow handling as `retry`/`retrying`: ``fallback`` and
@@ -212,7 +211,6 @@ __all__ = [
     "RedisCircuitBreakerAdapter",
     "RedisRateLimiterAdapter",
     "ResilienceError",
-    "ResilienceSettingsValidationError",
     "Retry",
     "RetryAttempt",
     "RetryBackoffConfig",

--- a/grelmicro/resilience/errors.py
+++ b/grelmicro/resilience/errors.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from grelmicro.errors import (
     AdmissionError,
     GrelmicroError,
-    SettingsValidationError,
 )
 
 
@@ -15,12 +14,6 @@ class ResilienceError(GrelmicroError):
     This class serves as the base for all errors related to resilience mechanisms
     such as circuit breakers, retries, etc.
     """
-
-
-class ResilienceSettingsValidationError(
-    ResilienceError, SettingsValidationError
-):
-    """Resilience Settings Validation Error."""
 
 
 class BulkheadFullError(ResilienceError, AdmissionError):

--- a/grelmicro/resilience/fallback.py
+++ b/grelmicro/resilience/fallback.py
@@ -73,36 +73,38 @@ def _coerce_to_match(value: Any) -> Match:  # noqa: ANN401
         return Match.exception(value)
     msg = (
         "when= must be a Match, an Exception class, a tuple of "
-        f"Exception classes, or a callable. Got {value!r}"
+        f"Exception classes, or a callable. Got {type(value).__name__}"
     )
-    raise TypeError(msg)
+    # `ValueError`, not `TypeError`: pydantic converts only `ValueError` and
+    # `AssertionError`, so a `TypeError` escaped every documented `except`.
+    raise ValueError(msg)
 
 
 def _resolve_fqn(fqn: str) -> type[Exception]:
     """Resolve a fully-qualified name to an Exception class."""
     module_path, _, name = fqn.rpartition(".")
     if not module_path:
-        msg = "when= env entry must be a fully-qualified name"
+        msg = (
+            "when= env entry must be a fully-qualified name, "
+            "such as 'httpx.HTTPError'"
+        )
         raise ValueError(msg)
     try:
         module = import_module(module_path)
     except ModuleNotFoundError as exc:
-        msg = (
-            f"when= env entry names module {module_path!r}, "
-            f"which cannot be imported ({exc})"
-        )
+        msg = "when= env entry names a module that cannot be imported"
         raise ValueError(msg) from exc
     try:
         cls = getattr(module, name)
     except AttributeError as exc:
-        msg = (
-            f"when= env entry names module {module_path!r}, "
-            f"which has no attribute {name!r}"
-        )
+        msg = "when= env entry names an attribute its module does not define"
         raise ValueError(msg) from exc
     if not (isinstance(cls, type) and issubclass(cls, Exception)):
-        msg = f"when= env entry names {name!r}, which is not an Exception subclass"
-        raise TypeError(msg)
+        # `ValueError`, not `TypeError`: pydantic converts only `ValueError`
+        # and `AssertionError` into a `ValidationError`, so a `TypeError` here
+        # escaped `except SettingsValidationError` and `except ValueError` both.
+        msg = "when= env entry does not name an Exception subclass"
+        raise ValueError(msg)  # noqa: TRY004
     return cls
 
 

--- a/grelmicro/resilience/fallback.py
+++ b/grelmicro/resilience/fallback.py
@@ -19,7 +19,12 @@ from typing import (
     overload,
 )
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from typing_extensions import Doc
 
 from grelmicro._config import (
@@ -31,6 +36,7 @@ from grelmicro._config import (
     parse_csv_or_json,
 )
 from grelmicro._json import json_loads
+from grelmicro.errors import SettingsValidationError
 from grelmicro.resilience._match import Match, Matcher
 from grelmicro.resilience._outcome import Outcome
 from grelmicro.resilience.retry import WhenInput  # noqa: TC001
@@ -76,26 +82,26 @@ def _resolve_fqn(fqn: str) -> type[Exception]:
     """Resolve a fully-qualified name to an Exception class."""
     module_path, _, name = fqn.rpartition(".")
     if not module_path:
-        msg = f"when= env entry must be a fully-qualified name, got {fqn!r}"
+        msg = "when= env entry must be a fully-qualified name"
         raise ValueError(msg)
     try:
         module = import_module(module_path)
     except ModuleNotFoundError as exc:
         msg = (
-            f"when= env entry {fqn!r}: cannot import module "
-            f"{module_path!r} ({exc})"
+            f"when= env entry names module {module_path!r}, "
+            f"which cannot be imported ({exc})"
         )
         raise ValueError(msg) from exc
     try:
         cls = getattr(module, name)
     except AttributeError as exc:
         msg = (
-            f"when= env entry {fqn!r}: module {module_path!r} has no "
-            f"attribute {name!r}"
+            f"when= env entry names module {module_path!r}, "
+            f"which has no attribute {name!r}"
         )
         raise ValueError(msg) from exc
     if not (isinstance(cls, type) and issubclass(cls, Exception)):
-        msg = f"when= env entry {fqn!r} is not an Exception subclass"
+        msg = f"when= env entry names {name!r}, which is not an Exception subclass"
         raise TypeError(msg)
     return cls
 
@@ -193,6 +199,19 @@ class _State:
     matcher: Matcher
 
 
+def _validate(build: Callable[[], Any]) -> FallbackConfig:
+    """Run `build`, raising `SettingsValidationError` on a bad value.
+
+    `Fallback` resolves its own configuration, so it wraps the pydantic
+    error here instead of through `resolve_config`. Without this the raw
+    error escapes carrying `input_value`, which is the rejected value.
+    """
+    try:
+        return build()
+    except ValidationError as error:
+        raise SettingsValidationError(error) from None
+
+
 def _resolve_config(
     name: str,
     *,
@@ -218,14 +237,14 @@ def _resolve_config(
     if env_load is None:
         env_load = env_load_default()
     if not env_load:
-        return FallbackConfig.model_validate(kwargs)
+        return _validate(lambda: FallbackConfig.model_validate(kwargs))
 
     env_prefix, kind_prefix = env_prefixes("FALLBACK", name)
     _load_default_from_env(kwargs, env_prefix)
     settings_cls = _build_settings_cls(
         FallbackConfig, env_prefix, kind_env_prefix=kind_prefix
     )
-    return settings_cls(**kwargs)  # ty: ignore[invalid-return-type]
+    return _validate(lambda: settings_cls(**kwargs))
 
 
 def _load_default_from_env(kwargs: dict[str, Any], env_prefix: str) -> None:
@@ -495,7 +514,7 @@ def fallback(
     kwargs: dict[str, Any] = {"when": when, "factory": factory}
     if default is not _UNSET:
         kwargs["default"] = default
-    config = FallbackConfig.model_validate(kwargs)
+    config = _validate(lambda: FallbackConfig.model_validate(kwargs))
     matcher: Matcher = config.when
 
     def wrap(fn: F) -> F:
@@ -552,5 +571,5 @@ def falling_back(
     kwargs: dict[str, Any] = {"when": when, "factory": factory}
     if default is not _UNSET:
         kwargs["default"] = default
-    config = FallbackConfig.model_validate(kwargs)
+    config = _validate(lambda: FallbackConfig.model_validate(kwargs))
     return _FallbackBlock(config, config.when)

--- a/grelmicro/resilience/retry.py
+++ b/grelmicro/resilience/retry.py
@@ -104,26 +104,26 @@ def _resolve_fqn(fqn: str) -> type[Exception]:
     """Resolve a fully-qualified name to an Exception class."""
     module_path, _, name = fqn.rpartition(".")
     if not module_path:
-        msg = f"when= env entry must be a fully-qualified name, got {fqn!r}"
+        msg = "when= env entry must be a fully-qualified name"
         raise ValueError(msg)
     try:
         module = import_module(module_path)
     except ModuleNotFoundError as exc:
         msg = (
-            f"when= env entry {fqn!r}: cannot import module "
-            f"{module_path!r} ({exc})"
+            f"when= env entry names module {module_path!r}, "
+            f"which cannot be imported ({exc})"
         )
         raise ValueError(msg) from exc
     try:
         cls = getattr(module, name)
     except AttributeError as exc:
         msg = (
-            f"when= env entry {fqn!r}: module {module_path!r} has no "
-            f"attribute {name!r}"
+            f"when= env entry names module {module_path!r}, "
+            f"which has no attribute {name!r}"
         )
         raise ValueError(msg) from exc
     if not (isinstance(cls, type) and issubclass(cls, Exception)):
-        msg = f"when= env entry {fqn!r} is not an Exception subclass"
+        msg = f"when= env entry names {name!r}, which is not an Exception subclass"
         raise TypeError(msg)
     return cls
 

--- a/grelmicro/resilience/retry.py
+++ b/grelmicro/resilience/retry.py
@@ -95,36 +95,38 @@ def _coerce_to_match(value: Any) -> Match:  # noqa: ANN401
         return Match.exception(value)
     msg = (
         "when= must be a Match, an Exception class, a tuple of "
-        f"Exception classes, or a callable. Got {value!r}"
+        f"Exception classes, or a callable. Got {type(value).__name__}"
     )
-    raise TypeError(msg)
+    # `ValueError`, not `TypeError`: pydantic converts only `ValueError` and
+    # `AssertionError`, so a `TypeError` escaped every documented `except`.
+    raise ValueError(msg)
 
 
 def _resolve_fqn(fqn: str) -> type[Exception]:
     """Resolve a fully-qualified name to an Exception class."""
     module_path, _, name = fqn.rpartition(".")
     if not module_path:
-        msg = "when= env entry must be a fully-qualified name"
+        msg = (
+            "when= env entry must be a fully-qualified name, "
+            "such as 'httpx.HTTPError'"
+        )
         raise ValueError(msg)
     try:
         module = import_module(module_path)
     except ModuleNotFoundError as exc:
-        msg = (
-            f"when= env entry names module {module_path!r}, "
-            f"which cannot be imported ({exc})"
-        )
+        msg = "when= env entry names a module that cannot be imported"
         raise ValueError(msg) from exc
     try:
         cls = getattr(module, name)
     except AttributeError as exc:
-        msg = (
-            f"when= env entry names module {module_path!r}, "
-            f"which has no attribute {name!r}"
-        )
+        msg = "when= env entry names an attribute its module does not define"
         raise ValueError(msg) from exc
     if not (isinstance(cls, type) and issubclass(cls, Exception)):
-        msg = f"when= env entry names {name!r}, which is not an Exception subclass"
-        raise TypeError(msg)
+        # `ValueError`, not `TypeError`: pydantic converts only `ValueError`
+        # and `AssertionError` into a `ValidationError`, so a `TypeError` here
+        # escaped `except SettingsValidationError` and `except ValueError` both.
+        msg = "when= env entry does not name an Exception subclass"
+        raise ValueError(msg)  # noqa: TRY004
     return cls
 
 

--- a/grelmicro/resilience/shield/_profile.py
+++ b/grelmicro/resilience/shield/_profile.py
@@ -31,30 +31,29 @@ def _resolve_fqn(fqn: str) -> type[BaseException]:
     """Resolve a fully-qualified name to an exception class."""
     module_path, _, name = fqn.rpartition(".")
     if not module_path:
-        msg = "timeout_errors entry must be a fully-qualified name"
+        msg = (
+            "timeout_errors entry must be a fully-qualified name, "
+            "such as 'httpx.HTTPError'"
+        )
         raise ValueError(msg)
     try:
         module = import_module(module_path)
     except ModuleNotFoundError as exc:
-        msg = (
-            f"timeout_errors entry names module {module_path!r}, "
-            f"which cannot be imported ({exc})"
-        )
+        msg = "timeout_errors entry names a module that cannot be imported"
         raise ValueError(msg) from exc
     try:
         cls = getattr(module, name)
     except AttributeError as exc:
         msg = (
-            f"timeout_errors entry names module {module_path!r}, "
-            f"which has no attribute {name!r}"
+            "timeout_errors entry names an attribute its module does not define"
         )
         raise ValueError(msg) from exc
     if not (isinstance(cls, type) and issubclass(cls, Exception)):
-        msg = (
-            f"timeout_errors entry names {name!r}, which is not an "
-            f"Exception subclass"
-        )
-        raise TypeError(msg)
+        # `ValueError`, not `TypeError`: pydantic converts only `ValueError`
+        # and `AssertionError` into a `ValidationError`, so a `TypeError` here
+        # escaped `except SettingsValidationError` and `except ValueError` both.
+        msg = "timeout_errors entry does not name an Exception subclass"
+        raise ValueError(msg)  # noqa: TRY004
     return cls
 
 

--- a/grelmicro/resilience/shield/_profile.py
+++ b/grelmicro/resilience/shield/_profile.py
@@ -31,28 +31,29 @@ def _resolve_fqn(fqn: str) -> type[BaseException]:
     """Resolve a fully-qualified name to an exception class."""
     module_path, _, name = fqn.rpartition(".")
     if not module_path:
-        msg = (
-            f"timeout_errors entry must be a fully-qualified name, got {fqn!r}"
-        )
+        msg = "timeout_errors entry must be a fully-qualified name"
         raise ValueError(msg)
     try:
         module = import_module(module_path)
     except ModuleNotFoundError as exc:
         msg = (
-            f"timeout_errors entry {fqn!r}: cannot import module "
-            f"{module_path!r} ({exc})"
+            f"timeout_errors entry names module {module_path!r}, "
+            f"which cannot be imported ({exc})"
         )
         raise ValueError(msg) from exc
     try:
         cls = getattr(module, name)
     except AttributeError as exc:
         msg = (
-            f"timeout_errors entry {fqn!r}: module {module_path!r} has "
-            f"no attribute {name!r}"
+            f"timeout_errors entry names module {module_path!r}, "
+            f"which has no attribute {name!r}"
         )
         raise ValueError(msg) from exc
     if not (isinstance(cls, type) and issubclass(cls, Exception)):
-        msg = f"timeout_errors entry {fqn!r} is not an Exception subclass"
+        msg = (
+            f"timeout_errors entry names {name!r}, which is not an "
+            f"Exception subclass"
+        )
         raise TypeError(msg)
     return cls
 

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -106,6 +106,7 @@ def _fill_from_env(
     passed: Any,  # noqa: ANN401
     read: Callable[[str], str | None],
     *,
+    env_prefix: str,
     cast: Callable[[str], Any] | None = None,
 ) -> None:
     """Take the caller's value, else the environment's, else leave unset.
@@ -114,8 +115,8 @@ def _fill_from_env(
     `resolve_config` applies for every other pattern.
 
     A value the cast refuses raises `SettingsValidationError` naming the
-    variable. `float()` reports the rejected string in its own message,
-    so it is never allowed to escape.
+    variable, in the same shape `resolve_config` renders. `float()` reports
+    the rejected string in its own message, so it never escapes.
     """
     if passed is not None:
         kwargs[field] = passed
@@ -129,7 +130,7 @@ def _fill_from_env(
     try:
         kwargs[field] = cast(value)
     except ValueError:
-        msg = f"{field}: input is not a valid number"
+        msg = f"- {env_prefix}{field.upper()}: input is not a valid number"
         raise SettingsValidationError(msg) from None
 
 
@@ -164,8 +165,12 @@ def _resolve_config_from_env(
         return value
 
     kwargs: dict[str, Any] = {"kind": profile}
-    _fill_from_env(kwargs, "timeout_errors", timeout_errors, _env)
-    _fill_from_env(kwargs, "max_rate", max_rate, _env, cast=float)
+    _fill_from_env(
+        kwargs, "timeout_errors", timeout_errors, _env, env_prefix=env_prefix
+    )
+    _fill_from_env(
+        kwargs, "max_rate", max_rate, _env, env_prefix=env_prefix, cast=float
+    )
     if cache is not None:
         kwargs["cache"] = cache
     if cache_key is not None:

--- a/grelmicro/resilience/shield/_shield.py
+++ b/grelmicro/resilience/shield/_shield.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from logging import getLogger
 from typing import Annotated, Any, Self, TypeVar
 
-from pydantic import Discriminator, PositiveFloat
+from pydantic import Discriminator, PositiveFloat, ValidationError
 from typing_extensions import Doc
 
 from grelmicro._config import (
@@ -23,6 +23,7 @@ from grelmicro._config import (
     warn_ignored_env,
 )
 from grelmicro.clock import monotonic, sleep
+from grelmicro.errors import SettingsValidationError
 from grelmicro.metrics import _emit
 from grelmicro.resilience.errors import ResilienceError
 from grelmicro.resilience.shield._adaptive_gate import _AdaptiveGate
@@ -77,11 +78,26 @@ def _load_profile_from_env(name: str) -> str:
         value = os.environ.get(env_key, "").strip().lower()
     if value and value not in _PROFILE_BY_NAME:
         msg = (
-            f"{env_key}={value!r} is not a valid profile. "
+            f"{env_key} is not a valid profile. "
             f"Expected one of: internal, api, slow."
         )
-        raise ValueError(msg)
+        raise SettingsValidationError(msg)
     return value or "api"
+
+
+def _validate(
+    cls: type[_BaseShieldConfig], kwargs: dict[str, Any]
+) -> _BaseShieldConfig:
+    """Build `cls`, raising `SettingsValidationError` on a bad value.
+
+    `Shield` resolves its own configuration, so it wraps the pydantic
+    error here instead of through `resolve_config`. Without this the raw
+    error escapes carrying `input_value`, which is the rejected value.
+    """
+    try:
+        return cls.model_validate(kwargs)
+    except ValidationError as error:
+        raise SettingsValidationError(error) from None
 
 
 def _fill_from_env(
@@ -96,6 +112,10 @@ def _fill_from_env(
 
     A keyword beats the environment, which is the same order
     `resolve_config` applies for every other pattern.
+
+    A value the cast refuses raises `SettingsValidationError` naming the
+    variable. `float()` reports the rejected string in its own message,
+    so it is never allowed to escape.
     """
     if passed is not None:
         kwargs[field] = passed
@@ -103,7 +123,14 @@ def _fill_from_env(
     value = read(field.upper())
     if value is None or (cast is not None and value.strip() == ""):
         return
-    kwargs[field] = cast(value) if cast is not None else value
+    if cast is None:
+        kwargs[field] = value
+        return
+    try:
+        kwargs[field] = cast(value)
+    except ValueError:
+        msg = f"{field}: input is not a valid number"
+        raise SettingsValidationError(msg) from None
 
 
 def _resolve_config_from_env(
@@ -145,7 +172,7 @@ def _resolve_config_from_env(
         kwargs["cache_key"] = cache_key
     if fallback is not None:
         kwargs["fallback"] = fallback
-    return cls.model_validate(kwargs)
+    return _validate(cls, kwargs)
 
 
 def _build_config(
@@ -198,7 +225,7 @@ def _build_config(
             kwargs,
             kind_env_prefix=kind_prefix,
         )
-    return cls.model_validate(kwargs)
+    return _validate(cls, kwargs)
 
 
 @dataclass(frozen=True, slots=True)

--- a/grelmicro/task/__init__.py
+++ b/grelmicro/task/__init__.py
@@ -8,7 +8,6 @@ from grelmicro.task.errors import (
     FunctionTypeError,
     TaskAddOperationError,
     TaskError,
-    TaskSettingsValidationError,
     TaskStartOperationError,
     TimezoneError,
 )
@@ -23,7 +22,6 @@ __all__ = [
     "TaskAddOperationError",
     "TaskError",
     "TaskRouter",
-    "TaskSettingsValidationError",
     "TaskStartOperationError",
     "Tasks",
     "TasksConfig",

--- a/grelmicro/task/_tasks.py
+++ b/grelmicro/task/_tasks.py
@@ -18,7 +18,6 @@ from grelmicro._timezone import SHARED_TIMEZONE_ENV, UTC_NAME
 from grelmicro.errors import OutOfContextError
 from grelmicro.task._protocol import Task
 from grelmicro.task.errors import (
-    TaskSettingsValidationError,
     TaskStartOperationError,
 )
 from grelmicro.task.router import TaskRouter
@@ -147,7 +146,7 @@ class Tasks(TaskRouter, Reconfigurable[TasksConfig]):
         """Initialize Tasks.
 
         Raises:
-            TaskSettingsValidationError: If a setting fails validation.
+            SettingsValidationError: If a setting fails validation.
         """
         config = resolve_config(
             TasksConfig,
@@ -159,7 +158,6 @@ class Tasks(TaskRouter, Reconfigurable[TasksConfig]):
             env_prefix=env_prefix or default_env_prefix("TASK", "default"),
             env_load=env_load,
             shared_env=SHARED_TIMEZONE_ENV,
-            error_type=TaskSettingsValidationError,
         )
         self._setup(config, auto_start=auto_start, tasks=tasks)
         self._track_reconfigure(

--- a/grelmicro/task/errors.py
+++ b/grelmicro/task/errors.py
@@ -1,18 +1,10 @@
 """Task Errors."""
 
-from grelmicro.errors import GrelmicroError, SettingsValidationError
+from grelmicro.errors import GrelmicroError
 
 
 class TaskError(GrelmicroError):
     """Base grelmicro Task error."""
-
-
-class TaskSettingsValidationError(TaskError, SettingsValidationError):
-    """Task Settings Validation Error.
-
-    Raised when `Tasks` settings fail validation, whether they came from
-    keyword arguments or from the `GREL_TASK_` environment variables.
-    """
 
 
 class FunctionTypeError(TaskError, TypeError):

--- a/grelmicro/trace/__init__.py
+++ b/grelmicro/trace/__init__.py
@@ -14,7 +14,7 @@ from grelmicro.trace.config import (
     TraceProcessorType,
     TraceSamplerType,
 )
-from grelmicro.trace.errors import TraceError, TraceSettingsValidationError
+from grelmicro.trace.errors import TraceError
 
 __all__ = [
     "Trace",
@@ -23,7 +23,6 @@ __all__ = [
     "TraceExporterType",
     "TraceProcessorType",
     "TraceSamplerType",
-    "TraceSettingsValidationError",
     "add_context",
     "get_context",
     "instrument",

--- a/grelmicro/trace/_autoinstrument.py
+++ b/grelmicro/trace/_autoinstrument.py
@@ -52,12 +52,10 @@ def validate_directive(directive: InstrumentDirective, known: set[str]) -> None:
     silently treated as "include".
 
     Raises:
-        TraceSettingsValidationError: If the directive names an unknown target
+        SettingsValidationError: If the directive names an unknown target
             or maps a name to a non-bool value.
     """
-    from grelmicro.trace.errors import (  # noqa: PLC0415
-        TraceSettingsValidationError,
-    )
+    from grelmicro.errors import SettingsValidationError  # noqa: PLC0415
 
     if isinstance(directive, Mapping):
         # `str(key)` keeps the sort well defined: `isinstance` narrows the
@@ -72,7 +70,7 @@ def validate_directive(directive: InstrumentDirective, known: set[str]) -> None:
                 f"Trace(instrument=...) maps {bad_values} to non-bool values. "
                 f"Map a name to True or False."
             )
-            raise TraceSettingsValidationError(msg)
+            raise SettingsValidationError(msg)
     names = explicit_names(directive)
     if names is None:
         return
@@ -82,7 +80,7 @@ def validate_directive(directive: InstrumentDirective, known: set[str]) -> None:
             f"Trace(instrument=...) names unknown targets "
             f"{sorted(unknown)}. Known targets are {sorted(known)}."
         )
-        raise TraceSettingsValidationError(msg)
+        raise SettingsValidationError(msg)
 
 
 def is_selected(name: str, directive: InstrumentDirective) -> bool:

--- a/grelmicro/trace/_component.py
+++ b/grelmicro/trace/_component.py
@@ -21,7 +21,6 @@ from grelmicro.trace.config import (
 )
 from grelmicro.trace.errors import (
     TraceError,
-    TraceSettingsValidationError,
 )
 
 if TYPE_CHECKING:
@@ -304,7 +303,6 @@ class Trace:
                 kwargs=self._kwargs,
                 env_prefix="GREL_TRACE_",
                 env_load=self._env_load,
-                error_type=TraceSettingsValidationError,
             )
         return self._resolved
 

--- a/grelmicro/trace/errors.py
+++ b/grelmicro/trace/errors.py
@@ -1,11 +1,7 @@
 """Tracing Errors."""
 
-from grelmicro.errors import GrelmicroError, SettingsValidationError
+from grelmicro.errors import GrelmicroError
 
 
 class TraceError(GrelmicroError):
     """Base trace error."""
-
-
-class TraceSettingsValidationError(TraceError, SettingsValidationError):
-    """Trace Settings Validation Error."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,7 @@ nav:
     - reference/cache.md
     - reference/clock.md
     - reference/config.md
+    - reference/errors.md
     - reference/fastapi.md
     - reference/faststream.md
     - reference/litestar.md

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -61,9 +61,6 @@
     "CacheSerializer": {
       "()": "(*args, **kwargs)"
     },
-    "CacheSettingsValidationError": {
-      "()": "(error)"
-    },
     "CachedFunction": {
       "()": "(*args, **kwargs)"
     },
@@ -124,9 +121,6 @@
     },
     "CoordinationBackendError": null,
     "CoordinationError": null,
-    "CoordinationSettingsValidationError": {
-      "()": "(error)"
-    },
     "LeaderElection": {
       "()": "(name, *, backend=..., worker=..., lease_duration=..., renew_deadline=..., retry_interval=..., retry_jitter=..., backend_timeout=..., error_interval=..., env_prefix=..., env_load=..., metadata=...)",
       ".from_config": "(name, config, *, backend=..., metadata=...)"
@@ -244,9 +238,6 @@
       "()": "(message, *, details=...)"
     },
     "HealthReport": null,
-    "HealthSettingsValidationError": {
-      "()": "(error)"
-    },
     "HealthStatus": {
       "()": "(*values)"
     }
@@ -264,9 +255,6 @@
     },
     "IdempotencyError": null,
     "IdempotencyKeyMakerError": null,
-    "IdempotencySettingsValidationError": {
-      "()": "(error)"
-    },
     "IdempotencyStateError": null,
     "IdempotencyWaitTimeoutError": {
       "()": "(*, name, key, timeout)"
@@ -355,9 +343,6 @@
     "LogSerializerType": {
       "()": "(*values)"
     },
-    "LogSettingsValidationError": {
-      "()": "(error)"
-    },
     "ProbeFilter": {
       "()": "(paths=...)"
     },
@@ -387,14 +372,41 @@
     "MetricsExporterType": {
       "()": "(*values)"
     },
-    "MetricsSettingsValidationError": {
-      "()": "(error)"
-    },
     "measure": {
       "()": "(func=..., *, name=..., record_in_flight=...)"
     },
     "metrics_router": {
       "()": "(component=..., *, prefix=..., path=..., dependencies=...)"
+    }
+  },
+  "grelmicro.outbox": {
+    "Cancel": {
+      "()": "(reason)"
+    },
+    "HandlerAlreadyRegisteredError": null,
+    "HandlerNotFoundError": null,
+    "Message": {
+      "()": "(id, topic, key, data, payload, headers, attempts)"
+    },
+    "Outbox": {
+      "()": "(source, *, requires=..., name=..., relay=..., table=..., poll_interval=..., batch_size=..., lease_duration=..., max_attempts=..., retry_base=..., retry_max=..., retry_jitter=..., concurrency=..., dead_letter=..., keep_delivered=..., auto_migrate=..., notify=..., env_load=..., shutdown_timeout=...)",
+      ".current": "(name=...)",
+      ".from_config": "(source, config, *, requires=..., name=..., shutdown_timeout=...)"
+    },
+    "OutboxBackend": {
+      "()": "(*args, **kwargs)"
+    },
+    "OutboxConfig": {
+      "()": "(*, table=..., relay=..., poll_interval=..., batch_size=..., lease_duration=..., max_attempts=..., retry_base=..., retry_max=..., retry_jitter=..., concurrency=..., dead_letter=..., keep_delivered=..., auto_migrate=..., notify=...)"
+    },
+    "OutboxError": null,
+    "OutboxHandleError": null,
+    "OutboxRecord": {
+      "()": "(id, topic, payload, key=..., headers=..., dedup_key=..., attempts=..., available_at=...)"
+    },
+    "OutboxTransactionError": null,
+    "Retry": {
+      "()": "(*, delay=...)"
     }
   },
   "grelmicro.providers": {
@@ -547,9 +559,6 @@
       "()": "(*, provider=..., env_prefix=..., prefix=...)"
     },
     "ResilienceError": null,
-    "ResilienceSettingsValidationError": {
-      "()": "(error)"
-    },
     "Retry": {
       "()": "(name, backoff=..., *, when=..., attempts=..., max_seconds=..., env_load=...)",
       ".constant": "(name, *, when, attempts=..., max_seconds=..., delay=..., env_load=...)",
@@ -742,9 +751,6 @@
     "TaskRouter": {
       "()": "(*, tasks=..., timezone=...)"
     },
-    "TaskSettingsValidationError": {
-      "()": "(error)"
-    },
     "TaskStartOperationError": {
       "()": "()"
     },
@@ -788,9 +794,6 @@
     "TraceSamplerType": {
       "()": "(*values)"
     },
-    "TraceSettingsValidationError": {
-      "()": "(error)"
-    },
     "add_context": {
       "()": "(**fields)"
     },
@@ -803,5 +806,14 @@
     "span": {
       "()": "(name, **fields)"
     }
+  },
+  "grelmicro.types": {
+    "BackendScope": null,
+    "Environment": null,
+    "LogLevel": null,
+    "SecretUrl": {
+      "()": "(secret_value)"
+    },
+    "TimeZoneName": null
   }
 }

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -69,19 +69,19 @@ class TestInit:
         assert info.currsize == 0
 
     def test_negative_maxsize_raises(self, backend: MemoryCacheAdapter) -> None:
-        """Test that negative maxsize raises a Pydantic validation error."""
+        """Test that negative maxsize raises `SettingsValidationError`."""
         # Act / Assert
         with pytest.raises(SettingsValidationError, match="maxsize"):
             TTLCache(maxsize=-1, ttl=60, backend=backend)
 
     def test_zero_ttl_raises(self, backend: MemoryCacheAdapter) -> None:
-        """Test that zero ttl raises a Pydantic validation error."""
+        """Test that zero ttl raises `SettingsValidationError`."""
         # Act / Assert
         with pytest.raises(SettingsValidationError, match="ttl"):
             TTLCache(maxsize=10, ttl=0, backend=backend)
 
     def test_negative_ttl_raises(self, backend: MemoryCacheAdapter) -> None:
-        """Test that negative ttl raises a Pydantic validation error."""
+        """Test that negative ttl raises `SettingsValidationError`."""
         # Act / Assert
         with pytest.raises(SettingsValidationError, match="ttl"):
             TTLCache(maxsize=10, ttl=-1, backend=backend)

--- a/tests/cache/test_ttl.py
+++ b/tests/cache/test_ttl.py
@@ -7,7 +7,7 @@ from time import monotonic
 from unittest.mock import patch
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from grelmicro import Grelmicro
 from grelmicro.cache import Cache, TTLCacheConfig
@@ -19,7 +19,7 @@ from grelmicro.cache.ttl import (
     CacheInfo,
     TTLCache,
 )
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import OutOfContextError, SettingsValidationError
 
 pytestmark = [pytest.mark.timeout(10)]
 
@@ -71,19 +71,19 @@ class TestInit:
     def test_negative_maxsize_raises(self, backend: MemoryCacheAdapter) -> None:
         """Test that negative maxsize raises a Pydantic validation error."""
         # Act / Assert
-        with pytest.raises(ValidationError, match="maxsize"):
+        with pytest.raises(SettingsValidationError, match="maxsize"):
             TTLCache(maxsize=-1, ttl=60, backend=backend)
 
     def test_zero_ttl_raises(self, backend: MemoryCacheAdapter) -> None:
         """Test that zero ttl raises a Pydantic validation error."""
         # Act / Assert
-        with pytest.raises(ValidationError, match="ttl"):
+        with pytest.raises(SettingsValidationError, match="ttl"):
             TTLCache(maxsize=10, ttl=0, backend=backend)
 
     def test_negative_ttl_raises(self, backend: MemoryCacheAdapter) -> None:
         """Test that negative ttl raises a Pydantic validation error."""
         # Act / Assert
-        with pytest.raises(ValidationError, match="ttl"):
+        with pytest.raises(SettingsValidationError, match="ttl"):
             TTLCache(maxsize=10, ttl=-1, backend=backend)
 
     def test_from_config(self, backend: MemoryCacheAdapter) -> None:

--- a/tests/coordination/test_kubernetes_lock.py
+++ b/tests/coordination/test_kubernetes_lock.py
@@ -10,14 +10,13 @@ from lightkube.models.coordination_v1 import LeaseSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.coordination_v1 import Lease
 
-from grelmicro.coordination.errors import CoordinationSettingsValidationError
 from grelmicro.coordination.kubernetes import (
     _MAX_NAME_LENGTH,
     KubernetesLockAdapter,
     _get_expire_at,
     _sanitize_lease_name,
 )
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import OutOfContextError, SettingsValidationError
 
 pytestmark = [pytest.mark.timeout(1)]
 
@@ -121,7 +120,7 @@ def test_kubernetes_env_var_settings_validation_error() -> None:
     """Test Kubernetes Settings Validation Error."""
     # Assert / Act
     with pytest.raises(
-        CoordinationSettingsValidationError,
+        SettingsValidationError,
         match=(r"Could not validate settings:\n"),
     ):
         KubernetesLockAdapter()

--- a/tests/coordination/test_leaderelection.py
+++ b/tests/coordination/test_leaderelection.py
@@ -12,13 +12,12 @@ from pytest_mock import MockerFixture
 import grelmicro.coordination._base as base_module
 import grelmicro.coordination.leaderelection as le_module
 from grelmicro.coordination._protocol import LeaderElectionBackend
-from grelmicro.coordination.errors import CoordinationSettingsValidationError
 from grelmicro.coordination.leaderelection import (
     LeaderElection,
     LeaderElectionConfig,
 )
 from grelmicro.coordination.memory import MemoryLeaderElectionAdapter
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import OutOfContextError, SettingsValidationError
 from grelmicro.errors import WouldBlockError as WouldBlock
 from tests.task._helpers import cancel_group, start_task
 
@@ -687,9 +686,7 @@ async def test_leader_reconfigure_rejects_worker_change(
         update={"worker": "other-worker"},
     )
 
-    with pytest.raises(
-        CoordinationSettingsValidationError, match="worker is immutable"
-    ):
+    with pytest.raises(SettingsValidationError, match="worker is immutable"):
         await leader_election.reconfigure(new_config)
 
 

--- a/tests/coordination/test_lock.py
+++ b/tests/coordination/test_lock.py
@@ -14,7 +14,6 @@ import grelmicro.coordination.lock as lock_module
 from grelmicro.coordination._handle import LockHandle
 from grelmicro.coordination._protocol import LockBackend
 from grelmicro.coordination.errors import (
-    CoordinationSettingsValidationError,
     LockAcquireError,
     LockLockedCheckError,
     LockNotOwnedError,
@@ -24,7 +23,7 @@ from grelmicro.coordination.errors import (
 )
 from grelmicro.coordination.lock import Lock
 from grelmicro.coordination.memory import MemoryLockAdapter
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import OutOfContextError, SettingsValidationError
 from grelmicro.errors import WouldBlockError as WouldBlock
 from tests._faults import cancel_midflight
 
@@ -963,9 +962,7 @@ async def test_reconfigure_rejects_worker_change(lock: Lock) -> None:
     """Changing `worker` is not allowed because the token identity is live."""
     new_config = lock.config.model_copy(update={"worker": "other-worker"})
 
-    with pytest.raises(
-        CoordinationSettingsValidationError, match="worker is immutable"
-    ):
+    with pytest.raises(SettingsValidationError, match="worker is immutable"):
         await lock.reconfigure(new_config)
 
     assert lock.config.worker != "other-worker"

--- a/tests/coordination/test_readwritelock.py
+++ b/tests/coordination/test_readwritelock.py
@@ -25,10 +25,13 @@ from grelmicro.coordination._protocol import (
 )
 from grelmicro.coordination.errors import (
     CoordinationBackendError,
-    CoordinationSettingsValidationError,
 )
 from grelmicro.coordination.memory import MemoryReadWriteLockAdapter
-from grelmicro.errors import OutOfContextError, WouldBlockError
+from grelmicro.errors import (
+    OutOfContextError,
+    SettingsValidationError,
+    WouldBlockError,
+)
 
 pytestmark = [pytest.mark.timeout(10, func_only=True)]
 
@@ -519,9 +522,7 @@ async def test_reconfigure_keeps_the_worker(
     )
     assert lock.config.lease_duration == _RECONFIGURED_LEASE_DURATION
 
-    with pytest.raises(
-        CoordinationSettingsValidationError, match="worker is immutable"
-    ):
+    with pytest.raises(SettingsValidationError, match="worker is immutable"):
         await lock.reconfigure(
             lock.config.model_copy(update={"worker": "web-2"})
         )

--- a/tests/coordination/test_tasklock.py
+++ b/tests/coordination/test_tasklock.py
@@ -13,7 +13,6 @@ from pytest_mock import MockerFixture
 from grelmicro.coordination._protocol import LockBackend
 from grelmicro.coordination._tokens import generate_task_token
 from grelmicro.coordination.errors import (
-    CoordinationSettingsValidationError,
     LockAcquireError,
     LockLockedCheckError,
     LockNotOwnedError,
@@ -23,7 +22,7 @@ from grelmicro.coordination.errors import (
 from grelmicro.coordination.lock import Lock, LockConfig
 from grelmicro.coordination.memory import MemoryLockAdapter
 from grelmicro.coordination.tasklock import TaskLock, TaskLockConfig
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import OutOfContextError, SettingsValidationError
 from grelmicro.errors import WouldBlockError as WouldBlock
 
 pytestmark = [pytest.mark.timeout(10)]
@@ -750,9 +749,7 @@ async def test_tasklock_reconfigure_rejects_worker_change(
     )
     new_config = task_lock.config.model_copy(update={"worker": WORKER_2})
 
-    with pytest.raises(
-        CoordinationSettingsValidationError, match="worker is immutable"
-    ):
+    with pytest.raises(SettingsValidationError, match="worker is immutable"):
         await task_lock.reconfigure(new_config)
 
 

--- a/tests/health/test_checks.py
+++ b/tests/health/test_checks.py
@@ -12,7 +12,7 @@ from grelmicro import (
     ComponentNotRegisteredError,
     Grelmicro,
 )
-from grelmicro.health import HealthSettingsValidationError
+from grelmicro.errors import SettingsValidationError
 from grelmicro.health._checks import HealthChecks
 from grelmicro.health._models import HealthStatus
 from grelmicro.health._types import HealthDetails
@@ -498,19 +498,19 @@ async def test_timeout_logs_warning(
 
 def test_timeout_zero_raises() -> None:
     """timeout=0 is rejected."""
-    with pytest.raises(HealthSettingsValidationError, match="greater than 0"):
+    with pytest.raises(SettingsValidationError, match="greater than 0"):
         HealthChecks(timeout=0)
 
 
 def test_timeout_negative_raises() -> None:
     """Negative timeout is rejected."""
-    with pytest.raises(HealthSettingsValidationError, match="greater than 0"):
+    with pytest.raises(SettingsValidationError, match="greater than 0"):
         HealthChecks(timeout=-1.0)
 
 
 def test_cache_ttl_negative_raises() -> None:
     """Negative cache_ttl is rejected."""
-    with pytest.raises(HealthSettingsValidationError):
+    with pytest.raises(SettingsValidationError):
         HealthChecks(cache_ttl=-1.0)
 
 

--- a/tests/health/test_checks_config.py
+++ b/tests/health/test_checks_config.py
@@ -3,7 +3,6 @@
 import pytest
 
 from grelmicro.errors import SettingsValidationError
-from grelmicro.health import HealthSettingsValidationError
 from grelmicro.health._checks import HealthChecks, HealthChecksConfig
 
 TIMEOUT_KWARG = 2.5
@@ -99,8 +98,8 @@ def test_from_config_keeps_default_name() -> None:
 
 
 def test_invalid_config_raises_settings_error() -> None:
-    """Invalid kwargs raise a catchable `HealthSettingsValidationError`."""
-    with pytest.raises(HealthSettingsValidationError) as exc_info:
+    """Invalid kwargs raise a catchable `SettingsValidationError`."""
+    with pytest.raises(SettingsValidationError) as exc_info:
         HealthChecks(timeout=-5)
     assert isinstance(exc_info.value, SettingsValidationError)
     assert "timeout" in str(exc_info.value)
@@ -108,5 +107,5 @@ def test_invalid_config_raises_settings_error() -> None:
 
 
 def test_settings_error_is_settings_validation_error() -> None:
-    """`HealthSettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(HealthSettingsValidationError, SettingsValidationError)
+    """`SettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(SettingsValidationError, SettingsValidationError)

--- a/tests/health/test_checks_config.py
+++ b/tests/health/test_checks_config.py
@@ -104,8 +104,3 @@ def test_invalid_config_raises_settings_error() -> None:
     assert isinstance(exc_info.value, SettingsValidationError)
     assert "timeout" in str(exc_info.value)
     assert "-5" not in str(exc_info.value)
-
-
-def test_settings_error_is_settings_validation_error() -> None:
-    """`SettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(SettingsValidationError, SettingsValidationError)

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -27,7 +27,6 @@ from grelmicro.idempotency import (
     Idempotency,
     IdempotencyConfig,
     IdempotencyConflictError,
-    IdempotencySettingsValidationError,
     IdempotencyStateError,
     IdempotencyWaitTimeoutError,
     idempotent,
@@ -655,17 +654,15 @@ class TestCoverageGaps:
 
 
 def test_invalid_config_raises_settings_error() -> None:
-    """Invalid kwargs raise a catchable `IdempotencySettingsValidationError`."""
-    with pytest.raises(IdempotencySettingsValidationError) as exc_info:
+    """Invalid kwargs raise a catchable `SettingsValidationError`."""
+    with pytest.raises(SettingsValidationError) as exc_info:
         Idempotency("charge", ttl=-1)
     assert isinstance(exc_info.value, SettingsValidationError)
 
 
 def test_settings_error_is_settings_validation_error() -> None:
-    """`IdempotencySettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(
-        IdempotencySettingsValidationError, SettingsValidationError
-    )
+    """`SettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(SettingsValidationError, SettingsValidationError)
 
 
 async def test_idempotency_block_waits_out_the_timeout() -> None:

--- a/tests/idempotency/test_idempotency.py
+++ b/tests/idempotency/test_idempotency.py
@@ -660,11 +660,6 @@ def test_invalid_config_raises_settings_error() -> None:
     assert isinstance(exc_info.value, SettingsValidationError)
 
 
-def test_settings_error_is_settings_validation_error() -> None:
-    """`SettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(SettingsValidationError, SettingsValidationError)
-
-
 async def test_idempotency_block_waits_out_the_timeout() -> None:
     """A duplicate past `wait_timeout` raises the wait error."""
     # Arrange

--- a/tests/logging/test_backends.py
+++ b/tests/logging/test_backends.py
@@ -14,8 +14,8 @@ import structlog
 from loguru import logger as loguru_logger
 
 from grelmicro._json import json_default
-from grelmicro.errors import DependencyNotFoundError
-from grelmicro.log import LogSettingsValidationError, configure
+from grelmicro.errors import DependencyNotFoundError, SettingsValidationError
+from grelmicro.log import configure
 from grelmicro.log._shared import (
     _logfmt_format_value,
     get_otel_trace_context,
@@ -218,7 +218,7 @@ class TestConfigureLoggingLevel:
 
         # Act / Assert
         with pytest.raises(
-            LogSettingsValidationError,
+            SettingsValidationError,
             match=(
                 r"Input should be 'DEBUG', 'INFO', 'WARNING', "
                 r"'ERROR' or 'CRITICAL'"
@@ -484,7 +484,7 @@ class TestLoadSettings:
         monkeypatch.setenv("GREL_LOG_LEVEL", "INVALID")
 
         # Act / Assert
-        with pytest.raises(LogSettingsValidationError):
+        with pytest.raises(SettingsValidationError):
             load_settings()
 
 

--- a/tests/logging/test_dedup.py
+++ b/tests/logging/test_dedup.py
@@ -7,9 +7,9 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from freezegun import freeze_time
 
+from grelmicro.errors import SettingsValidationError
 from grelmicro.log import (
     DuplicateFilter,
-    LogSettingsValidationError,
     configure,
 )
 from grelmicro.log._dedup import _key_by_rendered
@@ -371,8 +371,8 @@ def test_explicit_key_callable_overrides_mode() -> None:
 
 
 def test_invalid_key_mode_rejected() -> None:
-    """Unknown ``key_mode`` values raise a LogSettingsValidationError."""
-    with pytest.raises(LogSettingsValidationError, match="key_mode"):
+    """Unknown ``key_mode`` values raise a SettingsValidationError."""
+    with pytest.raises(SettingsValidationError, match="key_mode"):
         DuplicateFilter(key_mode="bogus")  # ty: ignore[invalid-argument-type]
 
 
@@ -450,8 +450,8 @@ def test_ttl_none_disables_time_expiry() -> None:
 
 @pytest.mark.parametrize("bad_ttl", [0, -0.5, -1])
 def test_non_positive_ttl_rejected(bad_ttl: float) -> None:
-    """Non-positive ``ttl`` values raise a LogSettingsValidationError."""
-    with pytest.raises(LogSettingsValidationError, match="greater than 0"):
+    """Non-positive ``ttl`` values raise a SettingsValidationError."""
+    with pytest.raises(SettingsValidationError, match="greater than 0"):
         DuplicateFilter(ttl=bad_ttl)
 
 
@@ -460,8 +460,8 @@ def test_non_positive_ttl_rejected(bad_ttl: float) -> None:
     [(0, 10), (-1, 10), (10, 0), (10, -5)],
 )
 def test_invalid_config_rejected(allowed: int, cache: int) -> None:
-    """Non-positive config values raise a LogSettingsValidationError."""
-    with pytest.raises(LogSettingsValidationError, match="greater than 0"):
+    """Non-positive config values raise a SettingsValidationError."""
+    with pytest.raises(SettingsValidationError, match="greater than 0"):
         DuplicateFilter(allowed_repetitions=allowed, cache_size=cache)
 
 

--- a/tests/logging/test_log_config.py
+++ b/tests/logging/test_log_config.py
@@ -5,7 +5,6 @@ import pytest
 from grelmicro.errors import GrelmicroConfigWarning, SettingsValidationError
 from grelmicro.log import (
     LogConfig,
-    LogSettingsValidationError,
     configure,
     configure_with,
 )
@@ -78,16 +77,16 @@ def test_configure_invalid_level_raises_settings_error(
     monkeypatch: pytest.MonkeyPatch,
     reset_backend: None,  # noqa: ARG001
 ) -> None:
-    """Invalid env values raise a catchable `LogSettingsValidationError`."""
+    """Invalid env values raise a catchable `SettingsValidationError`."""
     monkeypatch.setenv("GREL_LOG_LEVEL", "BOGUS")
-    with pytest.raises(LogSettingsValidationError) as exc_info:
+    with pytest.raises(SettingsValidationError) as exc_info:
         configure()
     assert isinstance(exc_info.value, SettingsValidationError)
 
 
 def test_logging_settings_error_is_settings_validation_error() -> None:
-    """`LogSettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(LogSettingsValidationError, SettingsValidationError)
+    """`SettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(SettingsValidationError, SettingsValidationError)
 
 
 def test_configure_with_returns_passed_config(

--- a/tests/logging/test_log_config.py
+++ b/tests/logging/test_log_config.py
@@ -84,11 +84,6 @@ def test_configure_invalid_level_raises_settings_error(
     assert isinstance(exc_info.value, SettingsValidationError)
 
 
-def test_logging_settings_error_is_settings_validation_error() -> None:
-    """`SettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(SettingsValidationError, SettingsValidationError)
-
-
 def test_configure_with_returns_passed_config(
     reset_backend: None,  # noqa: ARG001
 ) -> None:

--- a/tests/logging/test_ratelimit.py
+++ b/tests/logging/test_ratelimit.py
@@ -6,8 +6,8 @@ from collections.abc import Generator
 import pytest
 from pydantic import ValidationError
 
+from grelmicro.errors import SettingsValidationError
 from grelmicro.log import (
-    LogSettingsValidationError,
     RateLimitFilter,
     RateLimitFilterConfig,
 )
@@ -79,9 +79,9 @@ def test_config_property_is_frozen() -> None:
     ],
 )
 def test_invalid_config(capacity: int, refill_rate: float, cost: float) -> None:
-    """Test non-positive values raise LogSettingsValidationError."""
+    """Test non-positive values raise SettingsValidationError."""
     # Act & Assert
-    with pytest.raises(LogSettingsValidationError, match="greater than"):
+    with pytest.raises(SettingsValidationError, match="greater than"):
         RateLimitFilter(capacity=capacity, refill_rate=refill_rate, cost=cost)
 
 

--- a/tests/metrics/test_component.py
+++ b/tests/metrics/test_component.py
@@ -23,7 +23,6 @@ from grelmicro.metrics._component import (
 )
 from grelmicro.metrics.errors import (
     MetricsError,
-    MetricsSettingsValidationError,
 )
 
 
@@ -282,18 +281,18 @@ def test_metrics_singleton_skips_other_kinds() -> None:
 async def test_metrics_invalid_env_config_raises_settings_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Invalid env config raises a catchable `MetricsSettingsValidationError`."""
+    """Invalid env config raises a catchable `SettingsValidationError`."""
     monkeypatch.setenv("GREL_METRICS_EXPORTER", "bogus")
     micro = Grelmicro(uses=[Metrics(env_load=True)])
-    with pytest.raises(MetricsSettingsValidationError) as exc_info:
+    with pytest.raises(SettingsValidationError) as exc_info:
         async with micro:
             pass
     assert isinstance(exc_info.value, SettingsValidationError)
 
 
 def test_metrics_settings_error_is_settings_validation_error() -> None:
-    """`MetricsSettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(MetricsSettingsValidationError, SettingsValidationError)
+    """`SettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(SettingsValidationError, SettingsValidationError)
 
 
 def test_auto_exporter_resolves_to_none_without_endpoint(

--- a/tests/metrics/test_component.py
+++ b/tests/metrics/test_component.py
@@ -290,11 +290,6 @@ async def test_metrics_invalid_env_config_raises_settings_error(
     assert isinstance(exc_info.value, SettingsValidationError)
 
 
-def test_metrics_settings_error_is_settings_validation_error() -> None:
-    """`SettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(SettingsValidationError, SettingsValidationError)
-
-
 def test_auto_exporter_resolves_to_none_without_endpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/outbox/test_component.py
+++ b/tests/outbox/test_component.py
@@ -8,11 +8,10 @@ import pytest
 from pydantic import BaseModel
 
 from grelmicro import Grelmicro
-from grelmicro.errors import OutOfContextError
+from grelmicro.errors import OutOfContextError, SettingsValidationError
 from grelmicro.outbox import Message, Outbox
 from grelmicro.outbox.errors import (
     HandlerAlreadyRegisteredError,
-    OutboxSettingsValidationError,
 )
 from grelmicro.outbox.memory import MemoryOutboxAdapter
 from grelmicro.outbox.postgres import PostgresOutboxAdapter
@@ -47,7 +46,7 @@ def test_config_from_kwargs() -> None:
 
 def test_invalid_config_raises() -> None:
     """An out-of-range setting raises the component error."""
-    with pytest.raises(OutboxSettingsValidationError):
+    with pytest.raises(SettingsValidationError):
         Outbox(MemoryOutboxAdapter(), max_attempts=0)
 
 

--- a/tests/outbox/test_config.py
+++ b/tests/outbox/test_config.py
@@ -7,8 +7,8 @@ from datetime import timedelta
 import pytest
 from pydantic import ValidationError
 
+from grelmicro.errors import SettingsValidationError
 from grelmicro.outbox import Outbox, OutboxConfig
-from grelmicro.outbox.errors import OutboxSettingsValidationError
 from grelmicro.outbox.memory import MemoryOutboxAdapter
 
 pytestmark = [pytest.mark.timeout(5)]
@@ -84,7 +84,7 @@ def test_from_config_ignores_the_environment(
 
 def test_invalid_value_raises() -> None:
     """An out-of-range setting raises the component error."""
-    with pytest.raises(OutboxSettingsValidationError):
+    with pytest.raises(SettingsValidationError):
         Outbox(MemoryOutboxAdapter(), poll_interval=0)
 
 

--- a/tests/resilience/shield/test_env.py
+++ b/tests/resilience/shield/test_env.py
@@ -24,7 +24,7 @@ def test_resolve_fqn_rejects_bare_name() -> None:
 
 def test_resolve_fqn_rejects_missing_module() -> None:
     """A missing module surfaces a clear error."""
-    with pytest.raises(ValueError, match="cannot import module"):
+    with pytest.raises(ValueError, match="cannot be imported"):
         _resolve_fqn("not_a_real_module_anywhere.X")
 
 

--- a/tests/resilience/shield/test_env.py
+++ b/tests/resilience/shield/test_env.py
@@ -30,13 +30,13 @@ def test_resolve_fqn_rejects_missing_module() -> None:
 
 def test_resolve_fqn_rejects_missing_attribute() -> None:
     """A missing attribute on the module surfaces a clear error."""
-    with pytest.raises(ValueError, match="no attribute"):
+    with pytest.raises(ValueError, match="does not define"):
         _resolve_fqn("builtins.NotAClass")
 
 
 def test_resolve_fqn_rejects_non_exception() -> None:
     """A name that resolves to a non-exception object is rejected."""
-    with pytest.raises(TypeError, match="not an Exception subclass"):
+    with pytest.raises(ValueError, match="Exception subclass"):
         _resolve_fqn("builtins.int")
 
 

--- a/tests/resilience/test_errors.py
+++ b/tests/resilience/test_errors.py
@@ -97,7 +97,6 @@ def test_resilience_module_exports() -> None:
         "RedisCircuitBreakerAdapter",
         "RedisRateLimiterAdapter",
         "ResilienceError",
-        "ResilienceSettingsValidationError",
         "Retry",
         "RetryAttempt",
         "RetryBackoffConfig",

--- a/tests/resilience/test_fallback.py
+++ b/tests/resilience/test_fallback.py
@@ -5,6 +5,7 @@ import asyncio as _asyncio
 import pytest
 from pydantic import ValidationError
 
+from grelmicro.errors import SettingsValidationError
 from grelmicro.resilience import (
     Fallback,
     FallbackConfig,
@@ -87,7 +88,7 @@ def test_fallback_accepts_tuple_filter() -> None:
 
 def test_fallback_rejects_both_default_and_factory() -> None:
     """Class form enforces mutual exclusion too."""
-    with pytest.raises(ValidationError):
+    with pytest.raises(SettingsValidationError):
         Fallback("test", when=ValueError, default=1, factory=lambda _e: 2)
 
 
@@ -406,7 +407,7 @@ async def test_env_when_rejects_unknown_module(
     monkeypatch.setenv("GREL_FALLBACK_BAD2_WHEN", "no_such_module.NoClass")
     monkeypatch.setenv("GREL_FALLBACK_BAD2_DEFAULT", "0")
     with pytest.raises(
-        (ValidationError, ValueError), match="cannot import module"
+        (ValidationError, ValueError), match="cannot be imported"
     ):
         Fallback("bad2")
 

--- a/tests/resilience/test_fallback.py
+++ b/tests/resilience/test_fallback.py
@@ -336,7 +336,7 @@ async def test_env_when_rejects_non_dotted_name(
     """Bare-name env entry raises a clear error."""
     monkeypatch.setenv("GREL_FALLBACK_BAD_WHEN", "ValueError")
     monkeypatch.setenv("GREL_FALLBACK_BAD_DEFAULT", "0")
-    with pytest.raises((ValidationError, ValueError)):
+    with pytest.raises(SettingsValidationError):
         Fallback("bad")
 
 
@@ -393,7 +393,7 @@ def test_config_string_default_is_not_json_parsed() -> None:
 
 def test_when_rejects_invalid_value() -> None:
     """Non-Match, non-class, non-tuple, non-callable raises."""
-    with pytest.raises((ValidationError, TypeError)):
+    with pytest.raises(SettingsValidationError):
         Fallback("api", when=42, default=0)  # ty: ignore[invalid-argument-type]
 
 
@@ -418,7 +418,7 @@ async def test_env_when_rejects_unknown_attribute(
     """FQN that points to a missing attribute raises with a clear message."""
     monkeypatch.setenv("GREL_FALLBACK_BAD3_WHEN", "builtins.NoSuchClass")
     monkeypatch.setenv("GREL_FALLBACK_BAD3_DEFAULT", "0")
-    with pytest.raises((ValidationError, ValueError), match="has no attribute"):
+    with pytest.raises(SettingsValidationError, match="does not define"):
         Fallback("bad3")
 
 
@@ -428,7 +428,7 @@ async def test_env_when_rejects_non_exception_class(
     """FQN that resolves to a non-Exception class raises."""
     monkeypatch.setenv("GREL_FALLBACK_BAD4_WHEN", "builtins.int")
     monkeypatch.setenv("GREL_FALLBACK_BAD4_DEFAULT", "0")
-    with pytest.raises((ValidationError, TypeError)):
+    with pytest.raises(SettingsValidationError):
         Fallback("bad4")
 
 

--- a/tests/resilience/test_fallback_mutants.py
+++ b/tests/resilience/test_fallback_mutants.py
@@ -42,7 +42,5 @@ def test_env_when_rejects_non_exception_fqn(
     """An env FQN that resolves to a non-Exception type is rejected."""
     monkeypatch.setenv("GREL_FALLBACK_NOTEXC_WHEN", "builtins.int")
     monkeypatch.setenv("GREL_FALLBACK_NOTEXC_DEFAULT", "null")
-    with pytest.raises(
-        (ValueError, TypeError), match="not an Exception subclass"
-    ):
+    with pytest.raises((ValueError, TypeError), match="Exception subclass"):
         Fallback("notexc", env_load=True)

--- a/tests/resilience/test_retry.py
+++ b/tests/resilience/test_retry.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
+from grelmicro.errors import SettingsValidationError
 from grelmicro.resilience import (
     ConstantBackoff,
     ExponentialBackoff,
@@ -741,7 +742,7 @@ def test_when_accepts_match_directly(fast_constant: ConstantBackoff) -> None:
 
 def test_when_rejects_invalid_value(fast_constant: ConstantBackoff) -> None:
     """Non-Match, non-class, non-tuple, non-callable raises."""
-    with pytest.raises((ValidationError, TypeError)):
+    with pytest.raises(SettingsValidationError):
         Retry("api", fast_constant, when=42)  # ty: ignore[invalid-argument-type]
 
 
@@ -750,7 +751,7 @@ async def test_env_when_rejects_non_dotted_name(
 ) -> None:
     """Bare-name env entry raises a clear error."""
     monkeypatch.setenv("GREL_RETRY_BAD_WHEN", "ValueError")
-    with pytest.raises((ValidationError, ValueError)):
+    with pytest.raises(SettingsValidationError):
         Retry("bad")
 
 
@@ -759,7 +760,7 @@ async def test_env_when_rejects_non_exception_class(
 ) -> None:
     """FQN that resolves to a non-Exception class raises."""
     monkeypatch.setenv("GREL_RETRY_BAD2_WHEN", "builtins.int")
-    with pytest.raises((ValidationError, TypeError)):
+    with pytest.raises(SettingsValidationError):
         Retry("bad2")
 
 
@@ -811,7 +812,7 @@ async def test_env_when_rejects_unknown_attribute(
 ) -> None:
     """FQN that points to a missing attribute raises with a clear message."""
     monkeypatch.setenv("GREL_RETRY_BAD4_WHEN", "builtins.NoSuchClass")
-    with pytest.raises((ValidationError, ValueError), match="has no attribute"):
+    with pytest.raises(SettingsValidationError, match="does not define"):
         Retry("bad4")
 
 

--- a/tests/resilience/test_retry.py
+++ b/tests/resilience/test_retry.py
@@ -801,7 +801,7 @@ async def test_env_when_rejects_unknown_module(
     """FQN that points to a missing module raises with a clear message."""
     monkeypatch.setenv("GREL_RETRY_BAD3_WHEN", "no_such_module.NoClass")
     with pytest.raises(
-        (ValidationError, ValueError), match="cannot import module"
+        (ValidationError, ValueError), match="cannot be imported"
     ):
         Retry("bad3")
 

--- a/tests/resilience/test_retry_mutants.py
+++ b/tests/resilience/test_retry_mutants.py
@@ -1069,7 +1069,5 @@ def test_env_when_rejects_non_exception_fqn(
 ) -> None:
     """An FQN that resolves to a non-Exception type is rejected."""
     monkeypatch.setenv("GREL_RETRY_NOTEXC_WHEN", "builtins.int")
-    with pytest.raises(
-        (ValueError, TypeError), match="not an Exception subclass"
-    ):
+    with pytest.raises((ValueError, TypeError), match="Exception subclass"):
         Retry("notexc", env_load=True)

--- a/tests/task/test_timezone.py
+++ b/tests/task/test_timezone.py
@@ -6,11 +6,11 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from grelmicro.errors import SettingsValidationError
 from grelmicro.task import (
     TaskRouter,
     Tasks,
     TasksConfig,
-    TaskSettingsValidationError,
     TimezoneError,
 )
 from grelmicro.task._cron import CronExpression, CronTask, _delay_to_next_minute
@@ -217,14 +217,14 @@ def test_from_config_bypasses_the_environment() -> None:
 def test_invalid_timezone_reports_a_settings_error() -> None:
     """`Tasks` reports a bad timezone through the settings error type."""
     # Act / Assert
-    with pytest.raises(TaskSettingsValidationError, match="timezone"):
+    with pytest.raises(SettingsValidationError, match="timezone"):
         Tasks(timezone="Nope/Zone")
 
 
 def test_negative_shutdown_timeout_is_rejected() -> None:
     """A negative drain budget fails validation."""
     # Act / Assert
-    with pytest.raises(TaskSettingsValidationError, match="shutdown_timeout"):
+    with pytest.raises(SettingsValidationError, match="shutdown_timeout"):
         Tasks(shutdown_timeout=-1)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -208,31 +208,17 @@ def test_invalid_env_value_raises_validation_error(
         )
 
 
-def test_error_type_wraps_validation_error() -> None:
-    """`error_type` wraps a `ValidationError` into the typed settings error."""
-    with pytest.raises(_SampleSettingsError) as exc_info:
+def test_wraps_validation_error() -> None:
+    """A bad value raises `SettingsValidationError`, never pydantic's."""
+    with pytest.raises(SettingsValidationError) as exc_info:
         resolve_config(
             _Sample,
             explicit=None,
             kwargs={"name": "a", "timeout": -1.0},
             env_prefix="X_",
             env_load=False,
-            error_type=_SampleSettingsError,
         )
-    assert isinstance(exc_info.value, SettingsValidationError)
-
-
-def test_from_mapping_error_type_wraps_validation_error() -> None:
-    """`resolve_config_from_mapping` wraps with `error_type` too."""
-    current = _Sample(name="a")
-    with pytest.raises(_SampleSettingsError) as exc_info:
-        resolve_config_from_mapping(
-            current,
-            env_prefix="X_",
-            mapping={"X_TIMEOUT": "-1.0"},
-            error_type=_SampleSettingsError,
-        )
-    assert isinstance(exc_info.value, SettingsValidationError)
+    assert not isinstance(exc_info.value, ValidationError)
 
 
 def test_from_mapping_without_error_type_raises_validation_error() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,10 +30,6 @@ _CONFIG_DEFAULT = 60.0
 """`LockConfig.lease_duration` default, reached when no variable matches."""
 
 
-class _SampleSettingsError(SettingsValidationError):
-    """Settings error used to test `error_type` wrapping."""
-
-
 DEFAULT_TIMEOUT = 5.0
 DEFAULT_RETRIES = 3
 KWARG_TIMEOUT = 1.0
@@ -218,11 +214,11 @@ def test_wraps_validation_error() -> None:
             env_prefix="X_",
             env_load=False,
         )
-    assert not isinstance(exc_info.value, ValidationError)
+    assert "-1.0" not in str(exc_info.value)
 
 
-def test_from_mapping_without_error_type_raises_validation_error() -> None:
-    """Without `error_type`, the raw `ValidationError` propagates."""
+def test_from_mapping_raises_raw_validation_error() -> None:
+    """The reload path lets the raw `ValidationError` through, by design."""
     current = _Sample(name="a")
     with pytest.raises(ValidationError):
         resolve_config_from_mapping(

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -171,7 +171,9 @@ def test_every_documented_module_is_snapshotted() -> None:
         match.group(1)
         for page in reference.glob("*.md")
         for match in re.finditer(
-            r"^::: (grelmicro[\w.]*)$", page.read_text(), re.MULTILINE
+            r"^::: (grelmicro[\w.]*)$",
+            page.read_text(encoding="utf-8"),
+            re.MULTILINE,
         )
     }
     guarded = set(PUBLIC_MODULES)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import re
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -47,6 +49,7 @@ PUBLIC_MODULES = [
     "grelmicro.integrations.litestar",
     "grelmicro.log",
     "grelmicro.metrics",
+    "grelmicro.outbox",
     "grelmicro.providers",
     "grelmicro.resilience",
     "grelmicro.resilience.backoffs",
@@ -57,7 +60,15 @@ PUBLIC_MODULES = [
     "grelmicro.task",
     "grelmicro.testing",
     "grelmicro.trace",
+    "grelmicro.types",
 ]
+"""Every module the API reference renders, which is what public means here.
+
+A module `docs/reference/` documents is one a reader is told to import
+from, so its `__all__` is a promise and belongs in the snapshot.
+`grelmicro.outbox` and `grelmicro.types` were documented but unguarded,
+so their exports could change without the snapshot noticing.
+"""
 
 
 @pytest.fixture
@@ -146,6 +157,32 @@ def build_public_api() -> dict[str, dict[str, Any]]:
 def test_public_api_matches_snapshot(snapshot_json) -> None:  # noqa: ANN001
     """The live public surface equals the committed snapshot."""
     assert build_public_api() == snapshot_json
+
+
+def test_every_documented_module_is_snapshotted() -> None:
+    """A module the reference renders cannot slip out of the snapshot.
+
+    `grelmicro.outbox` and `grelmicro.types` were documented for
+    releases while their exports went unguarded. Reading the reference
+    pages closes that by construction, so adding a page adds the guard.
+    """
+    reference = Path(__file__).parent.parent / "docs" / "reference"
+    documented = {
+        match.group(1)
+        for page in reference.glob("*.md")
+        for match in re.finditer(
+            r"^::: (grelmicro[\w.]*)$", page.read_text(), re.MULTILINE
+        )
+    }
+    guarded = set(PUBLIC_MODULES)
+    missing = sorted(
+        name
+        for name in documented - guarded
+        if hasattr(importlib.import_module(name), "__all__")
+    )
+    assert not missing, (
+        f"documented in docs/reference/ but absent from PUBLIC_MODULES: {missing}"
+    )
 
 
 @pytest.mark.parametrize("module_name", PUBLIC_MODULES)

--- a/tests/test_settings_error_contract.py
+++ b/tests/test_settings_error_contract.py
@@ -75,6 +75,62 @@ ENV_CASES: list[tuple[str, str, Callable[[], object]]] = [
 _MIN_ENV_CASES = 12
 """Floor for the sweep, so a shrunken list cannot pass silently."""
 
+DOTTED_SECRET = "acme.vault.Sk_live_abc"
+"""A value shaped like an import path, which the FQN fields try to resolve.
+
+`SECRET` has no dot, so every FQN field rejected it on the first branch
+("must be a fully-qualified name") and three later branches went untested.
+Those branches raised `TypeError`, which pydantic never converts, so they
+escaped `except SettingsValidationError` and `except ValueError` alike, and
+two of them rebuilt the rejected value out of the module path and the
+attribute name.
+"""
+
+FQN_CASES: list[tuple[str, str, Callable[[], object]]] = [
+    ("Retry.when", "GREL_RETRY_FQ_WHEN", lambda: Retry("fq")),
+    ("Fallback.when", "GREL_FALLBACK_FQ_WHEN", lambda: Fallback("fq")),
+    (
+        "Shield.timeout_errors",
+        "GREL_SHIELD_FQ_TIMEOUT_ERRORS",
+        lambda: Shield("fq"),
+    ),
+]
+"""Every field that resolves an env value as a dotted import path."""
+
+RESOLVABLE_NON_EXCEPTION = "os.getcwd"
+"""Importable, but not an Exception subclass: the branch that raised `TypeError`."""
+
+
+@pytest.mark.parametrize(
+    ("label", "variable", "build"),
+    FQN_CASES,
+    ids=[case[0] for case in FQN_CASES],
+)
+@pytest.mark.parametrize(
+    "value",
+    [DOTTED_SECRET, RESOLVABLE_NON_EXCEPTION],
+    ids=["unimportable", "not-an-exception"],
+)
+def test_fqn_field_rejects_without_escaping_or_echoing(
+    label: str,
+    variable: str,
+    build: Callable[[], object],
+    value: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every branch of the FQN resolvers wraps, and none rebuilds the value."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv(variable, value)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with pytest.raises(SettingsValidationError) as exc_info:
+            build()
+    message = str(exc_info.value)
+    for part in value.split("."):
+        assert part not in message, (
+            f"{label} rebuilt the rejected value from {part!r}"
+        )
+
 
 def test_every_pattern_is_covered() -> None:
     """The sweep refuses to pass on a list someone quietly trimmed."""

--- a/tests/test_settings_error_contract.py
+++ b/tests/test_settings_error_contract.py
@@ -1,0 +1,164 @@
+"""The one contract every configuration path owes its caller.
+
+A bad value raises `SettingsValidationError` and never carries the value.
+Both halves were false in 0.39.0 for the three classes that resolve their
+own configuration instead of going through `resolve_config`, and the
+release notes claimed otherwise. A per-class test cannot catch that,
+because the rule holds for a family and each member was tested alone.
+
+The second half is the one worth the machinery. Wrapping strips pydantic's
+copy of the input, but a validator that names the value it rejected writes
+it straight into `msg`, which the wrapper renders verbatim.
+"""
+
+import importlib
+import pkgutil
+import warnings
+from collections.abc import Callable
+
+import pytest
+
+import grelmicro
+from grelmicro.cache import TTLCache
+from grelmicro.coordination import (
+    LeaderElection,
+    Lock,
+    ReadWriteLock,
+    TaskLock,
+)
+from grelmicro.errors import SettingsValidationError
+from grelmicro.resilience import (
+    Bulkhead,
+    CircuitBreaker,
+    Fallback,
+    RateLimiter,
+    Retry,
+    Shield,
+    Timeout,
+)
+
+SECRET = "s3cret-value-never-echoed"
+"""Stand-in for a credential an operator put behind a variable by mistake."""
+
+ENV_CASES: list[tuple[str, str, Callable[[], object]]] = [
+    ("Timeout", "GREL_TIMEOUT_T_SECONDS", lambda: Timeout("t")),
+    ("Retry", "GREL_RETRY_R_WHEN", lambda: Retry("r")),
+    ("Bulkhead", "GREL_BULKHEAD_B_MAX_CONCURRENT", lambda: Bulkhead("b")),
+    ("Fallback", "GREL_FALLBACK_F_WHEN", lambda: Fallback("f")),
+    ("Shield", "GREL_SHIELD_S_MAX_RATE", lambda: Shield("s")),
+    ("Shield.profile", "GREL_SHIELD_P_PROFILE", lambda: Shield("p")),
+    (
+        "RateLimiter",
+        "GREL_RATELIMITER_RL_CAPACITY",
+        lambda: RateLimiter.token_bucket("rl", refill_rate=1),
+    ),
+    (
+        "CircuitBreaker",
+        "GREL_CIRCUITBREAKER_CB_ERROR_THRESHOLD",
+        lambda: CircuitBreaker.consecutive_count("cb"),
+    ),
+    ("Lock", "GREL_LOCK_L_LEASE_DURATION", lambda: Lock("l")),
+    (
+        "LeaderElection",
+        "GREL_LEADERELECTION_LE_LEASE_DURATION",
+        lambda: LeaderElection("le"),
+    ),
+    (
+        "ReadWriteLock",
+        "GREL_READWRITELOCK_RW_LEASE_DURATION",
+        lambda: ReadWriteLock("rw"),
+    ),
+    ("TaskLock", "GREL_TASKLOCK_TL_LEASE_DURATION", lambda: TaskLock("tl")),
+]
+"""One env-path case per pattern that reads the environment."""
+
+_MIN_ENV_CASES = 12
+"""Floor for the sweep, so a shrunken list cannot pass silently."""
+
+
+def test_every_pattern_is_covered() -> None:
+    """The sweep refuses to pass on a list someone quietly trimmed."""
+    assert len(ENV_CASES) >= _MIN_ENV_CASES
+
+
+@pytest.mark.parametrize(
+    ("label", "variable", "build"),
+    ENV_CASES,
+    ids=[case[0] for case in ENV_CASES],
+)
+def test_bad_env_value_raises_settings_error_without_echoing_it(
+    label: str,
+    variable: str,
+    build: Callable[[], object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected env value raises the one error and stays out of it."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "1")
+    monkeypatch.setenv(variable, SECRET)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with pytest.raises(SettingsValidationError) as exc_info:
+            build()
+    assert SECRET not in str(exc_info.value), (
+        f"{label} echoed the rejected value into its error"
+    )
+
+
+KWARG_CASES: list[tuple[str, Callable[[], object]]] = [
+    ("Timeout", lambda: Timeout("t", seconds=-1)),
+    ("Retry", lambda: Retry("r", attempts=-1)),
+    ("Bulkhead", lambda: Bulkhead("b", max_concurrent=-1)),
+    (
+        "Fallback",
+        lambda: Fallback("f", when=ValueError, default=1, factory=lambda _: 2),
+    ),
+    ("Shield", lambda: Shield("s", max_rate=-1)),
+    (
+        "RateLimiter",
+        lambda: RateLimiter.token_bucket("rl", capacity=-1, refill_rate=1),
+    ),
+    (
+        "CircuitBreaker",
+        lambda: CircuitBreaker.consecutive_count("cb", error_threshold=-1),
+    ),
+    ("Lock", lambda: Lock("l", lease_duration=-1)),
+    ("TTLCache", lambda: TTLCache(ttl=-1)),
+]
+"""The kwargs path, which must fail the same way as the env path."""
+
+
+@pytest.mark.parametrize(
+    "build",
+    [case[1] for case in KWARG_CASES],
+    ids=[case[0] for case in KWARG_CASES],
+)
+def test_bad_kwarg_raises_settings_error(
+    build: Callable[[], object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both construction doors report a bad value the same way."""
+    monkeypatch.setenv("GREL_ENV_LOAD", "0")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with pytest.raises(SettingsValidationError):
+            build()
+
+
+def test_no_module_declares_a_settings_error_subclass() -> None:
+    """One error, so a per-module subclass never comes back by accident."""
+    offenders = []
+    for info in pkgutil.walk_packages(grelmicro.__path__, prefix="grelmicro."):
+        if not info.name.endswith(".errors"):
+            continue
+        module = importlib.import_module(info.name)
+        offenders += [
+            f"{info.name}.{name}"
+            for name, obj in vars(module).items()
+            if isinstance(obj, type)
+            and issubclass(obj, SettingsValidationError)
+            and obj is not SettingsValidationError
+            and obj.__module__ == info.name
+        ]
+    assert not offenders, (
+        f"configuration errors are not split by module: {offenders}"
+    )

--- a/tests/tracing/test_autoinstrument.py
+++ b/tests/tracing/test_autoinstrument.py
@@ -22,6 +22,7 @@ from starlette.applications import Starlette
 from starlette.status import HTTP_200_OK
 
 from grelmicro import Grelmicro
+from grelmicro.errors import SettingsValidationError
 from grelmicro.providers.memory import MemoryProvider
 from grelmicro.providers.postgres import PostgresProvider
 from grelmicro.providers.redis import RedisProvider
@@ -39,7 +40,6 @@ from grelmicro.trace._autoinstrument import (
     uninstrument_providers,
     validate_directive,
 )
-from grelmicro.trace.errors import TraceSettingsValidationError
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -91,17 +91,17 @@ def test_validate_directive_allows_bool_and_known_names() -> None:
 
 def test_validate_directive_rejects_unknown_names() -> None:
     """An unknown name in a string, list, or map raises (typo guard)."""
-    with pytest.raises(TraceSettingsValidationError, match="unknown targets"):
+    with pytest.raises(SettingsValidationError, match="unknown targets"):
         validate_directive("typo", known={"redis"})
-    with pytest.raises(TraceSettingsValidationError, match="unknown targets"):
+    with pytest.raises(SettingsValidationError, match="unknown targets"):
         validate_directive(["reddis"], known={"redis"})
-    with pytest.raises(TraceSettingsValidationError, match="unknown targets"):
+    with pytest.raises(SettingsValidationError, match="unknown targets"):
         validate_directive({"typo": False}, known={"redis"})
 
 
 def test_validate_directive_rejects_non_bool_map_values() -> None:
     """A map value that is not a bool raises, so options are not swallowed."""
-    with pytest.raises(TraceSettingsValidationError, match="non-bool"):
+    with pytest.raises(SettingsValidationError, match="non-bool"):
         validate_directive({"redis": {"opt": 1}}, known={"redis"})  # ty: ignore[invalid-argument-type]
 
 
@@ -444,7 +444,7 @@ async def test_app_unknown_target_raises() -> None:
     """An unknown instrument target fails app startup."""
     redis = RedisProvider(REDIS_URL)
     micro = Grelmicro(uses=[_none_trace(instrument=["bogus"]), redis])
-    with pytest.raises(TraceSettingsValidationError, match="unknown targets"):
+    with pytest.raises(SettingsValidationError, match="unknown targets"):
         async with micro:
             pass
 

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -266,11 +266,6 @@ async def test_trace_invalid_env_config_raises_settings_error(
     assert isinstance(exc_info.value, SettingsValidationError)
 
 
-def test_trace_settings_error_is_settings_validation_error() -> None:
-    """`SettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(SettingsValidationError, SettingsValidationError)
-
-
 def test_exporter_defaults_to_auto() -> None:
     """The exporter field defaults to `auto`."""
     assert TraceConfig().exporter == TraceExporterType.AUTO

--- a/tests/tracing/test_component.py
+++ b/tests/tracing/test_component.py
@@ -24,7 +24,6 @@ from grelmicro.trace._component import (
 )
 from grelmicro.trace.errors import (
     TraceError,
-    TraceSettingsValidationError,
 )
 
 
@@ -258,18 +257,18 @@ async def test_trace_raises_when_private_otel_global_missing(
 async def test_trace_invalid_env_config_raises_settings_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Invalid env config raises a catchable `TraceSettingsValidationError`."""
+    """Invalid env config raises a catchable `SettingsValidationError`."""
     monkeypatch.setenv("GREL_TRACE_EXPORTER", "bogus")
     micro = Grelmicro(uses=[Trace(env_load=True)])
-    with pytest.raises(TraceSettingsValidationError) as exc_info:
+    with pytest.raises(SettingsValidationError) as exc_info:
         async with micro:
             pass
     assert isinstance(exc_info.value, SettingsValidationError)
 
 
 def test_trace_settings_error_is_settings_validation_error() -> None:
-    """`TraceSettingsValidationError` is a `SettingsValidationError`."""
-    assert issubclass(TraceSettingsValidationError, SettingsValidationError)
+    """`SettingsValidationError` is a `SettingsValidationError`."""
+    assert issubclass(SettingsValidationError, SettingsValidationError)
 
 
 def test_exporter_defaults_to_auto() -> None:


### PR DESCRIPTION
Closes #750.

A bad configuration value raised three different exception types depending on
which class you built. Now it raises one, everywhere.

## The decision

`SettingsValidationError`, for every pattern and every component. The ten
per-module subclasses are deleted, not deprecated, which is the pre-1.0 rule.

Two things settled it. No caller ever reacted differently by module: there is
not one `except *SettingsValidationError` in `docs/`, `examples/`, or the
README, and none of `except CoordinationError` / `except ResilienceError`
either. And the message already names the exact variable, which locates the
problem better than a class name can. R7 in
[Configuration internals](https://grelmicro.grel.info/architecture/config/)
and `docs/migration.md` were already written in terms of the base error, so the
code was contradicting the published contract rather than extending it.

Removed: `CacheSettingsValidationError`, `CoordinationSettingsValidationError`,
`HealthSettingsValidationError`, `IdempotencySettingsValidationError`,
`LogSettingsValidationError`, `MetricsSettingsValidationError`,
`OutboxSettingsValidationError`, `ResilienceSettingsValidationError`,
`TaskSettingsValidationError`, `TraceSettingsValidationError`.

`except SettingsValidationError`, `except ValueError`, and
`except GrelmicroError` all keep working.

## Two defects found on the way, neither in the issue

**0.39.0 shipped a false claim.** Its release notes say "Every configuration
path raises `SettingsValidationError` for a bad value". `Fallback`, `Shield`,
and `TTLCache` resolve their own configuration instead of going through
`resolve_config`, so all three still let pydantic's error through, carrying the
rejected value:

```
GREL_FALLBACK_F_WHEN=secret  ->  ValidationError: ... input_value='secret'
GREL_SHIELD_S_MAX_RATE=token ->  ValueError: could not convert string to float: 'token'
```

`Shield` was the worst of the three: a bare `ValueError` out of an unguarded
`float()`, which pydantic never saw, so no pydantic setting could have fixed it.
That changelog entry is corrected in place rather than left standing.

**Wrapping alone does not satisfy R7.** This is the one worth reading. The
wrapper strips pydantic's `input_value`, but it renders `msg` verbatim, so a
validator that interpolates the rejected value into its own message leaks
straight through the wrapper:

```
- GREL_FALLBACK_F_WHEN: Value error, when= env entry must be a fully-qualified name, got 'secret-value-here'
```

Shipping only the type change would have repeated 0.39.0's mistake: claiming a
leak was closed while it was open. The `when=` and `timeout_errors` messages on
`Retry`, `Fallback`, and `Shield` now name the module path and the attribute
instead of the raw entry.

R7 is amended to state the rule the code can actually keep: pydantic's automatic
echo is always stripped, and a validator may name a value only where the field's
domain is a public closed set and the value is the whole diagnostic, as an
unknown timezone name is. That is a per-field decision, never the default.

## Also in here

- `error_type` is removed from `resolve_config` and `resolve_config_from_mapping`.
  On the mapping function it was dead: the only caller, `reconfigure_all`, never
  passed it and deliberately catches the raw error to log a redacted summary.
- New `docs/reference/errors.md`. `SettingsValidationError` is now the single
  configuration error and had no documented home.
- The public API snapshot covers `grelmicro.outbox` and `grelmicro.types`. Both
  were rendered in the API reference while their `__all__` went unguarded. A new
  test reads the reference pages, so documenting a module now guards it.
  Replacing the whole hand-rolled snapshot with a real tool is #758.

## Scope I did not take

`RedisProviderConfigError` and `PostgresProviderConfigError` stay. Providers read
the vendor namespace under R1 (`REDIS_*`, `POSTGRES_*`), not `GREL_*`, so those
are per-problem rather than per-module, and `docs/providers/index.md` documents
them as a pair.

## Verification

`tests/test_settings_error_contract.py` sweeps every pattern on both the env and
the kwargs path, asserting the type and asserting the rejected value is absent
from the message. It has a floor so a trimmed list cannot pass silently.

I checked it fails when the bug returns, rather than trusting it because it is
green: reintroducing the 0.39.0 `Fallback` behaviour fails both the type and the
leak assertion.

Full `pre-commit run --all-files` passes, including the integration tier and the
100% coverage gate. Every file touched here is at 100%.
