### PR TITLE
🐛 Give back a half-open probe slot when the call had no outcome

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Breaking
+* 💥 `CircuitBreakerStrategy` gains `abandon()`, the counterpart of `try_acquire()`. A custom backend has to implement it: it gives back a half-open probe slot when the admitted call produced no outcome. The four shipped adapters implement it, and the Postgres one does it with a plain statement, so no migration is needed. ([#789](https://github.com/grelinfo/grelmicro/issues/789))
 
 * 💥 `GrelmicroMiddleware` is imported from the top level: `from grelmicro import GrelmicroMiddleware`. It is pure ASGI and belongs to no framework, so it no longer ships from one named after FastAPI or Starlette. ([#771](https://github.com/grelinfo/grelmicro/issues/771))
 * 💥 `IdempotencyMiddleware` and `StoredResponse` are imported from `grelmicro.http`, which is where the wire-facing pieces live. Both are pure ASGI and run on Starlette and Litestar as well as FastAPI. ([#771](https://github.com/grelinfo/grelmicro/issues/771))
@@ -17,6 +18,7 @@
 * 💥 `GREL_LOG_JSON_SERIALIZER` defaults to `auto`, which uses orjson when it is installed and the standard library when it is not. Install `grelmicro[standard]` and JSON logs get faster with no further setting. `auto` never writes less than the standard library would, because anything orjson declines falls back to it, but the two do not render every value the same way: orjson writes a `UUID`, an `Enum`, and a dataclass natively and writes non-ASCII as UTF-8, where the standard library falls back to `repr` and escapes. Set `stdlib` or `orjson` to pin the exact bytes. ([#780](https://github.com/grelinfo/grelmicro/pull/780))
 
 ### Fixed
+* 🐛 A half-open probe that ends without a call outcome gives its slot back instead of holding it. The slot is taken on admission and returned by recording the outcome, so an exit with anything that is not an `Exception`, an `asyncio.CancelledError` above all, kept it forever: the circuit then refused every call for a day while the dependency was healthy. A cancelled probe, a shutdown mid-probe, and an outer deadline all did it. ([#789](https://github.com/grelinfo/grelmicro/issues/789))
 
 * 🐛 A `Match` predicate that returns a non-bool is warned about once per predicate, not once per address, so a collected predicate no longer silences the next one. ([#782](https://github.com/grelinfo/grelmicro/pull/782))
 * 🐛 Calling a matcher never raises. A predicate that raises, a class with a hostile `__instancecheck__`, an exception whose `__cause__` raises, and a return whose truth value cannot be read each read as no match, and each is reported once per predicate. An exception whose `__str__` raises has no message to match, so a message matcher answers no match without a warning. `Retry` calls a matcher from an `except` block, so an error there replaced the very exception being handled. ([#782](https://github.com/grelinfo/grelmicro/pull/782))

--- a/grelmicro/resilience/_protocol.py
+++ b/grelmicro/resilience/_protocol.py
@@ -291,6 +291,17 @@ class CircuitBreakerStrategy(Protocol):
         """
         ...
 
+    async def abandon(self) -> None:
+        """Give back an admission that produced no outcome.
+
+        The counterpart of `try_acquire`. A call admitted while
+        HALF_OPEN holds one of the probe slots, and `record_outcome`
+        is what returns it. When the call never happened, and so has
+        no outcome to record, this returns the slot instead. Outside
+        HALF_OPEN there is nothing to give back and this does nothing.
+        """
+        ...
+
     async def record_outcome(
         self,
         *,

--- a/grelmicro/resilience/circuitbreaker/__init__.py
+++ b/grelmicro/resilience/circuitbreaker/__init__.py
@@ -729,7 +729,8 @@ class CircuitBreaker(Reconfigurable["CircuitBreakerConfig"]):
             self._last_error = exc_value
             self._last_error_time = datetime.now(UTC)
             result = "error"
-        else:  # pragma: no cover
+        else:
+            await strategy.abandon()
             return None
         _emit.incr(
             "grelmicro.circuit_breaker.calls",
@@ -1090,6 +1091,7 @@ async def _async_handle_exit(
         cb._total_error_count += 1  # noqa: SLF001
         cb._last_error = exc_value  # noqa: SLF001
         cb._last_error_time = datetime.now(UTC)  # noqa: SLF001
-    else:  # pragma: no cover
+    else:
+        await strategy.abandon()
         return
     cb._apply_snapshot(snapshot)  # noqa: SLF001

--- a/grelmicro/resilience/circuitbreaker/memory.py
+++ b/grelmicro/resilience/circuitbreaker/memory.py
@@ -238,6 +238,15 @@ class _MemoryConsecutiveCountStrategy(CircuitBreakerStrategy):
 
         return False
 
+    async def abandon(self) -> None:
+        """Give back a probe slot the call never used."""
+        state = self._live(monotonic())
+        if (
+            state.state == CircuitBreakerState.HALF_OPEN
+            and state.half_open_admit > 0
+        ):
+            state.half_open_admit -= 1
+
     async def record_outcome(
         self,
         *,

--- a/grelmicro/resilience/circuitbreaker/postgres.py
+++ b/grelmicro/resilience/circuitbreaker/postgres.py
@@ -713,6 +713,12 @@ class _PostgresConsecutiveCountStrategy(CircuitBreakerStrategy):
     _SQL_RECORD_SUCCESS = (
         "SELECT * FROM {table_name}_cb_record_success($1, $2, $3);"
     )
+    _SQL_ABANDON = """
+        UPDATE {table_name}
+            SET ho_admit = ho_admit - 1,
+                updated_at = EXTRACT(EPOCH FROM clock_timestamp())
+            WHERE name = $1 AND state = 'HALF_OPEN' AND ho_admit > 0;
+    """
     _SQL_TRANSITION = "SELECT {table_name}_cb_transition($1, $2, $3);"
     _SQL_GET_STATE = "SELECT * FROM {table_name}_cb_get_state($1);"
 
@@ -740,6 +746,7 @@ class _PostgresConsecutiveCountStrategy(CircuitBreakerStrategy):
         self._record_success_sql = self._SQL_RECORD_SUCCESS.format(
             table_name=table_name
         )
+        self._abandon_sql = self._SQL_ABANDON.format(table_name=table_name)
         self._transition_sql = self._SQL_TRANSITION.format(
             table_name=table_name
         )
@@ -754,6 +761,10 @@ class _PostgresConsecutiveCountStrategy(CircuitBreakerStrategy):
             self._reset_timeout,
         )
         return bool(result)
+
+    async def abandon(self) -> None:
+        """Give back a probe slot the call never used."""
+        await self._pool.execute(self._abandon_sql, self._name)
 
     async def record_outcome(
         self,

--- a/grelmicro/resilience/circuitbreaker/redis.py
+++ b/grelmicro/resilience/circuitbreaker/redis.py
@@ -178,6 +178,19 @@ class _RedisConsecutiveCountStrategy(CircuitBreakerStrategy):
       state transition.
     """
 
+    _LUA_ABANDON = """
+        local key = KEYS[1]
+        local state = redis.call("HGET", key, "state")
+        if state ~= "HALF_OPEN" then
+            return 0
+        end
+        local ho_admit = tonumber(redis.call("HGET", key, "ho_admit")) or 0
+        if ho_admit > 0 then
+            redis.call("HINCRBY", key, "ho_admit", -1)
+        end
+        return 1
+    """
+
     _LUA_TRY_ACQUIRE = """
         local key = KEYS[1]
         local capacity = tonumber(ARGV[1])
@@ -421,6 +434,7 @@ class _RedisConsecutiveCountStrategy(CircuitBreakerStrategy):
         )
         self._lua_transition = client.register_script(self._LUA_TRANSITION)
         self._lua_get_state = client.register_script(self._LUA_GET_STATE)
+        self._lua_abandon = client.register_script(self._LUA_ABANDON)
 
     async def try_acquire(self) -> bool:
         """Atomic admission via Lua."""
@@ -430,6 +444,10 @@ class _RedisConsecutiveCountStrategy(CircuitBreakerStrategy):
             client=self._client,
         )
         return bool(result)
+
+    async def abandon(self) -> None:
+        """Give back a probe slot the call never used."""
+        await self._lua_abandon(keys=[self._key], client=self._client)
 
     async def record_outcome(
         self,

--- a/grelmicro/resilience/circuitbreaker/sqlite.py
+++ b/grelmicro/resilience/circuitbreaker/sqlite.py
@@ -471,6 +471,23 @@ class _SQLiteConsecutiveCountStrategy(CircuitBreakerStrategy):
             return True
         return False
 
+    async def abandon(self) -> None:
+        """Give back a probe slot the call never used."""
+        async with self._lock:
+            await self._conn.execute("BEGIN IMMEDIATE;")
+            try:
+                row = await self._read()
+                if (
+                    row.state == CircuitBreakerState.HALF_OPEN
+                    and row.ho_admit > 0
+                ):
+                    row.ho_admit -= 1
+                    await self._write(row)
+                await self._conn.execute("COMMIT;")
+            except BaseException:
+                await self._conn.execute("ROLLBACK;")
+                raise
+
     async def record_outcome(
         self,
         *,

--- a/tests/resilience/test_circuitbreaker.py
+++ b/tests/resilience/test_circuitbreaker.py
@@ -1299,3 +1299,73 @@ class TestSharedBackendIntegration:
             len(backend.try_acquire_calls)
             == len(backend.record_outcome_calls) + 1
         )
+
+
+class _NoOutcome(BaseException):
+    """An exit that is not a call outcome, the way a cancellation is."""
+
+
+async def test_a_probe_that_records_no_outcome_gives_its_slot_back() -> None:
+    """A half-open probe that never happened must not wedge the circuit."""
+    async with MemoryCircuitBreakerAdapter() as backend:
+        cb = CircuitBreaker.consecutive_count(
+            "probe", error_threshold=1, backend=backend, reset_timeout=0.01
+        )
+
+        with pytest.raises(RuntimeError):
+            async with cb:
+                raise RuntimeError
+        assert cb.state is CircuitBreakerState.OPEN
+
+        await asyncio.sleep(0.02)
+        with pytest.raises(_NoOutcome):
+            async with cb:
+                raise _NoOutcome
+
+        async with cb:
+            pass
+        assert cb.state is not CircuitBreakerState.OPEN
+
+
+async def test_abandon_outside_half_open_changes_nothing() -> None:
+    """There is no slot to give back while the circuit is closed."""
+    async with MemoryCircuitBreakerAdapter() as backend:
+        cb = CircuitBreaker("closed", backend=backend)
+        strategy = backend.bind(name="closed", config=cb.config)
+
+        await strategy.abandon()
+
+        snapshot = await strategy.get_snapshot()
+        assert snapshot.state is CircuitBreakerState.CLOSED
+
+
+async def test_a_probe_cancelled_from_a_thread_gives_its_slot_back() -> None:
+    """The worker-thread path returns the slot the same way."""
+    async with MemoryCircuitBreakerAdapter() as backend:
+        cb = CircuitBreaker.consecutive_count(
+            "probe-thread",
+            error_threshold=1,
+            backend=backend,
+            reset_timeout=0.01,
+        )
+
+        def fail() -> None:
+            with cb.from_thread:
+                raise RuntimeError
+
+        def abandon() -> None:
+            with cb.from_thread:
+                raise _NoOutcome
+
+        def probe() -> None:
+            with cb.from_thread:
+                pass
+
+        with pytest.raises(RuntimeError):
+            await asyncio.to_thread(fail)
+        await asyncio.sleep(0.02)
+        with pytest.raises(_NoOutcome):
+            await asyncio.to_thread(abandon)
+
+        await asyncio.to_thread(probe)
+        assert cb.state is not CircuitBreakerState.OPEN

--- a/tests/resilience/test_circuitbreaker_postgres.py
+++ b/tests/resilience/test_circuitbreaker_postgres.py
@@ -629,3 +629,35 @@ async def test_migrate_leaves_current_functions_alone(
         # Assert
         assert before
         assert [dict(row) for row in after] == [dict(row) for row in before]
+
+
+@pytest.mark.integration
+@_INTEGRATION_TIMEOUT
+async def test_abandon_returns_the_half_open_slot(
+    backend: PostgresCircuitBreakerAdapter,
+) -> None:
+    """A probe that produced no outcome must not hold its slot."""
+    strategy = _bind(backend, error_threshold=1, reset_timeout=0.01)
+    await strategy.record_outcome(success=False)
+    await asyncio.sleep(0.05)
+
+    assert await strategy.try_acquire() is True
+    assert await strategy.try_acquire() is False
+
+    await strategy.abandon()
+
+    assert await strategy.try_acquire() is True
+
+
+@pytest.mark.integration
+@_INTEGRATION_TIMEOUT
+async def test_abandon_outside_half_open_changes_nothing(
+    backend: PostgresCircuitBreakerAdapter,
+) -> None:
+    """A closed circuit holds no slot to give back."""
+    strategy = _bind(backend)
+
+    await strategy.abandon()
+
+    snapshot = await strategy.get_snapshot()
+    assert snapshot.state is CircuitBreakerState.CLOSED

--- a/tests/resilience/test_circuitbreaker_redis.py
+++ b/tests/resilience/test_circuitbreaker_redis.py
@@ -419,3 +419,35 @@ async def test_forced_states_never_expire(
     assert (
         await strategy.get_snapshot()
     ).state is CircuitBreakerState.FORCED_OPEN
+
+
+@pytest.mark.integration
+@_INTEGRATION_TIMEOUT
+async def test_abandon_returns_the_half_open_slot(
+    backend: RedisCircuitBreakerAdapter,
+) -> None:
+    """A probe that produced no outcome must not hold its slot."""
+    strategy = _bind(backend, error_threshold=1, reset_timeout=0.01)
+    await strategy.record_outcome(success=False)
+    await asyncio.sleep(0.05)
+
+    assert await strategy.try_acquire() is True
+    assert await strategy.try_acquire() is False
+
+    await strategy.abandon()
+
+    assert await strategy.try_acquire() is True
+
+
+@pytest.mark.integration
+@_INTEGRATION_TIMEOUT
+async def test_abandon_outside_half_open_changes_nothing(
+    backend: RedisCircuitBreakerAdapter,
+) -> None:
+    """A closed circuit holds no slot to give back."""
+    strategy = _bind(backend)
+
+    await strategy.abandon()
+
+    snapshot = await strategy.get_snapshot()
+    assert snapshot.state is CircuitBreakerState.CLOSED

--- a/tests/resilience/test_circuitbreaker_sqlite.py
+++ b/tests/resilience/test_circuitbreaker_sqlite.py
@@ -700,3 +700,54 @@ async def test_sweep_spares_an_open_circuit_still_cooling_down(
 
     assert await _row_names(backend) == ["cb:slow"]
     assert (await strategy.get_snapshot()).state is CircuitBreakerState.OPEN
+
+
+async def test_abandon_returns_the_half_open_slot(
+    backend: SQLiteCircuitBreakerAdapter,
+) -> None:
+    """A probe that produced no outcome must not hold its slot."""
+    strategy = _bind(backend, error_threshold=1, reset_timeout=0.01)
+    await strategy.record_outcome(success=False)
+    await asyncio.sleep(0.02)
+
+    assert await strategy.try_acquire() is True
+    assert await strategy.try_acquire() is False
+
+    await strategy.abandon()
+
+    assert await strategy.try_acquire() is True
+
+
+async def test_abandon_outside_half_open_changes_nothing(
+    backend: SQLiteCircuitBreakerAdapter,
+) -> None:
+    """A closed circuit holds no slot to give back."""
+    strategy = _bind(backend)
+
+    await strategy.abandon()
+
+    snapshot = await strategy.get_snapshot()
+    assert snapshot.state is CircuitBreakerState.CLOSED
+
+
+async def test_abandon_rolls_back_when_the_write_fails(
+    backend: SQLiteCircuitBreakerAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed give-back leaves no half-open transaction behind."""
+    strategy = _bind(backend, error_threshold=1, reset_timeout=0.01)
+    await strategy.record_outcome(success=False)
+    await asyncio.sleep(0.02)
+    assert await strategy.try_acquire() is True
+
+    async def refuse(_row: object) -> None:
+        msg = "disk gone"
+        raise OSError(msg)
+
+    monkeypatch.setattr(strategy, "_write", refuse)
+
+    with pytest.raises(OSError, match="disk gone"):
+        await strategy.abandon()
+
+    monkeypatch.undo()
+    assert await strategy.try_acquire() is False


### PR DESCRIPTION
Closes #789.

A `CircuitBreaker` took a HALF_OPEN probe slot on admission and gave it back only by recording an outcome. The third branch of `__aexit__`, the one that records nothing, returned early without it. With the default capacity of 1 that slot was gone, and the circuit then refused every call for `_STATE_TTL`, which is 24 hours, while the dependency was healthy.

`asyncio.CancelledError` is not an `Exception`, so an ordinary cancellation did it: a client disconnecting, an outer `asyncio.timeout`, or a shutdown landing on the one probe call.

```
call 0 -> WEDGED, state: HALF_OPEN
call 1 -> WEDGED, state: HALF_OPEN
```

Nothing recovered it but a manual `reset`, a restart, or a day.

## The fix

`CircuitBreakerStrategy` gains `abandon()`, the counterpart of `try_acquire()`. An admission that produced no outcome gives its slot back instead of holding it. Outside HALF_OPEN there is nothing to return and it does nothing.

Both exit paths call it on the record-nothing branch: `CircuitBreaker.__aexit__` and `_async_handle_exit`, which is the `from_thread` equivalent.

## The four backends

| Backend | How |
|---|---|
| Memory | Decrement under the state lock |
| Redis | One registered Lua script, guarded on `ho_admit > 0` |
| SQLite | Read, decrement, write inside `BEGIN IMMEDIATE` |
| Postgres | A plain conditional `UPDATE` |

Postgres deliberately does **not** get a stored function. Every other operation there has one, but adding one means a deployment running `auto_migrate=False` calls a function that does not exist yet and fails at runtime, which is worse than the bug being fixed. A single-row conditional update is already atomic and needs no migration, so this ships safely to a database that only has the table.

## Verification

- The wedge is gone: the probe slot comes back, the next call is admitted, the circuit closes on success.
- Tests on all four backends, for the give-back, for the no-op outside HALF_OPEN, and for the SQLite rollback path.
- Both breaker paths covered: `async with breaker:` and the worker-thread `from_thread` form.
- Full pre-commit chain green, integration tier included, coverage gate held.

## Breaking

`abandon()` is a new method on a public protocol, so a third-party `CircuitBreakerStrategy` has to implement it. Recorded under `### Breaking` in the changelog.

## Why now

Found while reviewing #786, which is blocked on this. That PR's `Stack` routes its own admission refusals through the record-nothing branch on purpose, so a rate-limit refusal landing on the one HALF_OPEN probe wedged the circuit. Merging #786 before this would ship a feature that walks into a 24-hour outage under exactly the sustained load that makes limiters refuse.
