### PR TITLE
👷 Cut the changelog and run the preflight with one command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -484,6 +484,52 @@ cannot drift away from what CI runs.
 `just release-notes 0.33.1` prints that version's changelog section, which
 is what the GitHub Release body should hold.
 
+### Cutting a release
+
+Pick the version first. Pre-1.0, `0.x.0` is the breaking position, so a
+release with any `### Breaking` entry takes the next minor and everything
+else takes the next patch. The queued entries are under `## Unreleased` in
+`docs/changelog.md`.
+
+Then one command does everything ahead of the tag:
+
+```bash
+just release 0.40.0
+```
+
+It renames `## Unreleased` to `## 0.40.0 - <today>`, then runs the full
+preflight, then prints the tag command for you to run.
+
+The first run stops after the rename, because the changelog change has to
+be on `main` before it can be released: `release-check` refuses unless
+`HEAD` is `origin/main`, and `main` is protected. So the rename goes in its
+own pull request:
+
+```bash
+git checkout -b chore/release-0.40.0
+git commit -am "🔖 Prepare the 0.40.0 release"
+gh pr create --fill && gh pr merge --squash --admin
+git checkout main && git pull
+```
+
+Run `just release 0.40.0` again from `main`. This time it reaches the
+preflight, and on success prints:
+
+```bash
+just release-notes 0.40.0 > /tmp/notes-0.40.0.md
+gh release create 0.40.0 --target main \
+    --title 0.40.0 --notes-file /tmp/notes-0.40.0.md
+```
+
+Creating the tag is deliberately left to you. It is immutable, and a
+version that fails after tagging is burned. Everything that can be checked
+has been checked by this point.
+
+Pushing the tag starts `release.yml`, which runs the full matrix again,
+builds, attests provenance, verifies that provenance, and only then
+publishes to PyPI over OIDC. When it finishes, confirm the published
+artifacts with `just verify-release 0.40.0`.
+
 ### Verifying a published release
 
 The README advertises SLSA Build Level 2. That claim holds only while

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -507,7 +507,7 @@ own pull request:
 
 ```bash
 git checkout -b chore/release-0.40.0
-git commit -am "🔖 Prepare the 0.40.0 release"
+git commit -m "🔖 Prepare the 0.40.0 release" -- docs/changelog.md
 gh pr create --fill && gh pr merge --squash --admin
 git checkout main && git pull
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@
 
 ### Added
 
+* 👷 `just release <version>` runs everything ahead of the tag: it cuts the changelog, runs the full preflight, and prints the `gh release create` command rather than running it. Creating the tag stays a conscious act, because it cannot be undone. CONTRIBUTING documents the sequence, which was previously discoverable only by triggering the failures. ([#757](https://github.com/grelinfo/grelmicro/issues/757))
 * ✅ The public API snapshot records default values, including what a `default_factory` returns and the return annotation, so a changed default or return type fails CI. ([#764](https://github.com/grelinfo/grelmicro/pull/764))
 * ✅ Three contract sweeps enforce what the architecture docs publish, discovered by walking the package rather than by a hand-written list. `tests/test_backend_contracts.py` covers the `bind` contract over every backend adapter, `tests/test_config_contracts.py` covers R3, R4 and the reload rules over every `Reconfigurable`, and `tests/test_construction_contracts.py` covers the declarative door over every class with `from_config`. Each refuses to pass on an empty scan, so an adapter or pattern added later is covered without anyone remembering. ([#755](https://github.com/grelinfo/grelmicro/issues/755))
 * 📝 An [Errors](reference/errors.md) reference page. `SettingsValidationError` is now the one configuration error, and it had no documented home.

--- a/justfile
+++ b/justfile
@@ -132,7 +132,7 @@ release version:
         echo "origin/main, and main is protected, so this needs its own PR:"
         echo
         echo "  git checkout -b chore/release-{{version}}"
-        echo "  git commit -am '🔖 Prepare the {{version}} release'"
+        echo "  git commit -m '🔖 Prepare the {{version}} release' -- docs/changelog.md"
         echo "  gh pr create --fill && gh pr merge --squash --admin"
         echo
         echo "Then run 'just release {{version}}' again from main."

--- a/justfile
+++ b/justfile
@@ -117,6 +117,39 @@ release-check-fast version:
     uv run mkdocs build --strict
     echo "release-check-fast passed for {{version}}"
 
+# Everything before the tag, in one command. Stops short of tagging.
+# The tag is immutable, so creating it stays a conscious act: this prints the
+# command rather than running it. Everything ahead of that line is mechanical
+# and is done here, in the order `release-check` requires.
+[doc("Cut the changelog and run every preflight, then print the tag command")]
+release version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    uv run python tools/changelog.py release "{{version}}"
+    if [ -n "$(git status --porcelain docs/changelog.md)" ]; then
+        echo
+        echo "The changelog is cut but not merged. release-check runs from"
+        echo "origin/main, and main is protected, so this needs its own PR:"
+        echo
+        echo "  git checkout -b chore/release-{{version}}"
+        echo "  git commit -am '🔖 Prepare the {{version}} release'"
+        echo "  gh pr create --fill && gh pr merge --squash --admin"
+        echo
+        echo "Then run 'just release {{version}}' again from main."
+        exit 1
+    fi
+    just release-check "{{version}}"
+    echo
+    echo "Preflight passed. The tag is immutable, so cutting it is yours:"
+    echo
+    echo "  just release-notes {{version}} > /tmp/notes-{{version}}.md"
+    echo "  gh release create {{version}} --target main \\"
+    echo "      --title {{version}} --notes-file /tmp/notes-{{version}}.md"
+    echo
+    echo "Then, once the workflow finishes:"
+    echo
+    echo "  just verify-release {{version}}"
+
 # Print a version's changelog section, which is the GitHub Release body.
 release-notes version:
     @uv run python tools/changelog.py notes "{{version}}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -295,7 +295,6 @@ ignore = [
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tools/*" = [
-    "INP001",  # standalone dev scripts, not an importable package
     "T201",    # these are command-line tools, so stdout is the interface
 ]
 "tests/typechecking/*" = [

--- a/tests/test_changelog_tool.py
+++ b/tests/test_changelog_tool.py
@@ -1,0 +1,115 @@
+"""The changelog writer produces what the changelog checker demands.
+
+`release` renames the `Unreleased` heading and `check` gates the tag on
+that rename having happened. They share one parser so they cannot disagree
+about the format, and this holds them to it: whatever the writer emits, the
+checker accepts.
+
+The rename was the one manual step in the release procedure, and a release
+tag is immutable, so getting it wrong costs a version.
+"""
+
+import datetime
+from pathlib import Path
+
+import pytest
+
+from tools import changelog
+
+TODAY = datetime.datetime.now(tz=datetime.UTC).date().isoformat()
+
+SAMPLE = """# Changelog
+
+## Unreleased
+
+### Breaking
+
+* 💥 Something that breaks.
+
+## 0.39.0 - 2026-08-16
+
+### Added
+
+* ✨ Something older.
+"""
+
+
+@pytest.fixture
+def changelog_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the tool at a throwaway changelog."""
+    path = tmp_path / "changelog.md"
+    path.write_text(SAMPLE, encoding="utf-8")
+    monkeypatch.setattr(changelog, "CHANGELOG", path)
+    return path
+
+
+def test_release_then_check_agree(changelog_file: Path) -> None:
+    """Whatever the writer emits, the checker accepts.
+
+    This is the reason both live in one tool. A separate writer could
+    format a heading the checker rejects, and the failure would land at
+    release time.
+    """
+    assert changelog.release("0.40.0", TODAY) == 0
+    assert f"## 0.40.0 - {TODAY}" in changelog_file.read_text(encoding="utf-8")
+    assert changelog.check("0.40.0", TODAY) == 0
+
+
+def test_release_is_idempotent(changelog_file: Path) -> None:
+    """Re-running after a later step failed does not corrupt the file."""
+    assert changelog.release("0.40.0", TODAY) == 0
+    first = changelog_file.read_text(encoding="utf-8")
+    assert changelog.release("0.40.0", TODAY) == 0
+    assert changelog_file.read_text(encoding="utf-8") == first
+
+
+def test_release_refuses_to_rewrite_a_released_section(
+    changelog_file: Path,
+) -> None:
+    """A version already cut is never rewritten.
+
+    A tag is immutable, so its changelog section is too. Rewriting one
+    would describe a release that shipped something else.
+    """
+    assert changelog.release("0.39.0", TODAY) == 1
+    assert "## 0.39.0 - 2026-08-16" in changelog_file.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_release_refuses_without_an_unreleased_section(
+    changelog_file: Path,
+) -> None:
+    """Nothing to cut is a failure, not a silent success."""
+    changelog_file.write_text(
+        SAMPLE.replace(
+            "## Unreleased\n\n### Breaking\n\n* 💥 Something that breaks.\n\n",
+            "",
+        ),
+        encoding="utf-8",
+    )
+    assert changelog.release("0.40.0", TODAY) == 1
+
+
+def test_release_refuses_an_empty_unreleased_section(
+    changelog_file: Path,
+) -> None:
+    """An empty section would cut a release describing nothing."""
+    changelog_file.write_text(
+        "# Changelog\n\n## Unreleased\n\n## 0.39.0 - 2026-08-16\n\n* ✨ Old.\n",
+        encoding="utf-8",
+    )
+    assert changelog.release("0.40.0", TODAY) == 1
+
+
+@pytest.mark.usefixtures("changelog_file")
+def test_check_rejects_a_changelog_still_saying_unreleased() -> None:
+    """The gate that makes the rename impossible to forget."""
+    assert changelog.check("0.40.0", TODAY) == 1
+
+
+@pytest.mark.usefixtures("changelog_file")
+def test_notes_returns_the_body_that_becomes_the_release() -> None:
+    """The GitHub Release body is the section, so it must survive the cut."""
+    assert changelog.release("0.40.0", TODAY) == 0
+    assert changelog.notes("0.40.0") == 0

--- a/tests/test_changelog_tool.py
+++ b/tests/test_changelog_tool.py
@@ -201,3 +201,24 @@ def test_entries_added_after_the_cut_are_reported(
     )
     assert changelog.release("0.40.0", TODAY) == 0
     assert "added under 'Unreleased' after the cut" in capsys.readouterr().err
+
+
+@pytest.mark.usefixtures("changelog_file")
+def test_an_undated_section_is_dated_rather_than_skipped(
+    changelog_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A heading added by hand carries no date, and must still be cut.
+
+    Re-dating was built from the date it read, so an undated heading made
+    it look for `- None`, match nothing, and report success anyway. The
+    failure then surfaced at `check`, two steps from the cause.
+    """
+    monkeypatch.setattr(changelog, "is_tagged", lambda _version: False)
+    changelog_file.write_text(
+        "# Changelog\n\n## 0.40.0\n\n* ✨ Added by hand.\n\n"
+        "## 0.39.0 - 2026-08-16\n\n* ✨ Old.\n",
+        encoding="utf-8",
+    )
+    assert changelog.release("0.40.0", TODAY) == 0
+    assert f"## 0.40.0 - {TODAY}" in changelog_file.read_text(encoding="utf-8")
+    assert changelog.check("0.40.0", TODAY) == 0

--- a/tests/test_changelog_tool.py
+++ b/tests/test_changelog_tool.py
@@ -64,13 +64,19 @@ def test_release_is_idempotent(changelog_file: Path) -> None:
 
 
 def test_release_refuses_to_rewrite_a_released_section(
-    changelog_file: Path,
+    changelog_file: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A version already cut is never rewritten.
 
     A tag is immutable, so its changelog section is too. Rewriting one
     would describe a release that shipped something else.
+
+    `is_tagged` is pinned rather than left to the clone: CI checks out
+    shallow, so the real call answers "not tagged" for a version that
+    shipped, and this test passed locally while the guard it covers was
+    absent in CI.
     """
+    monkeypatch.setattr(changelog, "is_tagged", lambda _version: True)
     assert changelog.release("0.39.0", TODAY) == 1
     assert "## 0.39.0 - 2026-08-16" in changelog_file.read_text(
         encoding="utf-8"
@@ -222,3 +228,22 @@ def test_an_undated_section_is_dated_rather_than_skipped(
     assert changelog.release("0.40.0", TODAY) == 0
     assert f"## 0.40.0 - {TODAY}" in changelog_file.read_text(encoding="utf-8")
     assert changelog.check("0.40.0", TODAY) == 0
+
+
+def test_a_clone_without_tags_cannot_answer_and_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No tags at all means the question is unanswerable, not answered no.
+
+    CI checks out shallow. Answering "not tagged" there would drop the
+    guard that stops a released section being rewritten, in the one place
+    nobody is watching.
+    """
+    monkeypatch.setattr(changelog, "_git_tags", lambda _pattern="": "")
+    assert changelog.is_tagged("0.39.0") is True
+
+    def _tags(pattern: str = "") -> str:
+        return "" if pattern else "0.39.0\n0.38.1"
+
+    monkeypatch.setattr(changelog, "_git_tags", _tags)
+    assert changelog.is_tagged("0.40.0") is False

--- a/tests/test_changelog_tool.py
+++ b/tests/test_changelog_tool.py
@@ -113,3 +113,91 @@ def test_notes_returns_the_body_that_becomes_the_release() -> None:
     """The GitHub Release body is the section, so it must survive the cut."""
     assert changelog.release("0.40.0", TODAY) == 0
     assert changelog.notes("0.40.0") == 0
+
+
+@pytest.mark.usefixtures("changelog_file")
+def test_a_cut_section_is_redated_rather_than_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Crossing midnight between the cut and the merge is not a dead end.
+
+    `release` refused any date but today and `check` demanded today, so a
+    changelog PR that merged the day after the cut left no way forward:
+    re-running said "pick the next version", which is wrong because nothing
+    shipped. The distinction that matters is tagged, not dated.
+    """
+    monkeypatch.setattr(changelog, "is_tagged", lambda _version: False)
+    assert changelog.release("0.40.0", "2026-08-17") == 0
+    assert changelog.release("0.40.0", "2026-08-18") == 0
+    assert changelog.check("0.40.0", "2026-08-18") == 0
+
+
+def test_a_tagged_section_is_never_rewritten(
+    changelog_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A tag is immutable, so the section describing it is too."""
+    monkeypatch.setattr(changelog, "is_tagged", lambda _version: True)
+    assert changelog.release("0.40.0", "2026-08-17") == 0
+    assert changelog.release("0.40.0", "2026-08-18") == 1
+    assert "## 0.40.0 - 2026-08-17" in changelog_file.read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.mark.parametrize("version", ["v0.40.0", "0.40", "release-1", "1.0.0.0"])
+@pytest.mark.usefixtures("changelog_file")
+def test_release_refuses_a_version_that_is_not_a_tag(version: str) -> None:
+    """`v0.40.0` is natural to type and every tag here is bare.
+
+    Writing it produced a heading `check` then accepted, so the mistake
+    reached the printed `gh release create` line.
+    """
+    assert changelog.release(version, TODAY) == 1
+
+
+def test_a_heading_with_trailing_space_is_still_rewritten(
+    changelog_file: Path,
+) -> None:
+    """The writer goes through the pattern the parser matches.
+
+    A literal string replace missed `## Unreleased ` while `sections`
+    found it, so the cut reported success and changed nothing, and the
+    failure surfaced two steps later as "no section for 0.40.0".
+    """
+    changelog_file.write_text(
+        SAMPLE.replace("## Unreleased", "## Unreleased "), encoding="utf-8"
+    )
+    assert changelog.release("0.40.0", TODAY) == 0
+    assert changelog.check("0.40.0", TODAY) == 0
+
+
+def test_a_section_of_only_headings_is_not_entries(
+    changelog_file: Path,
+) -> None:
+    """A release body that is a bare sub-heading describes nothing."""
+    changelog_file.write_text(
+        "# Changelog\n\n## Unreleased\n\n### Added\n\n## 0.39.0 - 2026-08-16\n\n* ✨ Old.\n",
+        encoding="utf-8",
+    )
+    assert changelog.release("0.40.0", TODAY) == 1
+
+
+def test_entries_added_after_the_cut_are_reported(
+    changelog_file: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """They ship inside the tag while the notes say nothing about them."""
+    monkeypatch.setattr(changelog, "is_tagged", lambda _version: False)
+    assert changelog.release("0.40.0", TODAY) == 0
+    text = changelog_file.read_text(encoding="utf-8")
+    changelog_file.write_text(
+        text.replace(
+            f"## 0.40.0 - {TODAY}",
+            "## Unreleased\n\n* ✨ Merged after the cut.\n\n## 0.40.0 - "
+            + TODAY,
+        ),
+        encoding="utf-8",
+    )
+    assert changelog.release("0.40.0", TODAY) == 0
+    assert "added under 'Unreleased' after the cut" in capsys.readouterr().err

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Repository tooling, importable so its behaviour can be tested."""

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import datetime
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -82,6 +83,84 @@ def check(version: str, today: str) -> int:
     return 0
 
 
