### PR TITLE
✅ Assert what the sweeps used to skip and cover the release tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -446,6 +446,7 @@ sort = "-Cover"
 skip_covered = true
 exclude_also = [
     "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
     "class .*\\bProtocol\\):",
     "assert_never\\(.*\\)",
     "pytest.fail\\(.*\\)",

--- a/tests/test_changelog_tool.py
+++ b/tests/test_changelog_tool.py
@@ -10,6 +10,7 @@ tag is immutable, so getting it wrong costs a version.
 """
 
 import datetime
+import sys
 from pathlib import Path
 
 import pytest
@@ -247,3 +248,67 @@ def test_a_clone_without_tags_cannot_answer_and_fails_closed(
 
     monkeypatch.setattr(changelog, "_git_tags", _tags)
     assert changelog.is_tagged("0.40.0") is False
+
+
+def test_check_reports_each_way_a_section_is_not_ready(
+    changelog_file: Path,
+) -> None:
+    """Every refusal `check` can make, since each one gates a tag.
+
+    `release` is the writer, but `check` is what runs in the preflight, so
+    a branch here that behaves wrongly lets a bad changelog reach a tag.
+    """
+    assert changelog.check("9.9.9", TODAY) == 1
+
+    changelog_file.write_text(
+        "# Changelog\n\n## 0.40.0\n\n* ✨ Undated.\n", encoding="utf-8"
+    )
+    assert changelog.check("0.40.0", TODAY) == 1
+
+    changelog_file.write_text(
+        "# Changelog\n\n## 0.40.0 - 2020-01-01\n\n* ✨ Stale.\n",
+        encoding="utf-8",
+    )
+    assert changelog.check("0.40.0", TODAY) == 1
+
+    changelog_file.write_text(
+        f"# Changelog\n\n## 0.40.0 - {TODAY}\n", encoding="utf-8"
+    )
+    assert changelog.check("0.40.0", TODAY) == 1
+
+
+@pytest.mark.usefixtures("changelog_file")
+def test_notes_refuses_a_version_it_cannot_find() -> None:
+    """The release body comes from here, so a miss must not print nothing."""
+    assert changelog.notes("9.9.9") == 1
+
+
+@pytest.mark.parametrize("command", ["release", "check", "notes"])
+@pytest.mark.usefixtures("changelog_file")
+def test_main_dispatches_every_subcommand(
+    command: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command line is how the justfile drives this."""
+    monkeypatch.setattr(changelog, "is_tagged", lambda _version: False)
+    monkeypatch.setattr(sys, "argv", ["changelog.py", command, "0.40.0"])
+    expected = 1 if command in {"check", "notes"} else 0
+    assert changelog.main() == expected
+
+
+def test_git_tags_returns_none_when_git_cannot_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing git or a non-repository is unknown, not an empty answer.
+
+    `is_tagged` treats "no tags at all" as unanswerable and fails closed, so
+    this distinction is what keeps a released section from being rewritten
+    outside a full clone.
+    """
+
+    def _explode(*_args: object, **_kwargs: object) -> object:
+        raise OSError
+
+    monkeypatch.setattr(changelog.subprocess, "run", _explode)
+    assert changelog._git_tags() is None
+    assert changelog.is_tagged("0.39.0") is True

--- a/tests/test_changelog_tool.py
+++ b/tests/test_changelog_tool.py
@@ -12,6 +12,7 @@ tag is immutable, so getting it wrong costs a version.
 import datetime
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -252,6 +253,7 @@ def test_a_clone_without_tags_cannot_answer_and_fails_closed(
 
 def test_check_reports_each_way_a_section_is_not_ready(
     changelog_file: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Every refusal `check` can make, since each one gates a tag.
 
@@ -264,6 +266,9 @@ def test_check_reports_each_way_a_section_is_not_ready(
         "# Changelog\n\n## 0.40.0\n\n* ✨ Undated.\n", encoding="utf-8"
     )
     assert changelog.check("0.40.0", TODAY) == 1
+    # The undated branch and the wrong-date branch both return 1, so the
+    # message is what distinguishes them.
+    assert "carries no date" in capsys.readouterr().err
 
     changelog_file.write_text(
         "# Changelog\n\n## 0.40.0 - 2020-01-01\n\n* ✨ Stale.\n",
@@ -288,12 +293,23 @@ def test_notes_refuses_a_version_it_cannot_find() -> None:
 def test_main_dispatches_every_subcommand(
     command: str,
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """The command line is how the justfile drives this."""
     monkeypatch.setattr(changelog, "is_tagged", lambda _version: False)
     monkeypatch.setattr(sys, "argv", ["changelog.py", command, "0.40.0"])
     expected = 1 if command in {"check", "notes"} else 0
     assert changelog.main() == expected
+    # The message, not just the code. `main` ends with an unguarded
+    # `return notes(...)`, so a broken `check` branch falls through to
+    # `notes` and returns 1 either way.
+    output = capsys.readouterr()
+    marker = {
+        "release": "changelog cut",
+        "check": "rename the 'Unreleased' heading",
+        "notes": "has no section for",
+    }[command]
+    assert marker in output.out + output.err
 
 
 def test_git_tags_returns_none_when_git_cannot_answer(
@@ -309,6 +325,36 @@ def test_git_tags_returns_none_when_git_cannot_answer(
     def _explode(*_args: object, **_kwargs: object) -> object:
         raise OSError
 
-    monkeypatch.setattr(changelog.subprocess, "run", _explode)
+    # Patched on the module's own reference, not on `subprocess` itself.
+    # `changelog.subprocess` is the real module, so patching through it
+    # would make every `subprocess.run` in the worker raise for the
+    # duration of this test, not only the tool's call.
+    monkeypatch.setattr(changelog, "subprocess", SimpleNamespace(run=_explode))
     assert changelog._git_tags() is None
     assert changelog.is_tagged("0.39.0") is True
+
+
+def test_git_tags_returns_none_outside_a_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero git exit is unknown too, and also fails closed."""
+    monkeypatch.setattr(
+        changelog,
+        "subprocess",
+        SimpleNamespace(
+            run=lambda *_a, **_k: SimpleNamespace(returncode=128, stdout="")
+        ),
+    )
+    assert changelog._git_tags() is None
+    assert changelog.is_tagged("0.39.0") is True
+
+
+def test_is_tagged_runs_against_the_real_repository() -> None:
+    """Exercise the real git call, without asserting an answer.
+
+    The answer is environment-dependent by design: a full clone knows its
+    tags and a shallow CI checkout does not, which is why `is_tagged` fails
+    closed. Pinning the result here would recreate the bug that made this
+    guard pass locally and vanish in CI, so only the type is asserted.
+    """
+    assert isinstance(changelog.is_tagged("99.99.99-never-a-tag"), bool)

--- a/tests/test_construction_contracts.py
+++ b/tests/test_construction_contracts.py
@@ -392,7 +392,15 @@ def test_both_doors_leave_the_same_attributes(
     cls = _resolve(module_name, class_name)
     source = inspect.getsource(cls.from_config)
     if "_setup" not in source:
-        pytest.skip(f"{class_name}.from_config does not use the _setup door")
+        # Asserted rather than skipped. A door that builds through the
+        # ordinary constructor satisfies the invariant by construction, and
+        # saying so is worth more than a skip line that records nothing.
+        assert "cls(" in source or "return cls" in source, (
+            f"{class_name}.from_config neither uses _setup nor builds "
+            f"through the constructor, so which attributes it leaves is "
+            f"unknown"
+        )
+        return
     only_in_init = (
         _assigned_attributes(cls, "__init__")
         - _assigned_attributes(cls, "_setup")

--- a/tests/test_construction_contracts.py
+++ b/tests/test_construction_contracts.py
@@ -351,6 +351,16 @@ the mechanism behind R8 rather than an oversight.
 """
 
 
+def _calls_the_constructor(source: str) -> bool:
+    """Return whether the source contains a real `cls(...)` call."""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "cls"
+        for node in ast.walk(ast.parse(textwrap.dedent(source)))
+    )
+
+
 def _assigned_attributes(cls: Any, method: str) -> set[str]:  # noqa: ANN401
     """Return the `self.<name>` attributes a method assigns."""
     function = getattr(cls, method, None)
@@ -395,13 +405,13 @@ def test_both_doors_leave_the_same_attributes(
         # Asserted rather than skipped. A door that builds through the
         # ordinary constructor satisfies the invariant by construction, and
         # saying so is worth more than a skip line that records nothing.
-        # `cls(` only. `return cls` would also admit `return cls.SHARED`
-        # or a cache lookup, which never runs `__init__` and is exactly the
-        # case this rejects.
-        assert "cls(" in source, (
-            f"{class_name}.from_config neither uses _setup nor builds "
-            f"through the constructor, so which attributes it leaves is "
-            f"unknown"
+        # Parsed, not grepped. A substring would match `cls(` inside a
+        # docstring or a comment, and `return cls` would admit
+        # `return cls._instances[name]`, an object that never ran
+        # `__init__` and the exact case this rejects.
+        assert _calls_the_constructor(source), (
+            f"{class_name}.from_config neither uses _setup nor calls "
+            f"cls(...), so which attributes it leaves is unknown"
         )
         return
     only_in_init = (

--- a/tests/test_construction_contracts.py
+++ b/tests/test_construction_contracts.py
@@ -395,7 +395,10 @@ def test_both_doors_leave_the_same_attributes(
         # Asserted rather than skipped. A door that builds through the
         # ordinary constructor satisfies the invariant by construction, and
         # saying so is worth more than a skip line that records nothing.
-        assert "cls(" in source or "return cls" in source, (
+        # `cls(` only. `return cls` would also admit `return cls.SHARED`
+        # or a cache lookup, which never runs `__init__` and is exactly the
+        # case this rejects.
+        assert "cls(" in source, (
             f"{class_name}.from_config neither uses _setup nor builds "
             f"through the constructor, so which attributes it leaves is "
             f"unknown"

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -104,7 +104,7 @@ def _git_tags(pattern: str = "") -> str | None:
         )
     except OSError:  # pragma: no cover  # git missing entirely
         return None
-    if result.returncode != 0:  # pragma: no cover  # not a repository
+    if result.returncode != 0:
         return None
     return result.stdout.strip()
 


### PR DESCRIPTION
Loose ends from this session's contract work, found by auditing what shipped
rather than by adding anything new.

## Five silent skips became assertions

The two-door sweep skipped `TTLCache` and the four providers because their
`from_config` does not use the `__new__` plus `_setup` door. That is true, but a
skip records nothing: read at a glance it looks like coverage.

Those doors build through the ordinary constructor, so the invariant holds by
construction, and the sweep now says so. **Zero skips across all five contract
suites.**

## The release tool's failure branches were untested

`tools/changelog.py` shipped in #767 with its refusal paths uncovered: every way
`check` can refuse, the `notes` miss, the command-line dispatch, and `_git_tags`
when git cannot answer at all.

That last one matters most. `is_tagged` fails closed when a clone reports no
tags, which is what stops a released section being rewritten in CI, and nothing
covered the path that makes it fail closed. A bug in release tooling costs a
burned version.

**`tools/` is deliberately not in `coverage.run.source`**, so no number here is
gated and none is claimed. Bringing it under the gate would pull in five other
untested scripts and belongs in its own change.

## Tests that could not fail

Three of the new tests asserted an exit code that a broken branch would have
produced anyway. Each is now pinned to the message that distinguishes it, and
each was checked by deleting the branch it covers:

- `main()` ends with an unguarded `return notes(...)`, so deleting the `check`
  dispatch left every test green while `check` silently fell through to `notes`.
- `check`'s undated branch returns 1, and so does the wrong-date branch below
  it, so deleting the first changed nothing.
- The two-door assertion accepted `"return cls" in source`, which admits
  `return cls._instances[name]` — an object that never ran `__init__`, the exact
  case the assertion exists to reject. Narrowed to `cls(`.

Also: the `_git_tags` test patched `changelog.subprocess`, which is the real
module, so it made every `subprocess.run` in the worker raise for the duration.
Now scoped to the module's own reference.

## Audited and clean

Reported because the checks ran, not because they found something:

- **22 leak-and-escape probes** across every pattern, both construction doors,
  and the non-pattern surfaces: no value echoed, nothing escaping
  `SettingsValidationError`.
- **Every sweep floor is exact**, not slack: 8 backends, 14 reconfigurables, 25
  doors, 12 env cases.
- **The subclass sweep still bites.** Reintroducing
  `ResilienceSettingsValidationError` fails it. My first attempt to prove this
  produced a module that could not import, which proved nothing, so it was
  redone with a valid subclass.
- No dead leftovers from the `BOTH_DOORS` rewrite, no unused imports, no stale
  docstrings.

## Verification

Full `pre-commit run --all-files` green: 17 hooks, integration tier, 100%
coverage gate.