### PR TITLE
✅ Record what a default factory returns and scrub numbers from errors

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,7 @@
 
 ### Added
 
-* ✅ The public API snapshot records default values, so a changed default fails CI. A `default_factory` still reprs opaquely. ([#764](https://github.com/grelinfo/grelmicro/pull/764))
+* ✅ The public API snapshot records default values, including what a `default_factory` returns, so a changed default fails CI. ([#764](https://github.com/grelinfo/grelmicro/pull/764))
 * ✅ Three contract sweeps enforce what the architecture docs publish, discovered by walking the package rather than by a hand-written list. `tests/test_backend_contracts.py` covers the `bind` contract over every backend adapter, `tests/test_config_contracts.py` covers R3, R4 and the reload rules over every `Reconfigurable`, and `tests/test_construction_contracts.py` covers the declarative door over every class with `from_config`. Each refuses to pass on an empty scan, so an adapter or pattern added later is covered without anyone remembering. ([#755](https://github.com/grelinfo/grelmicro/issues/755))
 * 📝 An [Errors](reference/errors.md) reference page. `SettingsValidationError` is now the one configuration error, and it had no documented home.
 * ✅ The public API snapshot covers `grelmicro.outbox` and `grelmicro.types`. Both were documented in the API reference while their exports went unguarded, so a rename could have shipped unnoticed. A test now reads the reference pages, so documenting a module guards it.

--- a/grelmicro/errors.py
+++ b/grelmicro/errors.py
@@ -266,13 +266,22 @@ def _candidates(value: object) -> set[str]:
     that failed, not the level that offends: `union_tag_invalid` hands back
     the whole mapping, with the tag one key down.
 
+    Numbers count too. A validator that names a rejected number leaks a
+    value read from the environment the same way a string does, and the
+    reason to withhold it does not depend on its type.
+
     The strings are never split on separators. Splitting once seemed
     thorough and was the bug: a piece of the rejected value matches the
     correct value that shares it, so `Europe/Zurichh` redacted the `Europe`
     of the `did you mean 'Europe/Zurich'` written to replace it.
     """
-    if isinstance(value, str):
-        return {value} if len(value) >= _MIN_REDACTED_LENGTH else set()
+    if isinstance(value, bool):
+        # `True` and `False` carry nothing, and removing those words would
+        # garble a message that legitimately uses them.
+        return set()
+    if isinstance(value, (str, int, float)):
+        text = str(value)
+        return {text} if len(text) >= _MIN_REDACTED_LENGTH else set()
     if isinstance(value, dict):
         found: set[str] = set()
         for item in value.values():

--- a/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
+++ b/tests/__snapshots__/test_public_api/test_public_api_matches_snapshot.json
@@ -366,7 +366,7 @@
       ".from_config": "(config, *, name='default')"
     },
     "MetricsConfig": {
-      "()": "(*, service_name=None, exporter=<MetricsExporterType.AUTO: 'auto'>, endpoint=None, headers=<factory>, basic_auth_username=None, basic_auth_password=None, export_interval=60.0, export_timeout=30.0, resource_attributes=<factory>, shutdown_timeout=5.0)"
+      "()": "(*, service_name=None, exporter=<MetricsExporterType.AUTO: 'auto'>, endpoint=None, headers={}, basic_auth_username=None, basic_auth_password=None, export_interval=60.0, export_timeout=30.0, resource_attributes={}, shutdown_timeout=5.0)"
     },
     "MetricsError": null,
     "MetricsExporterType": {
@@ -572,7 +572,7 @@
       "()": "(*args, **kwargs)"
     },
     "RetryConfig": {
-      "()": "(*, attempts=3, max_seconds=None, when, backoff=<factory>)"
+      "()": "(*, attempts=3, max_seconds=None, when, backoff=ExponentialBackoff(kind='exponential', base_delay=0.1, max_delay=30.0, jitter='full'))"
     },
     "RetryStrategy": {
       "()": "(*args, **kwargs)"
@@ -782,7 +782,7 @@
       ".from_config": "(config, *, name='default')"
     },
     "TraceConfig": {
-      "()": "(*, service_name=None, exporter=<TraceExporterType.AUTO: 'auto'>, endpoint=None, headers=<factory>, basic_auth_username=None, basic_auth_password=None, processor=<TraceProcessorType.BATCH: 'batch'>, sampler=<TraceSamplerType.PARENTBASED_ALWAYS_ON: 'parentbased_always_on'>, sample_ratio=1.0, resource_attributes=<factory>, shutdown_timeout=5.0)"
+      "()": "(*, service_name=None, exporter=<TraceExporterType.AUTO: 'auto'>, endpoint=None, headers={}, basic_auth_username=None, basic_auth_password=None, processor=<TraceProcessorType.BATCH: 'batch'>, sampler=<TraceSamplerType.PARENTBASED_ALWAYS_ON: 'parentbased_always_on'>, sample_ratio=1.0, resource_attributes={}, shutdown_timeout=5.0)"
     },
     "TraceError": null,
     "TraceExporterType": {

--- a/tests/_contract_support.py
+++ b/tests/_contract_support.py
@@ -64,19 +64,19 @@ def called_names(tree: ast.AST) -> set[str]:
 
 
 def call_targets(tree: ast.AST) -> set[str]:
-    """Return the names `tree` actually calls, not every name it mentions.
+    """Return the bare names `tree` calls as plain functions.
 
     Following every mention would pull in a module-level function whenever
-    its name appears as an attribute or a variable, and then judge the
+    its name appeared as an attribute or a variable, and then judge the
     caller on a body it never runs.
+
+    Method calls are excluded for the same reason. `self._clock.monotonic()`
+    is not a call to whatever `monotonic` a module happens to import, and
+    resolving it against the module namespace would blame the caller for an
+    unrelated function's body.
     """
     return {
-        name
+        node.func.id
         for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        for name in (
-            getattr(node.func, "id", None),
-            getattr(node.func, "attr", None),
-        )
-        if isinstance(name, str)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
     }

--- a/tests/test_construction_contracts.py
+++ b/tests/test_construction_contracts.py
@@ -160,23 +160,30 @@ def _module_functions(module: Any) -> dict[str, str]:  # noqa: ANN401
     }
 
 
-def _imported_helper(module: Any, name: str) -> str | None:  # noqa: ANN401
-    """Return the source of a grelmicro function imported into `module`.
+def _imported_helper(module: Any, name: str) -> tuple[str, Any] | None:  # noqa: ANN401
+    """Return a grelmicro function imported into `module`, with its module.
 
     Following only same-module helpers left the obvious bypass open: put
     the read in a neighbouring grelmicro module and import it. Only
     first-party functions are followed, so the walk stops at the package
     boundary instead of descending into pydantic or the stdlib.
+
+    The function is unwrapped first. `lru_cache` and friends return a
+    non-function, and `_build_settings_cls` is exactly that shape: a cached
+    first-party helper that builds an environment-reading settings class.
     """
     target = getattr(module, name, None)
+    target = getattr(target, "__wrapped__", target)
     if not inspect.isfunction(target):
         return None
-    if not getattr(target, "__module__", "").startswith("grelmicro"):
+    origin = getattr(target, "__module__", "")
+    if not origin.startswith("grelmicro"):
         return None
     try:
-        return textwrap.dedent(inspect.getsource(target))
+        source = textwrap.dedent(inspect.getsource(target))
     except (OSError, TypeError):  # pragma: no cover  # no readable source
         return None
+    return source, sys.modules.get(origin, module)
 
 
 def _env_names_reached(source: str, module: Any) -> set[str]:  # noqa: ANN401
@@ -187,18 +194,25 @@ def _env_names_reached(source: str, module: Any) -> set[str]:  # noqa: ANN401
     followed transitively, whether the module defines them or imports them
     from elsewhere in grelmicro.
     """
-    functions = _module_functions(module)
     seen: set[str] = set()
-    pending = [source]
+    pending: list[tuple[str, Any]] = [(source, module)]
     found: set[str] = set()
     while pending:
-        tree = ast.parse(pending.pop())
+        body, owner = pending.pop()
+        tree = ast.parse(body)
         found |= called_names(tree) & ENV_READERS
+        # Each body resolves names in *its own* module. Keeping the original
+        # module pinned made the walk one hop deep, so a neighbour that
+        # delegated once more stayed invisible.
+        functions = _module_functions(owner)
         for name in sorted(call_targets(tree) - seen):
             seen.add(name)
-            body = functions.get(name) or _imported_helper(module, name)
-            if body is not None:
-                pending.append(body)
+            if name in functions:
+                pending.append((functions[name], owner))
+                continue
+            found_helper = _imported_helper(owner, name)
+            if found_helper is not None:
+                pending.append(found_helper)
     return found
 
 

--- a/tests/test_construction_contracts.py
+++ b/tests/test_construction_contracts.py
@@ -160,13 +160,32 @@ def _module_functions(module: Any) -> dict[str, str]:  # noqa: ANN401
     }
 
 
+def _imported_helper(module: Any, name: str) -> str | None:  # noqa: ANN401
+    """Return the source of a grelmicro function imported into `module`.
+
+    Following only same-module helpers left the obvious bypass open: put
+    the read in a neighbouring grelmicro module and import it. Only
+    first-party functions are followed, so the walk stops at the package
+    boundary instead of descending into pydantic or the stdlib.
+    """
+    target = getattr(module, name, None)
+    if not inspect.isfunction(target):
+        return None
+    if not getattr(target, "__module__", "").startswith("grelmicro"):
+        return None
+    try:
+        return textwrap.dedent(inspect.getsource(target))
+    except (OSError, TypeError):  # pragma: no cover  # no readable source
+        return None
+
+
 def _env_names_reached(source: str, module: Any) -> set[str]:  # noqa: ANN401
     """Return the env-reading names `source` reaches, following its callees.
 
     Checking only `from_config`'s own body was not enough: moving the read
-    one function away passed the sweep while breaking R8. Helpers defined
-    in the same module are followed transitively, which is where such a
-    helper realistically lives.
+    one function away passed the sweep while breaking R8. Helpers are
+    followed transitively, whether the module defines them or imports them
+    from elsewhere in grelmicro.
     """
     functions = _module_functions(module)
     seen: set[str] = set()
@@ -177,8 +196,9 @@ def _env_names_reached(source: str, module: Any) -> set[str]:  # noqa: ANN401
         found |= called_names(tree) & ENV_READERS
         for name in sorted(call_targets(tree) - seen):
             seen.add(name)
-            if name in functions:
-                pending.append(functions[name])
+            body = functions.get(name) or _imported_helper(module, name)
+            if body is not None:
+                pending.append(body)
     return found
 
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -26,7 +26,8 @@ A ``default_factory`` is resolved and recorded too, so changing what the
 factory returns fails the guard: ``RetryConfig``'s backoff strategy is chosen
 entirely by one. The factory is called twice and recorded only when both calls
 agree, so a ``worker`` field minting a fresh identifier stays ``<factory>``
-rather than writing a random value here.
+rather than writing a random value here. The result is normalised the same
+way a literal default is, since a factory may hand back a shared object.
 
 A default taken from an interpreter constant records the resolved value, so a
 future CPython raising ``pickle.HIGHEST_PROTOCOL`` fails this snapshot. That
@@ -143,6 +144,18 @@ def _factory_default(owner: object, name: str) -> str | None:
     if not isinstance(fields, dict):
         return None
     field = fields.get(name)
+    if field is None:
+        # The signature shows an aliased field under its alias, so a
+        # name-only lookup would miss it and leave it as `<factory>`, which
+        # is the blind spot this exists to close.
+        field = next(
+            (
+                candidate
+                for candidate in fields.values()
+                if getattr(candidate, "alias", None) == name
+            ),
+            None,
+        )
     factory = getattr(field, "default_factory", None)
     if factory is None:
         return None
@@ -150,7 +163,12 @@ def _factory_default(owner: object, name: str) -> str | None:
         first, second = factory(), factory()
     except Exception:  # noqa: BLE001  # pragma: no cover  # needs arguments
         return None
-    return repr(first) if repr(first) == repr(second) else None
+    if repr(first) != repr(second):
+        return None
+    # Normalised like a literal default. A factory returning a shared object
+    # reprs identically on both calls, so it passes the determinism check and
+    # would otherwise write a memory address into the committed snapshot.
+    return _ADDRESS.sub(" at 0x...", repr(first))
 
 
 def _signature(obj: object) -> str | None:
@@ -169,8 +187,8 @@ def _signature(obj: object) -> str | None:
         param.replace(
             annotation=inspect.Parameter.empty,
             default=(
-                _Rendered(_factory_default(obj, param.name) or "")
-                if _factory_default(obj, param.name)
+                _Rendered(factory)
+                if (factory := _factory_default(obj, param.name)) is not None
                 else _default(param.default)
                 if param.default is not inspect.Parameter.empty
                 else inspect.Parameter.empty

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -22,14 +22,17 @@ memory address is normalised. This catches a parameter rename, removal,
 reorder, required-to-optional flip, and a changed default, which is a
 behavioural break for every caller who never passed the argument.
 
-Two defaults it still cannot see through. A ``default_factory`` reprs as
-``<factory>``, so changing what the factory returns (``RetryConfig.backoff``,
-the ``worker`` fields, the ``headers`` maps) passes silently. And a default
-taken from an interpreter constant records the resolved value, so a future
-CPython raising ``pickle.HIGHEST_PROTOCOL`` fails this snapshot: that is a
-real change in what ``PickleSerializer()`` does, and
+A ``default_factory`` is resolved and recorded too, so changing what the
+factory returns fails the guard: ``RetryConfig``'s backoff strategy is chosen
+entirely by one. The factory is called twice and recorded only when both calls
+agree, so a ``worker`` field minting a fresh identifier stays ``<factory>``
+rather than writing a random value here.
+
+A default taken from an interpreter constant records the resolved value, so a
+future CPython raising ``pickle.HIGHEST_PROTOCOL`` fails this snapshot. That
+is a real change in what ``PickleSerializer()`` does, and
 ``test_interpreter_derived_defaults_are_still_current`` says which constant
-moved so the update is an informed one rather than a mystery.
+moved so the update is informed rather than a mystery.
 
 A new public module is itself a deliberate API change, so add it to
 ``PUBLIC_MODULES`` in the same change that introduces it.
@@ -124,6 +127,32 @@ def _default(value: object) -> _Rendered:
     return _Rendered(_ADDRESS.sub(" at 0x...", repr(value)))
 
 
+def _factory_default(owner: object, name: str) -> str | None:
+    """Return a pydantic ``default_factory`` result, when it is stable.
+
+    The signature only carries pydantic's opaque ``<factory>`` sentinel, so
+    the factory is looked up on the model and called. Changing what a
+    factory returns is a behavioural break exactly like changing a literal
+    default: `RetryConfig`'s backoff strategy is chosen entirely by one.
+
+    Called twice and recorded only when both calls agree. A `worker` field
+    mints a fresh identifier every time, so it stays `<factory>` rather
+    than writing a random value into the snapshot.
+    """
+    fields = getattr(owner, "model_fields", None)
+    if not isinstance(fields, dict):
+        return None
+    field = fields.get(name)
+    factory = getattr(field, "default_factory", None)
+    if factory is None:
+        return None
+    try:
+        first, second = factory(), factory()
+    except Exception:  # noqa: BLE001  # pragma: no cover  # needs arguments
+        return None
+    return repr(first) if repr(first) == repr(second) else None
+
+
 def _signature(obj: object) -> str | None:
     """Return a version-stable signature string, or None when not callable.
 
@@ -140,7 +169,9 @@ def _signature(obj: object) -> str | None:
         param.replace(
             annotation=inspect.Parameter.empty,
             default=(
-                _default(param.default)
+                _Rendered(_factory_default(obj, param.name) or "")
+                if _factory_default(obj, param.name)
+                else _default(param.default)
                 if param.default is not inspect.Parameter.empty
                 else inspect.Parameter.empty
             ),

--- a/tests/test_settings_error_contract.py
+++ b/tests/test_settings_error_contract.py
@@ -455,3 +455,32 @@ def test_scrub_removes_the_value_only_where_a_message_can_carry_it() -> None:
         "union_tag_invalid",
     )
     assert SECRET not in _scrub(f"got {SECRET}", [SECRET], "value_error")
+
+
+NUMERIC_CANARY = 943257
+"""A rejected number standing in for a value read from the environment."""
+
+
+def test_scrub_removes_a_rejected_number_too() -> None:
+    """A number is a value from the environment like any other.
+
+    Only strings were scrubbed, so a validator naming a rejected number
+    leaked it. Constraint messages stay untouched: `Input should be greater
+    than 0` describes the limit, not what arrived.
+    """
+    assert str(NUMERIC_CANARY) not in _scrub(
+        f"rejected {NUMERIC_CANARY}", NUMERIC_CANARY, "value_error"
+    )
+    assert str(NUMERIC_CANARY) not in _scrub(
+        f"rejected {NUMERIC_CANARY}", [NUMERIC_CANARY], "value_error"
+    )
+    assert (
+        _scrub("Input should be greater than 0", 0, "greater_than")
+        == "Input should be greater than 0"
+    )
+    # A bool would remove the words `True` and `False` from a message that
+    # legitimately uses them.
+    boolean_input: object = True
+    assert _scrub("Input should be True", boolean_input, "value_error") == (
+        "Input should be True"
+    )


### PR DESCRIPTION
Closes the three gaps #764 documented instead of fixing.

## A changed default factory was still invisible

`RetryConfig.backoff` picks the retry strategy for every caller who never
passes one, and it comes from a `default_factory`. The signature only carries
pydantic's opaque `<factory>` sentinel, so swapping `ExponentialBackoff` for
`ConstantBackoff` passed the guard silently.

The factory is now looked up on the model and called. Recorded:

```
RetryConfig(*, attempts=3, ..., backoff=ExponentialBackoff(kind='exponential',
    base_delay=0.1, max_delay=30.0, jitter='full'))
```

It is called **twice** and recorded only when both calls agree, so a `worker`
field minting a fresh identifier stays `<factory>` rather than writing a random
value into the snapshot. That distinction is the reason this is safe to do at
all.

Verified: swapping the default backoff strategy now fails the guard, and the
whole surface still rebuilds byte-identical on 3.12, 3.13 and 3.14.

## R8 could be bypassed across a module boundary

The check followed helpers the module defines, which closed the same-module
case. Putting the environment read in a neighbouring grelmicro module and
importing it still passed. It now follows first-party imported functions too,
stopping at the package boundary rather than descending into pydantic or the
stdlib. Verified by planting exactly that bypass.

## Errors scrubbed strings but not numbers

`_scrub` only removed string inputs, so a validator naming a rejected number
leaked it. A number read from the environment is a value from the environment,
and the reason to withhold it does not depend on its type. Booleans stay
excluded, since removing the words `True` and `False` would garble messages
that legitimately use them, and constraint messages are untouched as before.

## Verification

Each fix was checked by reintroducing the defect it closes, not by being green:
swapping the backoff factory, planting a cross-module env read, and scrubbing a
numeric canary.

Full `pre-commit run --all-files` green: 17 hooks, integration tier, 100%
coverage gate.