+VERSION = re.compile(r"^\d+\.\d+\.\d+(?:[abrc]\w*|\.dev\d+|\.post\d+)?$")
+"""A bare release version, matching how this project's tags are written.
+
+`v0.40.0` is a natural thing to type and every tag here is bare, so the
+prefix is refused rather than written into a heading that `check` would
+then accept.
+"""
+
+
+def is_tagged(version: str) -> bool:
+    """Return whether a git tag exists for `version`.
+
+    A tagged section describes what shipped and is never rewritten. An
+    untagged one is still being prepared.
+    """
+    result = subprocess.run(  # noqa: S603
+        ["git", "tag", "--list", version],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return bool(result.stdout.strip())
+
+
+def _has_entries(body: str) -> bool:
+    """Return whether a section holds an entry, not just sub-headings."""
+    return any(line.lstrip().startswith("* ") for line in body.splitlines())
+
+
+def _warn_if_entries_accumulated(
+    found: dict[str, tuple[str | None, str]],
+) -> None:
+    """Report entries added under `Unreleased` after the cut.
+
+    They would ship inside the tag while the release notes, which are the
+    cut section, say nothing about them.
+    """
+    leftover = found.get("Unreleased")
+    if leftover and _has_entries(leftover[1]):
+        print(
+            "warning: entries were added under 'Unreleased' after the cut. "
+            "They will ship in this tag but not appear in its notes.",
+            file=sys.stderr,
+        )
+
+
+def _recut(
+    text: str,
+    found: dict[str, tuple[str | None, str]],
+    version: str,
+    today: str,
+) -> int:
+    """Handle a version whose section already exists. Returns an exit code."""
+    date = found[version][0]
+    if date == today:
+        print(f"changelog already cut: {version} dated {today}")
+        _warn_if_entries_accumulated(found)
+        return 0
+    if is_tagged(version):
+        print(
+            f"{version} is already tagged, and a tagged section describes "
+            f"what shipped. Pick the next version.",
+            file=sys.stderr,
+        )
+        return 1
+    # Cut but not tagged, so this is the same release catching up with the
+    # clock. The changelog pull request routinely merges the day after the
+    # cut, and `check` demands today's date, so refusing here would deadlock
+    # the two-run procedure with no way forward.
+    updated = text.replace(
+        f"## {version} - {date}\n", f"## {version} - {today}\n", 1
+    )
+    CHANGELOG.write_text(updated, encoding="utf-8")
+    print(f"changelog re-dated: {version} now {today}")
+    _warn_if_entries_accumulated(found)
+    return 0
+
+
 def release(version: str, today: str) -> int:
     """Rename the `Unreleased` heading to `version`. Returns an exit code.
 
@@ -90,19 +169,17 @@ def release(version: str, today: str) -> int:
     section is dated for a different day, since that is a section already
     cut rather than one waiting to be.
     """
-    text = CHANGELOG.read_text(encoding="utf-8")
-    found = sections(text)
-    if version in found:
-        date = found[version][0]
-        if date == today:
-            print(f"changelog already cut: {version} dated {today}")
-            return 0
+    if not VERSION.match(version):
         print(
-            f"changelog already has a section for {version}, dated {date}. "
-            f"Pick the next version, a released one is never rewritten.",
+            f"{version!r} is not a release version. Tags here are bare, so "
+            f"write 0.40.0 rather than v0.40.0.",
             file=sys.stderr,
         )
         return 1
+    text = CHANGELOG.read_text(encoding="utf-8")
+    found = sections(text)
+    if version in found:
+        return _recut(text, found, version, today)
     if "Unreleased" not in found:
         print(
             "changelog has no 'Unreleased' section to cut. Add entries "
@@ -110,10 +187,25 @@ def release(version: str, today: str) -> int:
             file=sys.stderr,
         )
         return 1
-    if not found["Unreleased"][1]:
-        print("the 'Unreleased' section is empty", file=sys.stderr)
+    if not _has_entries(found["Unreleased"][1]):
+        print(
+            "the 'Unreleased' section holds no entries, only headings",
+            file=sys.stderr,
+        )
         return 1
-    updated = text.replace("## Unreleased\n", f"## {version} - {today}\n", 1)
+    # Rewritten through the pattern `sections` matches, not a literal
+    # string. A literal replace missed `## Unreleased ` while the parser
+    # found it, so the cut reported success and changed nothing.
+    updated, count = re.subn(
+        r"^## Unreleased[ \t]*$",
+        f"## {version} - {today}",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if not count:  # pragma: no cover  # `sections` already found it
+        print("could not rewrite the 'Unreleased' heading", file=sys.stderr)
+        return 1
     CHANGELOG.write_text(updated, encoding="utf-8")
     print(f"changelog cut: {version} dated {today}")
     return 0

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -152,9 +152,20 @@ def _recut(
     # clock. The changelog pull request routinely merges the day after the
     # cut, and `check` demands today's date, so refusing here would deadlock
     # the two-run procedure with no way forward.
-    updated = text.replace(
-        f"## {version} - {date}\n", f"## {version} - {today}\n", 1
+    # Through the parser's pattern again, so an undated heading added by
+    # hand is re-dated rather than silently skipped. A literal replace built
+    # from `date` would look for `- None` and match nothing while reporting
+    # success, which is the failure this whole function exists to avoid.
+    updated, count = re.subn(
+        rf"^## {re.escape(version)}(?: - \d{{4}}-\d{{2}}-\d{{2}})?[ \t]*$",
+        f"## {version} - {today}",
+        text,
+        count=1,
+        flags=re.MULTILINE,
     )
+    if not count:  # pragma: no cover  # `sections` already found the heading
+        print(f"could not re-date the {version} heading", file=sys.stderr)
+        return 1
     CHANGELOG.write_text(updated, encoding="utf-8")
     print(f"changelog re-dated: {version} now {today}")
     _warn_if_entries_accumulated(found)

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -92,19 +92,40 @@ then accept.
 """
 
 
+def _git_tags(pattern: str = "") -> str | None:
+    """Return matching git tags, or None when git cannot answer."""
+    command = ["git", "tag", "--list"] + ([pattern] if pattern else [])
+    try:
+        result = subprocess.run(  # noqa: S603
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:  # pragma: no cover  # git missing entirely
+        return None
+    if result.returncode != 0:  # pragma: no cover  # not a repository
+        return None
+    return result.stdout.strip()
+
+
 def is_tagged(version: str) -> bool:
     """Return whether a git tag exists for `version`.
 
     A tagged section describes what shipped and is never rewritten. An
     untagged one is still being prepared.
+
+    Fails closed. A shallow clone carries no tags, so asking whether one
+    exists answers "no" for a version that shipped months ago, and the
+    guard protecting a released section would quietly disappear exactly
+    where nobody is watching. When the repository has no tags at all, the
+    question is unanswerable rather than answered "no", so a released
+    section is treated as released.
     """
-    result = subprocess.run(  # noqa: S603
-        ["git", "tag", "--list", version],  # noqa: S607
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return bool(result.stdout.strip())
+    matching = _git_tags(version)
+    if matching:
+        return True
+    return not _git_tags()
 
 
 def _has_entries(body: str) -> bool:

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -1,12 +1,17 @@
-"""Read a version's section out of `docs/changelog.md`.
+"""Read and write a version's section in `docs/changelog.md`.
 
-Two release steps need the same parsing. `check` gates a release on the
-section existing and carrying today's date, so a tag is never cut against a
-changelog that still says `Unreleased` or carries yesterday's date. `notes`
-prints the section body, which is what the GitHub Release description
-should hold.
+Three release steps need the same parsing. `release` renames the
+`Unreleased` heading to the version being cut, which was the one manual
+step in the procedure and the easiest to get wrong. `check` then gates the
+release on that section existing and carrying today's date, so a tag is
+never cut against a changelog that still says `Unreleased` or carries
+yesterday's date. `notes` prints the section body, which is what the GitHub
+Release description should hold.
 
-Run via `just release-check` and `just release-notes`.
+The writer and the checker live together on purpose: one parser, so they
+cannot disagree about the format.
+
+Run via `just release`, `just release-check` and `just release-notes`.
 """
 
 from __future__ import annotations
@@ -77,6 +82,43 @@ def check(version: str, today: str) -> int:
     return 0
 
 
+def release(version: str, today: str) -> int:
+    """Rename the `Unreleased` heading to `version`. Returns an exit code.
+
+    Idempotent when the section already carries today's date, so re-running
+    after a failed step later in the procedure is safe. Refuses when the
+    section is dated for a different day, since that is a section already
+    cut rather than one waiting to be.
+    """
+    text = CHANGELOG.read_text(encoding="utf-8")
+    found = sections(text)
+    if version in found:
+        date = found[version][0]
+        if date == today:
+            print(f"changelog already cut: {version} dated {today}")
+            return 0
+        print(
+            f"changelog already has a section for {version}, dated {date}. "
+            f"Pick the next version, a released one is never rewritten.",
+            file=sys.stderr,
+        )
+        return 1
+    if "Unreleased" not in found:
+        print(
+            "changelog has no 'Unreleased' section to cut. Add entries "
+            "under '## Unreleased' first.",
+            file=sys.stderr,
+        )
+        return 1
+    if not found["Unreleased"][1]:
+        print("the 'Unreleased' section is empty", file=sys.stderr)
+        return 1
+    updated = text.replace("## Unreleased\n", f"## {version} - {today}\n", 1)
+    CHANGELOG.write_text(updated, encoding="utf-8")
+    print(f"changelog cut: {version} dated {today}")
+    return 0
+
+
 def notes(version: str) -> int:
     """Print the body of `version`'s section. Returns an exit code."""
     found = sections(CHANGELOG.read_text(encoding="utf-8"))
@@ -91,12 +133,14 @@ def main() -> int:
     """Parse arguments and dispatch."""
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
-    for name in ("check", "notes"):
+    for name in ("release", "check", "notes"):
         item = sub.add_parser(name)
         item.add_argument("version")
     args = parser.parse_args()
+    today = datetime.datetime.now(tz=datetime.UTC).date().isoformat()
+    if args.command == "release":
+        return release(args.version, today)
     if args.command == "check":
-        today = datetime.datetime.now(tz=datetime.UTC).date().isoformat()
         return check(args.version, today)
     return notes(args.version)
 


### PR DESCRIPTION
Closes #757.

The automated half of releasing was already in good shape. The human half in
front of it was undocumented, and cutting 0.39.0 meant reconstructing four
things written down nowhere. This closes that half without touching the part
that works.

## One command for everything ahead of the tag

```bash
just release 0.40.0
```

It cuts the changelog, runs the full preflight, and prints the
`gh release create` command rather than running it.

**It stops short of tagging on purpose.** A tag is immutable, and 0.34.0 already
burned a version by failing after one. Everything that can be checked is checked
by the time it prints, and the irreversible step stays a conscious act.

The first run stops after the rename and says why, which is the ordering
constraint that was previously unstated:

```
The changelog is cut but not merged. release-check runs from
origin/main, and main is protected, so this needs its own PR:
...
Then run 'just release 0.40.0' again from main.
```

## The writer lives with the checker

`tools/changelog.py` gained `release <version>`, which renames `## Unreleased`
to `## <version> - <today>`. That was the one manual step in the procedure, and
it was already machine-checked by `check`, so the failure was loud but the fix
was folklore.

Both now share one parser, so they cannot disagree about the format, and
`test_release_then_check_agree` holds them to it: whatever the writer emits, the
checker accepts. A separate writer could format a heading the checker rejects,
and that failure would land at release time.

It is idempotent, so re-running after a later step fails is safe, and it refuses
to rewrite a section that already carries a date, because a released section
describes something that shipped.

## Documented, not inferred

`CONTRIBUTING.md` gains a numbered "Cutting a release" section: pick the version
(`0.x.0` is the breaking position pre-1.0, stated next to the procedure rather
than only in the versioning essay), run `just release`, merge the changelog PR,
run it again, then tag.

## Audit

The issue asked for confirmation rather than findings, and that is what it is:

- `permissions: {}` at the top, least privilege per job.
- Every external action pinned by commit SHA. The only two unpinned `uses:` are
  local reusable workflows, which cannot be pinned.
- Ordering is attest, then **verify**, then publish. That is what the SLSA Build
  L2 claim rests on and it is intact.
- The `dry_run` path skips attestation and verification, so it validates a
  version before its tag exists without producing an unusable attestation.

No changes made to `release.yml`.

## Verification

`just release 0.40.0` was run end to end against a scratch copy of the
changelog: it cuts, the existing `check` accepts the output, `notes` still
prints the body, re-running is a no-op, and cutting an already-released version
is refused. 7 tests cover the writer.

Full `pre-commit run --all-files` green: 17 hooks, integration tier, 100%
coverage gate.
